### PR TITLE
feat(tools): Tool trait + ToolRegistry + 两级工具体系 + SystemPrompt 注入

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod platform;
 pub mod session;
 pub mod skills;
 pub mod system_prompt;
+pub mod tools;
 
 use tracing::info;
 

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -155,6 +155,23 @@ fn append_append_section(base: String) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Tools section builder
+// ---------------------------------------------------------------------------
+
+use crate::tools::ToolRegistry;
+
+/// Build the Tools section content from a registry.
+///
+/// Groups tools by their group name, formats each group with a header and
+/// tool list, then truncates at `TOOLS_SECTION_MAX_LEN` (1500 chars) if needed.
+pub fn build_tools_section(registry: &ToolRegistry, ctx: &crate::tools::ToolContext) -> Section {
+    // Use the registry's own async build method via block_on
+    let rt = tokio::runtime::Handle::current();
+    let content = rt.block_on(registry.build_tools_section(ctx));
+    Section::ToolsSection(content)
+}
+
+// ---------------------------------------------------------------------------
 // Convenience: build from file-based workspace sections
 // ---------------------------------------------------------------------------
 
@@ -195,7 +212,12 @@ pub fn build_from_workspace<P: AsRef<Path>>(
         if let Some((content, _)) = read_file_section(&memory_path) {
             sections.push(Section::MemorySection(content));
         }
+    } else {
+        sections.push(Section::MemorySection(String::new()));
     }
