### PR TITLE
fix: 简化 pre-commit hook 为仅行数检查

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-# 格式检查
-cargo fmt --check
-
-# lint
-cargo clippy --all -- -D warnings
-
 # 文件行数限制 — 仅检查 staged 文件，不背负历史技术债
 git diff --cached --name-only --diff-filter=ACMR -- '*.rs' | while read f; do
     lines=$(wc -l < "$f")

--- a/docs/developer/code-style.md
+++ b/docs/developer/code-style.md
@@ -203,14 +203,12 @@ too_many_arguments = 6
 git config core.hooksPath .githooks
 ```
 
-Hook 内容（仅检查 staged 文件，不背负历史技术债）：
+Hook 内容（仅检查 staged 文件行数，不背负历史技术债；
+cargo fmt 和 clippy 放 CI，因为它们检查整个 crate 无法按文件过滤）：
 
 ```bash
 #!/bin/bash
 set -e
-
-cargo fmt --check
-cargo clippy --all -- -D warnings
 
 # 仅检查本次提交涉及的文件
 git diff --cached --name-only --diff-filter=ACMR -- '*.rs' | while read f; do


### PR DESCRIPTION
cargo fmt 和 clippy 都检查整个 crate，无法按 staged 文件过滤。
现有代码有历史 warning 会导致所有 commit 失败。

pre-commit 只保留 staged 文件行数检查，fmt/clippy 移至 CI。

Source: user
Type: fix