### PR TITLE
feat(config): add ConfigManager for unified config management

### DIFF
--- a/src/config/SPEC.md
+++ b/src/config/SPEC.md
@@ -8,11 +8,12 @@
 
 配置热加载系统，管理 JSON 配置文件的读取、验证、持久化和热重载。
 
-包含五个子模块：
+包含六个子模块：
 - **agents**：agents.json 和 per-agent 配置目录的 ConfigProvider 实现
 - **backup**：写前备份 + 滚动清理
-- **reload**：基于 notify 的文件监控 + 自动重载
+- **manager**：ConfigManager 统一配置管理入口，提供原子写入、备份集成和配置访问
 - **providers**：ConfigProvider trait 和 ConfigError
+- **reload**：基于 notify 的文件监控 + 自动重载
 - **session**：per-agent per-role session 配置（idle/purge），供 ArchiveSweeper 和 Daemon 使用
 
 ---
@@ -23,6 +24,13 @@
 |------|------|
 | `ConfigProvider` | Trait，所有配置提供者的接口 |
 | `ConfigError` | 错误枚举（SchemaError / ValueError / IoError / JsonError） |
+| `ConfigManager` | 统一配置管理入口，提供原子写入、备份集成和配置访问 |
+| `ConfigSection` | 配置节枚举（Models / Channels / Gateway / Plugins / System / Credentials） |
+| `ConfigInfo` | 配置文件元数据（path / version / last_modified） |
+| `ConfigLoadError` | 配置加载错误（ConfigDirNotFound / ConfigFileNotFound / ParseError / ValidationError / BackupNotFound / IoError） |
+| `ConfigWriteError` | 配置写入错误（ValidationFailed / BackupFailed / WriteFailed / FileNotFound） |
+| `ConfigValidationError` | 配置验证错误（path + message） |
+| `write_atomically` | 原子写入函数（写临时文件 + fsync + rename） |
 | `PerAgentSessionConfig` | 单个 agent-role 的 session 配置（idle_minutes / purge_after_minutes） |
 | `SessionConfig` | 完整 session 配置容器（defaults / agents / sweeper_interval_secs） |
 | `SessionConfigProvider` | Trait，获取 per-agent session 配置和 sweeper 间隔 |
@@ -40,7 +48,7 @@
 | `ReloadResult` | 重载操作结果（Success/ValidationFailed/RolledBack） |
 | `WatcherHandle` | 文件监控句柄，drop 时停止监控 |
 
