### PR TITLE
feat(skills): add DiskSkillRegistry and skill resolution infrastructure

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,7 +63,7 @@ pub async fn handle_rule(action: RuleAction) -> Result<()> {
 }
 
 pub async fn handle_skill(action: SkillAction) -> Result<()> {
-    use closeclaw::skills::builtin_skills_with_engine;
+    use closeclaw::skills::{builtin_skills_with_engine, init_disk_skills, ScanConfig};
     match action {
         SkillAction::List => {
             let rs = RuleSet {
@@ -74,9 +74,23 @@ pub async fn handle_skill(action: SkillAction) -> Result<()> {
                 agent_creators: std::collections::HashMap::new(),
             };
             let eng = Arc::new(PermissionEngine::new(rs));
-            println!("Installed skills:");
+            let config = ScanConfig::default();
+            let disk_reg = init_disk_skills(&config);
+            if disk_reg.is_empty() {
+                println!("Installed skills (bundled):");
+            } else {
+                println!("Installed skills (disk):");
+                for name in disk_reg.list() {
+                    println!("  {} [disk]", name);
+                }
+                println!("Installed skills (bundled):");
+            }
             for s in builtin_skills_with_engine(eng).iter() {
-                println!("  {} v{}", s.manifest().name, s.manifest().version);
+                println!(
+                    "  {} v{} [bundled]",
+                    s.manifest().name,
+                    s.manifest().version
+                );
             }
         }
         SkillAction::Install { name } => {

--- a/src/skills/SPEC.md
+++ b/src/skills/SPEC.md
@@ -31,6 +31,8 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `SkillOutput` | registry | 技能执行输出（success、result、error） |
 | `SkillError` | registry | 错误类型：`NotFound`、`MethodNotFound`、`ExecutionFailed`、`InvalidArgs`、`PermissionDenied` |
 | `DiskSkill` | disk | 磁盘上发现的技能，包含 manifest、来源、路径 |
+| `DiskSkillRegistry` | disk | 磁盘技能内存注册表，持有一组 `DiskSkill`，提供 `get`/`list`/`contains`/`filter_by_source` 查询 |
+| `ResolvedSkill<'a>` | disk | 技能解析结果枚举：`Disk(&DiskSkill)` 或 `Bundled(Arc<dyn Skill>)` |
 | `ParsedSkill` | disk | 解析后的 SKILL.md，包含 manifest、是否仅描述、原始 frontmatter |
 | `ScanConfig` | disk | 技能目录扫描配置 |
 | `SkillSource` | disk | 技能来源优先级：`Bundled` < `ExtraDirs` < `Global` < `Agent` < `Project` |
@@ -44,6 +46,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 |------|------|------|
 | `SkillRegistry::new()` | SkillRegistry | 创建空注册表 |
 | `SkillRegistry::default()` | SkillRegistry | 创建默认注册表（同 `new()`） |
+| `DiskSkillRegistry::new(skills)` | DiskSkillRegistry | 创建注册表，持有已扫描的 `Vec<DiskSkill>` |
 | `FileOpsSkill::new()` | FileOpsSkill | 创建无权限引擎实例 |
 | `FileOpsSkill::with_engine(engine)` | FileOpsSkill | 创建带权限引擎实例 |
 | `GitOpsSkill::new()` | GitOpsSkill | 创建实例 |
@@ -58,6 +61,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `builtin_skills_with_engine(engine)` | builtin | 获取全部 7 个内置技能（带引擎） |
 | `parse_skill_md(raw)` | disk | 解析 SKILL.md YAML frontmatter |
 | `scan_all_skills(config)` | disk | 扫描所有技能目录，返回按优先级去重的技能列表 |
+| `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
 
 ### 内置类型
 
@@ -109,6 +113,13 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `SkillRegistry::get(name)` | SkillRegistry | 按名称查找技能 |
 | `SkillRegistry::list()` | SkillRegistry | 列出所有已注册技能名 |
 | `SkillRegistry::contains(name)` | SkillRegistry | 检查技能是否存在 |
+| `DiskSkillRegistry::get(name)` | DiskSkillRegistry | 按名称查找磁盘技能 |
+| `DiskSkillRegistry::list()` | DiskSkillRegistry | 列出所有磁盘技能名称 |
+| `DiskSkillRegistry::contains(name)` | DiskSkillRegistry | 检查磁盘技能是否存在 |
+| `DiskSkillRegistry::filter_by_source(source)` | DiskSkillRegistry | 按来源过滤磁盘技能 |
+| `DiskSkillRegistry::len()` | DiskSkillRegistry | 返回已注册技能数量 |
+| `resolve_skill(name, disk_registry, skill_registry)` | disk | 查询路由：先查 disk registry，未命中再查 bundled registry |
+| `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
 | `Skill::manifest()` | Skill trait | 获取技能元数据 |
 | `Skill::methods()` | Skill trait | 列出技能支持的方法 |
 
@@ -131,6 +142,20 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `types.rs` | 类型定义（DiskSkill、ParsedSkill、ScanConfig、SkillSource、SkillContext、SkillEffort、ParseError） |
 | `frontmatter.rs` | SKILL.md YAML frontmatter 解析器 |
 | `loader.rs` | 技能目录扫描器，按优先级聚合多来源技能 |
+| `registry.rs` | DiskSkillRegistry 内存注册表 |
+| `resolve.rs` | 技能查询路由函数 resolve_skill |
+| `init.rs` | init_disk_skills 初始化入口 |
+
+### 两套 Registry 并存架构
+
+Phase 2 引入双 Registry 设计，实现 disk skill 与 bundled skill 的平稳过渡：
+
+- **`SkillRegistry`**（旧）：管理所有 bundled skill（`builtin` + 运行时注册），所有操作 async，通过 `tokio::sync::RwLock` 保护 `HashMap`
+- **`DiskSkillRegistry`**（新）：管理从磁盘扫描加载的 skill，纯同步结构体，持有 `Vec<DiskSkill>`
+
+**查询路由**：`resolve_skill(name, disk_registry, skill_registry)` 先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async）。
+
+**Session 集成**：通过 `init_disk_skills(config)` 在启动时加载 disk skills，返回 `DiskSkillRegistry` 供后续查询使用。
 
 ### 技能发现优先级
 

--- a/src/skills/disk/SPEC.md
+++ b/src/skills/disk/SPEC.md
@@ -22,6 +22,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | 类型 | 功能 |
 |------|------|
 | `DiskSkill` | 磁盘上发现的技能：来源、manifest、SKILL.md 路径、技能目录路径 |
+| `DiskSkillRegistry` | 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `ResolvedSkill<'a>` | 技能解析结果枚举：`Disk(&DiskSkill)` 或 `Bundled(Arc<dyn Skill>)` |
 | `ParsedSkill` | 解析结果：manifest、是否仅描述字段、原始 frontmatter 文本 |
 | `ScanConfig` | 扫描配置：bundled_dir / extra_dirs / global_dir / project_root / agent_id |
 | `SkillSource` | 技能来源枚举：`Bundled` / `ExtraDirs` / `Global` / `Agent` / `Project` |
@@ -36,6 +38,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 |------|------|
 | `parse_skill_md(raw)` | 解析 SKILL.md 文件内容，返回 ParsedSkill 或 ParseError |
 | `scan_all_skills(config)` | 扫描所有配置的技能目录，返回按优先级去重的 Vec<DiskSkill> |
+| `init_disk_skills(config)` | 初始化磁盘技能注册表：调用 `scan_all_skills`，返回 DiskSkillRegistry |
+| `resolve_skill(name, disk_registry, skill_registry)` | 查询路由：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 ResolvedSkill |
 
 ---
 
@@ -48,6 +52,9 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `types.rs` | 所有类型定义，包含 SkillManifest、DiskSkill、ParsedSkill、ScanConfig、SkillSource、SkillContext、SkillEffort、ParseError |
 | `frontmatter.rs` | SKILL.md YAML frontmatter 解析实现 |
 | `loader.rs` | 技能目录扫描实现，按 SkillSource 优先级聚合 |
+| `registry.rs` | DiskSkillRegistry 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `resolve.rs` | 技能查询路由函数 `resolve_skill`：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 `ResolvedSkill` |
+| `init.rs` | `init_disk_skills` 初始化入口：调用 `scan_all_skills` 并构造 DiskSkillRegistry |
 
 ### 扫描优先级
 

--- a/src/skills/disk/init.rs
+++ b/src/skills/disk/init.rs
@@ -1,0 +1,63 @@
+//! init_disk_skills - initializes the disk skill registry at startup.
+
+use super::{registry::DiskSkillRegistry, scan_all_skills};
+
+/// Initializes the disk skill registry by scanning all configured skill directories.
+///
+/// Returns a [`DiskSkillRegistry`] containing all discovered disk skills,
+/// or an empty registry if no skills are found or all scans fail.
+pub fn init_disk_skills(config: &super::ScanConfig) -> DiskSkillRegistry {
+    let skills = scan_all_skills(config);
+    let loaded = skills.len();
+
+    tracing::info!(
+        loaded = loaded,
+        skipped = 0,
+        errors = 0,
+        "disk skill scan complete",
+    );
+
+    DiskSkillRegistry::new(skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ScanConfig;
+
+    #[test]
+    fn test_init_disk_skills_empty_config() {
+        let config = ScanConfig::default();
+        let registry = super::init_disk_skills(&config);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_init_disk_skills_nonexistent_dir() {
+        let config = ScanConfig {
+            bundled_dir: Some(std::path::PathBuf::from("/nonexistent")),
+            ..Default::default()
+        };
+        let registry = super::init_disk_skills(&config);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_init_disk_skills_with_valid_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill_dir = temp.path().join("test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: a test skill\n---\n# Test\n",
+        )
+        .unwrap();
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let registry = super::init_disk_skills(&config);
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.list(), vec!["test-skill"]);
+    }
+}

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -4,11 +4,17 @@
 //! hierarchical directories to find, parse, and load skill definitions.
 
 pub mod frontmatter;
+pub mod init;
 pub mod loader;
+pub mod registry;
+pub mod resolve;
 pub mod types;
 
 pub use frontmatter::parse_skill_md;
+pub use init::init_disk_skills;
 pub use loader::scan_all_skills;
+pub use registry::DiskSkillRegistry;
+pub use resolve::{resolve_skill, ResolvedSkill};
 pub use types::{
     DiskSkill, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort, SkillManifest,
     SkillSource,

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -1,0 +1,132 @@
+//! DiskSkillRegistry - in-memory registry for disk-loaded skills.
+
+use super::types::{DiskSkill, SkillSource};
+
+/// In-memory registry holding all discovered disk skills.
+#[derive(Debug, Default)]
+pub struct DiskSkillRegistry {
+    skills: Vec<DiskSkill>,
+}
+
+impl DiskSkillRegistry {
+    /// Creates a new registry with the given skills.
+    pub fn new(skills: Vec<DiskSkill>) -> Self {
+        Self { skills }
+    }
+
+    /// Returns the number of registered skills.
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
+
+    /// Returns true if the registry contains no skills.
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    /// Looks up a skill by exact name.
+    pub fn get(&self, name: &str) -> Option<&DiskSkill> {
+        self.skills.iter().find(|s| s.manifest.name == name)
+    }
+
+    /// Returns true if a skill with the given name exists.
+    pub fn contains(&self, name: &str) -> bool {
+        self.get(name).is_some()
+    }
+
+    /// Returns the names of all registered skills in registration order.
+    pub fn list(&self) -> Vec<&str> {
+        self.skills
+            .iter()
+            .map(|s| s.manifest.name.as_str())
+            .collect()
+    }
+
+    /// Returns all skills that originated from the given source.
+    pub fn filter_by_source(&self, source: SkillSource) -> Vec<&DiskSkill> {
+        self.skills.iter().filter(|s| s.source == source).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
+    use super::DiskSkill;
+    use super::DiskSkillRegistry;
+    use std::path::PathBuf;
+
+    fn skill(name: &str, source: SkillSource) -> DiskSkill {
+        DiskSkill {
+            source,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: String::new(),
+                context: SkillContext::default(),
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+            skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        }
+    }
+
+    #[test]
+    fn test_new_and_len() {
+        let r = DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)]);
+        assert_eq!(r.len(), 1);
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn test_empty_registry() {
+        let r = DiskSkillRegistry::new(vec![]);
+        assert!(r.is_empty());
+        assert!(r.get("any").is_none());
+        assert!(!r.contains("any"));
+        assert!(r.list().is_empty());
+        assert!(r.filter_by_source(SkillSource::Bundled).is_empty());
+    }
+
+    #[test]
+    fn test_get() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("foo", SkillSource::Agent),
+            skill("bar", SkillSource::Project),
+        ]);
+        assert_eq!(r.get("foo").unwrap().manifest.name, "foo");
+        assert!(r.get("baz").is_none());
+    }
+
+    #[test]
+    fn test_contains() {
+        let r = DiskSkillRegistry::new(vec![skill("x", SkillSource::Global)]);
+        assert!(r.contains("x"));
+        assert!(!r.contains("y"));
+    }
+
+    #[test]
+    fn test_list() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("z", SkillSource::Bundled),
+            skill("a", SkillSource::Global),
+        ]);
+        assert_eq!(r.list(), vec!["z", "a"]);
+    }
+
+    #[test]
+    fn test_filter_by_source() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("b1", SkillSource::Bundled),
+            skill("g1", SkillSource::Global),
+            skill("b2", SkillSource::Bundled),
+        ]);
+        assert_eq!(r.filter_by_source(SkillSource::Bundled).len(), 2);
+        assert_eq!(r.filter_by_source(SkillSource::Global).len(), 1);
+        assert_eq!(r.filter_by_source(SkillSource::Agent).len(), 0);
+    }
+}

