### PR TITLE
test(skills): add unit tests for registry.rs to improve coverage

### DIFF
--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -116,3 +116,192 @@ pub enum SkillError {
     #[error("Permission denied: {0}")]
     PermissionDenied(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockSkill {
+        name: String,
+    }
+
+    impl MockSkill {
+        fn new(name: &str) -> Self {
+            Self { name: name.to_string() }
+        }
+    }
+
+    #[async_trait]
+    impl Skill for MockSkill {
+        fn manifest(&self) -> SkillManifest {
+            SkillManifest {
+                name: self.name.clone(),
+                version: "1.0.0".to_string(),
+                description: format!("mock skill {}", self.name),
+                author: None,
+                dependencies: vec![],
+            }
+        }
+
+        fn methods(&self) -> Vec<&str> {
+            vec!["method1", "method2"]
+        }
+
+        async fn execute(
+            &self,
+            method: &str,
+            _args: serde_json::Value,
+        ) -> Result<serde_json::Value, SkillError> {
+            match method {
+                "method1" => Ok(serde_json::json!({"method": method})),
+                _ => Err(SkillError::MethodNotFound {
+                    skill: self.name.clone(),
+                    method: method.to_string(),
+                }),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register_and_get() {
+        let registry = SkillRegistry::new();
+        let skill = Arc::new(MockSkill::new("test_skill"));
+        registry.register(skill).await;
+
+        let found = registry.get("test_skill").await;
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().manifest().name, "test_skill");
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let registry = SkillRegistry::new();
+        let found = registry.get("nonexistent").await;
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let registry = SkillRegistry::new();
+        registry.register(Arc::new(MockSkill::new("skill_a"))).await;
+        registry.register(Arc::new(MockSkill::new("skill_b"))).await;
+
+        let mut names = registry.list().await;
+        names.sort();
+        assert_eq!(names, vec!["skill_a", "skill_b"]);
+    }
+
+    #[tokio::test]
+    async fn test_contains() {
+        let registry = SkillRegistry::new();
+        registry.register(Arc::new(MockSkill::new("exists"))).await;
+
+        assert!(registry.contains("exists").await);
+        assert!(!registry.contains("missing").await);
+    }
+
+    #[tokio::test]
+    async fn test_unregister() {
+        let registry = SkillRegistry::new();
+        registry.register(Arc::new(MockSkill::new("to_remove"))).await;
+
+        assert!(registry.unregister("to_remove").await);
+        assert!(!registry.contains("to_remove").await);
+        assert!(!registry.unregister("to_remove").await);
+    }
+
+    #[tokio::test]
+    async fn test_register_replaces() {
+        let registry = SkillRegistry::new();
+        registry.register(Arc::new(MockSkill::new("skill"))).await;
+        registry.register(Arc::new(MockSkill::new("skill"))).await;
+
+        let names = registry.list().await;
+        assert_eq!(names.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_method() {
+        let registry = SkillRegistry::new();
+        registry.register(Arc::new(MockSkill::new("exec_skill"))).await;
+
+        let skill = registry.get("exec_skill").await.unwrap();
+        let result = skill.execute("method1", serde_json::Value::Null).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap()["method"], "method1");
+    }
+
+    #[tokio::test]
+    async fn test_skill_error_display() {
+        let err = SkillError::NotFound("test".to_string());
+        assert!(err.to_string().contains("test"));
+
+        let err = SkillError::ExecutionFailed("boom".to_string());
+        assert!(err.to_string().contains("boom"));
+
+        let err = SkillError::InvalidArgs("bad".to_string());
+        assert!(err.to_string().contains("bad"));
+
+        let err = SkillError::PermissionDenied("no".to_string());
+        assert!(err.to_string().contains("no"));
+
+        let err = SkillError::MethodNotFound {
+            skill: "s".to_string(),
+            method: "m".to_string(),
+        };
+        assert!(err.to_string().contains("s"));
+        assert!(err.to_string().contains("m"));
+    }
+
+    #[test]
+    fn test_skill_manifest_serialization() {
+        let manifest = SkillManifest {
+            name: "test".to_string(),
+            version: "1.0.0".to_string(),
+            description: "desc".to_string(),
+            author: Some("author".to_string()),
+            dependencies: vec!["dep1".to_string()],
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let parsed: SkillManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, "test");
+        assert_eq!(parsed.author, Some("author".to_string()));
+        assert_eq!(parsed.dependencies, vec!["dep1".to_string()]);
+    }
+
+    #[test]
+    fn test_skill_output_serialization() {
+        let output = SkillOutput {
+            success: true,
+            result: Some(serde_json::json!("ok")),
+            error: None,
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        let parsed: SkillOutput = serde_json::from_str(&json).unwrap();
+        assert!(parsed.success);
+        assert!(parsed.error.is_none());
+    }
+
+    #[test]
+    fn test_skill_input_serialization() {
+        let input = SkillInput {
+            skill_name: "skill".to_string(),
+            method: "run".to_string(),
+            args: serde_json::json!({"key": "value"}),
+            agent_id: "agent1".to_string(),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let parsed: SkillInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.skill_name, "skill");
+    }
+
+    #[test]
+    fn test_registry_default() {
+        let registry = SkillRegistry::default();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let names = registry.list().await;
+            assert!(names.is_empty());
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Add 12 unit tests to `src/skills/registry.rs` to improve coverage from 43.14% to well above 50%.

Tests cover:
- SkillRegistry: register, get, list, contains, unregister, register-replace
- Skill trait: execute method
- SkillError: display for all 5 variants
- Serialization: SkillManifest, SkillInput, SkillOutput
- SkillRegistry::default

Source: issue #318
Type: test