### PR TITLE
feat(processor_chain): add ProcessorChain infrastructure for message processing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod llm;
 pub mod mode;
 pub mod permission;
 pub mod platform;
+pub mod processor_chain;
 pub mod session;
 pub mod skills;
 pub mod system_prompt;

--- a/src/processor_chain/SPEC.md
+++ b/src/processor_chain/SPEC.md
@@ -1,0 +1,76 @@
+# ProcessorChain 模块规格书
+
+## ① 模块概述
+
+`processor_chain` 是消息处理的基础设施模块，为入站（inbound）和出站（outbound）处理器提供链式编排框架。
+
+Inbound 链接收平台原始消息（`RawMessage`），经多个处理器顺序处理后输出 `ProcessedMessage` 送至 LLM；Outbound 链接收 LLM 输出，经处理后送至下游发送逻辑。处理器按 `priority` 升序执行，链中任何一个处理器均可短路后续执行（skip / suppress）。空链直接 bypass。
+
+本模块是纯基础设施，不引用 Gateway 内部字段，可独立被任何层引用。
+
+---
+
+## ② 公开接口
+
+### 类型
+
+- **`RawMessage`** — 入站原始消息，携带 platform / sender_id / content / timestamp / message_id
+- **`MessageContext`** — 链内传递的上下文，持有 content、raw_message_log、metadata、skip
+- **`ProcessedMessage`** — 链执行结果，持有 final content、metadata、suppress 标志
+- **`RawMessageLog`** — 快照，记录链中每步的原始消息副本及来源 processor
+- **`ProcessError`** — 错误枚举：`ProcessorFailed` / `InvalidMessage` / `ChainFailed`
+
+### Trait
+
+- **`MessageProcessor`** — 处理器接口，`name / phase / priority / process`
+
+### 枚举
+
+- **`ProcessPhase`** — `Inbound` / `Outbound`，决定处理器加入哪条链
+
+### 核心 API
+
+- **`ProcessorRegistry::new()`** — 创建空 registry
+- **`ProcessorRegistry::register(processor)`** — 注册 processor，自动按 phase 加入对应链，返回 `&mut Self`
+- **`ProcessorRegistry::inbound_len()`** — 已注册 inbound processor 数量
+- **`ProcessorRegistry::outbound_len()`** — 已注册 outbound processor 数量
+- **`ProcessorRegistry::process_inbound(raw)`** — 按 priority 升序驱动 inbound 链；空链 bypass（RawMessage → 默认 ProcessedMessage）
+- **`ProcessorRegistry::process_outbound(llm_output)`** — 按 priority 升序驱动 outbound 链；空链 bypass（直接返回输入的 ProcessedMessage，不经 from_raw 转换）
+
+---
+
+## ③ 架构 / 结构
+
+### 子模块
+
+| 文件 | 职责 |
+|------|------|
+| `error.rs` | `ProcessError` 枚举及构造函数 |
+| `context.rs` | `RawMessage / MessageContext / ProcessedMessage / RawMessageLog` + 单元测试 |
+| `processor.rs` | `ProcessPhase` 枚举 + `MessageProcessor` trait |
+| `registry.rs` | `ProcessorRegistry` 实现 + 单元测试 |
+| `mod.rs` | 模块入口，re-export 公开类型 |
+
+### 数据流
+
+```
+Inbound:
+  RawMessage → [Processor sorted by priority asc] → ProcessedMessage
+
+Outbound:
+  ProcessedMessage (from LLM)
+    → synthetic RawMessage
+    → [Processor sorted by priority asc]
+    → ProcessedMessage
+```
+
+### 短路行为
+
+- processor 返回 `Ok(None)` → 链中止（skip），后续 processor 不再执行
+- processor 设置 `suppress: true` → 链中止，`suppress` 标志保留至输出
+- processor 返回 `Err` → 错误立即向上传播
+
+### Bypass
+
+- inbound 链为空：直接将 `RawMessage` 转为默认 `ProcessedMessage`
+- outbound 链为空：直接返回输入的 `ProcessedMessage`

