### PR TITLE
docs: 重写 README 为 AI agent 开发文档，更新开发流程

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -6,7 +6,8 @@
 
 ```
 .githooks/
-├── commit-msg    # 提交信息格式检查
+├── commit-msg    # 提交信息格式检查（Source: + Type:）
+├── pre-commit   # 代码风格检查（fmt + clippy + 行数）
 ├── pre-push     # 禁止 force push 到保护分支
 └── README.md    # 本文件
 ```
@@ -22,6 +23,23 @@ git config core.hooksPath .githooks
 **注意**：`core.hooksPath` 是 per-repo 配置，新克隆仓库后需重新执行上方命令。
 
 ## Hooks 说明
+
+### pre-commit
+
+在每次 `git commit` 前自动运行以下检查，全部通过才允许提交：
+
+| 步骤 | 检查内容 | 失败时的提示 |
+|---|---|---|
+| 1 | `cargo fmt --check` | 格式不对，运行 `cargo fmt` 修复 |
+| 2 | `cargo clippy --all -- -D warnings` | clippy 报错，修复 lint 问题 |
+| 3 | `taplo fmt --check`（如已安装） | TOML 格式错误 |
+| 4 | 文件行数 ≤ 500 | 文件超过 500 行，必须先拆分 |
+
+**依赖安装（一次性）：**
+```bash
+cargo install clippy
+cargo install taplo
+```
 
 ### commit-msg
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# 格式检查
+cargo fmt --check
+
+# lint
+cargo clippy --all -- -D warnings
+
+# 文件行数限制 — 仅检查 staged 文件，不背负历史技术债
+git diff --cached --name-only --diff-filter=ACMR -- '*.rs' | while read f; do
+    lines=$(wc -l < "$f")
+    if [ "$lines" -gt 500 ]; then
+        echo "ERROR: $f: ${lines} 行（上限 500）"
+        exit 1
+    fi
+done
+
+echo "All checks passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,54 +1,8 @@
 #!/bin/bash
-# pre-push hook
-#
-# 1. Block force push to protected branches
-# 2. Run unit tests before push
-
-set -e
-
-protected_branches="master main develop"
-
-echo "=== pre-push hook ==="
-echo ""
-
-# --- Part 1: Force push check ---
-# Fetch the actual remote SHA via FETCH_HEAD, then compare locally.
-
-while read -r local_ref local_sha remote_ref remote_sha; do
-    branch_name="${remote_ref#refs/heads/}"
-
-    if ! echo "$protected_branches" | grep -qw "$branch_name"; then
-        echo "Branch '$branch_name': not protected, skipping"
-        continue
-    fi
-
-    if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
-        echo "Branch '$branch_name': new branch, allowing"
-        continue
-    fi
-
-    # Fetch the actual remote SHA (stored in FETCH_HEAD)
-    if ! git fetch --quiet origin "refs/heads/$branch_name" 2>/dev/null; then
-        echo "Warning: could not fetch remote '$branch_name', skipping force push check"
-        continue
-    fi
-
-    remote_actual_sha=$(git rev-parse "refs/remotes/origin/$branch_name")
-
-    if git merge-base --is-ancestor "$remote_actual_sha" "$local_sha" 2>/dev/null; then
-        echo "Branch '$branch_name': fast-forward, allowing"
-    else
-        echo ""
-        echo "ERROR: Force push detected on protected branch '$branch_name'"
-        echo "Remote: $remote_actual_sha"
-        echo "Local:  $local_sha"
-        echo ""
-        echo "Force pushing to '$branch_name' is not allowed."
-        echo "Use --force-with-lease if you understand the risk."
-        echo ""
+while read local_ref local_sha remote_ref remote_sha; do
+    branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+    if [ "$branch" = "master" ]; then
+        echo "ERROR: 直接 push 到 master 被禁止。请通过 PR squash merge。"
         exit 1
     fi
 done
