### PR TITLE
test(llm): use mockito for test_chat_network_error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +424,7 @@ dependencies = [
  "flume",
  "hex",
  "libc",
+ "mockito",
  "notify",
  "notify-debouncer-mini",
  "proptest",
@@ -439,6 +450,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -839,6 +859,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +983,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1371,6 +1411,31 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -2254,6 +2319,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ dirs = "5"
 proptest = "=1.4"
 tempfile = "3.10"
 serial_test = "3.4"
+mockito = "1.2"
 # Coverage reporting
 cargo-llvm-cov = "0.6"
 

--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -34,6 +34,7 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 
 - **`LLMRegistry::new`** — 创建空注册中心
 - **`LLMProvider::new`** — 构造 Provider 实例（MimMax、OpenAI、Anthropic、Stub 各有）
+- **`OpenAIProvider::new_with_base_url`** — 以自定义 base URL 构造 OpenAI Provider 实例（用于测试环境注入 mock server）
 - **`FakeProvider::new`** — 构造无场景的 `FakeProvider`（首次调用必然 panic，用于严格测试）
 - **`FakeProvider::builder`** — 构造 `Builder`，开始编排 `FakeProvider` 场景
 - **`FallbackClient::new`** — 同步构造（加载持久化 cooldown）

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -57,6 +57,13 @@ impl OpenAIProvider {
         }
     }
 
+    pub fn new_with_base_url(api_key: String, base_url: &str) -> Self {
+        Self {
+            api_key,
+            base_url: base_url.to_string(),
+        }
+    }
+
     fn chat_url(&self) -> String {
         format!("{}/chat/completions", self.base_url)
     }
@@ -136,6 +143,33 @@ impl LLMProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::Server;
+
+    #[tokio::test]
+    async fn test_chat_network_error() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/chat/completions")
+            .with_status(401)
+            .with_body(r#"{"error": {"message": "bad API key"}}"#)
+            .create_async()
+            .await;
+
+        let provider = OpenAIProvider::new_with_base_url("bad-key".to_string(), &server.url());
+        let request = ChatRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+        };
+        let result = provider.chat(request).await;
+        mock.assert_async().await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            LLMError::AuthFailed(_) => {}
+            _ => panic!("Expected AuthFailed"),
+        }
+    }
 
     #[test]
     fn test_openai_provider_new() {
@@ -240,19 +274,5 @@ mod tests {
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("max_tokens"));
-    }
-
-    #[tokio::test]
-    async fn test_chat_network_error() {
-        let provider = OpenAIProvider::new("bad-key".to_string());
-        let request = ChatRequest {
-            model: "gpt-4".to_string(),
-            messages: vec![],
-            temperature: 0.0,
-            max_tokens: None,
-        };
-        let result = provider.chat(request).await;
-        // Will fail with auth error from OpenAI (or network error in sandbox)
-        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Replace real HTTP call with mockito mock to eliminate network dependency in test_chat_network_error.

Source: issue #366
Type: test