### PR TITLE
feat(config): add auto-migration from openclaw.json to config/ directory

### DIFF
--- a/src/config/SPEC.md
+++ b/src/config/SPEC.md
@@ -8,10 +8,11 @@
 
 配置热加载系统，管理 JSON 配置文件的读取、验证、持久化和热重载。
 
-包含六个子模块：
+包含七个子模块：
 - **agents**：agents.json 和 per-agent 配置目录的 ConfigProvider 实现
 - **backup**：写前备份 + 滚动清理
 - **manager**：ConfigManager 统一配置管理入口，提供原子写入、备份集成和配置访问
+- **migration**：openclaw.json → config/ 目录的引导迁移
 - **providers**：ConfigProvider trait 和 ConfigError
 - **reload**：基于 notify 的文件监控 + 自动重载
 - **session**：per-agent per-role session 配置（idle/purge），供 ArchiveSweeper 和 Daemon 使用
@@ -47,6 +48,8 @@
 | `ConfigReloadEvent` | 热重载事件通知（Reloaded/Rollback/ValidationFailed） |
 | `ReloadResult` | 重载操作结果（Success/ValidationFailed/RolledBack） |
 | `WatcherHandle` | 文件监控句柄，drop 时停止监控 |
+| `migrate_if_needed` | 检测并执行 openclaw.json → config/ 目录的引导迁移 |
+| `ConfigMigrationError` | 迁移错误枚举（ReadError / ParseError / WriteError / MalformedJson / NotFound） |
 
 > 注：BackupManager、ConfigReloadManager<P>、ConfigReloadEvent、ReloadResult、WatcherHandle 存在但 mod.rs 未导出。SafeBackupManager 已 re-exported。
 

