### PR TITLE
test(chat): add unit tests for server.rs to improve coverage

### DIFF
--- a/src/chat/server.rs
+++ b/src/chat/server.rs
@@ -88,3 +88,43 @@ impl Default for ChatServer {
 pub fn spawn_chat_server(llm_registry: Arc<LLMRegistry>) -> ChatServer {
     ChatServer::new(llm_registry)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chat_server_new() {
+        let registry = Arc::new(LLMRegistry::new());
+        let server = ChatServer::new(registry);
+        // shutdown should work without panic
+        server.shutdown();
+    }
+
+    #[test]
+    fn test_chat_server_default() {
+        let server = ChatServer::default();
+        server.shutdown();
+    }
+
+    #[test]
+    fn test_spawn_chat_server() {
+        let registry = Arc::new(LLMRegistry::new());
+        let server = spawn_chat_server(registry);
+        server.shutdown();
+    }
+
+    #[test]
+    fn test_shutdown_multiple_times() {
+        let server = ChatServer::default();
+        server.shutdown();
+        // second shutdown should not panic
+        server.shutdown();
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(CHAT_BIND_ADDR, "127.0.0.1:18889");
+        assert_eq!(DEFAULT_AGENT_ID, "guide");
+    }
+}


### PR DESCRIPTION
## Summary

Add 5 unit tests to `src/chat/server.rs` to improve coverage from 0.00% to well above 50%.

Tests cover:
- ChatServer::new with LLM registry
- Default constructor
- spawn_chat_server helper
- Shutdown called multiple times without panic
- Constants validation (bind address, default agent)

Source: issue #295
Type: test