### PR TITLE
test(permission): add unit tests for sandbox module

### DIFF
--- a/src/permission/sandbox/ipc.rs
+++ b/src/permission/sandbox/ipc.rs
@@ -244,4 +244,84 @@ mod tests {
             serde_json::to_string(&deserialized).unwrap()
         );
     }
+
+    #[test]
+    fn test_sandbox_request_evaluate_serialization() {
+        let req = SandboxRequest::Evaluate {
+            request: crate::permission::PermissionRequest::Bare(
+                crate::permission::PermissionRequestBody::FileOp {
+                    agent: "test-agent".to_string(),
+                    path: "/tmp/test.txt".to_string(),
+                    op: "read".to_string(),
+                },
+            ),
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: SandboxRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_sandbox_request_reload_rules_serialization() {
+        let rules = crate::permission::engine::RuleSet {
+            version: "1.0".to_string(),
+            rules: vec![],
+            defaults: Default::default(),
+            template_includes: vec![],
+            agent_creators: Default::default(),
+        };
+        let req = SandboxRequest::ReloadRules { rules };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: SandboxRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_sandbox_response_permission_allowed_serialization() {
+        let resp =
+            SandboxResponse::PermissionResponse(crate::permission::PermissionResponse::Allowed {
+                token: "token123".to_string(),
+            });
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: SandboxResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_sandbox_response_rules_reloaded_serialization() {
+        let resp = SandboxResponse::RulesReloaded;
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: SandboxResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ipc_channel_new() {
+        let channel = IpcChannel::new("/tmp/test-socket.sock");
+        assert_eq!(
+            channel.path,
+            std::path::PathBuf::from("/tmp/test-socket.sock")
+        );
+    }
+
+    #[test]
+    fn test_ipc_channel_clean_up_nonexistent_path() {
+        // clean_up on a non-existent path should not panic (idempotent)
+        let channel = IpcChannel::new("/tmp/nonexistent-socket-12345.sock");
+        channel.clean_up(); // should not panic
+                            // Running it twice is also fine (idempotent)
+        channel.clean_up();
+    }
 }

--- a/src/permission/sandbox/mod.rs
+++ b/src/permission/sandbox/mod.rs
@@ -293,41 +293,4 @@ pub async fn run_engine_subprocess(ipc_path: PathBuf, rules: RuleSet) -> anyhow:
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_sandbox_state_default() {
-        let state = SandboxState::default();
-        assert_eq!(state, SandboxState::Unstarted);
-    }
-
-    #[test]
-    fn test_sandbox_error_display() {
-        let ipc_err = SandboxError::IpcTimeout;
-        let ipc_msg = ipc_err.to_string();
-        assert!(
-            ipc_msg.contains("timeout") || ipc_msg.contains("IPC"),
-            "IpcTimeout display should contain 'timeout' or 'IPC': {}",
-            ipc_msg
-        );
-
-        let process_err = SandboxError::ProcessError("engine died".to_string());
-        let process_msg = process_err.to_string();
-        assert!(
-            process_msg.contains("engine died"),
-            "ProcessError display should contain the message: {}",
-            process_msg
-        );
-
-        let invalid_state = SandboxError::InvalidState {
-            state: SandboxState::Running,
-        };
-        let invalid_msg = invalid_state.to_string();
-        assert!(
-            invalid_msg.contains("Running"),
-            "InvalidState display should contain the state: {}",
-            invalid_msg
-        );
-    }
-}
+mod tests;

--- a/src/permission/sandbox/security.rs
+++ b/src/permission/sandbox/security.rs
@@ -83,6 +83,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_security_policy_default_is_empty() {
+        let policy = SecurityPolicy::default();
+        assert!(!policy.seccomp, "default seccomp should be false");
+        assert!(!policy.landlock, "default landlock should be false");
+        assert!(
+            policy.allowed_fs_paths.is_empty(),
+            "default allowed_fs_paths should be empty"
+        );
+        assert!(
+            policy.blocked_syscalls.is_empty(),
+            "default blocked_syscalls should be empty"
+        );
+    }
+
+    #[test]
+    fn test_security_policy_apply_returns_ok() {
+        let policy = SecurityPolicy::default();
+        // apply() should return Ok on any platform (no-op on non-Linux, stub on Linux)
+        let result = policy.apply();
+        assert!(result.is_ok(), "apply() should succeed, got: {:?}", result);
+    }
+
+    #[test]
+    fn test_security_policy_custom() {
+        let policy = SecurityPolicy {
+            seccomp: false,
+            landlock: false,
+            allowed_fs_paths: vec![std::path::PathBuf::from("/tmp/custom")],
+            blocked_syscalls: vec!["read".to_string(), "write".to_string()],
+        };
+        assert!(!policy.seccomp);
+        assert!(!policy.landlock);
+        assert_eq!(policy.allowed_fs_paths.len(), 1);
+        assert_eq!(policy.blocked_syscalls.len(), 2);
+        let result = policy.apply();
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_default_restrictive_linux() {
         let policy = SecurityPolicy::default_restrictive();
         if cfg!(target_os = "linux") {

--- a/src/permission/sandbox/tests.rs
+++ b/src/permission/sandbox/tests.rs
@@ -1,0 +1,208 @@
+//! Sandbox module tests
+
+use super::*;
+use crate::permission::{Defaults, PermissionRequest, PermissionRequestBody, RuleSet};
+
+#[test]
+fn test_sandbox_state_default() {
+    let state = SandboxState::default();
+    assert_eq!(state, SandboxState::Unstarted);
+}
+
+#[test]
+fn test_sandbox_error_display() {
+    let ipc_err = SandboxError::IpcTimeout;
+    let ipc_msg = ipc_err.to_string();
+    assert!(
+        ipc_msg.contains("timeout") || ipc_msg.contains("IPC"),
+        "IpcTimeout display should contain 'timeout' or 'IPC': {}",
+        ipc_msg
+    );
+
+    let process_err = SandboxError::ProcessError("engine died".to_string());
+    let process_msg = process_err.to_string();
+    assert!(
+        process_msg.contains("engine died"),
+        "ProcessError display should contain the message: {}",
+        process_msg
+    );
+
+    let invalid_state = SandboxError::InvalidState {
+        state: SandboxState::Running,
+    };
+    let invalid_msg = invalid_state.to_string();
+    assert!(
+        invalid_msg.contains("Running"),
+        "InvalidState display should contain the state: {}",
+        invalid_msg
+    );
+}
+
+// -------------------------------------------------------------------------
+// Sandbox construction & builder
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_sandbox_new_state_is_unstarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let sandbox = Sandbox::new(&path);
+    assert_eq!(sandbox.state().await, SandboxState::Unstarted);
+}
+
+#[tokio::test]
+async fn test_sandbox_with_policy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let custom_policy = SecurityPolicy::default();
+    let _sandbox = Sandbox::new(&path).with_policy(custom_policy);
+    // Policy is stored in the sandbox; we verify construction completes
+    // without panic and state remains accessible
+}
+
+// -------------------------------------------------------------------------
+// State accessors
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_sandbox_state_unstarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let sandbox = Sandbox::new(&path);
+    assert_eq!(sandbox.state().await, SandboxState::Unstarted);
+}
+
+// -------------------------------------------------------------------------
+// Error paths — InvalidState on non-Running states
+// -------------------------------------------------------------------------
+
+fn dummy_request() -> PermissionRequest {
+    PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "test-agent".to_string(),
+        path: "/tmp/test".to_string(),
+        op: "read".to_string(),
+    })
+}
+
+fn dummy_rules() -> RuleSet {
+    RuleSet {
+        version: "1.0".to_string(),
+        rules: vec![],
+        defaults: Defaults::default(),
+        template_includes: vec![],
+        agent_creators: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn test_sandbox_evaluate_invalid_state_unstarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let sandbox = Sandbox::new(&path);
+    let result = sandbox.evaluate(dummy_request()).await;
+    let err = result.unwrap_err();
+    match err {
+        SandboxError::InvalidState { state } => {
+            assert_eq!(state, SandboxState::Unstarted);
+        }
+        other => panic!("expected InvalidState, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_sandbox_reload_rules_invalid_state_unstarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let sandbox = Sandbox::new(&path);
+    let result = sandbox.reload_rules(dummy_rules()).await;
+    let err = result.unwrap_err();
+    match err {
+        SandboxError::InvalidState { state } => {
+            assert_eq!(state, SandboxState::Unstarted);
+        }
+        other => panic!("expected InvalidState, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_sandbox_shutdown_unstarted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let mut sandbox = Sandbox::new(&path);
+    sandbox.shutdown().await;
+    assert_eq!(sandbox.state().await, SandboxState::Shutdown);
+}
+
+#[tokio::test]
+async fn test_sandbox_evaluate_invalid_state_shutdown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let mut sandbox = Sandbox::new(&path);
+    sandbox.shutdown().await;
+    assert_eq!(sandbox.state().await, SandboxState::Shutdown);
+    let result = sandbox.evaluate(dummy_request()).await;
+    let err = result.unwrap_err();
+    match err {
+        SandboxError::InvalidState { state } => {
+            assert_eq!(state, SandboxState::Shutdown);
+        }
+        other => panic!("expected InvalidState, got {:?}", other),
+    }
+}
+
+// -------------------------------------------------------------------------
+// SandboxError From<std::io::Error>
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_sandbox_error_from_io_error() {
+    use std::io;
+    let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
+    let sandbox_err: SandboxError = SandboxError::from(io_err);
+    match sandbox_err {
+        SandboxError::Ipc(_) => {}
+        other => panic!("expected Ipc variant, got {:?}", other),
+    }
+}
+
+// -------------------------------------------------------------------------
+// Drop
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_sandbox_drop_unstarted_no_panic() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("sandbox.sock");
+    let _sandbox = Sandbox::new(&path);
+    // drop should not panic
+}
+
+// -------------------------------------------------------------------------
+// SandboxState variants
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_sandbox_state_crashed_debug() {
+    let state = SandboxState::Crashed { exit_code: Some(1) };
+    let debug = format!("{:?}", state);
+    assert!(debug.contains("Crashed"));
+    assert!(debug.contains("1"));
+}
+
+#[test]
+fn test_sandbox_state_crashed_clone() {
+    let state = SandboxState::Crashed {
+        exit_code: Some(42),
+    };
+    let cloned = state.clone();
+    assert_eq!(state, cloned);
+}
+
+#[test]
+fn test_sandbox_state_crashed_partial_eq() {
+    let a = SandboxState::Crashed { exit_code: Some(1) };
+    let b = SandboxState::Crashed { exit_code: Some(1) };
+    let c = SandboxState::Crashed { exit_code: None };
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}


### PR DESCRIPTION
- Add tests for Sandbox::new, with_policy, state, evaluate, reload_rules, shutdown, Drop
- Add tests for SandboxError::From<std::io::Error>
- Add tests for SandboxState variant behaviors
- Add IPC message serialization roundtrip tests
- Add SecurityPolicy construction and apply tests

Source: issue #309
Type: test
