### PR TITLE
refactor(feishu): extract event handling logic from adapter.rs

### DIFF
--- a/src/platform/SPEC.md
+++ b/src/platform/SPEC.md
@@ -95,7 +95,8 @@ platform/
 ├── capabilities.rs     # 能力矩阵定义与服务
 └── feishu/
     ├── mod.rs          # 导出 FeishuAdapter、FallbackResult、CardService
-    ├── adapter.rs      # FeishuAdapter 核心：降级决策与流程编排
+    ├── adapter.rs      # FeishuAdapter 核心：结构体定义、构造函数、能力查询
+    ├── adapter_event.rs # FeishuAdapter 事件处理：execute_fallback、handle_mode_switch 及辅助方法
     ├── card.rs         # Plan 卡片结构：PlanCardConfig、PlanSection、StepStatus
     ├── card_updater.rs # CardService trait：卡片创建与更新操作抽象
     ├── fallback.rs     # 降级步骤定义：FallbackAction、FallbackStep
@@ -106,7 +107,9 @@ platform/
 
 **`capabilities.rs`** 定义能力枚举 `CapabilityLevel`、`FileUploadCapability`，结构体 `PlatformCapabilities`，以及查询服务 `PlatformCapabilityService` 和决策上下文 `ModeDecisionContext`。
 
-**`feishu/`** 是 Feishu 平台的具体实现子包，`adapter.rs` 是入口，按需组合 card、card_updater、fallback、updater、complexity 四个子模块。
+**`feishu/`** 是 Feishu 平台的具体实现子包，`adapter.rs` 是入口，按需组合 card、card_updater、fallback、updater、complexity 五个子模块。
+
+**`adapter_event.rs`** 包含 `FeishuAdapter` 的事件处理 impl 块：`execute_fallback`（Stream→Plan 降级流程编排）和 `handle_mode_switch`（模式切换判断），以及 `send_initial_message`、`create_plan_card`、`send_final_message` 三个私有辅助方法。`adapter.rs` 仅保留结构体/类型定义、构造函数和能力查询方法。
 
 ---
 

--- a/src/platform/feishu/adapter.rs
+++ b/src/platform/feishu/adapter.rs
@@ -5,13 +5,12 @@
 use std::sync::Arc;
 
 use crate::platform::capabilities::{PlatformCapabilityService, ReasoningMode};
-use crate::session::events::ModeSwitchEvent;
 
-use super::card::{default_plan_card_config, PlanCardConfig};
-use super::card_updater::{CardHandle, CardService};
-use super::complexity::{get_high_complexity_config, HighComplexityConfig};
+use super::card::PlanCardConfig;
+use super::card_updater::CardService;
+#[cfg(test)]
+use super::card_updater::{CardHandle, SectionUpdate};
 use super::error::FeishuAdapterError;
-use crate::platform::feishu::updater::run_streaming_with_card_update;
 
 /// Feishu message service trait (to be implemented by actual Feishu integration)
 #[async_trait::async_trait]
@@ -47,9 +46,11 @@ pub struct FeishuAdapter {
     /// Platform capability service
     capability_service: Arc<PlatformCapabilityService>,
     /// Card service
-    card_service: Arc<dyn CardService>,
+    pub(crate) card_service: Arc<dyn CardService>,
     /// Message service
-    message_service: Arc<dyn FeishuMessageService>,
+    pub(crate) message_service: Arc<dyn FeishuMessageService>,
+    /// Whether fallback is enabled
+    fallback_enabled: bool,
 }
 
 impl FeishuAdapter {
@@ -63,6 +64,7 @@ impl FeishuAdapter {
             capability_service,
             card_service,
             message_service,
+            fallback_enabled: true,
         }
     }
 
@@ -74,94 +76,20 @@ impl FeishuAdapter {
                 .supports_mode_fully("feishu", ReasoningMode::Stream)
     }
 
-    /// Get the fallback mode for Stream on Feishu
     pub fn get_fallback_mode(&self) -> ReasoningMode {
         ReasoningMode::Plan
     }
 
-    /// Check if fallback is enabled (from config)
     pub fn is_fallback_enabled(&self) -> bool {
-        // TODO: Read from config
-        true
+        self.fallback_enabled
     }
 
