### PR TITLE
refactor(llm): split oversized impl block in retry.rs

### DIFF
--- a/src/llm/retry.rs
+++ b/src/llm/retry.rs
@@ -130,7 +130,9 @@ impl CooldownManager {
         drop(cooldowns);
         self.save().await;
     }
+}
 
+impl CooldownManager {
     /// Load persisted cooldowns from disk (sync version for use in sync constructors).
     ///
     /// Uses a one-shot runtime to block on async file I/O. Safe to call from sync


### PR DESCRIPTION
Split the 183-line CooldownManager impl block into cooldown logic (85 lines) and persistence (98 lines) per issue #235.