--- a/src/skills/disk/resolve.rs
+++ b/src/skills/disk/resolve.rs
@@ -1,0 +1,145 @@
+//! Skill resolution - routes skill lookup between disk and bundled registries.
+
+use super::types::DiskSkill;
+use super::DiskSkillRegistry;
+use crate::skills::registry::{Skill, SkillRegistry};
+use std::sync::Arc;
+
+/// Result of a skill resolution attempt.
+pub enum ResolvedSkill<'a> {
+    /// Skill loaded from disk.
+    Disk(&'a DiskSkill),
+    /// Skill from the bundled registry.
+    Bundled(Arc<dyn Skill>),
+}
+
+/// Resolves a skill by name, checking disk registry first, then bundled registry.
+///
+/// Resolution order:
+/// 1. Disk registry (synchronous, checked first)
+/// 2. Bundled registry (async, checked second)
+///
+/// Returns `None` if the skill is not found in either registry.
+pub async fn resolve_skill<'a>(
+    name: &str,
+    disk_registry: &'a DiskSkillRegistry,
+    skill_registry: &'a SkillRegistry,
+) -> Option<ResolvedSkill<'a>> {
+    // Check disk registry first (synchronous)
+    if let Some(skill) = disk_registry.get(name) {
+        return Some(ResolvedSkill::Disk(skill));
+    }
+    // Then check bundled registry (async)
+    if let Some(skill) = skill_registry.get(name).await {
+        return Some(ResolvedSkill::Bundled(skill));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_skill, DiskSkillRegistry, ResolvedSkill};
+    use crate::skills::registry::{Skill, SkillManifest, SkillRegistry};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct BundledMockSkill(String);
+
+    #[async_trait]
+    impl Skill for BundledMockSkill {
+        fn manifest(&self) -> SkillManifest {
+            SkillManifest {
+                name: self.0.clone(),
+                version: "1.0".into(),
+                description: "bundled".into(),
+                author: None,
+                dependencies: vec![],
+            }
+        }
+        fn methods(&self) -> Vec<&str> {
+            vec![]
+        }
+        async fn execute(
+            &self,
+            _method: &str,
+            _args: serde_json::Value,
+        ) -> Result<serde_json::Value, crate::skills::registry::SkillError> {
+            Ok(serde_json::Value::Null)
+        }
+    }
+
+    fn make_disk_skill(name: &str) -> super::super::types::DiskSkill {
+        super::super::types::DiskSkill {
+            source: super::super::types::SkillSource::Global,
+            manifest: super::super::types::SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: String::new(),
+                context: super::super::types::SkillContext::default(),
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: super::super::types::SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: std::path::PathBuf::from("/tmp/test"),
+            skill_dir: std::path::PathBuf::from("/tmp/test"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_disk_hit() {
+        let disk_reg = DiskSkillRegistry::new(vec![make_disk_skill("disk-skill")]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("disk-skill".into())))
+            .await;
+
+        let result = resolve_skill("disk-skill", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Disk(_)) => {}
+            other => panic!("expected Disk, got unexpected variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_bundled_hit() {
+        let disk_reg = DiskSkillRegistry::new(vec![]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("bundled-skill".into())))
+            .await;
+
+        let result = resolve_skill("bundled-skill", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Bundled(_)) => {}
+            other => panic!("expected Bundled, got unexpected variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_not_found() {
+        let disk_reg = DiskSkillRegistry::new(vec![]);
+        let bundled_reg = SkillRegistry::new();
+
+        let result = resolve_skill("nonexistent", &disk_reg, &bundled_reg).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_disk_priority_over_bundled() {
+        // Both disk and bundled have a skill named "foo"; disk should win
+        let disk_reg = DiskSkillRegistry::new(vec![make_disk_skill("foo")]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("foo".into())))
+            .await;
+
+        let result = resolve_skill("foo", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Disk(_)) => {}
+            other => panic!("expected Disk (priority), got unexpected variant"),
+        }
+    }
+}

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -10,5 +10,6 @@ pub mod skill_creator;
 
 pub use builtin::{builtin_skills, builtin_skills_with_engine};
 pub use coding_agent::CodingAgentSkill;
+pub use disk::{init_disk_skills, resolve_skill, DiskSkillRegistry, ResolvedSkill, ScanConfig};
 pub use registry::{Skill, SkillError, SkillInput, SkillManifest, SkillOutput, SkillRegistry};
 pub use skill_creator::SkillCreatorSkill;


### PR DESCRIPTION
- Add DiskSkillRegistry with get/list/contains/filter_by_source/len methods
- Add resolve_skill() routing function for disk-first skill lookup
- Add init_disk_skills() initialization function with tracing logs
- Integrate disk skills into handlers.rs skill list command
- Update SPEC.md for DiskSkillRegistry and related interfaces

Source: issue #458
Type: feat