-    /// Send initial hint message
-    async fn send_initial_message(&self) -> Result<String, FeishuAdapterError> {
-        let content = "🔍 进入深度分析模式...";
-        self.message_service.send_message(content).await
+    pub(crate) fn card_service(&self) -> &Arc<dyn CardService> {
+        &self.card_service
     }
 
-    /// Create Plan card framework
-    async fn create_plan_card(&self, goal: Option<&str>) -> Result<CardHandle, FeishuAdapterError> {
-        let config = default_plan_card_config(goal);
-        self.card_service.create_card(&config).await
-    }
-
-    /// Send final conclusion message
-    async fn send_final_message(&self, card: &CardHandle) -> Result<String, FeishuAdapterError> {
-        let content = "✅ 分析完成，请查看上方计划卡片";
-        self.message_service.send_message(content).await
-    }
-}
-
-impl FeishuAdapter {
-    /// Execute the fallback flow
-    pub async fn execute_fallback(
-        &self,
-        intent: &ModeSwitchEvent,
-    ) -> Result<FallbackResult, FeishuAdapterError> {
-        if !self.is_fallback_enabled() {
-            return Err(FeishuAdapterError::FallbackNotEnabled);
-        }
-
-        // Get the goal for card creation
-        let goal = intent
-            .user_intent
-            .as_ref()
-            .and_then(|u| u.parsed_goal.as_ref())
-            .map(|s| s.as_str());
-
-        // Step 1: Send initial hint
-        let initial = self.send_initial_message().await?;
-
-        // Step 2: Create Plan card
-        let card = self.create_plan_card(goal).await?;
-
-        // Step 3: Run streaming updates with card
-        run_streaming_with_card_update(
-            &*self.card_service,
-            &card,
-            intent,
-            get_high_complexity_config(),
-        )
-        .await?;
-
-        // Step 4: Send final conclusion
-        let final_msg = self.send_final_message(&card).await?;
-
-        Ok(FallbackResult {
-            initial_message_id: initial,
-            card_message_id: card.message_id,
-            final_message_id: final_msg,
-        })
-    }
-
-    /// Handle a mode switch event, determining if fallback is needed
-    pub async fn handle_mode_switch(
-        &self,
-        event: &ModeSwitchEvent,
-    ) -> Result<Option<FallbackResult>, FeishuAdapterError> {
-        let target_mode = event
-            .target_mode
-            .or_else(|| event.requested_mode)
-            .unwrap_or(ReasoningMode::Direct);
-
-        if self.should_fallback(target_mode) {
-            let result = self.execute_fallback(event).await?;
-            Ok(Some(result))
-        } else {
-            Ok(None)
-        }
+    pub(crate) fn message_service(&self) -> &Arc<dyn FeishuMessageService> {
+        &self.message_service
     }
 }
 
@@ -269,26 +197,24 @@ mod tests {
         let adapter = create_test_adapter();
         assert_eq!(adapter.get_fallback_mode(), ReasoningMode::Plan);
     }
+}
 
