### PR TITLE
feat(config): add SystemConfigData provider for system config separation

### DIFF
--- a/src/config/SPEC.md
+++ b/src/config/SPEC.md
@@ -178,6 +178,34 @@ pub enum ConfigError {
 - `DEFAULT_MAX_MESSAGE_SIZE`（16384）
 - `DEFAULT_DM_SCOPE`（"per-channel-peer"）
 
+**`SystemConfigData`** — 从 `openclaw.json` 的 system 区段加载系统配置，实现 `ConfigProvider` trait。涵盖：wizard、update、meta、messages、commands、session、cron、hooks、browser、auth（仅 profiles，不含 apiKey）。
+
+**数据结构**：
+- `WizardConfig` — wizard 上一次运行状态（lastRunAt / lastRunVersion / lastRunCommand / lastRunMode），均为 `Option`
+- `UpdateConfig` — checkOnStart（默认 true）
+- `MetaConfig` — 上次 touch 版本和时间（lastTouchedVersion / lastTouchedAt），均为 `Option`
+- `MessagesConfig` — ackReactionScope（`Option`）
+- `CommandsConfig` — native / nativeSkills / restart（均默认 true）、ownerDisplay（`Option`）
+- `SessionConfig` — dmScope（默认 "per-account-channel-peer"）+ maintenance 子配置
+  - `SessionMaintenanceConfig` — mode（默认 "enforce"）、pruneAfter（默认 "7d"）、maxEntries（默认 500）
+- `CronConfig` — enabled（默认 true）
+- `HooksConfig` — internal 子配置（enabled + entries map）
+  - `HooksInternalConfig` — enabled（默认 true）、entries（`BTreeMap<String, HookEntryConfig>`）
+  - `HookEntryConfig` — enabled（默认 true）
+- `BrowserConfig` — executablePath（`Option`）、headless（默认 true）、defaultProfile（`Option`）
+- `AuthProfilesConfig` — profiles（`BTreeMap<String, AuthProfileEntryConfig>`）
+  - `AuthProfileEntryConfig` — provider（非空字符串）、mode（默认空字符串）
+
+**验证规则**：
+- `session.maintenance.mode` ∈ {enforce, warn, off}
+- `session.dmScope` ∈ {per-account-channel-peer, per-channel-peer, per-peer, main}
+
+**构造方法**：
+- `from_file(path)` — 从文件路径加载
+- `from_json_str(content)` — 从 JSON 字符串加载
+
+**`is_default` 判断**：所有子结构均为默认值时返回 true（与 JSON 中字段缺失/存在无关）。
+
 ---
 
 ### reload：热重载

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use manager::{
 };
 
 pub use agents::{AgentDirectoryEntry, AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
-pub use providers::{ConfigError, ConfigProvider, GatewayConfigData};
+pub use providers::{ConfigError, ConfigProvider, GatewayConfigData, SystemConfigData};
 pub use session::{
     JsonSessionConfigProvider, PerAgentSessionConfig, SessionConfig, SessionConfigProvider,
 };

--- a/src/config/providers/mod.rs
+++ b/src/config/providers/mod.rs
@@ -1,7 +1,9 @@
 //! ConfigProvider implementations
 
 pub mod gateway;
+pub mod system;
 pub use gateway::GatewayConfigData;
+pub use system::SystemConfigData;
 
 /// Configuration provider trait for extensible config management
 pub trait ConfigProvider {

--- a/src/config/providers/system/mod.rs
+++ b/src/config/providers/system/mod.rs
@@ -1,0 +1,11 @@
+//! System JSON ConfigProvider
+//!
+//! Loads and validates the system section of openclaw.json.
+//! Covers: wizard, update, meta, messages, commands, session, cron,
+//!         hooks, browser, auth (profiles only — no apiKey).
+
+mod system_core;
+pub use system_core::*;
+
+#[cfg(test)]
+mod tests;

--- a/src/config/providers/system/system_core.rs
+++ b/src/config/providers/system/system_core.rs
@@ -1,0 +1,432 @@
+//! System JSON ConfigProvider
+//!
+//! Loads and validates the system section of openclaw.json.
+//! Covers: wizard, update, meta, messages, commands, session, cron,
+//!         hooks, browser, auth (profiles only — no apiKey).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::providers::ConfigError;
+use crate::config::ConfigProvider;
+
+// ---------------------------------------------------------------------------
+// Sub-config structs
+// ---------------------------------------------------------------------------
+
+/// Wizard run state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WizardConfig {
+    #[serde(default)]
+    pub last_run_at: Option<String>,
+    #[serde(default)]
+    pub last_run_version: Option<String>,
+    #[serde(default)]
+    pub last_run_command: Option<String>,
+    #[serde(default)]
+    pub last_run_mode: Option<String>,
+}
+
+impl Default for WizardConfig {
+    fn default() -> Self {
+        Self {
+            last_run_at: None,
+            last_run_version: None,
+            last_run_command: None,
+            last_run_mode: None,
+        }
+    }
+}
+
+/// Update check settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateConfig {
+    #[serde(default)]
+    pub check_on_start: bool,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            check_on_start: true,
+        }
+    }
+}
+
+/// Meta / version touch tracking.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaConfig {
+    #[serde(default)]
+    pub last_touched_version: Option<String>,
+    #[serde(default)]
+    pub last_touched_at: Option<String>,
+}
+
+impl Default for MetaConfig {
+    fn default() -> Self {
+        Self {
+            last_touched_version: None,
+            last_touched_at: None,
+        }
+    }
+}
+
+/// Message acknowledgement settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MessagesConfig {
+    #[serde(default)]
+    pub ack_reaction_scope: Option<String>,
+}
+
+impl Default for MessagesConfig {
+    fn default() -> Self {
+        Self {
+            ack_reaction_scope: None,
+        }
+    }
+}
+
+/// Built-in command enable/disable flags.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandsConfig {
+    #[serde(default)]
+    pub native: bool,
+    #[serde(default)]
+    pub native_skills: bool,
+    #[serde(default)]
+    pub restart: bool,
+    #[serde(default)]
+    pub owner_display: Option<String>,
+}
+
+impl Default for CommandsConfig {
+    fn default() -> Self {
+        Self {
+            native: true,
+            native_skills: true,
+            restart: true,
+            owner_display: None,
+        }
+    }
+}
+
+/// Session maintenance settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMaintenanceConfig {
+    #[serde(default = "def_maint_mode")]
+    pub mode: String,
+    #[serde(default = "def_maint_prune")]
+    pub prune_after: String,
+    #[serde(default = "def_maint_entries")]
+    pub max_entries: u32,
+}
+
+fn def_maint_mode() -> String {
+    "enforce".to_string()
+}
+fn def_maint_prune() -> String {
+    "7d".to_string()
+}
+fn def_maint_entries() -> u32 {
+    500
+}
+
+impl Default for SessionMaintenanceConfig {
+    fn default() -> Self {
+        Self {
+            mode: def_maint_mode(),
+            prune_after: def_maint_prune(),
+            max_entries: def_maint_entries(),
+        }
+    }
+}
+
+/// Session configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionConfig {
+    #[serde(default = "def_dm_scope")]
+    pub dm_scope: String,
+    #[serde(default)]
+    pub maintenance: SessionMaintenanceConfig,
+}
+
+fn def_dm_scope() -> String {
+    "per-account-channel-peer".to_string()
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            dm_scope: def_dm_scope(),
+            maintenance: SessionMaintenanceConfig::default(),
+        }
+    }
+}
+
+/// Cron / scheduled task toggle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CronConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for CronConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Individual hook entry record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HookEntryConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+impl Default for HookEntryConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Internal hooks block.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HooksInternalConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub entries: BTreeMap<String, HookEntryConfig>,
+}
+
+impl Default for HooksInternalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+/// Hooks root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HooksConfig {
+    #[serde(default)]
+    pub internal: HooksInternalConfig,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            internal: HooksInternalConfig::default(),
+        }
+    }
+}
+
+/// Browser / headless browser settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserConfig {
+    #[serde(default)]
+    pub executable_path: Option<String>,
+    #[serde(default)]
+    pub headless: bool,
+    #[serde(default)]
+    pub default_profile: Option<String>,
+}
+
+impl Default for BrowserConfig {
+    fn default() -> Self {
+        Self {
+            executable_path: None,
+            headless: true,
+            default_profile: None,
+        }
+    }
+}
+
+/// Single auth profile entry (provider + mode only — no apiKey).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthProfileEntryConfig {
+    pub provider: String,
+    #[serde(default)]
+    pub mode: String,
+}
+
+impl Default for AuthProfileEntryConfig {
+    fn default() -> Self {
+        Self {
+            provider: String::new(),
+            mode: String::new(),
+        }
+    }
+}
+
+/// Auth profiles map.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthProfilesConfig {
+    #[serde(default)]
+    pub profiles: BTreeMap<String, AuthProfileEntryConfig>,
+}
+
+impl Default for AuthProfilesConfig {
+    fn default() -> Self {
+        Self {
+            profiles: BTreeMap::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SystemConfigData
+// ---------------------------------------------------------------------------
+
+/// Root system configuration.
+///
+/// Represents the union of all "system" fields in openclaw.json:
+/// wizard, update, meta, messages, commands, session, cron, hooks,
+/// browser, and auth (profiles only).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemConfigData {
+    #[serde(default)]
+    pub wizard: Option<WizardConfig>,
+    #[serde(default)]
+    pub update: Option<UpdateConfig>,
+    #[serde(default)]
+    pub meta: Option<MetaConfig>,
+    #[serde(default)]
+    pub messages: Option<MessagesConfig>,
+    #[serde(default)]
+    pub commands: Option<CommandsConfig>,
+    #[serde(default)]
+    pub session: Option<SessionConfig>,
+    #[serde(default)]
+    pub cron: Option<CronConfig>,
+    #[serde(default)]
+    pub hooks: Option<HooksConfig>,
+    #[serde(default)]
+    pub browser: Option<BrowserConfig>,
+    #[serde(default)]
+    pub auth: Option<AuthProfilesConfig>,
+}
+
+impl Default for SystemConfigData {
+    fn default() -> Self {
+        Self {
+            wizard: None,
+            update: None,
+            meta: None,
+            messages: None,
+            commands: None,
+            session: None,
+            cron: None,
+            hooks: None,
+            browser: None,
+            auth: None,
+        }
+    }
+}
+
+impl SystemConfigData {
+    /// Load from a file path.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let content = fs::read_to_string(path)?;
+        Self::from_json_str(&content)
+    }
+
+    /// Parse from a JSON string.
+    pub fn from_json_str(content: &str) -> Result<Self, ConfigError> {
+        let config: SystemConfigData = serde_json::from_str(content)?;
+        Ok(config)
+    }
+}
+
+impl ConfigProvider for SystemConfigData {
+    fn version(&self) -> &'static str {
+        "1.0.0"
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(ref session) = self.session {
+            let valid_modes = ["enforce", "warn", "off"];
+            if !valid_modes.contains(&session.maintenance.mode.as_str()) {
+                return Err(ConfigError::ValueError {
+                    field: "session.maintenance.mode".to_string(),
+                    message: format!(
+                        "mode must be one of {:?}, got '{}'",
+                        valid_modes, session.maintenance.mode
+                    ),
+                });
+            }
+        }
+        if let Some(ref session) = self.session {
+            let valid_scopes = [
+                "per-account-channel-peer",
+                "per-channel-peer",
+                "per-peer",
+                "main",
+            ];
+            if !valid_scopes.contains(&session.dm_scope.as_str()) {
+                return Err(ConfigError::ValueError {
+                    field: "session.dmScope".to_string(),
+                    message: format!(
+                        "dmScope must be one of {:?}, got '{}'",
+                        valid_scopes, session.dm_scope
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn config_path() -> &'static str
+    where
+        Self: Sized,
+    {
+        "openclaw.json (system section)"
+    }
+
+    fn is_default(&self) -> bool {
+        self.wizard.is_none()
+            && self.update.as_ref().map_or(true, |u| u.check_on_start)
+            && self.meta.is_none()
+            && self
+                .messages
+                .as_ref()
+                .map_or(true, |m| m.ack_reaction_scope.is_none())
+            && self
+                .commands
+                .as_ref()
+                .map_or(true, |c| c == &CommandsConfig::default())
+            && self
+                .session
+                .as_ref()
+                .map_or(true, |s| s == &SessionConfig::default())
+            && self.cron.as_ref().map_or(true, |c| c.enabled)
+            && self
+                .hooks
+                .as_ref()
+                .map_or(true, |h| h == &HooksConfig::default())
+            && self
+                .browser
+                .as_ref()
+                .map_or(true, |b| b == &BrowserConfig::default())
+            && self.auth.is_none()
+    }
+}

--- a/src/config/providers/system/tests.rs
+++ b/src/config/providers/system/tests.rs
@@ -1,0 +1,496 @@
+//! Unit tests for SystemConfigData
+
+use super::{
+    AuthProfileEntryConfig, AuthProfilesConfig, BrowserConfig, CommandsConfig, CronConfig,
+    HookEntryConfig, HooksConfig, HooksInternalConfig, MessagesConfig, MetaConfig, SessionConfig,
+    SessionMaintenanceConfig, SystemConfigData, UpdateConfig, WizardConfig,
+};
+use crate::config::ConfigProvider;
+
+fn minimal_config() -> SystemConfigData {
+    SystemConfigData::default()
+}
+
+fn full_config() -> SystemConfigData {
+    SystemConfigData {
+        wizard: Some(WizardConfig {
+            last_run_at: Some("2026-04-22T03:11:53.234Z".to_string()),
+            last_run_version: Some("2026.4.15".to_string()),
+            last_run_command: Some("configure".to_string()),
+            last_run_mode: Some("local".to_string()),
+        }),
+        update: Some(UpdateConfig {
+            check_on_start: false,
+        }),
+        meta: Some(MetaConfig {
+            last_touched_version: Some("2026.4.15".to_string()),
+            last_touched_at: Some("2026-04-22T03:11:53.549Z".to_string()),
+        }),
+        messages: Some(MessagesConfig {
+            ack_reaction_scope: Some("group-mentions".to_string()),
+        }),
+        commands: Some(CommandsConfig {
+            native: true,
+            native_skills: true,
+            restart: true,
+            owner_display: Some("raw".to_string()),
+        }),
+        session: Some(SessionConfig {
+            dm_scope: "per-account-channel-peer".to_string(),
+            maintenance: SessionMaintenanceConfig {
+                mode: "enforce".to_string(),
+                prune_after: "7d".to_string(),
+                max_entries: 500,
+            },
+        }),
+        cron: Some(CronConfig { enabled: true }),
+        hooks: Some(HooksConfig {
+            internal: HooksInternalConfig {
+                enabled: true,
+                entries: std::collections::BTreeMap::from([
+                    ("boot-md".to_string(), HookEntryConfig { enabled: true }),
+                    (
+                        "command-logger".to_string(),
+                        HookEntryConfig { enabled: true },
+                    ),
+                    (
+                        "session-memory".to_string(),
+                        HookEntryConfig { enabled: true },
+                    ),
+                ]),
+            },
+        }),
+        browser: Some(BrowserConfig {
+            executable_path: Some("/usr/bin/google-chrome".to_string()),
+            headless: true,
+            default_profile: Some("openclaw".to_string()),
+        }),
+        auth: Some(AuthProfilesConfig {
+            profiles: std::collections::BTreeMap::from([
+                (
+                    "minimax-portal:default".to_string(),
+                    AuthProfileEntryConfig {
+                        provider: "minimax-portal".to_string(),
+                        mode: "oauth".to_string(),
+                    },
+                ),
+                (
+                    "deepseek:default".to_string(),
+                    AuthProfileEntryConfig {
+                        provider: "deepseek".to_string(),
+                        mode: "api_key".to_string(),
+                    },
+                ),
+                (
+                    "zai:default".to_string(),
+                    AuthProfileEntryConfig {
+                        provider: "zai".to_string(),
+                        mode: "api_key".to_string(),
+                    },
+                ),
+            ]),
+        }),
+    }
+}
+
+#[test]
+fn test_default_config_is_valid() {
+    minimal_config()
+        .validate()
+        .expect("default config should be valid");
+}
+
+#[test]
+fn test_default_config_is_default() {
+    assert!(minimal_config().is_default());
+}
+
+#[test]
+fn test_full_config_is_not_default() {
+    assert!(!full_config().is_default());
+}
+
+#[test]
+fn test_full_config_is_valid() {
+    full_config()
+        .validate()
+        .expect("full config should be valid");
+}
+
+#[test]
+fn test_invalid_maintenance_mode_fails() {
+    let mut cfg = minimal_config();
+    cfg.session = Some(SessionConfig {
+        dm_scope: "per-account-channel-peer".to_string(),
+        maintenance: SessionMaintenanceConfig {
+            mode: "bad".to_string(),
+            prune_after: "7d".to_string(),
+            max_entries: 500,
+        },
+    });
+    assert!(cfg.validate().is_err());
+}
+
+#[test]
+fn test_invalid_dm_scope_fails() {
+    let mut cfg = minimal_config();
+    cfg.session = Some(SessionConfig {
+        dm_scope: "bad".to_string(),
+        ..Default::default()
+    });
+    assert!(cfg.validate().is_err());
+}
+
+#[test]
+fn test_from_json_str_empty() {
+    let cfg = SystemConfigData::from_json_str("{}").expect("empty JSON should parse");
+    assert!(cfg.is_default());
+}
+
+#[test]
+fn test_from_json_str_partial() {
+    let json = r#"{"wizard":{"lastRunAt":"2026-04-22T03:11:53.234Z","lastRunVersion":"2026.4.15"},"update":{"checkOnStart":false},"commands":{"ownerDisplay":"raw"}}"#;
+    let cfg = SystemConfigData::from_json_str(json).expect("partial JSON should parse");
+    assert!(cfg.wizard.is_some());
+    assert_eq!(
+        cfg.wizard.as_ref().unwrap().last_run_version.as_deref(),
+        Some("2026.4.15")
+    );
+    assert!(!cfg.update.as_ref().unwrap().check_on_start);
+    assert_eq!(
+        cfg.commands.as_ref().unwrap().owner_display.as_deref(),
+        Some("raw")
+    );
+}
+
+#[test]
+fn test_from_json_str_with_hooks() {
+    let json = r#"{"hooks":{"internal":{"enabled":true,"entries":{"boot-md":{"enabled":true}}}}}"#;
+    let cfg = SystemConfigData::from_json_str(json).expect("hooks JSON should parse");
+    let entries = &cfg.hooks.as_ref().unwrap().internal.entries;
+    assert!(entries.contains_key("boot-md"));
+    assert!(!entries.contains_key("nonexistent"));
+}
+
+#[test]
+fn test_from_json_str_with_auth_profiles() {
+    let json = r#"{"auth":{"profiles":{"minimax-portal:default":{"provider":"minimax-portal","mode":"oauth"}}}}"#;
+    let cfg = SystemConfigData::from_json_str(json).expect("auth profiles JSON should parse");
+    let entry = cfg
+        .auth
+        .as_ref()
+        .unwrap()
+        .profiles
+        .get("minimax-portal:default")
+        .unwrap();
+    assert_eq!(entry.provider, "minimax-portal");
+    assert_eq!(entry.mode, "oauth");
+}
+
+#[test]
+fn test_from_json_str_invalid_json() {
+    assert!(SystemConfigData::from_json_str("not json").is_err());
+}
+
+#[test]
+fn test_config_path() {
+    assert_eq!(
+        SystemConfigData::config_path(),
+        "openclaw.json (system section)"
+    );
+}
+
+#[test]
+fn test_version() {
+    assert_eq!(minimal_config().version(), "1.0.0");
+}
+
+#[test]
+fn test_serialize_camel_case() {
+    let json = serde_json::to_string(&full_config()).expect("should serialize");
+    assert!(json.contains('"'));
+    assert!(
+        !json.contains("last_run_at"),
+        "should use camelCase not snake_case"
+    );
+    assert!(json.contains("lastRunAt"));
+}
+
+#[test]
+fn test_serialize_roundtrip() {
+    let original = full_config();
+    let json = serde_json::to_string(&original).expect("should serialize");
+    let parsed: SystemConfigData = serde_json::from_str(&json).expect("should deserialize");
+    assert_eq!(parsed, original);
+}
+
+#[test]
+fn test_from_file_valid() {
+    let temp = tempfile::NamedTempFile::with_suffix(".json").unwrap();
+    std::fs::write(
+        temp.path(),
+        r#"{"wizard":{"lastRunAt":"2026-04-22T03:11:53.234Z"}}"#,
+    )
+    .unwrap();
+    let cfg = SystemConfigData::from_file(temp.path()).expect("should load from file");
+    assert!(cfg.wizard.is_some());
+    assert_eq!(
+        cfg.wizard.as_ref().unwrap().last_run_at.as_deref(),
+        Some("2026-04-22T03:11:53.234Z")
+    );
+}
+
+#[test]
+fn test_from_file_not_found() {
+    assert!(SystemConfigData::from_file("/nonexistent/path/nowhere.json").is_err());
+}
+
+#[test]
+fn test_wizard_config_default() {
+    let w = WizardConfig::default();
+    assert!(
+        w.last_run_at.is_none()
+            && w.last_run_version.is_none()
+            && w.last_run_command.is_none()
+            && w.last_run_mode.is_none()
+    );
+}
+
+#[test]
+fn test_update_config_default() {
+    assert!(UpdateConfig::default().check_on_start);
+}
+
+#[test]
+fn test_meta_config_default() {
+    assert!(
+        MetaConfig::default().last_touched_version.is_none()
+            && MetaConfig::default().last_touched_at.is_none()
+    );
+}
+
+#[test]
+fn test_messages_config_default() {
+    assert!(MessagesConfig::default().ack_reaction_scope.is_none());
+}
+
+#[test]
+fn test_commands_config_default() {
+    let c = CommandsConfig::default();
+    assert!(c.native && c.native_skills && c.restart && c.owner_display.is_none());
+}
+
+#[test]
+fn test_session_maintenance_config_default() {
+    let m = SessionMaintenanceConfig::default();
+    assert_eq!(m.mode, "enforce");
+    assert_eq!(m.prune_after, "7d");
+    assert_eq!(m.max_entries, 500);
+}
+
+#[test]
+fn test_session_config_default() {
+    let s = SessionConfig::default();
+    assert_eq!(s.dm_scope, "per-account-channel-peer");
+    assert_eq!(s.maintenance.mode, "enforce");
+}
+
+#[test]
+fn test_cron_config_default() {
+    assert!(CronConfig::default().enabled);
+}
+
+#[test]
+fn test_hooks_internal_config_default() {
+    let h = HooksInternalConfig::default();
+    assert!(h.enabled && h.entries.is_empty());
+}
+
+#[test]
+fn test_hooks_config_default() {
+    let h = HooksConfig::default();
+    assert!(h.internal.enabled && h.internal.entries.is_empty());
+}
+
+#[test]
+fn test_browser_config_default() {
+    let b = BrowserConfig::default();
+    assert!(b.executable_path.is_none() && b.headless && b.default_profile.is_none());
+}
+
+#[test]
+fn test_auth_profile_entry_config_default() {
+    let a = AuthProfileEntryConfig::default();
+    assert_eq!(a.provider, "");
+    assert_eq!(a.mode, "");
+}
+
+#[test]
+fn test_auth_profiles_config_default() {
+    assert!(AuthProfilesConfig::default().profiles.is_empty());
+}
+
+#[test]
+fn test_is_default_true_when_all_sub_structs_are_default() {
+    let cfg = SystemConfigData {
+        wizard: None,
+        update: Some(UpdateConfig {
+            check_on_start: true,
+        }),
+        meta: None,
+        messages: None,
+        commands: Some(CommandsConfig::default()),
+        session: Some(SessionConfig::default()),
+        cron: Some(CronConfig::default()),
+        hooks: Some(HooksConfig::default()),
+        browser: Some(BrowserConfig::default()),
+        auth: None,
+    };
+    assert!(cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_update_check_on_start_false() {
+    let cfg = SystemConfigData {
+        update: Some(UpdateConfig {
+            check_on_start: false,
+        }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_commands_native_false() {
+    let cfg = SystemConfigData {
+        commands: Some(CommandsConfig {
+            native: false,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_commands_owner_display_set() {
+    let cfg = SystemConfigData {
+        commands: Some(CommandsConfig {
+            owner_display: Some("raw".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_browser_headless_false() {
+    let cfg = SystemConfigData {
+        browser: Some(BrowserConfig {
+            headless: false,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_hooks_internal_disabled() {
+    let cfg = SystemConfigData {
+        hooks: Some(HooksConfig {
+            internal: HooksInternalConfig {
+                enabled: false,
+                ..Default::default()
+            },
+        }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_is_default_false_when_cron_disabled() {
+    let cfg = SystemConfigData {
+        cron: Some(CronConfig { enabled: false }),
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}
+
+#[test]
+fn test_validate_maintenance_mode_warn_valid() {
+    let cfg = SystemConfigData {
+        session: Some(SessionConfig {
+            dm_scope: "per-account-channel-peer".to_string(),
+            maintenance: SessionMaintenanceConfig {
+                mode: "warn".to_string(),
+                prune_after: "7d".to_string(),
+                max_entries: 500,
+            },
+        }),
+        ..Default::default()
+    };
+    cfg.validate().expect("mode=warn should be valid");
+}
+
+#[test]
+fn test_validate_maintenance_mode_off_valid() {
+    let cfg = SystemConfigData {
+        session: Some(SessionConfig {
+            dm_scope: "per-account-channel-peer".to_string(),
+            maintenance: SessionMaintenanceConfig {
+                mode: "off".to_string(),
+                prune_after: "7d".to_string(),
+                max_entries: 500,
+            },
+        }),
+        ..Default::default()
+    };
+    cfg.validate().expect("mode=off should be valid");
+}
+
+#[test]
+fn test_validate_dm_scope_per_channel_peer_valid() {
+    let cfg = SystemConfigData {
+        session: Some(SessionConfig {
+            dm_scope: "per-channel-peer".to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    cfg.validate()
+        .expect("dmScope=per-channel-peer should be valid");
+}
+
+#[test]
+fn test_validate_dm_scope_per_peer_valid() {
+    let cfg = SystemConfigData {
+        session: Some(SessionConfig {
+            dm_scope: "per-peer".to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    cfg.validate().expect("dmScope=per-peer should be valid");
+}
+
+#[test]
+fn test_validate_dm_scope_main_valid() {
+    let cfg = SystemConfigData {
+        session: Some(SessionConfig {
+            dm_scope: "main".to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    cfg.validate().expect("dmScope=main should be valid");
+}
+
+#[test]
+fn test_validate_empty_session_valid() {
+    SystemConfigData::default()
+        .validate()
+        .expect("no session config should be valid");
+}


### PR DESCRIPTION
- Add SystemConfigData struct mapping openclaw.json system section fields
- Implement ConfigProvider trait with validation and is_default
- Add comprehensive unit tests covering serialization, defaults, and validation
- Update SPEC.md with SystemConfigData documentation

Source: issue #202
Type: feat