--- a/src/config/migration.rs
+++ b/src/config/migration.rs
@@ -1,0 +1,239 @@
+//! Configuration migration from legacy `openclaw.json` to the new `config/` directory layout.
+//!
+//! This module handles the one-time migration of a legacy `openclaw.json` file into the
+//! new structured `config/` directory, splitting it into domain-specific JSON files.
+
+use std::fs;
+pub use std::path::{Path, PathBuf};
+
+pub use serde_json::Value;
+
+/// Errors that can occur during configuration migration.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigMigrationError {
+    #[error("failed to read openclaw.json: {0}")]
+    ReadError(std::io::Error),
+
+    #[error("failed to parse openclaw.json: {0}")]
+    ParseError(#[from] serde_json::Error),
+
+    #[error("failed to write config file: {0}")]
+    WriteError(std::io::Error),
+
+    #[error("migration aborted: openclaw.json is malformed")]
+    MalformedJson,
+
+    #[error("openclaw.json does not exist at {0}")]
+    NotFound(String),
+}
+
+/// Check if migration is needed and perform it if so.
+///
+/// Migration is triggered when ALL of the following conditions are met:
+/// - `openclaw_json_path` exists (openclaw.json is present)
+/// - `config_dir` does NOT exist (new config layout not yet present)
+/// - `config_dir / "openclaw_migrated"` marker file does NOT exist
+///
+/// On success:
+/// - `config/` directory is created with split JSON files
+/// - `openclaw.json` is renamed to `openclaw.json.bak`
+/// - `config/.backups/` directory is created
+/// - `config/openclaw_migrated` marker file is created
+///
+/// # Arguments
+/// * `openclaw_json_path` — absolute path to the legacy openclaw.json
+/// * `config_dir` — absolute path to the config directory (e.g. `~/.closeclaw/config`)
+pub fn migrate_if_needed(
+    openclaw_json_path: impl AsRef<Path>,
+    config_dir: impl AsRef<Path>,
+) -> Result<bool, ConfigMigrationError> {
+    let openclaw_path = openclaw_json_path.as_ref();
+    let cfg_dir = config_dir.as_ref();
+
+    // Condition 1: openclaw.json must exist
+    if !openclaw_path.exists() {
+        return Ok(false);
+    }
+
+    // Condition 2: config/ must not exist
+    if cfg_dir.exists() {
+        return Ok(false);
+    }
+
+    // Condition 3: marker file must not exist
+    let marker_path = cfg_dir.join("openclaw_migrated");
+    if marker_path.exists() {
+        return Ok(false);
+    }
+
+    // Perform migration
+    migrate(openclaw_path, cfg_dir)?;
+    Ok(true)
+}
+
+/// Perform the actual migration from openclaw.json to config/ directory.
+fn migrate(openclaw_path: &Path, config_dir: &Path) -> Result<(), ConfigMigrationError> {
+    // Read and parse openclaw.json
+    let content = fs::read_to_string(openclaw_path).map_err(ConfigMigrationError::ReadError)?;
+
+    let json: Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Err(ConfigMigrationError::MalformedJson),
+    };
+
+    // Create config/ directory
+    fs::create_dir_all(config_dir).map_err(ConfigMigrationError::WriteError)?;
+
+    // Create config/.backups/ directory
+    let backups_dir = config_dir.join(".backups");
+    fs::create_dir_all(&backups_dir).map_err(ConfigMigrationError::WriteError)?;
+
+    // Write domain-specific config files
+    write_if_present(config_dir, "models.json", json.get("models"))?;
+    write_channels(config_dir, &json)?;
+    write_if_present(config_dir, "gateway.json", json.get("gateway"))?;
+    write_if_present(config_dir, "plugins.json", json.get("plugins"))?;
+    write_system(config_dir, &json)?;
+    write_credentials(config_dir, &json)?;
+
+    // Rename openclaw.json → openclaw.json.bak
+    let backup_path = PathBuf::from(format!("{}.bak", openclaw_path.to_string_lossy()));
+    fs::rename(openclaw_path, &backup_path).map_err(ConfigMigrationError::WriteError)?;
+
+    // Create marker file
+    let marker_path = config_dir.join("openclaw_migrated");
+    fs::write(&marker_path, "").map_err(ConfigMigrationError::WriteError)?;
+
+    Ok(())
+}
+
+/// Write a JSON value to `config_dir/filename`, creating an empty `{}` if the value is None.
+fn write_if_present(
+    config_dir: &Path,
+    filename: &str,
+    value: Option<&Value>,
+) -> Result<(), ConfigMigrationError> {
+    let content = match value {
+        Some(v) => serde_json::to_string_pretty(v),
+        None => serde_json::to_string_pretty(&Value::Object(Default::default())),
+    };
+    let content = content.map_err(ConfigMigrationError::ParseError)?;
+    let path = config_dir.join(filename);
+    crate::config::manager::write_atomically(&path, content.as_bytes())
+        .map_err(ConfigMigrationError::WriteError)?;
+    Ok(())
+}
+
+/// Write channels.json by merging `channels` and `bindings` from the source JSON.
+fn write_channels(config_dir: &Path, json: &Value) -> Result<(), ConfigMigrationError> {
+    let default_channels = Value::Object(Default::default());
+    let default_bindings = Value::Array(Default::default());
+    let channels = json.get("channels").unwrap_or(&default_channels);
+    let bindings = json.get("bindings").unwrap_or(&default_bindings);
+    let merged = serde_json::json!({
+        "channels": channels,
+        "bindings": bindings,
+    });
+    let content =
+        serde_json::to_string_pretty(&merged).map_err(ConfigMigrationError::ParseError)?;
+    let path = config_dir.join("channels.json");
+    crate::config::manager::write_atomically(&path, content.as_bytes())
+        .map_err(ConfigMigrationError::WriteError)?;
+    Ok(())
+}
+
+/// Write system.json by merging wizard, update, meta, messages, commands,
+/// session, cron, hooks, browser, and auth (profiles only, no apiKey).
+fn write_system(config_dir: &Path, json: &Value) -> Result<(), ConfigMigrationError> {
+    let mut system = serde_json::Map::new();
+
+    if let Some(v) = json.get("wizard") {
+        system.insert("wizard".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("update") {
+        system.insert("update".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("meta") {
+        system.insert("meta".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("messages") {
+        system.insert("messages".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("commands") {
+        system.insert("commands".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("session") {
+        system.insert("session".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("cron") {
+        system.insert("cron".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("hooks") {
+        system.insert("hooks".to_string(), v.clone());
+    }
+    if let Some(v) = json.get("browser") {
+        system.insert("browser".to_string(), v.clone());
+    }
+    if let Some(auth) = json.get("auth") {
+        // Only carry forward profiles metadata, not apiKey
+        let mut auth_map = serde_json::Map::new();
+        if let Some(profiles) = auth.get("profiles") {
+            auth_map.insert("profiles".to_string(), profiles.clone());
+        }
+        system.insert("auth".to_string(), Value::Object(auth_map));
+    }
+
+    let value = Value::Object(system);
+    let content = serde_json::to_string_pretty(&value).map_err(ConfigMigrationError::ParseError)?;
+    let path = config_dir.join("system.json");
+    crate::config::manager::write_atomically(&path, content.as_bytes())
+        .map_err(ConfigMigrationError::WriteError)?;
+    Ok(())
+}
+
+/// Write per-provider credential files under `config/credentials/{provider}.json`
+/// from `auth.profiles`.
+fn write_credentials(config_dir: &Path, json: &Value) -> Result<(), ConfigMigrationError> {
+    let auth = match json.get("auth") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let profiles = match auth.get("profiles") {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+    let profiles_map = match profiles {
+        Value::Object(m) => m,
+        _ => return Ok(()),
+    };
+
+    let creds_dir = config_dir.join("credentials");
+    fs::create_dir_all(&creds_dir).map_err(ConfigMigrationError::WriteError)?;
+
+    for (provider, profile) in profiles_map {
+        let mut cred_obj = serde_json::Map::new();
+        cred_obj.insert("provider".to_string(), Value::String(provider.clone()));
+
+        // Copy all credential fields: apiKey, appId, appSecret, botName, etc.
+        if let Value::Object(profile_map) = profile {
+            for (k, v) in profile_map {
+                if k == "apiKey" || k == "appId" || k == "appSecret" || k == "botName" {
+                    cred_obj.insert(k.clone(), v.clone());
+                }
+            }
+        }
+
+        let content = serde_json::to_string_pretty(&Value::Object(cred_obj))
+            .map_err(ConfigMigrationError::ParseError)?;
+        let filename = format!("{}.json", provider);
+        let path = creds_dir.join(filename);
+        crate::config::manager::write_atomically(&path, content.as_bytes())
+            .map_err(ConfigMigrationError::WriteError)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "migration_tests.rs"]
+mod tests;

--- a/src/config/migration_tests.rs
+++ b/src/config/migration_tests.rs
@@ -1,0 +1,269 @@
+#[cfg(test)]
+mod tests {
+    use crate::config::migration::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    fn temp_dir() -> TempDir {
+        TempDir::new().unwrap()
+    }
+
+    fn openclaw_json(tmp: &TempDir) -> PathBuf {
+        tmp.path().join("openclaw.json")
+    }
+
+    fn config_dir(tmp: &TempDir) -> PathBuf {
+        tmp.path().join("config")
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: conditions
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_no_migration_when_openclaw_missing() {
+        let tmp = temp_dir();
+        // openclaw.json does not exist
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(!result);
+        assert!(!config_dir(&tmp).exists());
+    }
+
+    #[test]
+    fn test_no_migration_when_config_exists() {
+        let tmp = temp_dir();
+        // Create openclaw.json
+        fs::write(openclaw_json(&tmp), "{}").unwrap();
+        // Create config/ already
+        fs::create_dir(config_dir(&tmp)).unwrap();
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_no_migration_when_marker_exists() {
+        let tmp = temp_dir();
+        fs::write(openclaw_json(&tmp), "{}").unwrap();
+        let cfg = config_dir(&tmp);
+        fs::create_dir(&cfg).unwrap();
+        fs::write(cfg.join("openclaw_migrated"), "").unwrap();
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_no_migration_when_openclaw_json_missing() {
+        let tmp = temp_dir();
+        let result = migrate_if_needed("/nonexistent/openclaw.json", config_dir(&tmp)).unwrap();
+        assert!(!result);
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: malformed JSON
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_aborts_on_malformed_json() {
+        let tmp = temp_dir();
+        fs::write(openclaw_json(&tmp), "not valid json {{{").unwrap();
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp));
+        assert!(matches!(result, Err(ConfigMigrationError::MalformedJson)));
+        // config/ must NOT be created
+        assert!(!config_dir(&tmp).exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: full migration
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_full_migration() {
+        let tmp = temp_dir();
+        let openclaw = r#"{
+            "models": {"mode":"merge","providers":{"openai":{"apiKey":"sk-123"}}},
+            "channels": {"feishu":{"enabled":true}},
+            "bindings": [{"agentId":"a1","match":{"channel":"feishu"}}],
+            "gateway": {"port":3000},
+            "plugins": {"enabled":true},
+            "wizard": {"lastRunAt":"2024-01-01"},
+            "update": {"checkOnStart":false},
+            "auth": {
+                "profiles": {
+                    "openai": {"apiKey":"sk-secret"},
+                    "feishu": {"appId":"cli_abc","appSecret":"sec123"}
+                }
+            }
+        }"#;
+        fs::write(openclaw_json(&tmp), openclaw).unwrap();
+
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(result);
+
+        let cfg = config_dir(&tmp);
+
+        // models.json
+        let models: Value =
+            serde_json::from_slice(&fs::read(cfg.join("models.json")).unwrap()).unwrap();
+        assert_eq!(models["mode"], "merge");
+
+        // channels.json
+        let channels: Value =
+            serde_json::from_slice(&fs::read(cfg.join("channels.json")).unwrap()).unwrap();
+        assert_eq!(channels["channels"]["feishu"]["enabled"], true);
+        assert_eq!(channels["bindings"][0]["agentId"], "a1");
+
+        // gateway.json
+        let gateway: Value =
+            serde_json::from_slice(&fs::read(cfg.join("gateway.json")).unwrap()).unwrap();
+        assert_eq!(gateway["port"], 3000);
+
+        // plugins.json
+        let plugins: Value =
+            serde_json::from_slice(&fs::read(cfg.join("plugins.json")).unwrap()).unwrap();
+        assert_eq!(plugins["enabled"], true);
+
+        // system.json
+        let system: Value =
+            serde_json::from_slice(&fs::read(cfg.join("system.json")).unwrap()).unwrap();
+        assert_eq!(system["wizard"]["lastRunAt"], "2024-01-01");
+        assert_eq!(system["update"]["checkOnStart"], false);
+        // auth.profiles present, no apiKey at top level of auth
+        assert!(system["auth"]["profiles"].is_object());
+        assert!(system["auth"].get("apiKey").is_none());
+
+        // credentials/
+        let openai_creds: Value =
+            serde_json::from_slice(&fs::read(cfg.join("credentials/openai.json")).unwrap())
+                .unwrap();
+        assert_eq!(openai_creds["provider"], "openai");
+        assert_eq!(openai_creds["apiKey"], "sk-secret");
+
+        let feishu_creds: Value =
+            serde_json::from_slice(&fs::read(cfg.join("credentials/feishu.json")).unwrap())
+                .unwrap();
+        assert_eq!(feishu_creds["provider"], "feishu");
+        assert_eq!(feishu_creds["appId"], "cli_abc");
+        assert_eq!(feishu_creds["appSecret"], "sec123");
+
+        // openclaw.json.bak exists
+        assert!(openclaw_json(&tmp).with_extension("json.bak").exists());
+        // openclaw.json is gone
+        assert!(!openclaw_json(&tmp).exists());
+        // marker exists
+        assert!(cfg.join("openclaw_migrated").exists());
+        // .backups dir exists
+        assert!(cfg.join(".backups").is_dir());
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: partial fields missing
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_with_missing_fields() {
+        let tmp = temp_dir();
+        // Only some fields present
+        let openclaw = r#"{
+            "gateway": {"port":4000}
+        }"#;
+        fs::write(openclaw_json(&tmp), openclaw).unwrap();
+
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(result);
+
+        let cfg = config_dir(&tmp);
+
+        // Missing fields → empty objects
+        let models: Value =
+            serde_json::from_slice(&fs::read(cfg.join("models.json")).unwrap()).unwrap();
+        assert_eq!(models, serde_json::json!({}));
+
+        let channels: Value =
+            serde_json::from_slice(&fs::read(cfg.join("channels.json")).unwrap()).unwrap();
+        assert_eq!(channels["channels"], serde_json::json!({}));
+        assert_eq!(channels["bindings"], serde_json::json!([]));
+
+        let gateway: Value =
+            serde_json::from_slice(&fs::read(cfg.join("gateway.json")).unwrap()).unwrap();
+        assert_eq!(gateway["port"], 4000);
+
+        let plugins: Value =
+            serde_json::from_slice(&fs::read(cfg.join("plugins.json")).unwrap()).unwrap();
+        assert_eq!(plugins, serde_json::json!({}));
+
+        let system: Value =
+            serde_json::from_slice(&fs::read(cfg.join("system.json")).unwrap()).unwrap();
+        assert_eq!(system, serde_json::json!({}));
+
+        // No credentials dir
+        assert!(!cfg.join("credentials").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: no auth.profiles
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_no_auth_profiles() {
+        let tmp = temp_dir();
+        let openclaw = r#"{
+            "gateway": {"port":5000},
+            "auth": {"someOtherField": "value"}
+        }"#;
+        fs::write(openclaw_json(&tmp), openclaw).unwrap();
+
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(result);
+
+        let cfg = config_dir(&tmp);
+        // No credentials directory should be created
+        assert!(!cfg.join("credentials").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // migrate_if_needed: multiple credential providers
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_migration_multiple_credential_providers() {
+        let tmp = temp_dir();
+        let openclaw = r#"{
+            "auth": {
+                "profiles": {
+                    "provider_a": {"apiKey": "key-a"},
+                    "provider_b": {"appId": "id-b", "appSecret": "secret-b"},
+                    "provider_c": {"apiKey": "key-c", "extra": "ignored"}
+                }
+            }
+        }"#;
+        fs::write(openclaw_json(&tmp), openclaw).unwrap();
+
+        let result = migrate_if_needed(openclaw_json(&tmp), config_dir(&tmp)).unwrap();
+        assert!(result);
+
+        let cfg = config_dir(&tmp);
+        let creds_dir = cfg.join("credentials");
+        assert!(creds_dir.is_dir());
+
+        let a: Value =
+            serde_json::from_slice(&fs::read(creds_dir.join("provider_a.json")).unwrap()).unwrap();
+        assert_eq!(a["provider"], "provider_a");
+        assert_eq!(a["apiKey"], "key-a");
+
+        let b: Value =
+            serde_json::from_slice(&fs::read(creds_dir.join("provider_b.json")).unwrap()).unwrap();
+        assert_eq!(b["provider"], "provider_b");
+        assert_eq!(b["appId"], "id-b");
+        assert_eq!(b["appSecret"], "secret-b");
+
+        // extra field should NOT be in credentials
+        let c: Value =
+            serde_json::from_slice(&fs::read(creds_dir.join("provider_c.json")).unwrap()).unwrap();
+        assert_eq!(c["apiKey"], "key-c");
+        assert!(c.get("extra").is_none());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@
 pub mod agents;
 pub mod backup;
 pub mod manager;
+pub mod migration;
 pub mod providers;
 pub mod reload;
 pub mod session;
@@ -16,6 +17,7 @@ pub use manager::{
 };
 
 pub use agents::{AgentDirectoryEntry, AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
+pub use migration::{migrate_if_needed, ConfigMigrationError};
 pub use providers::{
     ChannelsConfigData, ConfigError, ConfigProvider, GatewayConfigData, ModelsConfigData,
     SystemConfigData,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -8,6 +8,7 @@ pub mod shutdown;
 use crate::audit::{AuditEventBuilder, AuditEventType, AuditLogger, AuditResult};
 use crate::chat::ChatServer;
 use crate::config::agents::AgentsConfigProvider;
+use crate::config::migration::migrate_if_needed;
 use crate::config::providers::ConfigProvider;
 use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig};
@@ -67,6 +68,22 @@ impl Daemon {
         info!("Starting CloseClaw daemon with config_dir={}", config_dir);
 
         Self::load_env(config_dir);
+
+        // Migrate legacy openclaw.json to config/ directory if needed
+        let openclaw_json_path = Path::new(config_dir).join("openclaw.json");
+        info!("Checking for legacy openclaw.json migration...");
+        match migrate_if_needed(&openclaw_json_path, config_dir) {
+            Ok(true) => {
+                info!("Legacy openclaw.json migration completed successfully");
+            }
+            Ok(false) => {
+                info!("No migration needed — config directory is up to date");
+            }
+            Err(e) => {
+                // Migration errors are non-fatal; log and continue
+                tracing::warn!(error = %e, "openclaw.json migration failed — continuing with existing config");
+            }
+        }
 
         // Initialize SQLite storage — fail hard if this fails (no MemoryStorage fallback)
         let data_dir = Path::new(config_dir);


### PR DESCRIPTION
- Add migration.rs module with migrate_if_needed() function and ConfigMigrationError
- Integrate migration call in Daemon::start() after load_env()
- Split openclaw.json into models.json, channels.json, gateway.json, plugins.json, system.json
- Split auth.profiles into credentials/{provider}.json files
- Create .bak backup and openclaw_migrated marker file
- Add comprehensive unit tests for all migration branches

Source: issue #209
Type: feat
