### PR TITLE
test(config): add unit tests for agents/provider.rs to improve coverage

### DIFF
--- a/src/config/agents/provider.rs
+++ b/src/config/agents/provider.rs
@@ -97,3 +97,103 @@ impl ConfigProvider for AgentsConfigProvider {
         validate_agents_config(&self.config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default() {
+        let provider = AgentsConfigProvider::default();
+        assert!(provider.is_default());
+        assert!(provider.agents().is_empty());
+    }
+
+    #[test]
+    fn test_version() {
+        let provider = AgentsConfigProvider::default();
+        assert_eq!(provider.version(), "1.0.0");
+    }
+
+    #[test]
+    fn test_config_path() {
+        assert_eq!(AgentsConfigProvider::config_path(), "agents.json");
+    }
+
+    #[test]
+    fn test_from_json_str_valid() {
+        let json = r#"{
+            "version": "1.0",
+            "agents": [
+                {"name": "agent-a", "model": "gpt-4"},
+                {"name": "agent-b", "model": "claude-3"}
+            ]
+        }"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.is_default()); // from_json_str uses "memory" path
+        assert_eq!(provider.agents().len(), 2);
+    }
+
+    #[test]
+    fn test_from_json_str_invalid() {
+        let json = "not json";
+        let result = AgentsConfigProvider::from_json_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_inner() {
+        let json = r#"{"version":"1","agents":[{"name":"x","model":"y"}]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert_eq!(provider.inner().version, "1");
+    }
+
+    #[test]
+    fn test_get_found() {
+        let json = r#"{"version":"1","agents":[{"name":"alpha","model":"m1"},{"name":"beta","model":"m2"}]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        let agent = provider.get("alpha").unwrap();
+        assert_eq!(agent.model, "m1");
+    }
+
+    #[test]
+    fn test_get_not_found() {
+        let json = r#"{"version":"1","agents":[{"name":"alpha","model":"m1"}]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_lookup() {
+        let json = r#"{"version":"1","agents":[{"name":"a","model":"m"},{"name":"b","model":"n"}]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        let map = provider.lookup();
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("a"));
+        assert!(map.contains_key("b"));
+    }
+
+    #[test]
+    fn test_validate_valid() {
+        let json = r#"{"version":"1","agents":[{"name":"agent1","model":"gpt-4"}]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.validate().is_ok());
+    }
+
+    #[test]
+    fn test_new_from_file_missing() {
+        let result = AgentsConfigProvider::new("/nonexistent/path/agents.json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_new_from_temp_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("agents.json");
+        let json = r#"{"version":"1","agents":[{"name":"test","model":"m"}]}"#;
+        std::fs::write(&path, json).unwrap();
+        let provider = AgentsConfigProvider::new(&path).unwrap();
+        assert_eq!(provider.agents().len(), 1);
+        assert!(!provider.is_default());
+    }
+}


### PR DESCRIPTION
## Summary

Add 12 unit tests to `src/config/agents/provider.rs` to improve coverage from 30.77% to above 50%.

Tests cover:
- Default construction, version, config_path
- from_json_str valid and invalid inputs
- Inner config access
- Get agent by name (found/not found)
- Lookup map builder
- Validate valid config
- New from file (missing path and valid temp file)

Source: issue #299
Type: test