### PR TITLE
refactor(llm): extract map_status_error from minimax chat

### DIFF
--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -75,6 +75,16 @@ impl MiniMaxProvider {
         std::env::var("MINIMAX_API_KEY").ok().map(Self::new)
     }
 
+    /// Map HTTP status code to the appropriate LLM error.
+    fn map_status_error(status: reqwest::StatusCode, body: String) -> LLMError {
+        match status.as_u16() {
+            401 => LLMError::AuthFailed(format!("MiniMax auth failed: {}", body)),
+            429 => LLMError::RateLimitExceeded,
+            400 => LLMError::InvalidRequest(format!("MiniMax invalid request: {}", body)),
+            _ => LLMError::ApiError(format!("MiniMax API error ({}): {}", status, body)),
+        }
+    }
+
     /// Strip MiniMax thinking tags from content.
     ///
     /// MiniMax thinking models return reasoning wrapped in XML tags:
@@ -145,15 +155,7 @@ impl LLMProvider for MiniMaxProvider {
 
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(if status.as_u16() == 401 {
-                LLMError::AuthFailed(format!("MiniMax auth failed: {}", body))
-            } else if status.as_u16() == 429 {
-                LLMError::RateLimitExceeded
-            } else if status.as_u16() == 400 {
-                LLMError::InvalidRequest(format!("MiniMax invalid request: {}", body))
-            } else {
-                LLMError::ApiError(format!("MiniMax API error ({}): {}", status, body))
-            });
+            return Err(Self::map_status_error(status, body));
         }
 
         let api_resp: MiniMaxResponse = response


### PR DESCRIPTION
Extract HTTP error status mapping into a dedicated helper method to reduce the chat function body from 56 to 48 lines per issue #233.