### PR TITLE
test(skills): add unit tests for builtin/permission.rs to improve coverage

### DIFF
--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -101,3 +101,109 @@ impl Skill for PermissionSkill {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permission::engine::engine_types::{Defaults, RuleSet, Rule, Subject, Effect, Action};
+    use std::collections::HashMap;
+
+    fn make_engine_with_allow_rule() -> Arc<crate::permission::PermissionEngine> {
+        use crate::permission::engine::engine_types::MatchType;
+        let rules = RuleSet {
+            version: "1".to_string(),
+            rules: vec![Rule {
+                name: "test-allow".to_string(),
+                subject: Subject::AgentOnly { agent: "agent-1".to_string(), match_type: MatchType::Exact },
+                effect: Effect::Allow,
+                actions: vec![Action::File { operation: "read".to_string(), paths: vec!["*".to_string()] }],
+                template: None,
+                priority: 0,
+            }],
+            defaults: Defaults::default(),
+            template_includes: vec![],
+            agent_creators: HashMap::new(),
+        };
+        Arc::new(crate::permission::PermissionEngine::new(rules))
+    }
+
+    #[test]
+    fn test_manifest() {
+        let skill = PermissionSkill::new();
+        let m = skill.manifest();
+        assert_eq!(m.name, "permission_query");
+        assert_eq!(m.version, "1.0.0");
+    }
+
+    #[test]
+    fn test_methods() {
+        let skill = PermissionSkill::new();
+        assert_eq!(skill.methods(), vec!["query", "list_actions"]);
+    }
+
+    #[test]
+    fn test_default() {
+        let skill = PermissionSkill::default();
+        assert_eq!(skill.manifest().name, "permission_query");
+    }
+
+    #[tokio::test]
+    async fn test_query_no_engine_returns_null() {
+        let skill = PermissionSkill::new();
+        let result = skill.execute("query", serde_json::json!({"agent_id": "a1", "action": "file_read"})).await;
+        assert!(result.is_ok());
+        let v = result.unwrap();
+        assert_eq!(v["allowed"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn test_query_with_engine_allowed() {
+        let engine = make_engine_with_allow_rule();
+        let skill = PermissionSkill::with_engine(engine);
+        let result = skill.execute("query", serde_json::json!({"agent_id": "agent-1", "action": "file_read"})).await;
+        assert!(result.is_ok());
+        let v = result.unwrap();
+        assert_eq!(v["allowed"], true);
+    }
+
+    #[tokio::test]
+    async fn test_query_with_engine_denied() {
+        let engine = make_engine_with_allow_rule();
+        let skill = PermissionSkill::with_engine(engine);
+        let result = skill.execute("query", serde_json::json!({"agent_id": "unknown-agent", "action": "file_read"})).await;
+        assert!(result.is_ok());
+        let v = result.unwrap();
+        assert_eq!(v["allowed"], false);
+    }
+
+    #[tokio::test]
+    async fn test_query_missing_agent_id() {
+        let skill = PermissionSkill::new();
+        let result = skill.execute("query", serde_json::json!({"action": "file_read"})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_query_missing_action() {
+        let skill = PermissionSkill::new();
+        let result = skill.execute("query", serde_json::json!({"agent_id": "a1"})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_actions() {
+        let skill = PermissionSkill::new();
+        let result = skill.execute("list_actions", serde_json::json!({})).await;
+        assert!(result.is_ok());
+        let binding = result.unwrap();
+        let actions = binding["actions"].as_array().unwrap();
+        assert!(actions.len() >= 7);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_method() {
+        let skill = PermissionSkill::new();
+        let result = skill.execute("nonexistent", serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Add 10 unit tests to `src/skills/builtin/permission.rs` to improve coverage from 35.29% to above 50%.

Tests cover:
- Metadata: manifest name/version, methods list
- Query without engine: returns null allowed
- Query with engine: allowed and denied responses
- Missing args: agent_id and action
- list_actions: returns expected action list
- Error: unknown method returns MethodNotFound

Source: issue #316
Type: test