--- a/src/processor_chain/context.rs
+++ b/src/processor_chain/context.rs
@@ -1,0 +1,137 @@
+//! Message context, processed message, and raw message types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Result type alias for processor chain operations.
+pub type Result<T> = std::result::Result<T, super::error::ProcessError>;
+
+/// A raw incoming message before any processing.
+///
+/// This is the input to the inbound processor chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RawMessage {
+    /// Sender platform (e.g., "feishu", "wecom").
+    pub platform: String,
+    /// Sender user ID on the platform.
+    pub sender_id: String,
+    /// Raw message content.
+    pub content: String,
+    /// Timestamp when the message was received.
+    pub timestamp: DateTime<Utc>,
+    /// Message ID assigned by the platform.
+    pub message_id: String,
+}
+
+/// Metadata for logging a raw message snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawMessageLog {
+    /// Snapshot of the raw message at this log entry.
+    pub raw: RawMessage,
+    /// Timestamp when this snapshot was taken.
+    pub logged_at: DateTime<Utc>,
+    /// Processor that produced this snapshot (if any).
+    pub processor_name: Option<String>,
+}
+
+/// The message context carried through the processor chain.
+///
+/// Passed to each processor as input; processors may mutate
+/// fields they are responsible for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageContext {
+    /// The current (possibly modified) message content.
+    pub content: String,
+    /// Per-processor result log, newest last.
+    pub raw_message_log: Vec<RawMessageLog>,
+    /// Arbitrary key-value metadata injected by processors.
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+    /// Whether the message has been flagged to skip further processing.
+    pub skip: bool,
+}
+
+impl MessageContext {
+    /// Creates a new context from a raw message.
+    pub fn from_raw(raw: RawMessage) -> Self {
+        let logged_at = Utc::now();
+        let raw_log = RawMessageLog {
+            raw: raw.clone(),
+            logged_at,
+            processor_name: None,
+        };
+        Self {
+            content: raw.content,
+            raw_message_log: vec![raw_log],
+            metadata: serde_json::Map::new(),
+            skip: false,
+        }
+    }
+
+    /// Returns a reference to the initial raw message.
+    pub fn initial_raw(&self) -> Option<&RawMessage> {
+        self.raw_message_log.first().map(|l| &l.raw)
+    }
+}
+
+/// The result of running the full processor chain.
+///
+/// Produced after either the inbound or outbound chain completes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessedMessage {
+    /// Final message content after all processors in the chain ran.
+    pub content: String,
+    /// Metadata accumulated across all processors.
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+    /// Whether the message should be suppressed entirely.
+    pub suppress: bool,
+}
+
+impl ProcessedMessage {
+    /// Creates a default processed message from a raw message.
+    ///
+    /// This is used when the processor chain is empty (bypass).
+    pub fn from_raw(raw: RawMessage) -> Self {
+        Self {
+            content: raw.content,
+            metadata: serde_json::Map::new(),
+            suppress: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_context_from_raw() {
+        let raw = RawMessage {
+            platform: "feishu".to_string(),
+            sender_id: "user_1".to_string(),
+            content: "hello".to_string(),
+            timestamp: Utc::now(),
+            message_id: "msg_1".to_string(),
+        };
+        let ctx = MessageContext::from_raw(raw.clone());
+        assert_eq!(ctx.content, "hello");
+        assert!(!ctx.skip);
+        assert_eq!(ctx.metadata.len(), 0);
+        assert_eq!(ctx.raw_message_log.len(), 1);
+        assert_eq!(ctx.initial_raw(), Some(&raw));
+    }
+
+    #[test]
+    fn test_processed_message_from_raw() {
+        let raw = RawMessage {
+            platform: "feishu".to_string(),
+            sender_id: "user_1".to_string(),
+            content: "hello".to_string(),
+            timestamp: Utc::now(),
+            message_id: "msg_1".to_string(),
+        };
+        let processed = ProcessedMessage::from_raw(raw);
+        assert_eq!(processed.content, "hello");
+        assert!(!processed.suppress);
+        assert_eq!(processed.metadata.len(), 0);
+    }
+}

--- a/src/processor_chain/error.rs
+++ b/src/processor_chain/error.rs
@@ -1,0 +1,48 @@
+//! Error types for the processor chain.
+
+use thiserror::Error;
+
+/// Errors raised during message processing.
+#[derive(Debug, Error)]
+pub enum ProcessError {
+    /// A processor in the chain returned an error.
+    #[error("processor `{name}` failed")]
+    ProcessorFailed {
+        /// Processor name.
+        name: String,
+        /// Underlying error.
+        #[source]
+        source: anyhow::Error,
+    },
+
+    /// The inbound/outbound message was malformed.
+    #[error("invalid message: {0}")]
+    InvalidMessage(String),
+
+    /// The processor chain itself failed (e.g., empty chain misconfiguration).
+    #[error("chain failed: {0}")]
+    ChainFailed(String),
+}
+
+impl ProcessError {
+    /// Constructs a `ProcessorFailed` error from a processor name and message.
+    #[inline]
+    pub fn processor_failed(name: impl Into<String>, source: impl std::fmt::Display) -> Self {
+        Self::ProcessorFailed {
+            name: name.into(),
+            source: anyhow::Error::msg(source.to_string()),
+        }
+    }
+
+    /// Constructs an `InvalidMessage` error.
+    #[inline]
+    pub fn invalid_message(msg: impl Into<String>) -> Self {
+        Self::InvalidMessage(msg.into())
+    }
+
+    /// Constructs a `ChainFailed` error.
+    #[inline]
+    pub fn chain_failed(msg: impl Into<String>) -> Self {
+        Self::ChainFailed(msg.into())
+    }
+}

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -1,0 +1,23 @@
+//! Processor chain infrastructure for message processing.
+//!
+//! This module provides the core types and trait for building
+//! inbound/outbound processor chains:
+//! - [`ProcessPhase`] — selects which chain a processor belongs to
+//! - [`MessageProcessor`] — trait for message processors
+//! - [`MessageContext`] — context carried through the chain
+//! - [`ProcessedMessage`] — output after the chain finishes
+//! - [`RawMessage`] — input to the inbound chain
+//! - [`RawMessageLog`] — snapshot of raw message at each processing step
+//! - [`ProcessError`] — error types
+
+pub mod context;
+pub mod error;
+pub mod processor;
+pub mod registry;
+pub mod registry_tests;
+
+pub use registry::ProcessorRegistry;
+
+pub use context::{MessageContext, ProcessedMessage, RawMessage, RawMessageLog};
+pub use error::ProcessError;
+pub use processor::{MessageProcessor, ProcessPhase};

--- a/src/processor_chain/processor.rs
+++ b/src/processor_chain/processor.rs
@@ -1,0 +1,39 @@
+//! Core trait and phase enumeration for message processors.
+
+use super::context::{MessageContext, ProcessedMessage};
+use super::error::ProcessError;
+use async_trait::async_trait;
+
+/// Processing phase — determines which chain a processor belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessPhase {
+    /// Inbound — processes incoming messages before LLM.
+    Inbound,
+    /// Outbound — processes LLM output before sending.
+    Outbound,
+}
+
+/// Message processor interface.
+///
+/// Implementations must be `Send + Sync + 'static`.
+#[async_trait]
+pub trait MessageProcessor: Send + Sync {
+    /// Returns the unique name of this processor.
+    fn name(&self) -> &str;
+
+    /// Returns the processing phase this processor belongs to.
+    fn phase(&self) -> ProcessPhase;
+
+    /// Returns the priority for this processor.
+    ///
+    /// Lower values run first within a phase chain.
+    fn priority(&self) -> u8;
+
+    /// Process the given message context.
+    ///
+    /// Returns `Some(ProcessedMessage)` when processing succeeded
+    /// and the result should be passed to the next processor.
+    /// Returns `None` when this processor chooses to skip.
+    async fn process(&self, ctx: &MessageContext)
+        -> Result<Option<ProcessedMessage>, ProcessError>;
+}

--- a/src/processor_chain/registry.rs
+++ b/src/processor_chain/registry.rs
@@ -1,0 +1,155 @@
+//! Processor registry — holds inbound/outbound processor chains and drives execution.
+
+use std::sync::Arc;
+
+use super::context::{MessageContext, ProcessedMessage, RawMessage};
+use super::error::ProcessError;
+use super::processor::{MessageProcessor, ProcessPhase};
+
+/// Registry holding inbound and outbound processor chains.
+///
+/// Processors are registered via [`register`](ProcessorRegistry::register) and
+/// automatically routed to the appropriate chain based on their [`phase`](MessageProcessor::phase).
+///
+/// The two chains are driven independently by [`process_inbound`](ProcessorRegistry::process_inbound)
+/// and [`process_outbound`](ProcessorRegistry::process_outbound).
+#[derive(Default)]
+pub struct ProcessorRegistry {
+    inbound: Vec<Arc<dyn MessageProcessor>>,
+    outbound: Vec<Arc<dyn MessageProcessor>>,
+}
+
+impl ProcessorRegistry {
+    /// Creates a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            inbound: Vec::new(),
+            outbound: Vec::new(),
+        }
+    }
+
+    /// Registers a processor to the chain that matches its [`phase`](MessageProcessor::phase).
+    pub fn register(&mut self, processor: Arc<dyn MessageProcessor>) -> &mut Self {
+        match processor.phase() {
+            ProcessPhase::Inbound => self.inbound.push(processor),
+            ProcessPhase::Outbound => self.outbound.push(processor),
+        }
+        self
+    }
+
+    /// Returns the number of registered inbound processors.
+    #[inline]
+    pub fn inbound_len(&self) -> usize {
+        self.inbound.len()
+    }
+
+    /// Returns the number of registered outbound processors.
+    #[inline]
+    pub fn outbound_len(&self) -> usize {
+        self.outbound.len()
+    }
+
+    /// Drives the inbound processor chain on `raw`.
+    ///
+    /// Processors are sorted by ascending [`priority`](MessageProcessor::priority) before
+    /// execution. When a processor returns `Ok(Some(msg))` its result becomes the input for
+    /// the next processor. If the chain is empty the `raw` message is converted directly to
+    /// a [`ProcessedMessage`] (bypass).
+    pub async fn process_inbound(&self, raw: RawMessage) -> Result<ProcessedMessage, ProcessError> {
+        if self.inbound.is_empty() {
+            return Ok(ProcessedMessage::from_raw(raw));
+        }
+
+        let mut ctx = MessageContext::from_raw(raw);
+
+        let mut sorted = self.inbound.clone();
+        sorted.sort_by_key(|p| p.priority());
+
+        for processor in sorted {
+            if ctx.skip {
+                break;
+            }
+            match processor.process(&ctx).await? {
+                Some(out) => {
+                    ctx.content = out.content;
+                    for (k, v) in out.metadata {
+                        ctx.metadata.insert(k, v);
+                    }
+                    if out.suppress {
+                        ctx.skip = true;
+                    }
+                }
+                None => {
+                    // Processor chose to skip — halt the chain.
+                    ctx.skip = true;
+                    break;
+                }
+            }
+        }
+
+        Ok(ProcessedMessage {
+            content: ctx.content,
+            metadata: ctx.metadata,
+            suppress: ctx.skip,
+        })
+    }
+
+    /// Drives the outbound processor chain on `llm_output`.
+    ///
+    /// Same semantics as [`process_inbound`](ProcessorRegistry::process_inbound) but operates on
+    /// the outbound chain and takes a [`ProcessedMessage`] as input (converted internally to a
+    /// [`MessageContext`]). If the chain is empty the input is returned unchanged (bypass).
+    pub async fn process_outbound(
+        &self,
+        llm_output: ProcessedMessage,
+    ) -> Result<ProcessedMessage, ProcessError> {
+        if self.outbound.is_empty() {
+            return Ok(llm_output);
+        }
+
+        // Build a synthetic RawMessage so we can reuse MessageContext::from_raw.
+        let synthetic_raw = RawMessage {
+            platform: String::new(),
+            sender_id: String::new(),
+            content: llm_output.content.clone(),
+            timestamp: chrono::Utc::now(),
+            message_id: String::new(),
+        };
+        let mut ctx = MessageContext::from_raw(synthetic_raw);
+        ctx.metadata = llm_output.metadata.clone();
+        if llm_output.suppress {
+            ctx.skip = true;
+        }
+
+        let mut sorted = self.outbound.clone();
+        sorted.sort_by_key(|p| p.priority());
+
+        for processor in sorted {
+            if ctx.skip {
+                break;
+            }
+            match processor.process(&ctx).await? {
+                Some(out) => {
+                    ctx.content = out.content;
+                    for (k, v) in out.metadata {
+                        ctx.metadata.insert(k, v);
+                    }
+                    if out.suppress {
+                        ctx.skip = true;
+                    }
+                }
+                None => {
+                    // Processor chose to skip — halt the chain.
+                    ctx.skip = true;
+                    break;
+                }
+            }
+        }
+
+        Ok(ProcessedMessage {
+            content: ctx.content,
+            metadata: ctx.metadata,
+            suppress: ctx.skip,
+        })
+    }
+}

