### PR TITLE
refactor(chat): split oversized impl block and extract handle_chat_message

### DIFF
--- a/src/chat/SPEC.md
+++ b/src/chat/SPEC.md
@@ -2,7 +2,9 @@
 
 ## 模块概述
 
-提供进程内 TCP 聊天服务，监听 `127.0.0.1:18889`，通过 JSON 换行分隔协议（NDJSON）与客户端交互。每个 TCP 连接对应一个独立会话，会话将用户消息委托给 LLM（带 fallback 链），完整响应后一次性写回客户端。
+提供进程内 TCP 聊天服务，监听 `127.0.0.1:18889`，通过 JSON 换行分隔协议（NDJSON）
+与客户端交互。每个 TCP 连接对应一个独立会话，会话将用户消息委托给 LLM
+（带 fallback 链），完整响应后一次性写回客户端。
 
 核心设计：per-connection session + broadcast shutdown + LLM fallback 链 + 历史窗口截断。
 
@@ -35,6 +37,7 @@
 - **`ChatSession::new()`** — 构造 session；从环境变量初始化 fallback_client、max_history、timeout
 - **`ChatSession::run()`** — 主事件循环：读客户端消息 → 分发处理 → 写回响应；并监听 shutdown 信号
 - **`ChatSession::handle_line()`** — 解析 ClientMessage，分发 ChatStart/ChatMessage/ChatStop
+- **`ChatSession::handle_chat_message()`** — 处理 ChatMessage：追加历史 → 截断 → 调用 LLM → 返回响应消息
 - **`ChatSession::call_llm()`** — 调用 LLM（通过 FallbackClient），返回响应内容
 - **`ChatSession::send_message()`** — 将 ServerMessage 写入 TCP（JSON + 换行 + flush）
 - **`ChatSession::truncate_history()`** — 裁剪 chat_history 到 max_history 条
@@ -61,9 +64,10 @@ ClientMessage ──► ChatSession::handle_line
                         │
                         ├─ ChatStart  ──► ChatSession::new agent_id  ──► ChatStarted
                         │
-                        ├─ ChatMessage ──► truncate_history()
+                        ├─ ChatMessage ──► handle_chat_message()
+                        │                   ──► append user to history → truncate_history()
                         │                   ──► call_llm() via FallbackClient
-                        │                   ──► append user + assistant to history
+                        │                   ──► append assistant to history
                         │                   ──► ChatResponse + ChatResponseDone
                         │
                         └─ ChatStop ──► active = false  ──► ChatResponseDone
@@ -98,7 +102,9 @@ TCP Client
 2. 将原始行 JSON 反序列化为 `ClientMessage`；失败返回 `ChatError`。
 3. 根据消息类型分发：
    - `ChatStart`：更新 `self.agent_id`，返回 `ChatStarted`。
-   - `ChatMessage`：追加 user 消息 → truncate → call LLM → 追加 assistant 消息 → 返回 `ChatResponse` + `ChatResponseDone`；LLM 失败时 content 字段填充 `[error]` 信息。
+   - `ChatMessage`：委托给 `handle_chat_message`：追加 user 消息 → truncate →
+     call LLM → 追加 assistant 消息 → 返回 `ChatResponse` + `ChatResponseDone`；
+     LLM 失败时 content 字段填充 `[error]` 信息。
    - `ChatStop`：设置 `active = false`，返回 `ChatResponseDone`。
 4. `send_message` 写响应 JSON 加 `\n` 后 flush 到客户端；写入失败则退出循环。
 
@@ -150,4 +156,5 @@ TCP Client
 ---
 
 *变更历史*
+- 2026-04-20：#226 提取 `handle_chat_message` 方法，同步 SPEC
 - 2026-04-14：按 v3 标准重写，精简接口签名、补充架构/数据流章节

--- a/src/chat/session.rs
+++ b/src/chat/session.rs
@@ -35,6 +35,8 @@ pub struct ChatSession {
     max_history: usize,
 }
 
