### PR TITLE
test(llm): add unit tests for anthropic.rs to improve coverage

### DIFF
--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -34,3 +34,54 @@ impl LLMProvider for AnthropicProvider {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_anthropic_provider_new() {
+        let provider = AnthropicProvider::new("test-key".to_string());
+        assert_eq!(provider.name(), "anthropic");
+    }
+
+    #[test]
+    fn test_anthropic_provider_name() {
+        let provider = AnthropicProvider::new("key".to_string());
+        assert_eq!(provider.name(), "anthropic");
+    }
+
+    #[test]
+    fn test_anthropic_provider_models() {
+        let provider = AnthropicProvider::new("key".to_string());
+        let models = provider.models();
+        assert_eq!(
+            models,
+            vec!["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"]
+        );
+    }
+
+    #[test]
+    fn test_anthropic_is_stub() {
+        let provider = AnthropicProvider::new("key".to_string());
+        assert!(provider.is_stub());
+    }
+
+    #[tokio::test]
+    async fn test_anthropic_chat_returns_error() {
+        let provider = AnthropicProvider::new("key".to_string());
+        let request = ChatRequest {
+            model: "claude-3-opus".to_string(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+        };
+        let result = provider.chat(request).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err {
+            LLMError::ApiError(msg) => assert!(msg.contains("stub")),
+            _ => panic!("Expected ApiError"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add 5 unit tests to `src/llm/anthropic.rs` to improve coverage from 0.00% to well above 50%.

Tests cover all public methods of the AnthropicProvider stub:
- new constructor
- name returns "anthropic"
- models lists claude-3-opus/sonnet/haiku
- is_stub returns true
- chat returns ApiError with stub message

Source: issue #306
Type: test