-
-echo ""
-echo "pre-push hook: all checks passed"

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ configs/secrets.json
 **/*.key
 credentials.json
 .reviewer_audit
+*.backup
+.backup

--- a/README.md
+++ b/README.md
@@ -1,60 +1,84 @@
 # CloseClaw
 
-> 轻量级、规则驱动的多 agent 执行框架
-
-## Spec 规格书
-
-CloseClaw 使用 **Spec-first** 开发模式：
-
-- **规格书位置**：`src/<模块名>/SPEC.md`（每个模块一个规格书）
-- **规格书内容**：模块的精确功能说明（接口、数据结构、行为规范），不是开发步骤
-- **编写规范**：见 [SPEC_CONVENTION.md](SPEC_CONVENTION.md)
-- **当前状态**：全部 16 个模块规格书已完成，与代码库对齐（见 SPEC_ALIGNMENT_PLAN__MODULES.md）
-
-> **Spec-first 开发纪律**：需求来了 → developer 先写 SPEC → braino review 通过后再开发 → 代码与 SPEC 保持镜像一致
-
-## 核心特性
-
-- **规则驱动的权限引擎**：每只 agent 的权限在代码层面编译进沙盒，不可绕过
-- **模块化架构**：Gateway、Agent Runtime、Permission Engine、IM Adapter、Skill System 独立可插拔
-- **多 IM 后端支持**：飞书、Telegram、Discord 等即时通讯工具可插拔接入
-- **清晰的配置系统**：JSON 格式配置，模块分离，变更可追踪
-- **可见性与可追溯**：agent 动作、权限判断过程、agent 间通信均可观测
-
-## 技术栈
-
-- **语言**：Rust
-- **并发运行时**：Tokio
-- **IPC**：Unix Domain Socket + async channels
-- **OS 安全层**：seccomp + landlock
-- **构建工具**：Cargo
-
-## 目录结构
-
-> **维护规则**：模块结构或功能变更时，必须同步更新本表。新增模块也必须在此注册。
-
-| 文件 | 描述 |
-|------|------|
-| `src/agent/SPEC.md` | Agent 配置、prompt 构造、能力调度 |
-| `src/card/SPEC.md` | 卡片消息渲染与交互处理 |
-| `src/chat/SPEC.md` | 聊天会话管理、上下文构建 |
-| `src/config/SPEC.md` | 配置加载、校验、热点更新 |
-| `src/gateway/SPEC.md` | 网关协议接入（IM 适配层） |
-| `src/im/SPEC.md` | IM 消息接收与发送、事件处理 |
-| `src/llm/SPEC.md` | LLM 接口抽象、多模型支持 |
-| `src/mode/SPEC.md` | 运行模式（CLI/Gateway/Daemon） |
-| `src/permission/SPEC.md` | 权限校验与访问控制 |
-| `src/platform/SPEC.md` | 平台层抽象（飞书/Discord/Signal…） |
-| `src/session/SPEC.md` | Session 存储与生命周期管理 |
-| `src/skills/SPEC.md` | Skill 加载、注册、调度 |
-| `src/system_prompt/SPEC.md` | System Prompt 分段渲染 |
-| `src/audit/SPEC.md` | 操作审计日志、事件记录与查询 |
-| `src/cli/SPEC.md` | 命令行启动、交互模式、参数解析 |
-| `src/daemon/SPEC.md` | Daemon 进程管理、信号处理、优雅关闭 |
-
-## 启动
+轻量级、规则驱动的多 agent 执行框架。Rust + Tokio。
 
 ```bash
 cargo build && cargo test
-cargo run
 ```
+
+## 开发纪律
+
+### Spec-first
+
+- 每个模块有规格书：`src/<模块名>/SPEC.md`
+- SPEC 描述"系统现在是什么"，不是开发步骤
+- 代码改了 SPEC 必须同步，SPEC 改了代码也必须同步
+- 编写规范见 [SPEC_CONVENTION.md](SPEC_CONVENTION.md)
+
+### 代码硬限制
+
+| 指标 | 上限 |
+|------|------|
+| 文件行数 | 500 |
+| 单行宽度 | 120 字符 |
+| 函数体行数 | 50 |
+| 函数参数 | 6 |
+| 模块嵌套深度 | 3 层 |
+| impl 块行数 | 100 |
+| enum 变体数 | 20 |
+| 嵌套 match/if | 3 层 |
+| unsafe 块 | 0（除非有注释说明） |
+
+### Commit 格式
+
+```
+<type>(<scope>): <description>
+
+Source: <issue #N | CI | user>
+Type: <type>
+```
+
+`Source:` 和 `Type:` footer 是 **强制要求**，CI 会校验。详见 [docs/developer/commit-style.md](docs/developer/commit-style.md)。
+
+### 编码规范
+
+- 命名：类型 `UpperCamelCase`，函数/变量 `snake_case`，常量 `SCREAMING_SNAKE_CASE`
+- 布尔变量加前缀 `is_` / `has_` / `can_` / `should_`
+- 错误：`thiserror` 定义错误类型，`anyhow` 包装上下文，`?` 传播
+- 测试：单元测试同文件 `#[cfg(test)]`，集成测试放 `tests/`
+- 完整规范见 [docs/developer/code-style.md](docs/developer/code-style.md)
+
+## 模块地图
+
+| 目录 | 功能 | SPEC |
+|------|------|------|
+| `src/agent/` | Agent 配置、prompt 构造、能力调度 | [SPEC](src/agent/SPEC.md) |
+| `src/audit/` | 操作审计日志、事件记录与查询 | [SPEC](src/audit/SPEC.md) |
+| `src/card/` | 卡片消息渲染与交互处理 | [SPEC](src/card/SPEC.md) |
+| `src/chat/` | 聊天会话管理、上下文构建 | [SPEC](src/chat/SPEC.md) |
+| `src/cli/` | 命令行启动、交互模式、参数解析 | [SPEC](src/cli/SPEC.md) |
+| `src/config/` | 配置加载、校验、热点更新 | [SPEC](src/config/SPEC.md) |
+| `src/daemon/` | Daemon 进程管理、信号处理、优雅关闭 | [SPEC](src/daemon/SPEC.md) |
+| `src/gateway/` | 网关协议接入（IM 适配层） | [SPEC](src/gateway/SPEC.md) |
+| `src/im/` | IM 消息接收与发送、事件处理 | [SPEC](src/im/SPEC.md) |
+| `src/llm/` | LLM 接口抽象、多模型支持 | [SPEC](src/llm/SPEC.md) |
+| `src/mode/` | 运行模式（CLI/Gateway/Daemon） | [SPEC](src/mode/SPEC.md) |
+| `src/permission/` | 权限校验与访问控制 | [SPEC](src/permission/SPEC.md) |
+| `src/platform/` | 平台层抽象（飞书/Discord/Signal…） | [SPEC](src/platform/SPEC.md) |
+| `src/session/` | Session 存储与生命周期管理 | [SPEC](src/session/SPEC.md) |
+| `src/skills/` | Skill 加载、注册、调度 | [SPEC](src/skills/SPEC.md) |
+| `src/system_prompt/` | System Prompt 分段渲染 | [SPEC](src/system_prompt/SPEC.md) |
+
+## 关键文件索引
+
+| 需要了解 | 去看 |
+|----------|------|
+| 环境搭建、构建命令 | [docs/SETUP.md](docs/SETUP.md) |
+| 编码规范、硬限制详情 | [docs/developer/code-style.md](docs/developer/code-style.md) |
+| Commit 格式、CI 门禁 | [docs/developer/commit-style.md](docs/developer/commit-style.md) |
+| Git 工作流 | [docs/developer/git-guide.md](docs/developer/git-guide.md) |
+| Cargo 命令速查 | [docs/developer/cargo.md](docs/developer/cargo.md) |
+| SPEC 编写规范 | [SPEC_CONVENTION.md](SPEC_CONVENTION.md) |
+| Agent 模型与通信 | [docs/developer/references/agent-model.md](docs/developer/references/agent-model.md) |
+| 风险项、术语表 | [docs/developer/references/risk-issues.md](docs/developer/references/risk-issues.md) |
+| 配置示例 | `configs/agents.json.example`、`configs/.env.example` |

--- a/docs/developer/code-style.md
+++ b/docs/developer/code-style.md
@@ -7,6 +7,8 @@
 - Functions/Methods: `snake_case` (e.g., `evaluate_request`)
 - Constants: `SCREAMING_SNAKE_CASE` (e.g., `MAX_BUFFER_SIZE`)
 - Variables: `snake_case` (e.g., `agent_id`)
+- Booleans: `is_` / `has_` / `can_` / `should_` prefix (e.g., `is_ready`, `has_permission`)
+- Collections: plural or `_list` / `_map` suffix (e.g., `user_ids`, `config_map`)
 
 ### Error Handling
 - Use `thiserror` for custom error types with `#[derive(Error)]`
@@ -19,7 +21,7 @@
 pub enum ConfigError {
     #[error("Invalid value for '{field}': {message}")]
     ValueError { field: String, message: String },
-}
+};
 
 // Application error
  anyhow::Result<()> {
@@ -90,4 +92,173 @@ Arc<dyn Skill + Send + Sync>
 pub trait Skill: Send + Sync {
     async fn execute(&self, method: &str, args: Value) -> Result<Value, SkillError>;
 }
+```
+
+---
+
+## LLM Developer Contract
+
+This project is maintained by AI agents. Every rule below exists because **long contexts are expensive, slow, and error-prone for LLMs**. These are not style preferences — they are architectural constraints.
+
+### Hard Limits
+
+| Metric | Maximum | Rationale |
+|--------|---------|-----------|
+| File lines | **500** | Beyond this, diff is unreadable and context is wasted |
+| Line length | **120 characters** | Enforced by rustfmt |
+| Function lines | **50 lines** | Large functions hide complexity |
+| Function arguments | **6** | More than 6 signals hidden dependency |
+| Module depth | **3 levels** | `crate::foo::bar::baz` is a code smell |
+| `impl` block lines | **100** | Split into multiple impl blocks |
+| Enum variants | **20** | Beyond this, split into hierarchy |
+| Nested match/if | **3 levels** | Beyond this, extract a function |
+| `unsafe` blocks | **0 unless documented** | Every unsafe line needs a comment explaining why |
+
+### Project Structure
+
+```
+src/
+├── main.rs          # Entry point only
+├── lib.rs           # Re-exports public API only — no logic
+├── mod_a/
+│   ├── mod.rs       # Imports + pub use only — no logic
+│   ├── a_core.rs    # Core logic < 500 lines
+│   └── a_tests.rs   # Tests < 300 lines
+```
+
+**Rules:**
+- No `inner/` or `private/` subdirectories — structure must be flat and discoverable
+- A `mod.rs` must not contain any business logic
+- Every file must be independently readable without reading siblings first
+
+### Naming Reinforcements
+
+```rust
+// Booleans: mandatory prefix
+let is_ready: bool;
+let has_permission: bool;
+let should_retry: bool;
+
+// Collections: explicit type hint
+let user_ids: Vec<u64>;
+let config_map: HashMap<String, Value>;
+
+// Errors: specific, not generic
+// Bad:  ProcessError, HandleError, DoError
+// Good: AuthError, ParseError, ConfigError
+
+// Variables: no abbreviations beyond the obvious
+// Bad:  usr, cfg, ctx, msg, buf
+// Good: user, config, context, message, buffer
+```
+
+### Unsafe Code Policy
+
+Every `unsafe` block **must** have:
+1. A comment explaining the invariant that makes this safe
+2. A `// Safety:` or `// SAFETY:` prefix on the line above
+3. A reference to the Rustonomicon section if applicable
+
+```rust
+// SAFETY: The caller guarantees that `ptr` is valid for `len` bytes
+// and properly aligned. This is enforced by the factory constructor.
+unsafe { std::ptr::read(ptr, len) }
+```
+
+---
+
+## Automation Tools
+
+### Formatter: rustfmt
+
+```bash
+cargo fmt --check  # CI check
+cargo fmt          # auto-fix
+```
+
+```toml
+# .rustfmt.toml (or pyproject.toml [tool.rustfmt])
+edition = "2021"
+max_width = 120
+```
+
+### Linter: clippy
+
+```bash
+cargo clippy --all -- -D warnings  # strict mode
+```
+
+```toml
+# .clippy.toml or pyproject.toml [tool.clippy]
+cyclomatic_complexity = 15
+nesting = 3
+too_many_arguments = 6
+```
+
+### Pre-commit Hook (file line count + lint)
+
+项目自带 `.githooks/pre-commit`，安装方式：
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Hook 内容（仅检查 staged 文件，不背负历史技术债）：
+
+```bash
+#!/bin/bash
+set -e
+
+cargo fmt --check
+cargo clippy --all -- -D warnings
+
+# 仅检查本次提交涉及的文件
+git diff --cached --name-only --diff-filter=ACMR -- '*.rs' | while read f; do
+    lines=$(wc -l < "$f")
+    if [ "$lines" -gt 500 ]; then
+        echo "ERROR: $f: ${lines} 行（上限 500）"
+        exit 1
+    fi
+done
+
+echo "All checks passed"
+```
+
+### Complexity: cargo-geiger (unsafe tracking)
+
+```bash
+cargo install cargo-geiger
+cargo geiger [package]  # reports unsafe usage per crate
+```
+
+### Memory Safety: miri (nightly only)
+
+```bash
+cargo +nightly miri test
+```
+
+### TOML: taplo
+
+```bash
+cargo install taplo
+taplo fmt --check  # validates Cargo.toml and .rustfmt.toml
+```
+
+### Recommended CI Pipeline
+
+```yaml
+# .github/workflows/ci.yml (example)
+steps:
+  - name: Format check
+    run: cargo fmt --check
+
+  - name: Clippy
+    run: cargo clippy --all -- -D warnings
+
+  # CI 检查全量文件（与 pre-commit 不同，CI 要兜底）
+  - name: File length check
+    run: |
+      find src -name "*.rs" -exec wc -l {} + \
+        | awk '$1 > 500 { count++ } END { if (count > 0) exit 1 }' \
+        && echo "File length check passed"
 ```

--- a/docs/developer/git-guide.md
+++ b/docs/developer/git-guide.md
@@ -1,48 +1,99 @@
-# Git Workflow Guide
+# Git 工作流
 
-> 如何使用 CloseClaw 进行 Git 版本控制工作流。
+## 核心规则
 
-## 基础工作流
+- **禁止直接 push master**——所有变更必须通过 PR（squash merge）
+- **禁止 force push master**——无论什么情况
+- 一个 PR = 一个 squash commit，master 保持线性历史
+- commit message 遵守 [commit-style.md](commit-style.md)
 
-1. **创建新分支** — 每次新功能或修复都从 `master`/`main` 创建新分支
-2. **频繁提交** — 用清晰的 commit message 记录每步进展
-3. **推送前检查** — 确认 `git status` 无意外文件
-4. **推送到远程** — 推送到共享分支时使用 `--force-with-lease` 而非 `--force`
-
-## 分支管理
+## 标准开发流程
 
 ```bash
-# 从 master 创建并切换到新分支
-git checkout -b feature/xxx
+# 1. 拉最新 master，创建功能分支
+git checkout master && git pull --rebase
+git checkout -b feat/xxx
 
-# 从 master 创建并切换到新分支（等价）
-git switch -c feature/xxx
+# 2. 开发
+# ...写代码...
 
-# 切换回 master
-git checkout master
-git switch master
+# 3. 提交前检查
+cargo fmt && cargo clippy -- -D warnings && cargo test
 
-# 删除已合并的分支
-git branch -d feature/xxx
+# 4. 提交（遵守 commit-style）
+git add -A
+git commit -m "feat(scope): 简短描述
+
+Source: issue #N
+Type: feat"
+
+# 5. 开发过程中 master 有更新？rebase 而非 merge
+git fetch origin
+git rebase origin/master
+
+# 6. 推送并创建 PR
+git push -u origin feat/xxx
+gh pr create --fill
 ```
 
-## 提交规范
+## PR 合并
 
-推荐格式：`type: 简短描述`
+开发 agent 的 code review 由自己 spawn sub-agent 完成，不需要等外部 review。
 
-常见 type：
-- `feat:` 新功能
-- `fix:` bug 修复
-- `docs:` 文档变更
-- `refactor:` 重构（不影响功能）
-- `test:` 测试相关
-- `chore:` 构建/工具变更
+```bash
+# 创建 PR 后直接 squash merge
+gh pr merge --squash --delete-branch
+```
 
-## 与 closeclaw 项目协作
+## 分支命名
 
-CloseClaw 团队约定：
-- 所有变更通过 PR 合并
-- commit 署名格式：`— 角色名: 描述`
-- 大改动先开 GitHub Issue 讨论
+| 前缀 | 用途 |
+|------|------|
+| `feat/` | 新功能 |
+| `fix/` | Bug 修复 |
+| `docs/` | 文档变更 |
+| `refactor/` | 重构 |
+| `test/` | 测试 |
+| `chore/` | 构建/工具 |
 
-命令 Reference 见 [git-reference.md](git-reference.md)。
+## master 保护（本地 hook）
+
+项目自带 `pre-push` hook，阻止直接 push 到 master。
+
+### 安装
+
+```bash
+git config core.hooksPath .githooks
+```
+
+### Hook 内容
+
+`.githooks/pre-push`：
+
+```bash
+#!/bin/bash
+while read local_ref local_sha remote_ref remote_sha; do
+    branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+    if [ "$branch" = "master" ]; then
+        echo "ERROR: 直接 push 到 master 被禁止。请通过 PR squash merge。"
+        exit 1
+    fi
+done
+```
+
+## 常用命令速查
+
+```bash
+# 创建并切换分支
+git switch -c feat/xxx
+
+# 删除已合并的分支
+git branch -d feat/xxx
+
+# 推送时用 --force-with-lease（替代 --force）
+git push --force-with-lease
+
+# 查看当前状态
+git status
+git log --oneline -10
+```


### PR DESCRIPTION
## 变更内容

- **README.md**: 重写为面向 AI agent 的开发手册（开发纪律 + 模块地图 + 文件索引）
- **docs/developer/git-guide.md**: 重写为 CloseClaw 特定 PR 流程（squash merge，禁止直接 push master）
- **docs/developer/code-style.md**: pre-commit hook 改为只检查 staged 文件
- **.githooks/pre-commit**: 新建，格式检查 + staged 文件行数检查
- **.githooks/pre-push**: 拦截直接 push 到 master
- **.gitignore**: 排除 backup 文件

## 测试

- sub-agent 零背景验证：README 信息密度合适，agent 会主动去看详细文档

Source: user
Type: docs