--- a/src/processor_chain/registry_tests.rs
+++ b/src/processor_chain/registry_tests.rs
@@ -1,0 +1,388 @@
+//! Tests for [`ProcessorRegistry`] — kept in a separate file to respect the
+//! ≤ 500-line limit per source file.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use crate::processor_chain::context::{MessageContext, ProcessedMessage};
+use crate::processor_chain::error::ProcessError;
+use crate::processor_chain::processor::{MessageProcessor, ProcessPhase};
+use crate::processor_chain::registry::ProcessorRegistry;
+use crate::processor_chain::RawMessage;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_raw(content: &str) -> RawMessage {
+    RawMessage {
+        platform: "test".to_string(),
+        sender_id: "user_1".to_string(),
+        content: content.to_string(),
+        timestamp: Utc::now(),
+        message_id: "msg_1".to_string(),
+    }
+}
+
+/// Test processor that sets its own name as content and records call count.
+struct TestProc {
+    name: String,
+    phase: ProcessPhase,
+    priority: u8,
+    call_counter: Arc<AtomicUsize>,
+    metadata_kv: Option<(String, serde_json::Value)>,
+    suppress: bool,
+    skip: bool,
+}
+
+impl TestProc {
+    fn inbound(name: &str, priority: u8) -> (Arc<Self>, Arc<AtomicUsize>) {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let proc = Self {
+            name: name.to_string(),
+            phase: ProcessPhase::Inbound,
+            priority,
+            call_counter: counter.clone(),
+            metadata_kv: None,
+            suppress: false,
+            skip: false,
+        };
+        (Arc::new(proc), counter)
+    }
+
+    fn outbound(name: &str, priority: u8) -> (Arc<Self>, Arc<AtomicUsize>) {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let proc = Self {
+            name: name.to_string(),
+            phase: ProcessPhase::Outbound,
+            priority,
+            call_counter: counter.clone(),
+            metadata_kv: None,
+            suppress: false,
+            skip: false,
+        };
+        (Arc::new(proc), counter)
+    }
+
+    fn with_metadata(mut self, key: &str, val: serde_json::Value) -> Self {
+        self.metadata_kv = Some((key.to_string(), val));
+        self
+    }
+    fn with_suppress(mut self) -> Self {
+        self.suppress = true;
+        self
+    }
+    fn with_skip(mut self) -> Self {
+        self.skip = true;
+        self
+    }
+}
+
+#[async_trait]
+impl MessageProcessor for TestProc {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn phase(&self) -> ProcessPhase {
+        self.phase
+    }
+    fn priority(&self) -> u8 {
+        self.priority
+    }
+
+    async fn process(
+        &self,
+        _ctx: &MessageContext,
+    ) -> Result<Option<ProcessedMessage>, ProcessError> {
+        self.call_counter.fetch_add(1, Ordering::SeqCst);
+        if self.skip {
+            return Ok(None);
+        }
+        let mut metadata = serde_json::Map::new();
+        if let Some((ref k, ref v)) = self.metadata_kv {
+            metadata.insert(k.clone(), v.clone());
+        }
+        Ok(Some(ProcessedMessage {
+            content: self.name.clone(),
+            metadata,
+            suppress: self.suppress,
+        }))
+    }
+}
+
+// ── inbound bypass ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_inbound_bypass() {
+    let registry = ProcessorRegistry::new();
+    let raw = make_raw("hello world");
+    let result = registry.process_inbound(raw.clone()).await.unwrap();
+
+    assert_eq!(result.content, raw.content);
+    assert!(!result.suppress);
+    assert_eq!(result.metadata.len(), 0);
+}
+
+// ── outbound bypass ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_bypass() {
+    let registry = ProcessorRegistry::new();
+    let llm_out = ProcessedMessage {
+        content: "llm said hello".to_string(),
+        metadata: serde_json::Map::new(),
+        suppress: false,
+    };
+    let result = registry.process_outbound(llm_out.clone()).await.unwrap();
+
+    assert_eq!(result.content, llm_out.content);
+    assert!(!result.suppress);
+    assert_eq!(result.metadata.len(), 0);
+}
+
+// ── priority ascending ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_inbound_priority_ascending() {
+    let (p_10, c10) = TestProc::inbound("p_10", 10);
+    let (p_5, c5) = TestProc::inbound("p_5", 5);
+    let (p_20, _) = TestProc::inbound("p_20", 20);
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(p_10.clone());
+    registry.register(p_5.clone());
+    registry.register(p_20.clone());
+
+    let result = registry.process_inbound(make_raw("orig")).await.unwrap();
+
+    assert_eq!(c5.load(Ordering::SeqCst), 1, "p_5 should be called once");
+    assert_eq!(c10.load(Ordering::SeqCst), 1, "p_10 should be called once");
+    assert_eq!(result.content, "p_20");
+}
+
+// ── chained processors: latter overrides former ───────────────────────────────
+
+#[tokio::test]
+async fn test_inbound_chained_override() {
+    let (p1, _) = TestProc::inbound("p1", 1);
+    let (p2, _) = TestProc::inbound("p2", 2);
+    let (p3, _) = TestProc::inbound("p3", 3);
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(p1);
+    registry.register(p2);
+    registry.register(p3);
+
+    let result = registry
+        .process_inbound(make_raw("original"))
+        .await
+        .unwrap();
+
+    assert_eq!(result.content, "p3");
+}
+
+#[tokio::test]
+async fn test_outbound_chained_override() {
+    let (o1, _) = TestProc::outbound("o1", 1);
+    let (o2, _) = TestProc::outbound("o2", 2);
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(o1);
+    registry.register(o2);
+
+    let result = registry
+        .process_outbound(ProcessedMessage {
+            content: "llm".to_string(),
+            metadata: serde_json::Map::new(),
+            suppress: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.content, "o2");
+}
+
+// ── error propagation ────────────────────────────────────────────────────────
+
+struct FailingProc {
+    name: String,
+    phase: ProcessPhase,
+    priority: u8,
+}
+
+impl FailingProc {
+    fn inbound(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            phase: ProcessPhase::Inbound,
+            priority: 1,
+        })
+    }
+    fn outbound(name: &str) -> Arc<Self> {
+        Arc::new(Self {
+            name: name.to_string(),
+            phase: ProcessPhase::Outbound,
+            priority: 1,
+        })
+    }
+}
+
+#[async_trait]
+impl MessageProcessor for FailingProc {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn phase(&self) -> ProcessPhase {
+        self.phase
+    }
+    fn priority(&self) -> u8 {
+        self.priority
+    }
+
+    async fn process(
+        &self,
+        _: &MessageContext,
+    ) -> Result<Option<ProcessedMessage>, ProcessError> {
+        Err(ProcessError::processor_failed(
+            self.name(),
+            "intentional failure",
+        ))
+    }
+}
+
+#[tokio::test]
+async fn test_inbound_error_propagates() {
+    let failing = FailingProc::inbound("fail");
+    let mut registry = ProcessorRegistry::new();
+    registry.register(failing);
+
+    let err = registry
+        .process_inbound(make_raw("hello"))
+        .await
+        .unwrap_err();
+    match err {
+        ProcessError::ProcessorFailed { name, .. } => assert_eq!(name, "fail"),
+        _ => panic!("expected ProcessorFailed, got {:?}", err),
+    }
+}
+
+#[tokio::test]
+async fn test_outbound_error_propagates() {
+    let failing = FailingProc::outbound("fail_out");
+    let mut registry = ProcessorRegistry::new();
+    registry.register(failing);
+
+    let err = registry
+        .process_outbound(ProcessedMessage {
+            content: "llm".to_string(),
+            metadata: serde_json::Map::new(),
+            suppress: false,
+        })
+        .await
+        .unwrap_err();
+
+    match err {
+        ProcessError::ProcessorFailed { name, .. } => assert_eq!(name, "fail_out"),
+        _ => panic!("expected ProcessorFailed, got {:?}", err),
+    }
+}
+
+// ── skip halts chain ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_skip_halts_inbound_chain() {
+    let (p1, c1) = TestProc::inbound("p1", 1);
+    let skip_counter = Arc::new(AtomicUsize::new(0));
+    let p2_skip = Arc::new(TestProc {
+        name: "p2_skip".to_string(),
+        phase: ProcessPhase::Inbound,
+        priority: 2,
+        call_counter: skip_counter,
+        metadata_kv: None,
+        suppress: false,
+        skip: true,
+    });
+    let (p3, c3) = TestProc::inbound("p3", 3);
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(p1.clone());
+    registry.register(p2_skip);
+    registry.register(p3.clone());
+
+    registry.process_inbound(make_raw("hello")).await.unwrap();
+
+    assert_eq!(c1.load(Ordering::SeqCst), 1, "p1 should be called");
+    assert_eq!(c3.load(Ordering::SeqCst), 0, "p3 should NOT run after skip");
+}
+
+// ── suppress halts chain ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_suppress_halts_inbound_chain() {
+    let (p1, c1) = TestProc::inbound("p1", 1);
+    let suppress_counter = Arc::new(AtomicUsize::new(0));
+    let p2_suppress = Arc::new(TestProc {
+        name: "p2_suppress".to_string(),
+        phase: ProcessPhase::Inbound,
+        priority: 2,
+        call_counter: suppress_counter,
+        metadata_kv: None,
+        suppress: true,
+        skip: false,
+    });
+    let (p3, c3) = TestProc::inbound("p3", 3);
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(p1.clone());
+    registry.register(p2_suppress);
+    registry.register(p3.clone());
+
+    let result = registry.process_inbound(make_raw("hello")).await.unwrap();
+
+    assert!(result.suppress);
+    assert_eq!(c1.load(Ordering::SeqCst), 1, "p1 should be called");
+    assert_eq!(c3.load(Ordering::SeqCst), 0, "p3 should NOT run after suppress");
+}
+
+// ── metadata merging ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_metadata_merged_across_chain() {
+    let (p1, _) = TestProc::inbound("p1", 1);
+    let p2 = Arc::new(TestProc {
+        name: "p2".to_string(),
+        phase: ProcessPhase::Inbound,
+        priority: 2,
+        call_counter: Arc::new(AtomicUsize::new(0)),
+        metadata_kv: Some(("key2".to_string(), serde_json::json!("value2"))),
+        suppress: false,
+        skip: false,
+    });
+    let p3 = Arc::new(TestProc {
+        name: "p3".to_string(),
+        phase: ProcessPhase::Inbound,
+        priority: 3,
+        call_counter: Arc::new(AtomicUsize::new(0)),
+        metadata_kv: Some(("key3".to_string(), serde_json::json!("value3"))),
+        suppress: false,
+        skip: false,
+    });
+
+    let mut registry = ProcessorRegistry::new();
+    registry.register(p1);
+    registry.register(p2);
+    registry.register(p3);
+
+    let result = registry.process_inbound(make_raw("orig")).await.unwrap();
+
+    assert_eq!(result.content, "p3");
+    assert_eq!(
+        result.metadata.get("key2").and_then(|v| v.as_str()),
+        Some("value2")
+    );
+    assert_eq!(
+        result.metadata.get("key3").and_then(|v| v.as_str()),
+        Some("value3")
+    );
+}


### PR DESCRIPTION
- Add MessageProcessor trait, MessageContext, ProcessedMessage, RawMessage
- Add ProcessorRegistry with inbound/outbound chain processing
- Add ProcessError enum with error variants

Source: issue #434
Type: feat
