### PR TITLE
test(gateway): add unit tests for gateway/mod.rs to improve coverage

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -129,3 +129,186 @@ impl From<super::im::AdapterError> for GatewayError {
         GatewayError::AdapterError(e.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::im::IMAdapter;
+    use async_trait::async_trait;
+
+    /// Mock adapter that records calls
+    struct MockAdapter {
+        should_fail: bool,
+    }
+
+    #[async_trait]
+    impl IMAdapter for MockAdapter {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn handle_webhook(
+            &self,
+            _payload: &[u8],
+        ) -> Result<Message, super::super::im::AdapterError> {
+            Ok(Message {
+                id: "1".into(),
+                from: "a".into(),
+                to: "b".into(),
+                content: "hi".into(),
+                channel: "mock".into(),
+                timestamp: 0,
+                metadata: HashMap::new(),
+            })
+        }
+
+        async fn send_message(
+            &self,
+            _message: &Message,
+        ) -> Result<(), super::super::im::AdapterError> {
+            if self.should_fail {
+                return Err(super::super::im::AdapterError::SendFailed(
+                    "mock error".into(),
+                ));
+            }
+            Ok(())
+        }
+
+        async fn validate_signature(&self, _signature: &str, _payload: &[u8]) -> bool {
+            true
+        }
+    }
+
+    fn make_config() -> GatewayConfig {
+        GatewayConfig {
+            name: "test".to_string(),
+            rate_limit_per_minute: 100,
+            max_message_size: 1024,
+        }
+    }
+
+    fn make_message(to: &str, content: &str) -> Message {
+        Message {
+            id: "msg_1".to_string(),
+            from: "ou_sender".to_string(),
+            to: to.to_string(),
+            content: content.to_string(),
+            channel: "mock".to_string(),
+            timestamp: chrono::Utc::now().timestamp(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_gateway_config_serialization() {
+        let config = make_config();
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: GatewayConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, "test");
+        assert_eq!(parsed.rate_limit_per_minute, 100);
+        assert_eq!(parsed.max_message_size, 1024);
+    }
+
+    #[test]
+    fn test_message_serialization() {
+        let msg = make_message("agent-1", "hello");
+        let json = serde_json::to_string(&msg).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "msg_1");
+        assert_eq!(parsed.content, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_register_and_route() {
+        let gw = Gateway::new(make_config());
+        let adapter = Arc::new(MockAdapter { should_fail: false });
+        gw.register_adapter("mock".to_string(), adapter).await;
+
+        let msg = make_message("agent-1", "hello");
+        let result = gw.route_message("mock", msg).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_route_unknown_channel() {
+        let gw = Gateway::new(make_config());
+        let msg = make_message("agent-1", "hello");
+        let result = gw.route_message("unknown", msg).await;
+        assert!(matches!(result, Err(GatewayError::UnknownChannel(_))));
+    }
+
+    #[tokio::test]
+    async fn test_route_message_too_large() {
+        let mut config = make_config();
+        config.max_message_size = 5;
+        let gw = Gateway::new(config);
+        let adapter = Arc::new(MockAdapter { should_fail: false });
+        gw.register_adapter("mock".to_string(), adapter).await;
+
+        let msg = make_message("agent-1", "this is too long");
+        let result = gw.route_message("mock", msg).await;
+        assert!(matches!(result, Err(GatewayError::MessageTooLarge)));
+    }
+
+    #[tokio::test]
+    async fn test_route_adapter_error() {
+        let gw = Gateway::new(make_config());
+        let adapter = Arc::new(MockAdapter { should_fail: true });
+        gw.register_adapter("mock".to_string(), adapter).await;
+
+        let msg = make_message("agent-1", "hello");
+        let result = gw.route_message("mock", msg).await;
+        assert!(matches!(result, Err(GatewayError::AdapterError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_session_created_on_route() {
+        let gw = Gateway::new(make_config());
+        let adapter = Arc::new(MockAdapter { should_fail: false });
+        gw.register_adapter("mock".to_string(), adapter).await;
+
+        let msg = make_message("agent-1", "hello");
+        gw.route_message("mock", msg).await.unwrap();
+
+        let sessions = gw.get_agent_sessions("agent-1").await;
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].agent_id, "agent-1");
+        assert_eq!(sessions[0].channel, "mock");
+    }
+
+    #[tokio::test]
+    async fn test_no_sessions_for_unknown_agent() {
+        let gw = Gateway::new(make_config());
+        let sessions = gw.get_agent_sessions("nobody").await;
+        assert!(sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_session_not_duplicated() {
+        let gw = Gateway::new(make_config());
+        let adapter = Arc::new(MockAdapter { should_fail: false });
+        gw.register_adapter("mock".to_string(), adapter).await;
+
+        let msg1 = make_message("agent-1", "first");
+        let msg2 = make_message("agent-1", "second");
+        gw.route_message("mock", msg1).await.unwrap();
+        gw.route_message("mock", msg2).await.unwrap();
+
+        let sessions = gw.get_agent_sessions("agent-1").await;
+        assert_eq!(sessions.len(), 1);
+    }
+
+    #[test]
+    fn test_gateway_error_display() {
+        assert!(GatewayError::UnknownChannel("x".into())
+            .to_string()
+            .contains("x"));
+        assert!(GatewayError::MessageTooLarge
+            .to_string()
+            .contains("too large"));
+        assert!(GatewayError::AdapterError("e".into())
+            .to_string()
+            .contains("e"));
+        assert!(GatewayError::RateLimitExceeded.to_string().contains("Rate"));
+    }
+}


### PR DESCRIPTION
## Summary

Add 10 unit tests to `src/gateway/mod.rs` to improve coverage from 0.00% to well above 50%.

Tests cover:
- GatewayConfig and Message serialization
- register_adapter and route_message success/error paths
- Unknown channel, message too large, adapter error
- Session creation, lookup, deduplication
- GatewayError display variants

Source: issue #303
Type: test