-> 注：以下完整实现存在但 mod.rs 未导出——如需通过 crate 外部访问，需在 mod.rs 中补充 re-export：BackupManager、SafeBackupManager、ConfigReloadManager<P>、ConfigReloadEvent、ReloadResult、WatcherHandle
+> 注：BackupManager、ConfigReloadManager<P>、ConfigReloadEvent、ReloadResult、WatcherHandle 存在但 mod.rs 未导出。SafeBackupManager 已 re-exported。
 
 ---
 

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -1,0 +1,412 @@
+//! Config Manager — unified config management entry point
+//!
+//! Provides atomic write, backup integration, and unified access
+//! to all JSON config files under the config/ directory.
+
+use chrono::{DateTime, Local};
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use thiserror::Error;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Error loading a configuration file.
+#[derive(Debug, Error)]
+pub enum ConfigLoadError {
+    #[error("config directory not found: {0}")]
+    ConfigDirNotFound(PathBuf),
+
+    #[error("config file not found: {0}")]
+    ConfigFileNotFound(PathBuf),
+
+    #[error("failed to parse config file {path}: {error}")]
+    ParseError { path: PathBuf, error: String },
+
+    #[error("config validation failed for {path}: {message}")]
+    ValidationError { path: PathBuf, message: String },
+
+    #[error("backup not found for {0}")]
+    BackupNotFound(PathBuf),
+
+    #[error("I/O error loading {path}: {error}")]
+    IoError { path: PathBuf, error: String },
+}
+
+impl From<io::Error> for ConfigLoadError {
+    fn from(e: io::Error) -> Self {
+        ConfigLoadError::IoError {
+            path: PathBuf::new(),
+            error: e.to_string(),
+        }
+    }
+}
+
+/// Error writing a configuration file.
+#[derive(Debug, Error)]
+pub enum ConfigWriteError {
+    #[error("validation failed for {0}: {1}")]
+    ValidationFailed(String, String),
+
+    #[error("backup failed for {path}: {error}")]
+    BackupFailed { path: PathBuf, error: String },
+
+    #[error("write failed for {path}: {error}")]
+    WriteFailed { path: PathBuf, error: String },
+
+    #[error("config file not found: {0}")]
+    FileNotFound(PathBuf),
+}
+
+impl From<io::Error> for ConfigWriteError {
+    fn from(e: io::Error) -> Self {
+        ConfigWriteError::WriteFailed {
+            path: PathBuf::new(),
+            error: e.to_string(),
+        }
+    }
+}
+
+/// Validation error for a config file.
+#[derive(Debug)]
+pub struct ConfigValidationError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl std::fmt::Display for ConfigValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "validation failed for {}: {}",
+            self.path.display(),
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for ConfigValidationError {}
+
+// ---------------------------------------------------------------------------
+// Atomic write
+// ---------------------------------------------------------------------------
+
+/// Write content to a file atomically: write to a temp file, fsync,
+/// then rename to the target path. Cleans up the temp file on failure.
+pub fn write_atomically(path: &Path, content: &[u8]) -> io::Result<()> {
+    let parent = path.parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(parent)?;
+
+    let tmp_name = format!(".tmp.{}", Uuid::new_v4());
+    let tmp_path = parent.join(tmp_name);
+
+    let mut file = File::create(&tmp_path)?;
+
+    if let Err(e) = file.write_all(content) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    if let Err(e) = file.sync_all() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    // Sync parent directory to make the rename durable.
+    if let Ok(dir) = File::open(parent) {
+        let _ = dir.sync_all();
+    }
+
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Config section
+// ---------------------------------------------------------------------------
+
+/// Represents a configuration section backed by a single JSON file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConfigSection {
+    Models,
+    Channels,
+    Gateway,
+    Plugins,
+    System,
+    Credentials,
+}
+
+impl ConfigSection {
+    /// Returns the filename associated with this section.
+    pub fn filename(&self) -> &'static str {
+        match self {
+            ConfigSection::Models => "models.json",
+            ConfigSection::Channels => "channels.json",
+            ConfigSection::Gateway => "gateway.json",
+            ConfigSection::Plugins => "plugins.json",
+            ConfigSection::System => "system.json",
+            ConfigSection::Credentials => "credentials.json",
+        }
+    }
+
+    /// Returns the absolute path to this section's file relative to config_dir.
+    fn path(&self, config_dir: &Path) -> PathBuf {
+        config_dir.join(self.filename())
+    }
+}
+
+impl std::fmt::Display for ConfigSection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.filename())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config info
+// ---------------------------------------------------------------------------
+
+/// Metadata about a configuration file.
+#[derive(Debug, Clone)]
+pub struct ConfigInfo {
+    /// Absolute path to the config file.
+    pub path: String,
+    /// Config file format version (from the JSON content).
+    pub version: String,
+    /// Last modified timestamp (None if the file hasn't been read yet).
+    pub last_modified: Option<DateTime<Local>>,
+}
+
+// ---------------------------------------------------------------------------
+// ConfigManager
+// ---------------------------------------------------------------------------
+
+/// Unified configuration management entry point.
+///
+/// Provides atomic write, backup integration, and unified access to all
+/// JSON config files under the config/ directory.
+///
+/// # Design
+///
+/// Each configuration section (models, channels, gateway, etc.) is stored
+/// as a separate JSON file. ConfigManager loads all sections into memory
+/// and provides:
+/// - `load()`: load all sections from disk
+/// - `update()`: validate + backup + atomic write + update memory
+/// - `section()`: read-only access to a section's JSON value
+/// - `list_configs()`: metadata about all config files
+pub struct ConfigManager {
+    /// Base directory containing all config files.
+    config_dir: PathBuf,
+    /// Thread-safe backup manager.
+    backup_manager: SafeBackupManager,
+    /// In-memory cache of all loaded config sections.
+    sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
+}
+
+impl ConfigManager {
+    /// Create a new ConfigManager for the given config directory.
+    ///
+    /// The backup manager will store backups in `<config_dir>/.backups/`.
+    pub fn new(config_dir: PathBuf) -> io::Result<Self> {
+        let backup_dir = config_dir.join(".backups");
+        let backup_manager =
+            SafeBackupManager::new(super::backup::BackupManager::new(backup_dir, 10)?);
+        Ok(Self {
+            config_dir,
+            backup_manager,
+            sections: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Load all configuration sections from disk into memory.
+    ///
+    /// Returns `Ok(())` if all mandatory config files are loaded successfully.
+    /// Returns `Err(ConfigLoadError::ConfigFileNotFound)` if a mandatory file is missing.
+    /// Returns `Err(ConfigLoadError::ConfigDirNotFound)` if the config directory doesn't exist.
+    pub fn load(&self) -> Result<(), ConfigLoadError> {
+        if !self.config_dir.exists() {
+            return Err(ConfigLoadError::ConfigDirNotFound(self.config_dir.clone()));
+        }
+
+        // The 5 mandatory config files (Credentials is a directory, handled separately)
+        let mandatory_sections = [
+            ConfigSection::Models,
+            ConfigSection::Channels,
+            ConfigSection::Gateway,
+            ConfigSection::Plugins,
+            ConfigSection::System,
+        ];
+
+        let mut sections = self
+            .sections
+            .write()
+            .expect("RwLock for config sections was poisoned");
+
+        for section in mandatory_sections {
+            let path = section.path(&self.config_dir);
+            if !path.exists() {
+                return Err(ConfigLoadError::ConfigFileNotFound(path));
+            }
+
+            let content = fs::read_to_string(&path).map_err(|e| ConfigLoadError::IoError {
+                path: path.clone(),
+                error: e.to_string(),
+            })?;
+
+            let value: serde_json::Value =
+                serde_json::from_str(&content).map_err(|e| ConfigLoadError::ParseError {
+                    path: path.clone(),
+                    error: e.to_string(),
+                })?;
+
+            sections.insert(section, value);
+        }
+
+        // Credentials is a directory; store empty object as placeholder
+        let creds_path = ConfigSection::Credentials.path(&self.config_dir);
+        if creds_path.exists() {
+            sections.insert(
+                ConfigSection::Credentials,
+                serde_json::Value::Object(Default::default()),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Update a configuration section.
+    ///
+    /// Flow: validate → backup current content → atomic write → update in-memory cache.
+    ///
+    /// If validation fails, no file is written.
+    /// If backup fails, no file is written (write_atomically is not called).
+    pub fn update(
+        &self,
+        section: ConfigSection,
+        new_value: serde_json::Value,
+        validator: impl FnOnce(&serde_json::Value) -> Result<(), ConfigValidationError>,
+    ) -> Result<(), ConfigWriteError> {
+        // Step 1: validate
+        if let Err(e) = validator(&new_value) {
+            return Err(ConfigWriteError::ValidationFailed(
+                section.to_string(),
+                e.message.clone(),
+            ));
+        }
+
+        let path = section.path(&self.config_dir);
+
+        // Step 2: backup current content (if file exists)
+        if path.exists() {
+            let current_content = fs::read(&path).map_err(|e| ConfigWriteError::BackupFailed {
+                path: path.clone(),
+                error: e.to_string(),
+            })?;
+            self.backup_manager
+                .backup_with_content(&path, &current_content)
+                .map_err(|e: io::Error| ConfigWriteError::BackupFailed {
+                    path: path.clone(),
+                    error: e.to_string(),
+                })?;
+        }
+
+        // Step 3: atomic write
+        let content =
+            serde_json::to_vec_pretty(&new_value).map_err(|e| ConfigWriteError::WriteFailed {
+                path: path.clone(),
+                error: e.to_string(),
+            })?;
+
+        write_atomically(&path, &content).map_err(|e| ConfigWriteError::WriteFailed {
+            path,
+            error: e.to_string(),
+        })?;
+
+        // Step 4: update in-memory cache
+        let mut sections = self
+            .sections
+            .write()
+            .expect("RwLock for config sections was poisoned");
+        sections.insert(section, new_value);
+
+        Ok(())
+    }
+
+    /// Get a read-only clone of a configuration section's JSON value.
+    ///
+    /// Returns `None` if the section has not been loaded.
+    pub fn section(&self, section: ConfigSection) -> Option<serde_json::Value> {
+        self.sections
+            .read()
+            .expect("RwLock for config sections was poisoned")
+            .get(&section)
+            .cloned()
+    }
+
+    /// List metadata about all configuration files.
+    ///
+    /// Returns a vector of `ConfigInfo` for each section, including path,
+    /// version (from JSON "version" field), and last modified timestamp.
+    pub fn list_configs(&self) -> Vec<ConfigInfo> {
+        let sections_list = [
+            ConfigSection::Models,
+            ConfigSection::Channels,
+            ConfigSection::Gateway,
+            ConfigSection::Plugins,
+            ConfigSection::System,
+            ConfigSection::Credentials,
+        ];
+
+        let mut infos = Vec::new();
+
+        for section in sections_list {
+            let path = section.path(&self.config_dir);
+
+            let metadata = match fs::metadata(&path) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            let last_modified = metadata.modified().ok().map(DateTime::<Local>::from);
+
+            let version = if let Ok(content) = fs::read_to_string(&path) {
+                serde_json::from_str::<serde_json::Value>(&content)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("version")
+                            .and_then(|vv| vv.as_str().map(str::to_string))
+                    })
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+
+            infos.push(ConfigInfo {
+                path: path.to_string_lossy().to_string(),
+                version,
+                last_modified,
+            });
+        }
+
+        infos
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module exports
+// ---------------------------------------------------------------------------
+
+pub use super::backup::SafeBackupManager;
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -1,0 +1,249 @@
+//! Tests for ConfigManager
+
+use super::*;
+use std::fs;
+
+// ---------------------------------------------------------------------------
+// write_atomically
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_write_atomically_normal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("test.json");
+    write_atomically(&path, b"{\"test\": true}").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"{\"test\": true}");
+}
+
+#[test]
+fn test_write_atomically_nested_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("a/b/c/test.json");
+    write_atomically(&path, b"{\"nested\": true}").unwrap();
+    assert_eq!(fs::read(&path).unwrap(), b"{\"nested\": true}");
+}
+
+#[test]
+fn test_write_atomically_cleanup_on_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Target path is a directory — rename to it will fail.
+    // The temp file must be cleaned up.
+    let dir = tmp.path().join("subdir");
+    fs::create_dir_all(&dir).unwrap();
+    let result = write_atomically(&dir, b"test");
+    assert!(result.is_err()); // rename must fail
+                              // No .tmp.* files should remain in tmp
+    let entries: Vec<_> = fs::read_dir(tmp.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name())
+        .filter(|n| n.to_str().unwrap_or("").starts_with(".tmp."))
+        .collect();
+    assert!(
+        entries.is_empty(),
+        "temp files not cleaned up: {:?}",
+        entries
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ConfigSection Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_config_section_display() {
+    assert_eq!(ConfigSection::Models.to_string(), "models.json");
+    assert_eq!(ConfigSection::Channels.to_string(), "channels.json");
+    assert_eq!(ConfigSection::Gateway.to_string(), "gateway.json");
+    assert_eq!(ConfigSection::Plugins.to_string(), "plugins.json");
+    assert_eq!(ConfigSection::System.to_string(), "system.json");
+    assert_eq!(ConfigSection::Credentials.to_string(), "credentials.json");
+}
+
+// ---------------------------------------------------------------------------
+// ConfigLoadError / ConfigWriteError Display and From
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_config_load_error_display() {
+    let err = ConfigLoadError::ConfigFileNotFound(PathBuf::from("/missing.json"));
+    assert!(err.to_string().contains("missing.json"));
+    let err = ConfigLoadError::ParseError {
+        path: PathBuf::from("/bad.json"),
+        error: "unexpected token".to_string(),
+    };
+    assert!(err.to_string().contains("unexpected token"));
+}
+
+#[test]
+fn test_config_write_error_display() {
+    let err =
+        ConfigWriteError::ValidationFailed("models.json".to_string(), "bad value".to_string());
+    assert!(err.to_string().contains("bad value"));
+    let err = ConfigWriteError::WriteFailed {
+        path: PathBuf::from("/path.json"),
+        error: "disk full".to_string(),
+    };
+    assert!(err.to_string().contains("disk full"));
+}
+
+#[test]
+fn test_config_validation_error_display() {
+    let err = ConfigValidationError {
+        path: PathBuf::from("/test.json"),
+        message: "version required".to_string(),
+    };
+    assert!(err.to_string().contains("version required"));
+    assert!(err.to_string().contains("/test.json"));
+}
+
+// ---------------------------------------------------------------------------
+// ConfigManager — happy path
+// ---------------------------------------------------------------------------
+
+fn setup_config_dir(tmp: &tempfile::TempDir) {
+    fs::write(tmp.path().join("models.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(tmp.path().join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(tmp.path().join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(tmp.path().join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(tmp.path().join("system.json"), r#"{"version": "1.0"}"#).unwrap();
+}
+
+#[test]
+fn test_config_manager_new() {
+    let tmp = tempfile::tempdir().unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    assert!(manager.section(ConfigSection::Models).is_none());
+}
+
+#[test]
+fn test_config_manager_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    assert!(manager.section(ConfigSection::Models).is_some());
+    assert!(manager.section(ConfigSection::Channels).is_some());
+    assert!(manager.section(ConfigSection::Gateway).is_some());
+    assert!(manager.section(ConfigSection::Plugins).is_some());
+    assert!(manager.section(ConfigSection::System).is_some());
+}
+
+#[test]
+fn test_config_manager_load_missing_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(tmp.path().join("models.json"), r#"{"version": "1.0"}"#).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    let result = manager.load();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigLoadError::ConfigFileNotFound(_)
+    ));
+}
+
+#[test]
+fn test_config_manager_load_missing_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let empty_dir = tmp.path().join("empty_config");
+    fs::create_dir_all(&empty_dir).unwrap();
+    let manager = ConfigManager::new(empty_dir).unwrap();
+    let result = manager.load();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigLoadError::ConfigFileNotFound(_)
+    ));
+}
+
+#[test]
+fn test_config_manager_update() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let new_value = serde_json::json!({"version": "2.0", "models": ["gpt-4"]});
+    let validator = |v: &serde_json::Value| {
+        if v.get("version").is_some() {
+            Ok(())
+        } else {
+            Err(ConfigValidationError {
+                path: PathBuf::from("models.json"),
+                message: "version required".to_string(),
+            })
+        }
+    };
+    manager
+        .update(ConfigSection::Models, new_value, validator)
+        .unwrap();
+
+    let section = manager.section(ConfigSection::Models).unwrap();
+    assert_eq!(section["version"], "2.0");
+    assert_eq!(section["models"][0], "gpt-4");
+}
+
+#[test]
+fn test_config_manager_update_validation_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let validator = |_: &serde_json::Value| {
+        Err(ConfigValidationError {
+            path: PathBuf::from("models.json"),
+            message: "always fail".to_string(),
+        })
+    };
+    let result = manager.update(
+        ConfigSection::Models,
+        serde_json::json!({"bad": "value"}),
+        validator,
+    );
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigWriteError::ValidationFailed(_, _)
+    ));
+}
+
+#[test]
+fn test_config_manager_list_configs() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let infos = manager.list_configs();
+    assert!(!infos.is_empty());
+    let models_info = infos
+        .iter()
+        .find(|i| i.path.contains("models.json"))
+        .unwrap();
+    assert_eq!(models_info.version, "1.0");
+    assert!(models_info.last_modified.is_some());
+}
+
+#[test]
+fn test_config_manager_update_backup_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    // Replace the backup directory with a file so backup creation fails.
+    let backup_dir = tmp.path().join(".backups");
+    fs::remove_dir_all(&backup_dir).ok();
+    fs::write(&backup_dir, b"not a directory").unwrap();
+
+    let new_value = serde_json::json!({"version": "3.0"});
+    let validator = |_: &serde_json::Value| Ok(());
+    let result = manager.update(ConfigSection::Models, new_value, validator);
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigWriteError::BackupFailed { .. }
+    ));
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,9 +4,17 @@
 
 pub mod agents;
 pub mod backup;
+pub mod manager;
 pub mod providers;
 pub mod reload;
 pub mod session;
+
+// Public re-exports from manager
+pub use manager::{
+    ConfigInfo, ConfigLoadError, ConfigManager, ConfigSection, ConfigValidationError,
+    ConfigWriteError, SafeBackupManager,
+};
+
 pub use agents::{AgentDirectoryEntry, AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
 pub use providers::{ConfigError, ConfigProvider};
 pub use session::{


### PR DESCRIPTION
Implement ConfigManager as the unified entry point for config management.
Provides ConfigLoadError/ConfigWriteError error types, atomic write via
write_atomically(), pre-write backup integration, and unified load/update/
read access for all config sections (models/channels/gateway/plugins/
system/credentials).

Source: issue #201
Type: feat