+
+    // Tools section — inserted between RoleSection and MemorySection
+    sections.push(Section::ToolsSection(String::new()));
 
     // Dynamic sections
     sections.extend(dynamic_sections);

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -158,16 +158,14 @@ fn append_append_section(base: String) -> String {
 // Tools section builder
 // ---------------------------------------------------------------------------
 
-use crate::tools::ToolRegistry;
+use crate::tools::{ToolContext, ToolRegistry};
 
 /// Build the Tools section content from a registry.
 ///
 /// Groups tools by their group name, formats each group with a header and
 /// tool list, then truncates at `TOOLS_SECTION_MAX_LEN` (1500 chars) if needed.
-pub fn build_tools_section(registry: &ToolRegistry, ctx: &crate::tools::ToolContext) -> Section {
-    // Use the registry's own async build method via block_on
-    let rt = tokio::runtime::Handle::current();
-    let content = rt.block_on(registry.build_tools_section(ctx));
+pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> Section {
+    let content = registry.build_tools_section(ctx).await;
     Section::ToolsSection(content)
 }
 
@@ -227,8 +225,11 @@ pub fn build_from_workspace<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
+    use super::super::sections::Section;
     use super::super::sections::{clear_append_section, set_append_section};
     use super::*;
+    use crate::tools::builtin::register_builtin_tools;
+    use crate::tools::ToolRegistry;
 
     #[test]
     fn test_build_system_prompt_with_override() {
@@ -300,7 +301,6 @@ mod tests {
     }
 
     #[test]
-
     fn test_dynamic_sections_not_cached() {
         clear_append_section();
         let sections = vec![Section::SessionState {
@@ -310,5 +310,115 @@ mod tests {
         let result1 = build_system_prompt(sections.clone());
         let result2 = build_system_prompt(sections);
         assert_eq!(result1, result2);
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_returns_tools_section() {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(&registry).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        match section {
+            Section::ToolsSection(_) => {}
+            _ => panic!("expected ToolsSection, got {:?}", section),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_contains_group_headers() {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(&registry).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        // Should contain file_ops and meta group headers
+        assert!(
+            content.contains("file_ops"),
+            "missing file_ops group: {}",
+            content
+        );
+        assert!(content.contains("meta"), "missing meta group: {}", content);
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_contains_tool_names() {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(&registry).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        // All 7 tool names should appear
+        for name in &[
+            "Read",
+            "Write",
+            "Edit",
+            "Grep",
+            "Ls",
+            "ToolSearch",
+            "PermissionQuery",
+        ] {
+            assert!(
+                content.contains(name),
+                "tool {} not found in: {}",
+                name,
+                content
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_respects_max_length() {
+        let registry = ToolRegistry::new();
+        register_builtin_tools(&registry).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        // With 7 tools the section should be well under 1500 chars
+        assert!(
+            content.chars().count() <= 1500,
+            "section too long: {}",
+            content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_empty_registry() {
+        let registry = ToolRegistry::new();
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        // Empty registry should produce empty content
+        assert!(
+            content.is_empty(),
+            "expected empty content, got: {}",
+            content
+        );
     }
 }

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -14,8 +14,8 @@ pub mod slash_commands;
 pub mod workdir;
 
 pub use builder::{
-    build_from_workspace, build_system_prompt, set_agent_prompt, set_custom_prompt,
-    set_override_prompt,
+    build_from_workspace, build_system_prompt, build_tools_section, set_agent_prompt,
+    set_custom_prompt, set_override_prompt,
 };
 pub use sections::{
     clear_append_section, get_append_section, get_cached_section, invalidate_all_sections,

--- a/src/tools/SPEC.md
+++ b/src/tools/SPEC.md
@@ -1,0 +1,71 @@
+# tools — 两级工具体系
+
+## 模块概述
+
+`tools` 模块为 CloseClaw 实现两级工具体系：LLM 可调用的能力（Tool）与领域知识按需读取（Skill）完全独立。
+
+核心设计：
+- `Tool` trait 定义工具的核心接口，所有工具必须实现 `Send + Sync + 'static`
+- `ToolRegistry` 是并发安全的注册中心，内部用 `tokio::sync::RwLock` 包裹 `HashMap<String, Arc<dyn Tool>>`
+- `ToolDescriptor` 仅含 name / group / summary / is_deferred，用于 system prompt 一级索引
+- 工具 detail 和 input_schema 按需通过 `ToolSearch` 触发注入，不在一级索引展开
+- `builtin` 子模块提供 5 个 file_ops 工具和 2 个 meta 工具，全部通过 `register_builtin_tools()` 一键注册
+- System prompt 集成：builder.rs 提供 `build_tools_section(registry, ctx)` async 函数，返回 `Section::ToolsSection`；`build_from_workspace` 中预埋 `Section::ToolsSection(String::new())` 占位符（位于 RoleSection 之后 MemorySection 之前）。当前 `build_tools_section` 尚未在 sync 路径中与 `build_from_workspace` 打通，内容通过 dynamic_sections 外部传入
+
+边界：builtin tools 不依赖 `crate::skills` 模块；`ToolRegistry` 依赖 `tokio`（异步运行时）。
+
+---
+
+## 公开接口
+
+### 核心类型（mod.rs）
+
+- `Tool` trait — 工具核心接口，6 个方法：name / group / summary / detail / input_schema / flags
+- `ToolFlags` — bitflags 风格运行时标记（is_concurrency_safe / is_read_only / is_destructive / is_expensive / is_deferred_by_default）
+- `ToolContext` — 运行时上下文（agent_id + workdir）
+- `ToolDescriptor` — 一级摘要数据（name / group / summary / is_deferred）
+- `ToolError` — 工具层错误类型，用 thiserror 定义（NotFound / AlreadyRegistered / Serialization / Io）
+
+### 注册中心（registry.rs）
+
+- `ToolRegistry::new()` — 创建空注册表
+- `ToolRegistry::register(tool)` — 注册工具，冲突返回 `AlreadyRegistered`
+- `ToolRegistry::list_descriptors(ctx)` — 列出所有 ToolDescriptor，按 ctx 过滤
+- `ToolRegistry::get_detail(name)` — 获取指定工具的 detail 字符串，不存在返回 `NotFound`
+- `ToolRegistry::list_by_group(group)` — 列出指定分组下的所有工具名
+- `ToolRegistry::build_tools_section(ctx)` — 生成分组索引字符串，超 1500 字符截断
+
+### 内建工具（builtin/）
+
+- `register_builtin_tools(registry)` — 将全部 7 个内建工具注册到指定注册表
+- `ReadTool` / `WriteTool` / `EditTool` / `GrepTool` / `LsTool` — file_ops 组，group = "file_ops"
+- `ToolSearchTool` / `PermissionQueryTool` — meta 组，group = "meta"，is_deferred_by_default = false
+
+---
+
+## 架构与结构
+
+### 子模块划分
+
+```
+tools/
+├── mod.rs          # Tool trait、ToolFlags、ToolContext、ToolDescriptor、ToolError
+├── registry.rs     # ToolRegistry 并发注册中心 + build_tools_section
+└── builtin/
+    ├── mod.rs      # register_builtin_tools 统一入口
+    ├── file_ops.rs # Read / Write / Edit / Grep / Ls
+    ├── search.rs   # ToolSearchTool
+    └── permission.rs # PermissionQueryTool
+```
+
+### 两级设计
+
+**一级索引**（`ToolRegistry::build_tools_section` 输出）：按 group 聚合，展示 `**{group}** — (always loaded)` 标题 + 工具名列表（中文顿号分隔、按名称排序），供 LLM 了解可用工具范围。总长不超过 1500 字符，超长截断并附加 `... (N more tools, use ToolSearch to explore)` 提示。
+
+**二级详情**（`get_detail` 返回）：完整 detail 描述 + input_schema JSON，通过 `ToolSearch` 按关键词或精确名触发注入。
+
+### 关键数据不变式
+
+- `ToolFlags::is_eager()` 返回 `!is_deferred_by_default`
+- `build_tools_section` 按 group 名排序，保证输出稳定
+- `register_builtin_tools` 中 file_ops 工具不依赖 `crate::skills`

--- a/src/tools/builtin/file_ops.rs
+++ b/src/tools/builtin/file_ops.rs
@@ -1,0 +1,422 @@
+//! Built-in tools — file operations (Tool trait implementation).
+//!
+//! Each tool is an independent [`Tool`] implementation, completely separate
+//! from the [`crate::skills`] module.
+
+use crate::tools::{Tool, ToolContext, ToolError, ToolFlags};
+
+use serde_json::Value;
+use std::path::Path;
+
+// ---------------------------------------------------------------------------
+// Shared helper
+// ---------------------------------------------------------------------------
+
+fn workdir_path(ctx: &ToolContext, path: &str) -> std::path::PathBuf {
+    match ctx.workdir {
+        Some(ref wd) => std::path::Path::new(&wd.path).join(path),
+        None => std::path::Path::new(path).to_path_buf(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadTool
+// ---------------------------------------------------------------------------
+
+pub struct ReadTool;
+
+impl ReadTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for ReadTool {
+    fn name(&self) -> &str {
+        "Read"
+    }
+
+    fn group(&self) -> &str {
+        "file_ops"
+    }
+
+    fn summary(&self) -> String {
+        "Read file contents".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Read the full contents of a file given its path.\
+         Returns the text content as a JSON object with key `content`.\
+         Fails if the path does not exist or is not a readable file."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or workdir-relative file path"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            is_read_only: true,
+            ..Default::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WriteTool
+// ---------------------------------------------------------------------------
+
+pub struct WriteTool;
+
+impl WriteTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for WriteTool {
+    fn name(&self) -> &str {
+        "Write"
+    }
+
+    fn group(&self) -> &str {
+        "file_ops"
+    }
+
+    fn summary(&self) -> String {
+        "Write content to a file".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Write text content to a file, creating it or overwriting it.\
+         Takes `path` (string) and `content` (string).\
+         Parent directories are created automatically.\
+         Destructive: will overwrite existing files without warning."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or workdir-relative file path"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Text content to write"
+                }
+            },
+            "required": ["path", "content"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: false,
+            is_read_only: false,
+            is_destructive: true,
+            ..Default::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EditTool
+// ---------------------------------------------------------------------------
+
+pub struct EditTool;
+
+impl EditTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for EditTool {
+    fn name(&self) -> &str {
+        "Edit"
+    }
+
+    fn group(&self) -> &str {
+        "file_ops"
+    }
+
+    fn summary(&self) -> String {
+        "Apply a targeted edit to a file".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Apply a targeted edit to an existing file using exact text replacement.\
+         Takes `path`, `oldText` (exact string to replace), and `newText` (replacement).\
+         Only one replacement is performed per call.\
+         Fails if `oldText` is not found verbatim in the file.\
+         Destructive: modifies the file in place."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or workdir-relative file path"
+                },
+                "oldText": {
+                    "type": "string",
+                    "description": "Exact text to search for and replace"
+                },
+                "newText": {
+                    "type": "string",
+                    "description": "Replacement text"
+                }
+            },
+            "required": ["path", "oldText", "newText"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: false,
+            is_read_only: false,
+            is_destructive: true,
+            ..Default::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GrepTool
+// ---------------------------------------------------------------------------
+
+pub struct GrepTool;
+
+impl GrepTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for GrepTool {
+    fn name(&self) -> &str {
+        "Grep"
+    }
+
+    fn group(&self) -> &str {
+        "file_ops"
+    }
+
+    fn summary(&self) -> String {
+        "Search for text patterns in files".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Recursively search for lines matching a pattern in files.\
+         Takes `pattern` (string or regex), `path` (directory, default \".\"),\
+         and optional `is_regex` (bool, default false).\
+         Returns a JSON array of `{file, line_number, line}` objects.\
+         Read-only: does not modify any file."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Search pattern or regex"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search in (default .)"
+                },
+                "is_regex": {
+                    "type": "boolean",
+                    "description": "Treat pattern as regex (default false)"
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            is_read_only: true,
+            is_expensive: true,
+            ..Default::default()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LsTool
+// ---------------------------------------------------------------------------
+
+pub struct LsTool;
+
+impl LsTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for LsTool {
+    fn name(&self) -> &str {
+        "Ls"
+    }
+
+    fn group(&self) -> &str {
+        "file_ops"
+    }
+
+    fn summary(&self) -> String {
+        "List directory entries".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "List entries in a directory.\
+         Takes optional `path` (directory, default \".\").\
+         Returns a JSON array of entry names.\
+         Read-only: does not modify any file or directory."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory to list (default .)"
+                }
+            },
+            "required": []
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            is_read_only: true,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_ctx() -> ToolContext {
+        ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        }
+    }
+
+    #[test]
+    fn test_read_name_group_summary() {
+        let tool = ReadTool::new();
+        assert_eq!(tool.name(), "Read");
+        assert_eq!(tool.group(), "file_ops");
+        assert!(tool.summary().len() <= 50);
+        assert!(tool.flags().is_read_only);
+        assert!(!tool.flags().is_destructive);
+    }
+
+    #[test]
+    fn test_write_name_group_summary() {
+        let tool = WriteTool::new();
+        assert_eq!(tool.name(), "Write");
+        assert_eq!(tool.group(), "file_ops");
+        assert!(tool.summary().len() <= 50);
+        assert!(tool.flags().is_destructive);
+        assert!(!tool.flags().is_read_only);
+    }
+
+    #[test]
+    fn test_edit_name_group_summary() {
+        let tool = EditTool::new();
+        assert_eq!(tool.name(), "Edit");
+        assert_eq!(tool.group(), "file_ops");
+        assert!(tool.summary().len() <= 50);
+        assert!(tool.flags().is_destructive);
+        assert!(!tool.flags().is_read_only);
+    }
+
+    #[test]
+    fn test_grep_name_group_summary() {
+        let tool = GrepTool::new();
+        assert_eq!(tool.name(), "Grep");
+        assert_eq!(tool.group(), "file_ops");
+        assert!(tool.summary().len() <= 50);
+        assert!(tool.flags().is_read_only);
+    }
+
+    #[test]
+    fn test_ls_name_group_summary() {
+        let tool = LsTool::new();
+        assert_eq!(tool.name(), "Ls");
+        assert_eq!(tool.group(), "file_ops");
+        assert!(tool.summary().len() <= 50);
+        assert!(tool.flags().is_read_only);
+    }
+
+    #[test]
+    fn test_read_input_schema_has_path() {
+        let tool = ReadTool::new();
+        let schema = tool.input_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("path"));
+    }
+
+    #[test]
+    fn test_write_input_schema_has_path_and_content() {
+        let tool = WriteTool::new();
+        let schema = tool.input_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("path"));
+        assert!(props.contains_key("content"));
+    }
+
+    #[test]
+    fn test_edit_input_schema_has_all_fields() {
+        let tool = EditTool::new();
+        let schema = tool.input_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("path"));
+        assert!(props.contains_key("oldText"));
+        assert!(props.contains_key("newText"));
+    }
+
+    #[test]
+    fn test_grep_input_schema_has_pattern() {
+        let tool = GrepTool::new();
+        let schema = tool.input_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("pattern"));
+    }
+
+    #[test]
+    fn test_ls_input_schema_optional_path() {
+        let tool = LsTool::new();
+        let schema = tool.input_schema();
+        let required = schema.pointer("/required").unwrap().as_array().unwrap();
+        assert!(required.is_empty());
+    }
+}

--- a/src/tools/builtin/file_ops.rs
+++ b/src/tools/builtin/file_ops.rs
@@ -9,21 +9,16 @@ use serde_json::Value;
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
-// Shared helper
-// ---------------------------------------------------------------------------
-
-fn workdir_path(ctx: &ToolContext, path: &str) -> std::path::PathBuf {
-    match ctx.workdir {
-        Some(ref wd) => std::path::Path::new(&wd.path).join(path),
-        None => std::path::Path::new(path).to_path_buf(),
-    }
-}
-
-// ---------------------------------------------------------------------------
 // ReadTool
 // ---------------------------------------------------------------------------
 
 pub struct ReadTool;
+
+impl Default for ReadTool {
+    fn default() -> Self {
+        Self
+    }
+}
 
 impl ReadTool {
     pub fn new() -> Self {
@@ -78,6 +73,12 @@ impl Tool for ReadTool {
 // ---------------------------------------------------------------------------
 
 pub struct WriteTool;
+
+impl Default for WriteTool {
+    fn default() -> Self {
+        Self
+    }
+}
 
 impl WriteTool {
     pub fn new() -> Self {
@@ -138,6 +139,12 @@ impl Tool for WriteTool {
 // ---------------------------------------------------------------------------
 
 pub struct EditTool;
+
+impl Default for EditTool {
+    fn default() -> Self {
+        Self
+    }
+}
 
 impl EditTool {
     pub fn new() -> Self {
@@ -204,6 +211,12 @@ impl Tool for EditTool {
 
 pub struct GrepTool;
 
+impl Default for GrepTool {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl GrepTool {
     pub fn new() -> Self {
         Self
@@ -268,6 +281,12 @@ impl Tool for GrepTool {
 // ---------------------------------------------------------------------------
 
 pub struct LsTool;
+
+impl Default for LsTool {
+    fn default() -> Self {
+        Self
+    }
+}
 
 impl LsTool {
     pub fn new() -> Self {

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -1,0 +1,36 @@
+//! Built-in tools module.
+//!
+//! Re-exports all builtin tool implementations and provides a single
+//! registration entry point.
+
+pub mod file_ops;
+pub mod permission;
+pub mod search;
+
+pub use file_ops::{EditTool, GrepTool, LsTool, ReadTool, WriteTool};
+pub use permission::PermissionQueryTool;
+pub use search::ToolSearchTool;
+
+/// Registers all built-in tools with the given registry.
+///
+/// Currently registers the 5 file_ops tools:
+/// - [`ReadTool`]
+/// - [`WriteTool`]
+/// - [`EditTool`]
+/// - [`GrepTool`]
+/// - [`LsTool`]
+///
+/// And 2 meta tools:
+/// - [`ToolSearchTool`]
+/// - [`PermissionQueryTool`]
+pub async fn register_builtin_tools(registry: &crate::tools::ToolRegistry) {
+    // file_ops
+    registry.register(ReadTool::new()).await.ok();
+    registry.register(WriteTool::new()).await.ok();
+    registry.register(EditTool::new()).await.ok();
+    registry.register(GrepTool::new()).await.ok();
+    registry.register(LsTool::new()).await.ok();
+    // meta
+    registry.register(ToolSearchTool::new()).await.ok();
+    registry.register(PermissionQueryTool::new()).await.ok();
+}

--- a/src/tools/builtin/permission.rs
+++ b/src/tools/builtin/permission.rs
@@ -1,0 +1,118 @@
+//! Built-in meta tool — PermissionQuery.
+//!
+//! Allows the LLM to query which tools the current agent is permitted to use.
+
+use crate::tools::{Tool, ToolContext, ToolFlags};
+
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// PermissionQueryTool
+// ---------------------------------------------------------------------------
+
+/// Queries the tool permission profile for the current agent.
+///
+/// # What it does
+/// Returns a JSON object describing which tool groups or individual tools
+/// the calling agent (`ctx.agent_id`) is allowed to invoke.
+///
+/// # Permission model
+/// Permissions are checked at call time; this tool only describes the
+/// agent's own permissions. The actual permission enforcement happens in
+/// the tool-calling pipeline.
+///
+/// This tool is always loaded in the index (`is_deferred_by_default = false`).
+pub struct PermissionQueryTool;
+
+impl PermissionQueryTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for PermissionQueryTool {
+    fn name(&self) -> &str {
+        "PermissionQuery"
+    }
+
+    fn group(&self) -> &str {
+        "meta"
+    }
+
+    fn summary(&self) -> String {
+        "Query current agent tool permissions".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Query the tool permission profile for the current agent.\
+         Returns a JSON object describing which tool groups or individual \
+         tools the calling agent is permitted to invoke.\
+         \n\nThe returned object has the form:\
+         `{allowed_groups: [\"file_ops\", ...], denied_tools: [...]}`.\
+         \n\nIf `allowed_groups` is empty, the agent has no general tool access \
+         and must rely on explicit grants in `denied_tools`.\
+         \n\nUse this tool at the start of a session to understand what the \
+         agent can and cannot do."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            is_read_only: true,
+            is_destructive: false,
+            is_expensive: false,
+            is_deferred_by_default: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_query_name_group() {
+        let tool = PermissionQueryTool::new();
+        assert_eq!(tool.name(), "PermissionQuery");
+        assert_eq!(tool.group(), "meta");
+    }
+
+    #[test]
+    fn test_permission_query_summary_len() {
+        let tool = PermissionQueryTool::new();
+        assert!(tool.summary().len() <= 50);
+    }
+
+    #[test]
+    fn test_permission_query_flags() {
+        let tool = PermissionQueryTool::new();
+        let flags = tool.flags();
+        assert!(!flags.is_deferred_by_default);
+        assert!(flags.is_read_only);
+        assert!(flags.is_concurrency_safe);
+    }
+
+    #[test]
+    fn test_permission_query_input_schema_no_required() {
+        let tool = PermissionQueryTool::new();
+        let schema = tool.input_schema();
+        let required = schema.pointer("/required").unwrap().as_array().unwrap();
+        assert!(required.is_empty());
+    }
+
+    #[test]
+    fn test_permission_query_detail_contains_profile() {
+        let tool = PermissionQueryTool::new();
+        let detail = tool.detail();
+        assert!(detail.contains("allowed_groups") || detail.contains("permission"));
+    }
+}

--- a/src/tools/builtin/permission.rs
+++ b/src/tools/builtin/permission.rs
@@ -24,6 +24,12 @@ use serde_json::Value;
 /// This tool is always loaded in the index (`is_deferred_by_default = false`).
 pub struct PermissionQueryTool;
 
+impl Default for PermissionQueryTool {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl PermissionQueryTool {
     pub fn new() -> Self {
         Self

--- a/src/tools/builtin/search.rs
+++ b/src/tools/builtin/search.rs
@@ -1,0 +1,139 @@
+//! Built-in meta tool — ToolSearch.
+//!
+//! Allows the LLM to dynamically retrieve second-level tool detail
+//! by keyword or exact name match.
+
+use crate::tools::{Tool, ToolContext, ToolError, ToolFlags};
+
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// ToolSearchTool
+// ---------------------------------------------------------------------------
+
+/// Dynamic tool detail lookup by keyword or exact name.
+///
+/// # What it does
+/// When the LLM needs to understand a tool's full input schema or detail
+/// description, it calls `ToolSearch` with a `query` string.
+///
+/// - **exact mode** (query matches a tool name verbatim): returns that tool's
+///   full `detail()` + `input_schema()`.
+/// - **keyword mode** (query contains non-matching text): searches all tool
+///   names and summaries, returns matching tools' name + summary + group.
+///
+/// # Safety / Cost
+/// - `is_expensive = true` (registry scan across all tools)
+/// - `is_deferred_by_default = false` (always loaded in index)
+pub struct ToolSearchTool;
+
+impl ToolSearchTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Tool for ToolSearchTool {
+    fn name(&self) -> &str {
+        "ToolSearch"
+    }
+
+    fn group(&self) -> &str {
+        "meta"
+    }
+
+    fn summary(&self) -> String {
+        "Search for tool details by keyword or exact name".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Dynamically retrieve second-level tool detail by keyword or exact name.\
+         When the LLM needs the full description or input schema of a specific \
+         tool, call this tool with a `query` string.\
+         \n\n**Exact mode**: if `query` exactly matches a registered tool name \
+         (case-insensitive), returns that tool's full `detail()` text and \
+         `input_schema` JSON object.\
+         \n\n**Keyword mode**: if `query` does not exactly match any tool name, \
+         searches all tool names and summaries for any entry that contains \
+         the query substring (case-insensitive). Returns a list of \
+         `{name, group, summary}` for all matches, up to a limit of 10.\
+         \n\nThis is the only way to load a tool's second-level detail into the \
+         context, since first-level index only shows group + tool name list."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query: exact tool name or keyword substring"
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: false,
+            is_read_only: true,
+            is_destructive: false,
+            is_expensive: true,
+            is_deferred_by_default: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_ctx() -> ToolContext {
+        ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        }
+    }
+
+    #[test]
+    fn test_toolsearch_name_group() {
+        let tool = ToolSearchTool::new();
+        assert_eq!(tool.name(), "ToolSearch");
+        assert_eq!(tool.group(), "meta");
+    }
+
+    #[test]
+    fn test_toolsearch_summary_len() {
+        let tool = ToolSearchTool::new();
+        assert!(tool.summary().len() <= 50);
+    }
+
+    #[test]
+    fn test_toolsearch_flags() {
+        let tool = ToolSearchTool::new();
+        let flags = tool.flags();
+        assert!(!flags.is_deferred_by_default);
+        assert!(flags.is_expensive);
+        assert!(flags.is_read_only);
+    }
+
+    #[test]
+    fn test_toolsearch_input_schema_has_query() {
+        let tool = ToolSearchTool::new();
+        let schema = tool.input_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("query"));
+        let required = schema.pointer("/required").unwrap().as_array().unwrap();
+        assert!(required.contains(&serde_json::json!("query")));
+    }
+
+    #[test]
+    fn test_toolsearch_detail_contains_modes() {
+        let tool = ToolSearchTool::new();
+        let detail = tool.detail();
+        assert!(detail.contains("Exact mode"));
+        assert!(detail.contains("Keyword mode"));
+    }
+}

--- a/src/tools/builtin/search.rs
+++ b/src/tools/builtin/search.rs
@@ -27,6 +27,12 @@ use serde_json::Value;
 /// - `is_deferred_by_default = false` (always loaded in index)
 pub struct ToolSearchTool;
 
+impl Default for ToolSearchTool {
+    fn default() -> Self {
+        Self
+    }
+}
+
 impl ToolSearchTool {
     pub fn new() -> Self {
         Self

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,0 +1,180 @@
+//! Tools —两级工具体系核心类型
+//!
+//! # 架构
+//! - [`Tool`] trait：定义工具核心接口（name / group / summary / detail / input_schema / flags）
+//! - [`ToolFlags`]：bitflags 风格标记（is_concurrency_safe / is_read_only / is_destructive / etc.）
+//! - [`ToolContext`]：运行时上下文（agent_id + workdir）
+//! - [`ToolDescriptor`]：一级摘要数据，仅用于 system prompt 索引
+//! - [`ToolError`]：工具层错误类型
+//!
+//! Tool trait 是新类型体系，与 [`crate::skills::Skill`] trait 完全独立：
+//! - Skill = 领域知识按需读取
+//! - Tool = LLM 可调用能力
+
+pub mod builtin;
+pub mod registry;
+
+pub use registry::ToolRegistry;
+
+use serde_json::Value;
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// ToolFlags — bitflags 风格
+// ---------------------------------------------------------------------------
+
+/// Tool-level runtime flags.
+///
+/// All flags default to `false` unless noted.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolFlags {
+    /// Tool is safe to call concurrently from multiple agents.
+    pub is_concurrency_safe: bool,
+    /// Tool only reads data, never modifies files or state.
+    pub is_read_only: bool,
+    /// Tool may overwrite or delete data — requires explicit confirmation.
+    pub is_destructive: bool,
+    /// Tool may be slow or consume significant resources.
+    pub is_expensive: bool,
+    /// Tool detail is NOT loaded into system prompt by default
+    /// (requires explicit ToolSearch trigger).
+    pub is_deferred_by_default: bool,
+}
+
+impl ToolFlags {
+    /// Returns true if the tool should be loaded into the system prompt
+    /// by default (i.e., NOT deferred).
+    #[inline]
+    pub fn is_eager(&self) -> bool {
+        !self.is_deferred_by_default
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolContext —运行时上下文
+// ---------------------------------------------------------------------------
+
+/// Runtime context passed to tools at call time.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    /// ID of the agent invoking this tool.
+    pub agent_id: String,
+    /// Current working directory context (if set).
+    pub workdir: Option<crate::system_prompt::WorkdirContext>,
+}
+
+// ---------------------------------------------------------------------------
+// ToolDescriptor —一级摘要数据
+// ---------------------------------------------------------------------------
+
+/// Reduced tool info for the system prompt index.
+///
+/// Contains only the fields needed to render the first-level
+/// tool listing (group name + tool name + summary).
+#[derive(Debug, Clone)]
+pub struct ToolDescriptor {
+    /// Unique tool name.
+    pub name: String,
+    /// Group this tool belongs to.
+    pub group: String,
+    /// Short one-line summary (≤50 chars).
+    pub summary: String,
+    /// Whether this tool's detail is deferred by default.
+    pub is_deferred: bool,
+}
+
+// ---------------------------------------------------------------------------
+// ToolError —工具层错误
+// ---------------------------------------------------------------------------
+
+/// Errors raised by the tools layer.
+#[derive(Debug, Error)]
+pub enum ToolError {
+    #[error("tool not found: {0}")]
+    NotFound(String),
+
+    #[error("tool `{0}` already registered")]
+    AlreadyRegistered(String),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Tool —核心 trait
+// ---------------------------------------------------------------------------
+
+/// Core interface for a callable tool.
+///
+/// Each tool is a named, grouped capability that the LLM can invoke.
+/// Implementations must be `Send + Sync + 'static`.
+pub trait Tool: Send + Sync {
+    /// Returns the unique name of this tool.
+    fn name(&self) -> &str;
+
+    /// Returns the group name (e.g. "file_ops", "meta").
+    fn group(&self) -> &str;
+
+    /// Returns a short one-line summary (≤50 chars) for the system prompt.
+    ///
+    /// This string is embedded verbatim into the first-level tool listing.
+    fn summary(&self) -> String;
+
+    /// Returns the detailed description for this tool.
+    ///
+    /// Shown when the LLM requests second-level detail (via ToolSearch).
+    fn detail(&self) -> String;
+
+    /// Returns the JSON Schema for this tool's input parameters.
+    fn input_schema(&self) -> Value;
+
+    /// Returns this tool's runtime flags.
+    fn flags(&self) -> ToolFlags;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_flags_default() {
+        let flags = ToolFlags::default();
+        assert!(!flags.is_concurrency_safe);
+        assert!(!flags.is_read_only);
+        assert!(!flags.is_destructive);
+        assert!(!flags.is_expensive);
+        assert!(!flags.is_deferred_by_default);
+    }
+
+    #[test]
+    fn test_tool_flags_is_eager() {
+        let mut flags = ToolFlags::default();
+        assert!(flags.is_eager());
+
+        flags.is_deferred_by_default = true;
+        assert!(!flags.is_eager());
+    }
+
+    #[test]
+    fn test_tool_descriptor_construction() {
+        let desc = ToolDescriptor {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary: "Read file contents".to_string(),
+            is_deferred: false,
+        };
+        assert_eq!(desc.name, "Read");
+        assert_eq!(desc.group, "file_ops");
+        assert!(!desc.is_deferred);
+    }
+
+    #[test]
+    fn test_tool_error_display() {
+        let err = ToolError::NotFound("Read".to_string());
+        assert!(err.to_string().contains("Read"));
+        assert!(err.to_string().contains("not found"));
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1,0 +1,344 @@
+//! ToolRegistry —并发安全的工具注册中心
+//!
+//! 支持注册、查询、列表操作，内部使用 `tokio::sync::RwLock` 保证并发安全。
+
+use std::sync::Arc;
+
+use crate::tools::{Tool, ToolContext, ToolDescriptor, ToolError};
+
+/// Maximum length of the first-level tools section (in characters).
+const TOOLS_SECTION_MAX_LEN: usize = 1500;
+
+/// Thread-safe tool registry.
+///
+/// Wraps an inner `HashMap<String, Arc<dyn Tool>>` behind a Tokio
+/// read-write lock so that all operations are async-safe.
+pub struct ToolRegistry {
+    tools: tokio::sync::RwLock<std::collections::HashMap<String, Arc<dyn Tool>>>,
+}
+
+impl std::fmt::Debug for ToolRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToolRegistry").finish()
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToolRegistry {
+    /// Creates a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            tools: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Registers a tool.
+    ///
+    /// # Errors
+    /// Returns [`ToolError::AlreadyRegistered`] if a tool with the same name
+    /// is already present.
+    pub async fn register<T: Tool + 'static>(&self, tool: T) -> Result<(), ToolError> {
+        let name = tool.name().to_string();
+        let mut guard = self.tools.write().await;
+        if guard.contains_key(&name) {
+            return Err(ToolError::AlreadyRegistered(name));
+        }
+        guard.insert(name, Arc::new(tool));
+        Ok(())
+    }
+
+    /// Returns all registered tool descriptors, filtered by `ctx`.
+    pub async fn list_descriptors(&self, _ctx: &ToolContext) -> Vec<ToolDescriptor> {
+        let guard = self.tools.read().await;
+        guard
+            .values()
+            .map(|t| ToolDescriptor {
+                name: t.name().to_string(),
+                group: t.group().to_string(),
+                summary: t.summary(),
+                is_deferred: t.flags().is_deferred_by_default,
+            })
+            .collect()
+    }
+
+    /// Returns the detail string for a named tool.
+    ///
+    /// # Errors
+    /// Returns [`ToolError::NotFound`] if no tool with that name exists.
+    pub async fn get_detail(&self, name: &str) -> Result<String, ToolError> {
+        let guard = self.tools.read().await;
+        guard
+            .get(name)
+            .map(|t| t.detail())
+            .ok_or_else(|| ToolError::NotFound(name.to_string()))
+    }
+
+    /// Returns all tool names belonging to a given group.
+    pub async fn list_by_group(&self, group: &str) -> Vec<String> {
+        let guard = self.tools.read().await;
+        guard
+            .values()
+            .filter(|t| t.group() == group)
+            .map(|t| t.name().to_string())
+            .collect()
+    }
+
+    /// Returns the inner lock for read operations (used in tests only).
+    #[cfg(test)]
+    pub async fn len_for_test(&self) -> usize {
+        self.tools.read().await.len()
+    }
+
+    /// Build a first-level tools section string, grouped and truncated.
+    ///
+    /// Groups tools by `group()`, formats each group with a header and tool
+    /// list, then truncates at `TOOLS_SECTION_MAX_LEN` if needed.
+    pub async fn build_tools_section(&self, ctx: &ToolContext) -> String {
+        let descriptors = self.list_descriptors(ctx).await;
+
+        // Group by group name
+        let mut groups_map: std::collections::HashMap<String, Vec<(String, bool)>> =
+            std::collections::HashMap::new();
+        for d in descriptors {
+            groups_map
+                .entry(d.group)
+                .or_default()
+                .push((d.name, d.is_deferred));
+        }
+
+        // Build lines
+        let mut lines: Vec<String> = Vec::new();
+        let mut total_len = 0;
+
+        let mut sorted_groups: Vec<_> = groups_map.into_iter().collect();
+        sorted_groups.sort_by_key(|(g, _)| g.clone());
+
+        for (group_name, mut tools) in sorted_groups {
+            let tag = if tools.iter().any(|(_, deferred)| !deferred) {
+                "(always loaded)"
+            } else {
+                ""
+            };
+            let header = if tag.is_empty() {
+                format!("**{}**", group_name)
+            } else {
+                format!("**{}** — {}", group_name, tag)
+            };
+
+            tools.sort_by_key(|(n, _)| n.clone());
+            let tool_names: Vec<_> = tools.iter().map(|(n, _)| n.clone()).collect();
+            let tool_list = tool_names.join("、");
+            let line = format!("{}\n- {}\n", header, tool_list);
+            total_len += line.chars().count();
+
+            if total_len > TOOLS_SECTION_MAX_LEN {
+                let overflow = total_len - TOOLS_SECTION_MAX_LEN;
+                let exceeded = format!(
+                    "... ({} more tools, use ToolSearch to explore)",
+                    overflow / 10 + 1
+                );
+                lines.push(exceeded);
+                break;
+            }
+
+            lines.push(line);
+        }
+
+        lines.join("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::ToolFlags;
+
+    struct DummyTool {
+        name: String,
+        group: String,
+        summary_text: String,
+        is_deferred: bool,
+    }
+
+    impl Tool for DummyTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn group(&self) -> &str {
+            &self.group
+        }
+        fn summary(&self) -> String {
+            self.summary_text.clone()
+        }
+        fn detail(&self) -> String {
+            format!("detail for {}", self.name)
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
+        fn flags(&self) -> ToolFlags {
+            let mut f = ToolFlags::default();
+            f.is_deferred_by_default = self.is_deferred;
+            f
+        }
+    }
+
+    fn make_ctx() -> ToolContext {
+        ToolContext {
+            agent_id: "test-agent".to_string(),
+            workdir: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register_and_get_detail() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read file contents".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+
+        let detail = reg.get_detail("Read").await.unwrap();
+        assert!(detail.contains("Read"));
+    }
+
+    #[tokio::test]
+    async fn test_register_not_found() {
+        let reg = ToolRegistry::new();
+        let err = reg.get_detail("NonExistent").await.unwrap_err();
+        assert!(matches!(err, ToolError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_register_duplicate() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+
+        let err = reg
+            .register(DummyTool {
+                name: "Read".to_string(),
+                group: "file_ops".to_string(),
+                summary_text: "Read again".to_string(),
+                is_deferred: false,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::AlreadyRegistered(_)));
+    }
+
+    #[tokio::test]
+    async fn test_list_descriptors() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read files".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+        reg.register(DummyTool {
+            name: "Write".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Write files".to_string(),
+            is_deferred: true,
+        })
+        .await
+        .unwrap();
+
+        let ctx = make_ctx();
+        let descriptors = reg.list_descriptors(&ctx).await;
+        assert_eq!(descriptors.len(), 2);
+        let read_desc = descriptors.iter().find(|d| d.name == "Read").unwrap();
+        assert_eq!(read_desc.group, "file_ops");
+        assert!(!read_desc.is_deferred);
+        let write_desc = descriptors.iter().find(|d| d.name == "Write").unwrap();
+        assert!(write_desc.is_deferred);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_group() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "R".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+        reg.register(DummyTool {
+            name: "ToolSearch".to_string(),
+            group: "meta".to_string(),
+            summary_text: "T".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+
+        let file_ops = reg.list_by_group("file_ops").await;
+        assert_eq!(file_ops, vec!["Read"]);
+
+        let meta = reg.list_by_group("meta").await;
+        assert_eq!(meta, vec!["ToolSearch"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_group_empty() {
+        let reg = ToolRegistry::new();
+        let result = reg.list_by_group("nonexistent").await;
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read files".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+        reg.register(DummyTool {
+            name: "ToolSearch".to_string(),
+            group: "meta".to_string(),
+            summary_text: "Search tools".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+
+        let ctx = make_ctx();
+        let section = reg.build_tools_section(&ctx).await;
+        assert!(section.contains("file_ops"));
+        assert!(section.contains("Read"));
+        assert!(section.contains("meta"));
+        assert!(section.contains("ToolSearch"));
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_empty() {
+        let reg = ToolRegistry::new();
+        let ctx = make_ctx();
+        let section = reg.build_tools_section(&ctx).await;
+        assert!(section.is_empty());
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -30,6 +30,47 @@ impl Default for ToolRegistry {
 }
 
 impl ToolRegistry {
+    /// Format a single group into a section line, returning (output, new_total_len).
+    /// Returns None if truncation was triggered.
+    fn format_group_line(
+        group_name: &str,
+        tools: Vec<(String, bool)>,
+        total_len: usize,
+        max_len: usize,
+    ) -> Option<(String, usize)> {
+        let tag = if tools.iter().any(|(_, deferred)| !deferred) {
+            "(always loaded)"
+        } else {
+            ""
+        };
+        let header = if tag.is_empty() {
+            format!("**{}**", group_name)
+        } else {
+            format!("**{}** — {}", group_name, tag)
+        };
+        let mut sorted_tools = tools;
+        sorted_tools.sort_by_key(|(n, _)| n.clone());
+        let tool_list: String = sorted_tools
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect::<Vec<_>>()
+            .join("、");
+        let line = format!("{}\n- {}\n", header, tool_list);
+        let new_len = total_len + line.chars().count();
+        if new_len > max_len {
+            let overflow = new_len - max_len;
+            let exceeded = format!(
+                "... ({} more tools, use ToolSearch to explore)",
+                overflow / 10 + 1
+            );
+            Some((exceeded, new_len))
+        } else {
+            Some((line, new_len))
+        }
+    }
+}
+
+impl ToolRegistry {
     /// Creates a new empty registry.
     pub fn new() -> Self {
         Self {
@@ -93,7 +134,9 @@ impl ToolRegistry {
     pub async fn len_for_test(&self) -> usize {
         self.tools.read().await.len()
     }
+}
 
+impl ToolRegistry {
     /// Build a first-level tools section string, grouped and truncated.
     ///
     /// Groups tools by `group()`, formats each group with a header and tool
@@ -111,41 +154,19 @@ impl ToolRegistry {
                 .push((d.name, d.is_deferred));
         }
 
-        // Build lines
         let mut lines: Vec<String> = Vec::new();
         let mut total_len = 0;
 
         let mut sorted_groups: Vec<_> = groups_map.into_iter().collect();
         sorted_groups.sort_by_key(|(g, _)| g.clone());
 
-        for (group_name, mut tools) in sorted_groups {
-            let tag = if tools.iter().any(|(_, deferred)| !deferred) {
-                "(always loaded)"
-            } else {
-                ""
-            };
-            let header = if tag.is_empty() {
-                format!("**{}**", group_name)
-            } else {
-                format!("**{}** — {}", group_name, tag)
-            };
-
-            tools.sort_by_key(|(n, _)| n.clone());
-            let tool_names: Vec<_> = tools.iter().map(|(n, _)| n.clone()).collect();
-            let tool_list = tool_names.join("、");
-            let line = format!("{}\n- {}\n", header, tool_list);
-            total_len += line.chars().count();
-
-            if total_len > TOOLS_SECTION_MAX_LEN {
-                let overflow = total_len - TOOLS_SECTION_MAX_LEN;
-                let exceeded = format!(
-                    "... ({} more tools, use ToolSearch to explore)",
-                    overflow / 10 + 1
-                );
-                lines.push(exceeded);
+        for (group_name, tools) in sorted_groups {
+            let Some((line, new_len)) =
+                Self::format_group_line(&group_name, tools, total_len, TOOLS_SECTION_MAX_LEN)
+            else {
                 break;
-            }
-
+            };
+            total_len = new_len;
             lines.push(line);
         }
 


### PR DESCRIPTION
## Summary

实现 CloseClaw 的两级工具体系：

1. **Tool trait**：定义工具核心接口（name / group / summary / detail / input_schema / flags）
2. **ToolRegistry**：注册中心，支持一级摘要列表和二级详情按需查询
3. **Builtin file_ops 工具**：Read、Write、Edit、Grep、Ls 作为独立 Tool 实现
4. **Meta 工具**：ToolSearch、PermissionQuery
5. **System Prompt 注入**：build_tools_section() 生成分组索引

## Changes

- : Tool trait、ToolFlags、ToolContext、ToolDescriptor、ToolError
- : ToolRegistry 实现
- : 内置工具注册
- : 5 个 file_ops 工具
- : ToolSearchTool
- : PermissionQueryTool
- : build_tools_section 集成
- : 模块文档

Source: issue #408
Type: feat