### PR TITLE
test(skills): add unit tests for builtin/file_ops.rs to improve coverage

### DIFF
--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -127,3 +127,129 @@ impl Skill for FileOpsSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_manifest() {
+        let skill = FileOpsSkill::new();
+        let m = skill.manifest();
+        assert_eq!(m.name, "file_ops");
+        assert_eq!(m.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_methods() {
+        let skill = FileOpsSkill::new();
+        assert_eq!(skill.methods(), vec!["read", "write", "list", "delete", "exists"]);
+    }
+
+    #[tokio::test]
+    async fn test_read_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, "hello world").unwrap();
+
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("read", serde_json::json!({"path": path.to_str().unwrap()})).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap()["content"], "hello world");
+    }
+
+    #[tokio::test]
+    async fn test_read_missing_path() {
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("read", serde_json::json!({})).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SkillError::InvalidArgs(msg) => assert!(msg.contains("path")),
+            other => panic!("expected InvalidArgs, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_and_read() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.txt");
+
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("write", serde_json::json!({"path": path.to_str().unwrap(), "content": "data"})).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap()["success"], true);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "data");
+    }
+
+    #[tokio::test]
+    async fn test_write_missing_content() {
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("write", serde_json::json!({"path": "/tmp/x"})).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SkillError::InvalidArgs(msg) => assert!(msg.contains("content")),
+            other => panic!("expected InvalidArgs, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_exists_true_and_false() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("real.txt");
+        std::fs::write(&path, "").unwrap();
+
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("exists", serde_json::json!({"path": path.to_str().unwrap()})).await;
+        assert_eq!(result.unwrap()["exists"], true);
+
+        let fake = dir.path().join("fake.txt");
+        let result = skill.execute("exists", serde_json::json!({"path": fake.to_str().unwrap()})).await;
+        assert_eq!(result.unwrap()["exists"], false);
+    }
+
+    #[tokio::test]
+    async fn test_delete_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("del.txt");
+        std::fs::write(&path, "bye").unwrap();
+
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("delete", serde_json::json!({"path": path.to_str().unwrap()})).await;
+        assert!(result.is_ok());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_list_dir() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "").unwrap();
+
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("list", serde_json::json!({"path": dir.path().to_str().unwrap()})).await;
+        let binding = result.unwrap();
+        let entries = binding["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_method() {
+        let skill = FileOpsSkill::new();
+        let result = skill.execute("nonexistent", serde_json::json!({})).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SkillError::MethodNotFound { skill, .. } => assert_eq!(skill, "file_ops"),
+            other => panic!("expected MethodNotFound, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_default() {
+        let skill = FileOpsSkill::default();
+        let m = skill.manifest();
+        assert_eq!(m.name, "file_ops");
+    }
+}


### PR DESCRIPTION
## Summary

Add 11 unit tests to `src/skills/builtin/file_ops.rs` to improve coverage from 39.19% to well above 50%.

Tests cover:
- Metadata: manifest name/version, methods list
- Read: valid file, missing path arg
- Write: valid write+verify, missing content arg
- Exists: true and false cases
- Delete: file removal
- List: directory entries
- Error: unknown method returns MethodNotFound
- Default constructor

Source: issue #314
Type: test