### PR TITLE
test(config): add unit tests for agents/types.rs to improve coverage

### DIFF
--- a/src/config/agents/types.rs
+++ b/src/config/agents/types.rs
@@ -46,3 +46,100 @@ impl Default for AgentsConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_config_deserialize_full() {
+        let json = r#"{
+            "name": "test-agent",
+            "model": "gpt-4",
+            "persona": "A test agent",
+            "max_iterations": 50,
+            "timeout_minutes": 30,
+            "parent": "parent-agent"
+        }"#;
+        let config: AgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name, "test-agent");
+        assert_eq!(config.model, "gpt-4");
+        assert_eq!(config.persona, "A test agent");
+        assert_eq!(config.max_iterations, 50);
+        assert_eq!(config.timeout_minutes, Some(30));
+        assert_eq!(config.parent, Some("parent-agent".to_string()));
+    }
+
+    #[test]
+    fn test_agent_config_deserialize_minimal() {
+        let json = r#"{
+            "name": "minimal",
+            "model": "claude-3"
+        }"#;
+        let config: AgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name, "minimal");
+        assert_eq!(config.model, "claude-3");
+        assert_eq!(config.persona, "");
+        assert_eq!(config.max_iterations, 100);
+        assert_eq!(config.timeout_minutes, None);
+        assert_eq!(config.parent, None);
+    }
+
+    #[test]
+    fn test_agent_config_serialize_roundtrip() {
+        let config = AgentConfig {
+            name: "rt".to_string(),
+            model: "m".to_string(),
+            persona: "p".to_string(),
+            max_iterations: 10,
+            timeout_minutes: Some(5),
+            parent: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: AgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, config.name);
+        assert_eq!(parsed.max_iterations, config.max_iterations);
+    }
+
+    #[test]
+    fn test_agents_config_default() {
+        let config = AgentsConfig::default();
+        assert_eq!(config.version, "1.0.0");
+        assert!(config.agents.is_empty());
+    }
+
+    #[test]
+    fn test_agents_config_deserialize() {
+        let json = r#"{
+            "version": "2.0",
+            "agents": [
+                {"name": "a1", "model": "m1"},
+                {"name": "a2", "model": "m2", "max_iterations": 200}
+            ]
+        }"#;
+        let config: AgentsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.version, "2.0");
+        assert_eq!(config.agents.len(), 2);
+        assert_eq!(config.agents[0].max_iterations, 100);
+        assert_eq!(config.agents[1].max_iterations, 200);
+    }
+
+    #[test]
+    fn test_agents_config_serialize_roundtrip() {
+        let config = AgentsConfig {
+            version: "1.0".to_string(),
+            agents: vec![AgentConfig {
+                name: "x".to_string(),
+                model: "y".to_string(),
+                persona: String::new(),
+                max_iterations: 100,
+                timeout_minutes: None,
+                parent: Some("z".to_string()),
+            }],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: AgentsConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.agents.len(), 1);
+        assert_eq!(parsed.agents[0].parent.as_deref(), Some("z"));
+    }
+}


### PR DESCRIPTION
## Summary

Add 6 unit tests to `src/config/agents/types.rs` to improve coverage from 42.86% to well above 50%.

Tests cover:
- AgentConfig full and minimal deserialization
- AgentConfig serialize roundtrip
- AgentsConfig default values
- AgentsConfig deserialization with multiple agents
- AgentsConfig serialize roundtrip

Source: issue #300
Type: test