### PR TITLE
ci: 新增 cargo fmt 检查和 clippy lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,25 @@ jobs:
           echo "- Source: $(echo "$msg" | grep '^Source:' | sed 's/^Source: //')"
           echo "- Type: $(echo "$msg" | grep '^Type:' | sed 's/^Type: //')"
 
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all 2>&1 | tee clippy-output.txt
+        continue-on-error: true
+
+      - name: Check clippy warnings
+        run: |
+          warnings=$(grep -c '^warning' clippy-output.txt || true)
+          if [ "$warnings" -gt 0 ]; then
+            echo "⚠️ $warnings clippy warnings found. Fix before enabling strict mode."
+            echo "List of warnings:"
+            grep -E '(warning\[|warning:)' clippy-output.txt || true
+            echo ""
+            echo "Once all warnings are resolved, remove continue-on-error from the clippy step"
+            echo "and add -- -D warnings to fail on warnings."
+          fi
+
       - name: Run unit and binary tests
         run: cargo test --lib --bins
 


### PR DESCRIPTION
- cargo fmt --check：格式不符则 CI 失败
- cargo clippy：当前 continue-on-error，只报告不阻断，等历史 warning 清完后改严格模式

Source: user
Type: chore