### PR TITLE
chore: apply cargo fmt across codebase

### DIFF
--- a/src/card/builder.rs
+++ b/src/card/builder.rs
@@ -1,6 +1,8 @@
 //! Feishu card builder — constructs cards from plan data.
 
-use super::elements::{ButtonElement, ButtonStyle, CardAction, CardElement, MarkdownElement, ProgressElement};
+use super::elements::{
+    ButtonElement, ButtonStyle, CardAction, CardElement, MarkdownElement, ProgressElement,
+};
 use super::{CardHeader, PlanData, PlanStep, RichCard, StepStatus};
 
 /// Feishu card builder for constructing Plan mode cards.
@@ -63,12 +65,7 @@ impl FeishuCardBuilder {
             StepStatus::Completed => "✅",
         };
 
-        let content = format!(
-            "{} **{}**\n\n{}",
-            status_icon,
-            step.title,
-            step.content
-        );
+        let content = format!("{} **{}**\n\n{}", status_icon, step.title, step.content);
 
         CardElement::Markdown(MarkdownElement {
             content,
@@ -87,7 +84,11 @@ mod tests {
             title: "测试计划".to_string(),
             current_step: 2,
             total_steps: 3,
-            step_labels: vec!["需求分析".to_string(), "方案设计".to_string(), "实现".to_string()],
+            step_labels: vec![
+                "需求分析".to_string(),
+                "方案设计".to_string(),
+                "实现".to_string(),
+            ],
             steps: vec![
                 PlanStep {
                     title: "需求分析".to_string(),

--- a/src/card/events.rs
+++ b/src/card/events.rs
@@ -11,13 +11,9 @@ pub enum CardEvent {
         card_message_id: String,
     },
     /// User cancelled the plan
-    PlanCancelled {
-        session_id: String,
-    },
+    PlanCancelled { session_id: String },
     /// User requested plan regeneration
-    PlanRegenerate {
-        session_id: String,
-    },
+    PlanRegenerate { session_id: String },
     /// User toggled a step's collapsed state
     StepToggled {
         session_id: String,
@@ -73,10 +69,14 @@ mod tests {
     #[test]
     fn test_from_action_confirm() {
         let action = CardAction::Confirm;
-        let event = CardEvent::from_action(&action, "sess_123".to_string(), Some("msg_456".to_string()));
+        let event =
+            CardEvent::from_action(&action, "sess_123".to_string(), Some("msg_456".to_string()));
 
         match event {
-            Some(CardEvent::PlanConfirmed { session_id, card_message_id }) => {
+            Some(CardEvent::PlanConfirmed {
+                session_id,
+                card_message_id,
+            }) => {
                 assert_eq!(session_id, "sess_123");
                 assert_eq!(card_message_id, "msg_456");
             }
@@ -90,7 +90,9 @@ mod tests {
         let event = CardEvent::from_action(&action, "sess_123".to_string(), None);
 
         match event {
-            Some(CardEvent::PlanConfirmed { card_message_id, .. }) => {
+            Some(CardEvent::PlanConfirmed {
+                card_message_id, ..
+            }) => {
                 assert_eq!(card_message_id, "");
             }
             _ => panic!("Expected PlanConfirmed"),
@@ -131,7 +133,11 @@ mod tests {
         let event = CardEvent::from_action(&action, "sess_xyz".to_string(), None);
 
         match event {
-            Some(CardEvent::StepToggled { session_id, step_index, collapsed }) => {
+            Some(CardEvent::StepToggled {
+                session_id,
+                step_index,
+                collapsed,
+            }) => {
                 assert_eq!(session_id, "sess_xyz");
                 assert_eq!(step_index, 2);
                 assert!(!collapsed);
@@ -146,7 +152,11 @@ mod tests {
         let event = CardEvent::from_action(&action, "sess_123".to_string(), None);
 
         match event {
-            Some(CardEvent::StepToggled { step_index, collapsed, .. }) => {
+            Some(CardEvent::StepToggled {
+                step_index,
+                collapsed,
+                ..
+            }) => {
                 assert_eq!(step_index, 5);
                 assert!(collapsed);
             }

--- a/src/card/handler.rs
+++ b/src/card/handler.rs
@@ -81,10 +81,7 @@ pub async fn handle_card_event(
                 "plan cancelled via card button"
             );
             event_bus
-                .publish(
-                    "plan_cancelled",
-                    PlanCancelledPayload { session_id },
-                )
+                .publish("plan_cancelled", PlanCancelledPayload { session_id })
                 .await
                 .map_err(CardError::EventBus)
         }
@@ -95,10 +92,7 @@ pub async fn handle_card_event(
                 "plan regeneration requested via card button"
             );
             event_bus
-                .publish(
-                    "plan_regenerate",
-                    PlanRegeneratePayload { session_id },
-                )
+                .publish("plan_regenerate", PlanRegeneratePayload { session_id })
                 .await
                 .map_err(CardError::EventBus)
         }
@@ -133,7 +127,11 @@ pub async fn handle_card_event(
 #[async_trait::async_trait]
 pub trait CardEventBus: Send + Sync {
     /// Publish an event with the given name and payload.
-    async fn publish(&self, event_name: &str, payload: impl serde::Serialize + Send) -> Result<(), String>;
+    async fn publish(
+        &self,
+        event_name: &str,
+        payload: impl serde::Serialize + Send,
+    ) -> Result<(), String>;
 }
 
 #[cfg(test)]

--- a/src/card/mod.rs
+++ b/src/card/mod.rs
@@ -13,8 +13,8 @@ pub mod renderer;
 pub mod update;
 
 // Re-export commonly used types
-pub use elements::{CardAction, CardElement};
 pub use elements::{ButtonElement, ButtonStyle, ImageElement, MarkdownElement, ProgressElement};
+pub use elements::{CardAction, CardElement};
 pub use renderer::render_feishu_card;
 
 /// Card header configuration

--- a/src/card/renderer.rs
+++ b/src/card/renderer.rs
@@ -1,6 +1,9 @@
 //! Feishu card renderer — converts card elements to Feishu interactive card JSON.
 
-use super::elements::{ButtonElement, ButtonStyle, CardAction, CardElement, ImageElement, MarkdownElement, ProgressElement};
+use super::elements::{
+    ButtonElement, ButtonStyle, CardAction, CardElement, ImageElement, MarkdownElement,
+    ProgressElement,
+};
 
 /// Render a single card element to Feishu JSON format.
 pub fn render_element(element: &CardElement) -> serde_json::Value {
@@ -118,8 +121,10 @@ pub fn render_feishu_card(card: &super::RichCard) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::card::elements::{
+        ButtonElement, ButtonStyle, CardAction, CardElement, MarkdownElement, ProgressElement,
+    };
     use crate::card::{CardHeader, RichCard};
-    use crate::card::elements::{CardElement, ProgressElement, MarkdownElement, ButtonElement, CardAction, ButtonStyle};
 
     #[test]
     fn test_render_markdown() {
@@ -138,7 +143,13 @@ mod tests {
         let el = ProgressElement {
             current: 3,
             total: 5,
-            labels: Some(vec!["分析".to_string(), "设计".to_string(), "实现".to_string(), "测试".to_string(), "部署".to_string()]),
+            labels: Some(vec![
+                "分析".to_string(),
+                "设计".to_string(),
+                "实现".to_string(),
+                "测试".to_string(),
+                "部署".to_string(),
+            ]),
         };
         let json = render_element(&CardElement::Progress(el));
         assert_eq!(json["tag"], "markdown");
@@ -216,8 +227,8 @@ mod tests {
 
     #[test]
     fn test_render_feishu_card_with_header() {
-        use crate::card::{CardHeader, RichCard, StepStatus, PlanStep};
         use crate::card::elements::{CardElement, ProgressElement};
+        use crate::card::{CardHeader, PlanStep, RichCard, StepStatus};
 
         let card = RichCard {
             card_id: Some("msg_123".to_string()),
@@ -231,7 +242,11 @@ mod tests {
                 CardElement::Progress(ProgressElement {
                     current: 1,
                     total: 3,
-                    labels: Some(vec!["第一步".to_string(), "第二步".to_string(), "第三步".to_string()]),
+                    labels: Some(vec![
+                        "第一步".to_string(),
+                        "第二步".to_string(),
+                        "第三步".to_string(),
+                    ]),
                 }),
                 CardElement::Divider,
             ],
@@ -251,13 +266,11 @@ mod tests {
             card_id: None,
             title: "无头卡片".to_string(),
             header: None,
-            elements: vec![
-                CardElement::Markdown(MarkdownElement {
-                    content: "简单内容".to_string(),
-                    collapsible: false,
-                    collapsed: false,
-                }),
-            ],
+            elements: vec![CardElement::Markdown(MarkdownElement {
+                content: "简单内容".to_string(),
+                collapsible: false,
+                collapsed: false,
+            })],
         };
 
         let json = render_feishu_card(&card);

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -193,8 +193,8 @@ impl FeishuAdapter {
         }
 
         let payload = render_feishu_card(card);
-        let content = serde_json::to_string(&payload)
-            .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+        let content =
+            serde_json::to_string(&payload).map_err(|e| AdapterError::SendFailed(e.to_string()))?;
 
         let req = SendRequest {
             receive_id: chat_id,
@@ -224,9 +224,9 @@ impl FeishuAdapter {
             )));
         }
 
-        resp.data
-            .and_then(|d| d.message_id)
-            .ok_or_else(|| AdapterError::SendFailed("No message_id in card send response".to_string()))
+        resp.data.and_then(|d| d.message_id).ok_or_else(|| {
+            AdapterError::SendFailed("No message_id in card send response".to_string())
+        })
     }
 
     /// Update an existing card message identified by `message_id`.
@@ -252,8 +252,8 @@ impl FeishuAdapter {
         }
 
         // Feishu update requires the full card content string
-        let content = serde_json::to_string(patch)
-            .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+        let content =
+            serde_json::to_string(patch).map_err(|e| AdapterError::SendFailed(e.to_string()))?;
 
         let req = UpdateRequest { content: &content };
 

--- a/src/mode/decision.rs
+++ b/src/mode/decision.rs
@@ -58,8 +58,13 @@ impl ModeDecisionTree {
 
         // 3. Platform adaptation for requested mode
         if let Some(requested_mode) = context.requested_mode {
-            if !self.capability_service.supports_mode(platform, requested_mode) {
-                return self.capability_service.get_fallback_mode(platform, requested_mode);
+            if !self
+                .capability_service
+                .supports_mode(platform, requested_mode)
+            {
+                return self
+                    .capability_service
+                    .get_fallback_mode(platform, requested_mode);
             }
             return requested_mode;
         }
@@ -137,8 +142,8 @@ mod tests {
     #[test]
     fn test_platform_fallback() {
         let service = make_service();
-        let ctx = ModeDecisionContext::new("test-session")
-            .with_requested_mode(ReasoningMode::Stream);
+        let ctx =
+            ModeDecisionContext::new("test-session").with_requested_mode(ReasoningMode::Stream);
 
         // On Feishu, Stream should fall back to Plan
         let mode = decide_mode("写代码", "feishu", &ctx, &service);

--- a/src/mode/mod.rs
+++ b/src/mode/mod.rs
@@ -13,8 +13,8 @@ pub mod switch_event;
 pub use decision::{decide_mode, ModeDecisionTree};
 pub use natural_language::{parse_natural_language_intent, IntentResult, NaturalLanguagePatterns};
 pub use slash_command::{
-    format_mode, handle_slash_command, parse_slash_command, SlashCommand, SlashCommandResult,
-    SlashModeMap, SLASH_HELP_TEXT, SLASH_MODE_MAP, unknown_command_response,
+    format_mode, handle_slash_command, parse_slash_command, unknown_command_response, SlashCommand,
+    SlashCommandResult, SlashModeMap, SLASH_HELP_TEXT, SLASH_MODE_MAP,
 };
 pub use switch_event::{ModeSwitchEvent, ModeSwitchTrigger, UserIntent};
 
@@ -85,8 +85,8 @@ mod tests {
     #[test]
     fn test_decide_mode_priority() {
         let service = PlatformCapabilityService::new();
-        let ctx = ModeDecisionContext::new("test-session")
-            .with_requested_mode(ReasoningMode::Stream);
+        let ctx =
+            ModeDecisionContext::new("test-session").with_requested_mode(ReasoningMode::Stream);
 
         // Slash command should take highest priority
         let mode = decide_mode("/plan 设计系统", "feishu", &ctx, &service);

--- a/src/mode/slash_command.rs
+++ b/src/mode/slash_command.rs
@@ -139,8 +139,6 @@ impl SlashModeMap {
         }
     }
 
-
-
     /// Get the mode for a command
     pub fn get(&self, command: &str) -> Option<ReasoningMode> {
         self.mode_map.get(command).copied()
@@ -194,7 +192,10 @@ pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
     let target_mode = if is_meta_command {
         ReasoningMode::Direct // Meta commands don't switch mode
     } else {
-        *slash_map.mode_map.get(&command).unwrap_or(&ReasoningMode::Direct)
+        *slash_map
+            .mode_map
+            .get(&command)
+            .unwrap_or(&ReasoningMode::Direct)
     };
 
     Some(SlashCommand::new(
@@ -207,14 +208,14 @@ pub fn parse_slash_command(input: &str) -> Option<SlashCommand> {
 }
 
 /// Handle a parsed slash command and return the result
-/// 
+///
 /// For mode-switching commands (/plan, /code, etc.), returns SwitchMode.
 /// For meta commands (/help, /mode, /compact), returns appropriate result.
 /// For unrecognized commands, returns Unknown.
 pub fn handle_slash_command(cmd: &SlashCommand) -> SlashCommandResult {
     match cmd.command.as_str() {
         "/help" => SlashCommandResult::Text(SLASH_HELP_TEXT.to_string()),
-        
+
         "/mode" => {
             if cmd.args.is_empty() {
                 // /mode without args: caller should provide current mode
@@ -228,25 +229,28 @@ pub fn handle_slash_command(cmd: &SlashCommand) -> SlashCommandResult {
                     "stream" => ReasoningMode::Stream,
                     "hidden" => ReasoningMode::Hidden,
                     _ => {
-                        return SlashCommandResult::Text(
-                            format!("无效模式。可用模式：direct, plan, stream, hidden")
-                        )
+                        return SlashCommandResult::Text(format!(
+                            "无效模式。可用模式：direct, plan, stream, hidden"
+                        ))
                     }
                 };
                 SlashCommandResult::SwitchMode(target)
             }
         }
-        
+
         "/compact" => {
             // /compact: caller should perform actual compaction
             // Return placeholder with mock values - caller will replace
-            SlashCommandResult::Compact { before: 0, after: 0 }
+            SlashCommandResult::Compact {
+                before: 0,
+                after: 0,
+            }
         }
-        
+
         "/plan" | "/code" | "/review" | "/debug" | "/direct" | "/think" => {
             SlashCommandResult::SwitchMode(cmd.target_mode)
         }
-        
+
         _ => SlashCommandResult::Unknown(cmd.command.clone()),
     }
 }
@@ -263,10 +267,7 @@ pub fn format_mode(mode: ReasoningMode) -> &'static str {
 
 /// Build a friendly unknown command response
 pub fn unknown_command_response(command: &str) -> String {
-    format!(
-        "未知指令: {}。输入 /help 查看可用指令。",
-        command
-    )
+    format!("未知指令: {}。输入 /help 查看可用指令。", command)
 }
 
 #[cfg(test)]

--- a/src/mode/switch_event.rs
+++ b/src/mode/switch_event.rs
@@ -90,11 +90,17 @@ impl ModeSwitchEvent {
         args: impl Into<String>,
     ) -> Self {
         let raw: String = raw_input.into();
-        Self::new(session_id, from_mode, to_mode, ModeSwitchTrigger::SlashCommand, command)
-            .with_user_intent(UserIntent {
-                raw_input: raw.clone(),
-                parsed_goal: args.into(),
-            })
+        Self::new(
+            session_id,
+            from_mode,
+            to_mode,
+            ModeSwitchTrigger::SlashCommand,
+            command,
+        )
+        .with_user_intent(UserIntent {
+            raw_input: raw.clone(),
+            parsed_goal: args.into(),
+        })
     }
 
     /// Create from natural language
@@ -106,11 +112,17 @@ impl ModeSwitchEvent {
         raw_input: impl Into<String>,
     ) -> Self {
         let raw: String = raw_input.into();
-        Self::new(session_id, from_mode, to_mode, ModeSwitchTrigger::NaturalLanguage, keyword)
-            .with_user_intent(UserIntent {
-                raw_input: raw.clone(),
-                parsed_goal: raw,
-            })
+        Self::new(
+            session_id,
+            from_mode,
+            to_mode,
+            ModeSwitchTrigger::NaturalLanguage,
+            keyword,
+        )
+        .with_user_intent(UserIntent {
+            raw_input: raw.clone(),
+            parsed_goal: raw,
+        })
     }
 
     /// Create from platform adaptation

--- a/src/platform/capabilities.rs
+++ b/src/platform/capabilities.rs
@@ -165,7 +165,11 @@ impl PlatformCapabilityService {
     }
 
     /// Get the fallback mode for a platform when the requested mode is not supported
-    pub fn get_fallback_mode(&self, platform: &str, requested_mode: ReasoningMode) -> ReasoningMode {
+    pub fn get_fallback_mode(
+        &self,
+        platform: &str,
+        requested_mode: ReasoningMode,
+    ) -> ReasoningMode {
         match requested_mode {
             ReasoningMode::Stream => {
                 let caps = self.get_capabilities(platform);

--- a/src/platform/feishu/adapter.rs
+++ b/src/platform/feishu/adapter.rs
@@ -20,7 +20,11 @@ pub trait FeishuMessageService: Send + Sync {
     async fn send_message(&self, content: &str) -> Result<String, FeishuAdapterError>;
 
     /// Update an existing message
-    async fn update_message(&self, message_id: &str, content: &str) -> Result<(), FeishuAdapterError>;
+    async fn update_message(
+        &self,
+        message_id: &str,
+        content: &str,
+    ) -> Result<(), FeishuAdapterError>;
 
     /// Send a card message
     async fn send_card(&self, card_config: &PlanCardConfig) -> Result<String, FeishuAdapterError>;
@@ -65,7 +69,9 @@ impl FeishuAdapter {
     /// Check if fallback is needed for the given mode
     pub fn should_fallback(&self, mode: ReasoningMode) -> bool {
         mode == ReasoningMode::Stream
-            && !self.capability_service.supports_mode_fully("feishu", ReasoningMode::Stream)
+            && !self
+                .capability_service
+                .supports_mode_fully("feishu", ReasoningMode::Stream)
     }
 
     /// Get the fallback mode for Stream on Feishu
@@ -160,8 +166,8 @@ impl FeishuAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::platform::PlatformCapabilityService;
     use crate::platform::feishu::card_updater::SectionUpdate;
+    use crate::platform::PlatformCapabilityService;
     use async_trait::async_trait;
 
     struct MockCardService;

--- a/src/platform/feishu/card.rs
+++ b/src/platform/feishu/card.rs
@@ -54,7 +54,9 @@ pub fn build_initial_sections(goal: Option<&str>) -> Vec<PlanSection> {
         PlanSection {
             step_number: 1,
             title: "需求分析".to_string(),
-            content: goal.map(|g| format!("目标：{}", g)).unwrap_or_else(|| "分析中...".to_string()),
+            content: goal
+                .map(|g| format!("目标：{}", g))
+                .unwrap_or_else(|| "分析中...".to_string()),
             status: StepStatus::Pending,
         },
         PlanSection {

--- a/src/platform/feishu/card_updater.rs
+++ b/src/platform/feishu/card_updater.rs
@@ -43,10 +43,7 @@ impl std::error::Error for CardServiceError {}
 #[async_trait]
 pub trait CardService: Send + Sync {
     /// Create an interactive card
-    async fn create_card(
-        &self,
-        config: &PlanCardConfig,
-    ) -> Result<CardHandle, FeishuAdapterError>;
+    async fn create_card(&self, config: &PlanCardConfig) -> Result<CardHandle, FeishuAdapterError>;
 
     /// Update a specific section of the card
     async fn update_section(

--- a/src/platform/feishu/complexity.rs
+++ b/src/platform/feishu/complexity.rs
@@ -3,9 +3,7 @@
 use crate::session::events::ModeSwitchEvent;
 
 /// Complexity indicator keywords that suggest a high-complexity task.
-const COMPLEXITY_INDICATORS: &[&str] = &[
-    "系统", "架构", "设计", "实现", "重构", "迁移",
-];
+const COMPLEXITY_INDICATORS: &[&str] = &["系统", "架构", "设计", "实现", "重构", "迁移"];
 
 /// Determine whether a mode-switch event describes a high-complexity task.
 ///

--- a/src/platform/feishu/updater.rs
+++ b/src/platform/feishu/updater.rs
@@ -74,7 +74,9 @@ pub async fn update_card_content<C: CardService + ?Sized>(
         content: Some(content.to_string()),
         ..Default::default()
     };
-    card_service.update_section(card_id, section_index, update).await
+    card_service
+        .update_section(card_id, section_index, update)
+        .await
 }
 
 #[cfg(test)]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -75,7 +75,12 @@ mod tests {
     #[test]
     fn test_all_platforms_have_caps() {
         let service = PlatformCapabilityService::new();
-        let platforms = [PLATFORM_FEISHU, PLATFORM_TELEGRAM, PLATFORM_DISCORD, PLATFORM_SLACK];
+        let platforms = [
+            PLATFORM_FEISHU,
+            PLATFORM_TELEGRAM,
+            PLATFORM_DISCORD,
+            PLATFORM_SLACK,
+        ];
 
         for platform in platforms {
             let caps = service.get_capabilities(platform);

--- a/src/session/bootstrap.rs
+++ b/src/session/bootstrap.rs
@@ -80,11 +80,7 @@ impl BootstrapRegion {
         let full_hash = Self::compute_hash(content);
         // Store first 12 hex chars for marker compactness
         let content_hash = full_hash[..12].to_string();
-        let region_id = format!(
-            "{}_{}",
-            file_name,
-            content_hash[..8].to_string()
-        );
+        let region_id = format!("{}_{}", file_name, content_hash[..8].to_string());
 
         Self {
             region_id,
@@ -173,10 +169,16 @@ impl BootstrapRegion {
         }
 
         let file_name = file_name.ok_or_else(|| {
-            BootstrapProtectionError::MarkerParseError(format!("missing file in marker: {}", marker))
+            BootstrapProtectionError::MarkerParseError(format!(
+                "missing file in marker: {}",
+                marker
+            ))
         })?;
         let hash = hash.ok_or_else(|| {
-            BootstrapProtectionError::MarkerParseError(format!("missing hash in marker: {}", marker))
+            BootstrapProtectionError::MarkerParseError(format!(
+                "missing hash in marker: {}",
+                marker
+            ))
         })?;
         let char_count = chars.unwrap_or_else(|| content.chars().count());
         let is_reinject = reinject.unwrap_or(false);
@@ -228,7 +230,10 @@ impl BootstrapContext {
     }
 
     /// Check if any region has had its content corrupted (hash mismatch)
-    pub fn check_integrity<'a>(&self, contents: impl Iterator<Item = (&'a str, &'a str)>) -> Vec<String> {
+    pub fn check_integrity<'a>(
+        &self,
+        contents: impl Iterator<Item = (&'a str, &'a str)>,
+    ) -> Vec<String> {
         // contents: iterator of (file_name, content)
         let mut corrupted = Vec::new();
         for (file_name, content) in contents {
@@ -400,7 +405,8 @@ impl BootstrapProtection {
     pub fn before_compact(&self, ctx: &mut BootstrapContext) {
         ctx.pre_compact_hashes.clear();
         for region in &ctx.regions {
-            ctx.pre_compact_hashes.insert(region.region_id.clone(), region.content_hash.clone());
+            ctx.pre_compact_hashes
+                .insert(region.region_id.clone(), region.content_hash.clone());
         }
     }
 
@@ -416,9 +422,12 @@ impl BootstrapProtection {
                 if let Some(marker_end) = transcript[start_idx..].find('>') {
                     // body_content_start is right after the '>' of start marker
                     let body_content_start = start_idx + marker_end + 1;
-                    if let Some(end_rel) = transcript[body_content_start..].find(BOOTSTRAP_REGION_END) {
+                    if let Some(end_rel) =
+                        transcript[body_content_start..].find(BOOTSTRAP_REGION_END)
+                    {
                         // Extract content - strip leading newline (after >) and trailing newline (before </bootstrap>)
-                        let raw_content = &transcript[body_content_start..body_content_start + end_rel];
+                        let raw_content =
+                            &transcript[body_content_start..body_content_start + end_rel];
                         let content = raw_content.trim();
                         if !region.verify_integrity(content) {
                             to_reinject.push(region.file_name.clone());
@@ -445,8 +454,13 @@ impl BootstrapProtection {
 
     /// Generate reinject text for the specified files.
     /// Returns the full reinject block to prepend to transcript.
-    pub fn reinject(&self, file_names: &[String], ctx: &mut BootstrapContext) -> Result<String, BootstrapProtectionError> {
-        let workspace = self.workspace_path
+    pub fn reinject(
+        &self,
+        file_names: &[String],
+        ctx: &mut BootstrapContext,
+    ) -> Result<String, BootstrapProtectionError> {
+        let workspace = self
+            .workspace_path
             .as_ref()
             .ok_or(BootstrapProtectionError::WorkspacePathRequired)?;
 
@@ -479,8 +493,11 @@ impl BootstrapProtection {
     }
 
     /// Read bootstrap files from workspace and return as a map
-    pub fn read_bootstrap_files(&self) -> Result<HashMap<String, String>, BootstrapProtectionError> {
-        let workspace = self.workspace_path
+    pub fn read_bootstrap_files(
+        &self,
+    ) -> Result<HashMap<String, String>, BootstrapProtectionError> {
+        let workspace = self
+            .workspace_path
             .as_ref()
             .ok_or(BootstrapProtectionError::WorkspacePathRequired)?;
 
@@ -507,11 +524,7 @@ impl BootstrapProtection {
 }
 
 /// Utility: generate region marker string
-pub fn make_bootstrap_marker(
-    file_name: &str,
-    content: &str,
-    is_reinject: bool,
-) -> String {
+pub fn make_bootstrap_marker(file_name: &str, content: &str, is_reinject: bool) -> String {
     let hash = BootstrapRegion::compute_hash(content);
     let char_count = content.chars().count();
     format!(
@@ -633,7 +646,9 @@ mod tests {
         protection.before_compact(&mut ctx);
 
         assert_eq!(ctx.pre_compact_hashes.len(), 1);
-        assert!(ctx.pre_compact_hashes.contains_key(&ctx.regions[0].region_id));
+        assert!(ctx
+            .pre_compact_hashes
+            .contains_key(&ctx.regions[0].region_id));
     }
 
     #[test]
@@ -650,7 +665,11 @@ mod tests {
         let wrapped = ctx.regions[0].wrap_content(content);
         let to_reinject = protection.after_compact(&wrapped, &mut ctx);
 
-        assert!(to_reinject.is_empty(), "unexpected reinject needed: {:?}", to_reinject);
+        assert!(
+            to_reinject.is_empty(),
+            "unexpected reinject needed: {:?}",
+            to_reinject
+        );
         assert!(ctx.reinjected_after_last_compact);
     }
 

--- a/src/session/events.rs
+++ b/src/session/events.rs
@@ -108,9 +108,7 @@ pub enum CheckpointTrigger {
         to_mode: ReasoningMode,
     },
     /// 消息发送后
-    MessageSent {
-        message_id: String,
-    },
+    MessageSent { message_id: String },
     /// 网关关闭前（同步写入）
     GatewayShutdown,
     /// Compaction 发生前（用于保护 bootstrap 上下文）

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,8 +18,7 @@ pub mod storage;
 
 // Re-export commonly used types
 pub use bootstrap::{BootstrapContext, BootstrapProtection, BootstrapRegion};
-pub use persistence::{
-    CheckpointManager, PersistenceError, PersistenceService, ReasoningMode,
-    SessionCheckpoint,
-};
 pub use events::{CheckpointTrigger, ModeSwitchEvent, UserIntent};
+pub use persistence::{
+    CheckpointManager, PersistenceError, PersistenceService, ReasoningMode, SessionCheckpoint,
+};

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -3,11 +3,11 @@
 //! Defines the core [`SessionCheckpoint`] structure and [`PersistenceService`] trait
 //! for implementing pluggable storage backends.
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use async_trait::async_trait;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
@@ -198,10 +198,14 @@ pub enum PersistenceError {
 #[async_trait]
 pub trait PersistenceService: Send + Sync {
     /// 保存 Checkpoint
-    async fn save_checkpoint(&self, checkpoint: &SessionCheckpoint) -> Result<(), PersistenceError>;
+    async fn save_checkpoint(&self, checkpoint: &SessionCheckpoint)
+        -> Result<(), PersistenceError>;
 
     /// 加载 Checkpoint
-    async fn load_checkpoint(&self, session_id: &str) -> Result<Option<SessionCheckpoint>, PersistenceError>;
+    async fn load_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError>;
 
     /// 删除 Checkpoint
     async fn delete_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError>;
@@ -267,7 +271,10 @@ impl<S: PersistenceService + 'static> CheckpointManager<S> {
     }
 
     /// 加载 Checkpoint（优先本地缓存）
-    pub async fn load(&self, session_id: &str) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+    pub async fn load(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
         // 先查本地缓存
         {
             let cache = self.local_cache.read().await;
@@ -329,7 +336,10 @@ mod tests {
             .with_last_message_id(Some("msg123".to_string()))
             .with_mode(ReasoningMode::Plan)
             .with_mode_state(state)
-            .add_pending_message(PendingMessage::new("pending1".to_string(), "Pending content".to_string()))
+            .add_pending_message(PendingMessage::new(
+                "pending1".to_string(),
+                "Pending content".to_string(),
+            ))
     }
 
     #[tokio::test]

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -12,7 +12,9 @@ pub struct SessionRecoveryService<S: PersistenceService> {
     storage: Arc<S>,
     /// Callback to restore a session from checkpoint
     /// The closure receives the session_id and checkpoint, and should restore the session state.
-    restore_fn: RwLock<Option<Box<dyn Fn(&str, &SessionCheckpoint) -> Result<(), PersistenceError> + Send + Sync>>>,
+    restore_fn: RwLock<
+        Option<Box<dyn Fn(&str, &SessionCheckpoint) -> Result<(), PersistenceError> + Send + Sync>>,
+    >,
 }
 
 impl<S: PersistenceService> SessionRecoveryService<S> {
@@ -180,10 +182,7 @@ mod tests {
 
         service
             .set_restore_callback(move |session_id, _checkpoint| {
-                restored_clone
-                    .lock()
-                    .unwrap()
-                    .push(session_id.to_string());
+                restored_clone.lock().unwrap().push(session_id.to_string());
                 Ok(())
             })
             .await;

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -31,7 +31,10 @@ impl Default for MemoryStorage {
 
 #[async_trait]
 impl PersistenceService for MemoryStorage {
-    async fn save_checkpoint(&self, checkpoint: &SessionCheckpoint) -> Result<(), PersistenceError> {
+    async fn save_checkpoint(
+        &self,
+        checkpoint: &SessionCheckpoint,
+    ) -> Result<(), PersistenceError> {
         let mut checkpoints = self
             .checkpoints
             .write()

--- a/src/session/storage/redis.rs
+++ b/src/session/storage/redis.rs
@@ -5,8 +5,8 @@
 
 use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 use async_trait::async_trait;
-use redis::AsyncCommands;
 use redis;
+use redis::AsyncCommands;
 
 /// Redis storage backend
 #[derive(Debug, Clone)]
@@ -41,7 +41,10 @@ impl RedisStorage {
 
 #[async_trait]
 impl PersistenceService for RedisStorage {
-    async fn save_checkpoint(&self, checkpoint: &SessionCheckpoint) -> Result<(), PersistenceError> {
+    async fn save_checkpoint(
+        &self,
+        checkpoint: &SessionCheckpoint,
+    ) -> Result<(), PersistenceError> {
         let mut conn = self
             .client
             .get_multiplexed_async_connection()
@@ -158,16 +161,16 @@ mod tests {
 
     #[test]
     fn test_redis_storage_make_key_custom_prefix() {
-        let storage =
-            RedisStorage::new("redis://localhost:6379", "custom_prefix").expect("Failed to create RedisStorage");
+        let storage = RedisStorage::new("redis://localhost:6379", "custom_prefix")
+            .expect("Failed to create RedisStorage");
 
         assert_eq!(storage.make_key("abc"), "custom_prefix:abc");
     }
 
     #[test]
     fn test_redis_storage_key_prefix() {
-        let storage =
-            RedisStorage::new("redis://localhost:6379", "my_prefix").expect("Failed to create RedisStorage");
+        let storage = RedisStorage::new("redis://localhost:6379", "my_prefix")
+            .expect("Failed to create RedisStorage");
 
         assert_eq!(storage.key_prefix(), "my_prefix");
     }

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -3,8 +3,8 @@
 //! Orchestrates section assembly and renders the final system prompt string.
 
 use super::sections::{
-    get_append_section, get_cached_section, invalidate_all_sections, load_cached_file_section,
-    invalidate_section, read_file_section, Section,
+    get_append_section, get_cached_section, invalidate_all_sections, invalidate_section,
+    load_cached_file_section, read_file_section, Section,
 };
 use std::path::Path;
 use std::sync::RwLock;
@@ -199,9 +199,8 @@ pub fn build_from_workspace<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::sections::{clear_append_section, set_append_section};
-    
+    use super::*;
 
     #[test]
     fn test_build_system_prompt_with_override() {
@@ -234,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_build_system_prompt_default() {
         // Clear global state that could affect this test
         clear_append_section();
@@ -249,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_build_append_section_appended() {
         set_override_prompt(None);
         clear_append_section();
@@ -262,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_append_section_not_shown_when_empty() {
         clear_append_section();
         let sections = vec![Section::RoleSection("base".to_string())];
@@ -273,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_dynamic_sections_not_cached() {
         clear_append_section();
         let sections = vec![Section::SessionState {

--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -23,8 +23,15 @@ pub enum Section {
     MemorySection(String),
     HeartbeatSection(String),
     // --- Dynamic sections (always rebuilt) ---
-    ChannelContext { chat_name: String, sender_id: String, timestamp: String },
-    SessionState { turn_count: u32, pending_tasks: Vec<String> },
+    ChannelContext {
+        chat_name: String,
+        sender_id: String,
+        timestamp: String,
+    },
+    SessionState {
+        turn_count: u32,
+        pending_tasks: Vec<String>,
+    },
     AppendSection(String),
     GitStatus(String),
 }
@@ -251,7 +258,7 @@ pub fn clear_append_section() {
 mod tests {
     use super::*;
     use std::io::Write;
-    
+
     use tempfile::tempdir;
 
     #[test]
@@ -289,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_append_section_truncation() {
         let long_text = "a".repeat(600);
         let warning = set_append_section(long_text);
@@ -301,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_append_section_no_truncation() {
         let text = "short text".to_string();
         let warning = set_append_section(text.clone());
@@ -310,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_append_section_cleared_after_request() {
         set_append_section("test".to_string());
         assert!(get_append_section().is_some());

--- a/src/system_prompt/slash_commands.rs
+++ b/src/system_prompt/slash_commands.rs
@@ -3,7 +3,10 @@
 //! These are separate from the mode slash commands (in src/mode/slash_command.rs)
 //! and focus on system prompt manipulation.
 
-use super::sections::{clear_append_section, get_append_section, set_append_section as store_append, APPEND_SECTION_MAX_LEN};
+use super::sections::{
+    clear_append_section, get_append_section, set_append_section as store_append,
+    APPEND_SECTION_MAX_LEN,
+};
 use super::workdir::{build_git_status, clear_workdir, get_workdir, set_workdir};
 use crate::mode::slash_command::SlashCommandResult;
 
@@ -39,10 +42,7 @@ pub fn handle_system_command(args: &str) -> SlashCommandResult {
             get_append_section().unwrap_or_default()
         )
     } else {
-        format!(
-            "已设置追加内容：\n{}\n\n请求结束后自动清除。",
-            text
-        )
+        format!("已设置追加内容：\n{}\n\n请求结束后自动清除。", text)
     };
 
     SlashCommandResult::Text(response)
@@ -105,7 +105,7 @@ pub fn handle_git_command(args: &str) -> SlashCommandResult {
         Some(w) => w,
         None => {
             return SlashCommandResult::Text(
-                "未设置工作目录。使用 /cd <路径> 先切换。".to_string()
+                "未设置工作目录。使用 /cd <路径> 先切换。".to_string(),
             );
         }
     };
@@ -114,10 +114,7 @@ pub fn handle_git_command(args: &str) -> SlashCommandResult {
         return SlashCommandResult::Text("当前目录不是 git 仓库。".to_string());
     }
 
-    let git_args: Vec<&str> = args
-        .trim()
-        .split_whitespace()
-        .collect();
+    let git_args: Vec<&str> = args.trim().split_whitespace().collect();
 
     if git_args.is_empty() || git_args[0] == "status" {
         // Return embedded git status
@@ -158,10 +155,9 @@ pub fn handle_git_command(args: &str) -> SlashCommandResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
 
     #[test]
-    
+
     fn test_system_command_set_content() {
         clear_append_section();
         let result = handle_system_command("test append");
@@ -175,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_system_command_empty_shows_current() {
         clear_append_section();
         let result = handle_system_command("");
@@ -187,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    
+
     fn test_system_command_truncation() {
         clear_append_section();
         let long_text = "x".repeat(600);

--- a/src/system_prompt/workdir.rs
+++ b/src/system_prompt/workdir.rs
@@ -123,7 +123,11 @@ fn git_status_count(path: &Path, extra_arg: &str) -> usize {
         vec!["status", "--porcelain", extra_arg]
     };
 
-    let output = Command::new("git").args(&args).current_dir(path).output().ok();
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(path)
+        .output()
+        .ok();
 
     output
         .filter(|o| o.status.success())
@@ -154,7 +158,10 @@ pub fn build_git_status() -> Option<String> {
         format!("{} uncommitted change(s)", changes)
     };
 
-    Some(format!("On branch {}\n  status: {}", branch, status_summary))
+    Some(format!(
+        "On branch {}\n  status: {}",
+        branch, status_summary
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
全量 `cargo fmt`，使代码格式符合新制定的硬限制标准。

28 个文件有格式调整，无逻辑变更。

已有文件行数超限问题（如 `session/bootstrap.rs` 741 行）不在本次 scope 内。