+// --- Construction ---
+
 impl ChatSession {
     /// Create a new session for an accepted connection
     pub fn new(
@@ -47,15 +49,11 @@ impl ChatSession {
         let (reader, writer) = stream.into_split();
         let reader = BufReader::new(reader);
 
-        // Parse max_history from env var, default to DEFAULT_MAX_HISTORY
         let max_history: usize = std::env::var("CHAT_MAX_HISTORY")
             .unwrap_or_else(|_| DEFAULT_MAX_HISTORY.to_string())
             .parse()
             .unwrap_or(DEFAULT_MAX_HISTORY);
 
-        // Build fallback chain from LLM_FALLBACK_CHAIN env var
-        // Format: "minimax/MiniMax-M2.7,dashscope/qwen3-max"
-        // Defaults to just the primary model if not set
         let fallback_chain: Vec<String> = std::env::var("LLM_FALLBACK_CHAIN")
             .map(|s| s.split(',').map(str::trim).map(String::from).collect())
             .unwrap_or_else(|_| {
@@ -66,7 +64,6 @@ impl ChatSession {
                 vec![format!("{}/{}", provider, model)]
             });
 
-        // Parse timeout from env var, default to 30 seconds
         let timeout_secs: u64 = std::env::var("LLM_TIMEOUT_SECS")
             .unwrap_or_else(|_| "30".to_string())
             .parse()
@@ -104,21 +101,19 @@ impl ChatSession {
             );
         }
     }
+}
 
+// --- Main loop ---
+
+impl ChatSession {
     /// Run the session loop — read client messages, dispatch to agent, stream responses
     pub async fn run(mut self) {
-        info!(
-            session_id = %self.session_id,
-            agent_id = %self.agent_id,
-            "chat session started"
-        );
+        info!(session_id = %self.session_id, agent_id = %self.agent_id, "chat session started");
 
         let mut shutdown_rx = self.shutdown_rx.resubscribe();
 
         loop {
-            // Use read_line on the BufReader directly so we keep &mut self
             let mut line_buf = String::new();
-
             tokio::select! {
                 read_result = self.reader.read_line(&mut line_buf) => {
                     match read_result {
@@ -128,27 +123,25 @@ impl ChatSession {
                         }
                         Ok(_) => {
                             let line = line_buf.trim_end();
-                            if line.is_empty() {
-                                continue;
-                            }
+                            if line.is_empty() { continue; }
                             debug!(session_id = %self.session_id, line = %line, "received line");
                             let msgs = self.handle_line(line).await;
                             for msg in msgs {
                                 if let Err(e) = self.send_message(msg).await {
-                                    error!(session_id = %self.session_id, error = %e, "failed to send to client");
+                                    error!(session_id = %self.session_id, error = %e, "send failed");
                                     break;
                                 }
                             }
                             line_buf.clear();
                         }
                         Err(e) => {
-                            error!(session_id = %self.session_id, error = %e, "error reading from client");
+                            error!(session_id = %self.session_id, error = %e, "read error");
                             break;
                         }
                     }
                 }
                 _ = shutdown_rx.recv() => {
-                    info!(session_id = %self.session_id, "session shutting down due to server shutdown");
+                    info!(session_id = %self.session_id, "session shutting down");
                     let _ = self.send_message(ServerMessage::ChatError {
                         message: "server shutting down".to_string(),
                         id: uuid::Uuid::new_v4().to_string(),
@@ -157,110 +150,7 @@ impl ChatSession {
                 }
             }
         }
-
         info!(session_id = %self.session_id, "chat session ended");
-    }
-
-    /// Handle a single incoming JSON line, return zero or more server messages to send back
-    async fn handle_line(&mut self, line: &str) -> Vec<ServerMessage> {
-        let msg: ClientMessage = match serde_json::from_str(line) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!(session_id = %self.session_id, error = %e, raw = %line, "failed to parse client message");
-                return vec![ServerMessage::ChatError {
-                    message: format!("invalid message: {}", e),
-                    id: uuid::Uuid::new_v4().to_string(),
-                }];
-            }
-        };
-
-        match msg {
-            ClientMessage::ChatStart { agent_id, id } => {
-                info!(session_id = %self.session_id, agent_id = %agent_id, id = %id, "session start requested");
-                self.agent_id = agent_id;
-                vec![ServerMessage::ChatStarted {
-                    session_id: self.session_id.clone(),
-                    id,
-                }]
-            }
-            ClientMessage::ChatMessage { content, id } => {
-                info!(session_id = %self.session_id, content_len = %content.len(), id = %id, "chat message received");
-
-                // Add user message to history
-                self.chat_history.push(Message {
-                    role: "user".to_string(),
-                    content: content.clone(),
-                });
-
-                // Truncate if over max_history limit
-                self.truncate_history();
-
-                // Call LLM
-                let response = self.call_llm().await;
-
-                // Add assistant response to history
-                if let Ok(ref resp) = response {
-                    self.chat_history.push(Message {
-                        role: "assistant".to_string(),
-                        content: resp.clone(),
-                    });
-                }
-
-                match response {
-                    Ok(content) => vec![
-                        ServerMessage::ChatResponse {
-                            content,
-                            done: true,
-                            id: id.clone(),
-                        },
-                        ServerMessage::ChatResponseDone { id },
-                    ],
-                    Err(e) => {
-                        error!(session_id = %self.session_id, error = %e, "LLM call failed");
-                        vec![
-                            ServerMessage::ChatResponse {
-                                content: format!("[error] LLM call failed: {}", e),
-                                done: true,
-                                id: id.clone(),
-                            },
-                            ServerMessage::ChatResponseDone { id },
-                        ]
-                    }
-                }
-            }
-            ClientMessage::ChatStop { id } => {
-                info!(session_id = %self.session_id, id = %id, "session stop requested");
-                self.active = false;
-                vec![ServerMessage::ChatResponseDone { id }]
-            }
-        }
-    }
-
-    /// Call the LLM with the user's message and return the response content.
-    /// Uses FallbackClient which handles retry, cooldown tracking, and model fallback.
-    async fn call_llm(&self) -> anyhow::Result<String> {
-        let request = ChatRequest {
-            model: self.model.clone(),
-            messages: self.chat_history.clone(),
-            temperature: 0.7,
-            max_tokens: Some(2048),
-        };
-
-        // Use fallback client for automatic retry + fallback chain
-        let response = self
-            .fallback_client
-            .chat(request)
-            .await
-            .map_err(|e| anyhow::anyhow!("LLM error: {}", e))?;
-
-        debug!(
-            session_id = %self.session_id,
-            model = %response.model,
-            usage = ?response.usage,
-            "LLM response received"
-        );
-
-        Ok(response.content)
     }
 
     /// Send a ServerMessage to the client, appending a newline
@@ -270,5 +160,102 @@ impl ChatSession {
         self.writer.write_all(b"\n").await?;
         self.writer.flush().await?;
         Ok(())
+    }
+}
+
+// --- Message handling ---
+
+impl ChatSession {
+    /// Handle a single incoming JSON line, return zero or more server messages to send back
+    async fn handle_line(&mut self, line: &str) -> Vec<ServerMessage> {
+        let msg: ClientMessage = match serde_json::from_str(line) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(session_id = %self.session_id, error = %e, raw = %line, "parse error");
+                return vec![ServerMessage::ChatError {
+                    message: format!("invalid message: {}", e),
+                    id: uuid::Uuid::new_v4().to_string(),
+                }];
+            }
+        };
+
+        match msg {
+            ClientMessage::ChatStart { agent_id, id } => {
+                info!(session_id = %self.session_id, agent_id = %agent_id, id = %id, "session start");
+                self.agent_id = agent_id;
+                vec![ServerMessage::ChatStarted {
+                    session_id: self.session_id.clone(),
+                    id,
+                }]
+            }
+            ClientMessage::ChatMessage { content, id } => {
+                self.handle_chat_message(content, id).await
+            }
+            ClientMessage::ChatStop { id } => {
+                info!(session_id = %self.session_id, id = %id, "session stop");
+                self.active = false;
+                vec![ServerMessage::ChatResponseDone { id }]
+            }
+        }
+    }
+
+    /// Process a ChatMessage: update history, call LLM, return response messages
+    async fn handle_chat_message(&mut self, content: String, id: String) -> Vec<ServerMessage> {
+        info!(session_id = %self.session_id, content_len = %content.len(), id = %id, "chat message");
+
+        self.chat_history.push(Message {
+            role: "user".to_string(),
+            content: content.clone(),
+        });
+        self.truncate_history();
+
+        let response = self.call_llm().await;
+        if let Ok(ref resp) = response {
+            self.chat_history.push(Message {
+                role: "assistant".to_string(),
+                content: resp.clone(),
+            });
+        }
+
+        match response {
+            Ok(content) => vec![
+                ServerMessage::ChatResponse {
+                    content,
+                    done: true,
+                    id: id.clone(),
+                },
+                ServerMessage::ChatResponseDone { id },
+            ],
+            Err(e) => {
+                error!(session_id = %self.session_id, error = %e, "LLM call failed");
+                vec![
+                    ServerMessage::ChatResponse {
+                        content: format!("[error] LLM call failed: {}", e),
+                        done: true,
+                        id: id.clone(),
+                    },
+                    ServerMessage::ChatResponseDone { id },
+                ]
+            }
+        }
+    }
+
+    /// Call the LLM with the current chat history and return the response content
+    async fn call_llm(&self) -> anyhow::Result<String> {
+        let request = ChatRequest {
+            model: self.model.clone(),
+            messages: self.chat_history.clone(),
+            temperature: 0.7,
+            max_tokens: Some(2048),
+        };
+
+        let response = self
+            .fallback_client
+            .chat(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("LLM error: {}", e))?;
+
+        debug!(session_id = %self.session_id, model = %response.model, usage = ?response.usage, "LLM response");
+        Ok(response.content)
     }
 }


### PR DESCRIPTION
Split the 238-line impl block into 3 focused blocks and extract handle_chat_message per issue #226.