-    #[tokio::test]
-    async fn test_is_high_complexity_detection() {
-        use crate::session::events::UserIntent;
-        use std::sync::Arc;
-
-        let adapter = create_test_adapter();
-        let event = ModeSwitchEvent {
-            target_mode: Some(ReasoningMode::Stream),
-            user_intent: Some(Arc::new(UserIntent {
-                raw_input: "设计一个用户认证系统".to_string(),
-                parsed_goal: Some("设计一个用户认证系统".to_string()),
-                entities: vec![],
-            })),
-            ..Default::default()
-        };
-
-        // This would normally use is_high_complexity, but we test handle_mode_switch
-        // which calls execute_fallback
-        let result = adapter.handle_mode_switch(&event).await;
-        assert!(result.is_ok());
+/// Test-only constructor that allows controlling fallback_enabled.
+/// This lives outside the main impl block so it can be used by sibling test modules
+/// (e.g., adapter_event::tests) via pub(crate) visibility.
+#[cfg(test)]
+impl FeishuAdapter {
+    pub(crate) fn new_for_test(
+        capability_service: Arc<PlatformCapabilityService>,
+        card_service: Arc<dyn CardService>,
+        message_service: Arc<dyn FeishuMessageService>,
+        fallback_enabled: bool,
+    ) -> Self {
+        Self {
+            capability_service,
+            card_service,
+            message_service,
+            fallback_enabled,
+        }
     }
 }

--- a/src/platform/feishu/adapter_event.rs
+++ b/src/platform/feishu/adapter_event.rs
@@ -1,0 +1,309 @@
+//! Fallback event handling for Feishu Adapter
+
+use crate::platform::feishu::card::default_plan_card_config;
+use crate::platform::feishu::card_updater::CardHandle;
+use crate::platform::feishu::complexity::get_high_complexity_config;
+use crate::platform::feishu::error::FeishuAdapterError;
+use crate::platform::feishu::updater::run_streaming_with_card_update;
+use crate::session::events::ModeSwitchEvent;
+
+use super::adapter::FeishuAdapter;
+
+impl FeishuAdapter {
+    /// Send initial hint message
+    async fn send_initial_message(&self) -> Result<String, FeishuAdapterError> {
+        let content = "🔍 进入深度分析模式...";
+        self.message_service().send_message(content).await
+    }
+
+    /// Create Plan card framework
+    async fn create_plan_card(&self, goal: Option<&str>) -> Result<CardHandle, FeishuAdapterError> {
+        let config = default_plan_card_config(goal);
+        self.card_service().create_card(&config).await
+    }
+
+    /// Send final conclusion message
+    async fn send_final_message(&self, _card: &CardHandle) -> Result<String, FeishuAdapterError> {
+        let content = "✅ 分析完成，请查看上方计划卡片";
+        self.message_service().send_message(content).await
+    }
+
+    /// Execute the fallback flow
+    pub async fn execute_fallback(
+        &self,
+        intent: &ModeSwitchEvent,
+    ) -> Result<crate::platform::feishu::adapter::FallbackResult, FeishuAdapterError> {
+        if !self.is_fallback_enabled() {
+            return Err(FeishuAdapterError::FallbackNotEnabled);
+        }
+
+        // Get the goal for card creation
+        let goal = intent
+            .user_intent
+            .as_ref()
+            .and_then(|u| u.parsed_goal.as_ref())
+            .map(|s| s.as_str());
+
+        // Step 1: Send initial hint
+        let initial = self.send_initial_message().await?;
+
+        // Step 2: Create Plan card
+        let card = self.create_plan_card(goal).await?;
+
+        // Step 3: Run streaming updates with card
+        run_streaming_with_card_update(
+            &**self.card_service(),
+            &card,
+            intent,
+            get_high_complexity_config(),
+        )
+        .await?;
+
+        // Step 4: Send final conclusion
+        let final_msg = self.send_final_message(&card).await?;
+
+        Ok(crate::platform::feishu::adapter::FallbackResult {
+            initial_message_id: initial,
+            card_message_id: card.message_id,
+            final_message_id: final_msg,
+        })
+    }
+
+    /// Handle a mode switch event, determining if fallback is needed
+    pub async fn handle_mode_switch(
+        &self,
+        event: &ModeSwitchEvent,
+    ) -> Result<Option<crate::platform::feishu::adapter::FallbackResult>, FeishuAdapterError> {
+        use crate::platform::capabilities::ReasoningMode;
+
+        let target_mode = event
+            .target_mode
+            .or(event.requested_mode)
+            .unwrap_or(ReasoningMode::Direct);
+
+        if self.should_fallback(target_mode) {
+            let result = self.execute_fallback(event).await?;
+            Ok(Some(result))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::capabilities::ReasoningMode;
+    use crate::platform::feishu::card::PlanCardConfig;
+    use crate::platform::feishu::card_updater::{CardService, SectionUpdate};
+    use crate::platform::feishu::error::FeishuAdapterError;
+    use crate::platform::PlatformCapabilityService;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct MockCardService;
+    struct MockMessageService;
+
+    #[async_trait]
+    impl CardService for MockCardService {
+        async fn create_card(
+            &self,
+            _config: &PlanCardConfig,
+        ) -> Result<CardHandle, FeishuAdapterError> {
+            Ok(CardHandle {
+                message_id: "mock_card_id".to_string(),
+            })
+        }
+
+        async fn update_section(
+            &self,
+            _card_id: &str,
+            _section_index: usize,
+            _update: SectionUpdate,
+        ) -> Result<(), FeishuAdapterError> {
+            Ok(())
+        }
+
+        async fn update_progress(
+            &self,
+            _card_id: &str,
+            _current_step: u32,
+            _total_steps: u32,
+        ) -> Result<(), FeishuAdapterError> {
+            Ok(())
+        }
+
+        async fn mark_step_complete(
+            &self,
+            _card_id: &str,
+            _step_number: u32,
+        ) -> Result<(), FeishuAdapterError> {
+            Ok(())
+        }
+
+        async fn update_card(
+            &self,
+            _card_id: &str,
+            _config: &PlanCardConfig,
+        ) -> Result<(), FeishuAdapterError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl crate::platform::feishu::adapter::FeishuMessageService for MockMessageService {
+        async fn send_message(&self, _content: &str) -> Result<String, FeishuAdapterError> {
+            Ok("mock_message_id".to_string())
+        }
+
+        async fn update_message(
+            &self,
+            _message_id: &str,
+            _content: &str,
+        ) -> Result<(), FeishuAdapterError> {
+            Ok(())
+        }
+
+        async fn send_card(
+            &self,
+            _card_config: &PlanCardConfig,
+        ) -> Result<String, FeishuAdapterError> {
+            Ok("mock_card_id".to_string())
+        }
+    }
+
+    /// Create a standard test adapter with fallback enabled
+    fn create_test_adapter() -> FeishuAdapter {
+        FeishuAdapter::new(
+            Arc::new(PlatformCapabilityService::new()),
+            Arc::new(MockCardService),
+            Arc::new(MockMessageService),
+        )
+    }
+
+    /// Create a test adapter with fallback disabled
+    fn create_test_adapter_fallback_disabled() -> FeishuAdapter {
+        FeishuAdapter::new_for_test(
+            Arc::new(PlatformCapabilityService::new()),
+            Arc::new(MockCardService),
+            Arc::new(MockMessageService),
+            false,
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // execute_fallback tests
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_execute_fallback_success() {
+        use crate::session::events::UserIntent;
+
+        let adapter = create_test_adapter();
+        let event = ModeSwitchEvent {
+            target_mode: Some(ReasoningMode::Stream),
+            user_intent: Some(Arc::new(UserIntent {
+                raw_input: "设计一个用户认证系统".to_string(),
+                parsed_goal: Some("设计一个用户认证系统".to_string()),
+                entities: vec![],
+            })),
+            ..Default::default()
+        };
+
+        let result = adapter.execute_fallback(&event).await;
+        assert!(result.is_ok(), "execute_fallback should succeed");
+
+        let fallback = result.unwrap();
+        // Verify all 4 steps produced message IDs
+        assert_eq!(fallback.initial_message_id, "mock_message_id");
+        assert_eq!(fallback.card_message_id, "mock_card_id");
+        assert_eq!(fallback.final_message_id, "mock_message_id");
+    }
+
+    #[tokio::test]
+    async fn test_execute_fallback_not_enabled() {
+        use crate::session::events::UserIntent;
+
+        let adapter = create_test_adapter_fallback_disabled();
+        let event = ModeSwitchEvent {
+            target_mode: Some(ReasoningMode::Stream),
+            user_intent: Some(Arc::new(UserIntent {
+                raw_input: "设计一个用户认证系统".to_string(),
+                parsed_goal: Some("设计一个用户认证系统".to_string()),
+                entities: vec![],
+            })),
+            ..Default::default()
+        };
+
+        let result = adapter.execute_fallback(&event).await;
+        assert!(
+            result.is_err(),
+            "execute_fallback should fail when disabled"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            FeishuAdapterError::FallbackNotEnabled
+        ));
+    }
+
+    // ---------------------------------------------------------------------------
+    // handle_mode_switch tests
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_handle_mode_switch_no_fallback_needed() {
+        use crate::session::events::UserIntent;
+
+        let adapter = create_test_adapter();
+        // Direct mode does NOT need fallback
+        let event = ModeSwitchEvent {
+            target_mode: Some(ReasoningMode::Direct),
+            user_intent: Some(Arc::new(UserIntent {
+                raw_input: "简单问题".to_string(),
+                parsed_goal: Some("简单问题".to_string()),
+                entities: vec![],
+            })),
+            ..Default::default()
+        };
+
+        let result = adapter.handle_mode_switch(&event).await;
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap().is_none(),
+            "Direct mode should not need fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_mode_switch_fallback_needed() {
+        use crate::session::events::UserIntent;
+
+        let adapter = create_test_adapter();
+        // Stream mode needs fallback (Feishu only partially supports Stream)
+        let event = ModeSwitchEvent {
+            target_mode: Some(ReasoningMode::Stream),
+            user_intent: Some(Arc::new(UserIntent {
+                raw_input: "设计一个用户认证系统".to_string(),
+                parsed_goal: Some("设计一个用户认证系统".to_string()),
+                entities: vec![],
+            })),
+            ..Default::default()
+        };
+
+        let result = adapter.handle_mode_switch(&event).await;
+        assert!(result.is_ok());
+        let fallback = result.unwrap();
+        assert!(
+            fallback.is_some(),
+            "Stream mode should need fallback and return Some(FallbackResult)"
+        );
+        let fb = fallback.unwrap();
+        assert_eq!(fb.initial_message_id, "mock_message_id");
+        assert_eq!(fb.card_message_id, "mock_card_id");
+        assert_eq!(fb.final_message_id, "mock_message_id");
+    }
+}

--- a/src/platform/feishu/mod.rs
+++ b/src/platform/feishu/mod.rs
@@ -5,6 +5,7 @@
 //! supported by the platform.
 
 pub mod adapter;
+pub mod adapter_event;
 pub mod card;
 pub mod card_updater;
 pub mod complexity;


### PR DESCRIPTION
## Summary
Split the second `impl FeishuAdapter` block containing `execute_fallback` and `handle_mode_switch` into a dedicated `adapter_event.rs` module to meet the 100-line impl block limit.

## Changes
- New file `src/platform/feishu/adapter_event.rs` containing event handling impl block
- `src/platform/feishu/adapter.rs`: impl block reduced from 111 lines to ~30 lines
- `src/platform/feishu/mod.rs`: added `pub mod adapter_event;`
- `src/platform/SPEC.md`: documented new `adapter_event.rs` submodule

## Source
issue #241