### PR TITLE
refactor(sections): extract SessionState arm into helper in sections.rs

### DIFF
--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -63,6 +63,22 @@ impl Section {
             Section::GitStatus(_) => "git_status",
         }
     }
+    fn format_session_state(&self, turn_count: u32, pending_tasks: &[String]) -> String {
+        let tasks_str = if pending_tasks.is_empty() {
+            "  (none)".to_string()
+        } else {
+            pending_tasks
+                .iter()
+                .enumerate()
+                .map(|(i, t)| format!("  {}. {}", i + 1, t))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        format!(
+            "## Session State\n- turn_count: {}\n- pending_tasks:\n{}\n",
+            turn_count, tasks_str
+        )
+    }
 
     /// Render the section as a string for the system prompt
     pub fn render(&self) -> String {
@@ -95,22 +111,7 @@ impl Section {
             Section::SessionState {
                 turn_count,
                 pending_tasks,
-            } => {
-                let tasks_str = if pending_tasks.is_empty() {
-                    "  (none)".to_string()
-                } else {
-                    pending_tasks
-                        .iter()
-                        .enumerate()
-                        .map(|(i, t)| format!("  {}. {}", i + 1, t))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                };
-                format!(
-                    "## Session State\n- turn_count: {}\n- pending_tasks:\n{}\n",
-                    turn_count, tasks_str
-                )
-            }
+            } => self.format_session_state(*turn_count, pending_tasks),
             Section::AppendSection(content) => {
                 format!("## Append\n{}\n", content)
             }


### PR DESCRIPTION
## Summary

Fixes `render()` function body length in `src/system_prompt/sections.rs`.

**Before:** `render` 53 lines (limit 50)
**After:** `render` 38 lines + `format_session_state` 15 lines

| Metric | Before | After |
|--------|--------|-------|
| render fn body | 53 | 38 ✅ |
| impl Section | 84 | 85 ✅ |
| File lines | 382 | 383 ✅ |
| Compilation | ✅ | ✅ |
| Tests | ✅ | ✅ |

Closes #250