### PR TITLE
feat(skills): add ToolResult/ContextModifier types and SkillTool

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -63,7 +63,7 @@ pub async fn handle_rule(action: RuleAction) -> Result<()> {
 }
 
 pub async fn handle_skill(action: SkillAction) -> Result<()> {
-    use closeclaw::skills::builtin_skills_with_engine;
+    use closeclaw::skills::{builtin_skills_with_engine, init_disk_skills, ScanConfig};
     match action {
         SkillAction::List => {
             let rs = RuleSet {
@@ -74,9 +74,23 @@ pub async fn handle_skill(action: SkillAction) -> Result<()> {
                 agent_creators: std::collections::HashMap::new(),
             };
             let eng = Arc::new(PermissionEngine::new(rs));
-            println!("Installed skills:");
+            let config = ScanConfig::default();
+            let disk_reg = init_disk_skills(&config);
+            if disk_reg.is_empty() {
+                println!("Installed skills (bundled):");
+            } else {
+                println!("Installed skills (disk):");
+                for name in disk_reg.list() {
+                    println!("  {} [disk]", name);
+                }
+                println!("Installed skills (bundled):");
+            }
             for s in builtin_skills_with_engine(eng).iter() {
-                println!("  {} v{}", s.manifest().name, s.manifest().version);
+                println!(
+                    "  {} v{} [bundled]",
+                    s.manifest().name,
+                    s.manifest().version
+                );
             }
         }
         SkillAction::Install { name } => {

--- a/src/skills/SPEC.md
+++ b/src/skills/SPEC.md
@@ -31,6 +31,8 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `SkillOutput` | registry | 技能执行输出（success、result、error） |
 | `SkillError` | registry | 错误类型：`NotFound`、`MethodNotFound`、`ExecutionFailed`、`InvalidArgs`、`PermissionDenied` |
 | `DiskSkill` | disk | 磁盘上发现的技能，包含 manifest、来源、路径 |
+| `DiskSkillRegistry` | disk | 磁盘技能内存注册表，持有一组 `DiskSkill`，提供 `get`/`list`/`contains`/`filter_by_source` 查询 |
+| `ResolvedSkill<'a>` | disk | 技能解析结果枚举：`Disk(&DiskSkill)` 或 `Bundled(Arc<dyn Skill>)` |
 | `ParsedSkill` | disk | 解析后的 SKILL.md，包含 manifest、是否仅描述、原始 frontmatter |
 | `ScanConfig` | disk | 技能目录扫描配置 |
 | `SkillSource` | disk | 技能来源优先级：`Bundled` < `ExtraDirs` < `Global` < `Agent` < `Project` |
@@ -44,6 +46,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 |------|------|------|
 | `SkillRegistry::new()` | SkillRegistry | 创建空注册表 |
 | `SkillRegistry::default()` | SkillRegistry | 创建默认注册表（同 `new()`） |
+| `DiskSkillRegistry::new(skills)` | DiskSkillRegistry | 创建注册表，持有已扫描的 `Vec<DiskSkill>` |
 | `FileOpsSkill::new()` | FileOpsSkill | 创建无权限引擎实例 |
 | `FileOpsSkill::with_engine(engine)` | FileOpsSkill | 创建带权限引擎实例 |
 | `GitOpsSkill::new()` | GitOpsSkill | 创建实例 |
@@ -58,6 +61,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `builtin_skills_with_engine(engine)` | builtin | 获取全部 7 个内置技能（带引擎） |
 | `parse_skill_md(raw)` | disk | 解析 SKILL.md YAML frontmatter |
 | `scan_all_skills(config)` | disk | 扫描所有技能目录，返回按优先级去重的技能列表 |
+| `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
 
 ### 内置类型
 
@@ -109,6 +113,13 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `SkillRegistry::get(name)` | SkillRegistry | 按名称查找技能 |
 | `SkillRegistry::list()` | SkillRegistry | 列出所有已注册技能名 |
 | `SkillRegistry::contains(name)` | SkillRegistry | 检查技能是否存在 |
+| `DiskSkillRegistry::get(name)` | DiskSkillRegistry | 按名称查找磁盘技能 |
+| `DiskSkillRegistry::list()` | DiskSkillRegistry | 列出所有磁盘技能名称 |
+| `DiskSkillRegistry::contains(name)` | DiskSkillRegistry | 检查磁盘技能是否存在 |
+| `DiskSkillRegistry::filter_by_source(source)` | DiskSkillRegistry | 按来源过滤磁盘技能 |
+| `DiskSkillRegistry::len()` | DiskSkillRegistry | 返回已注册技能数量 |
+| `resolve_skill(name, disk_registry, skill_registry)` | disk | 查询路由：先查 disk registry，未命中再查 bundled registry |
+| `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
 | `Skill::manifest()` | Skill trait | 获取技能元数据 |
 | `Skill::methods()` | Skill trait | 列出技能支持的方法 |
 
@@ -131,6 +142,20 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `types.rs` | 类型定义（DiskSkill、ParsedSkill、ScanConfig、SkillSource、SkillContext、SkillEffort、ParseError） |
 | `frontmatter.rs` | SKILL.md YAML frontmatter 解析器 |
 | `loader.rs` | 技能目录扫描器，按优先级聚合多来源技能 |
+| `registry.rs` | DiskSkillRegistry 内存注册表 |
+| `resolve.rs` | 技能查询路由函数 resolve_skill |
+| `init.rs` | init_disk_skills 初始化入口 |
+
+### 两套 Registry 并存架构
+
+Phase 2 引入双 Registry 设计，实现 disk skill 与 bundled skill 的平稳过渡：
+
+- **`SkillRegistry`**（旧）：管理所有 bundled skill（`builtin` + 运行时注册），所有操作 async，通过 `tokio::sync::RwLock` 保护 `HashMap`
+- **`DiskSkillRegistry`**（新）：管理从磁盘扫描加载的 skill，纯同步结构体，持有 `Vec<DiskSkill>`
+
+**查询路由**：`resolve_skill(name, disk_registry, skill_registry)` 先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async）。
+
+**Session 集成**：通过 `init_disk_skills(config)` 在启动时加载 disk skills，返回 `DiskSkillRegistry` 供后续查询使用。
 
 ### 技能发现优先级
 

--- a/src/skills/disk/SPEC.md
+++ b/src/skills/disk/SPEC.md
@@ -22,6 +22,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | 类型 | 功能 |
 |------|------|
 | `DiskSkill` | 磁盘上发现的技能：来源、manifest、SKILL.md 路径、技能目录路径 |
+| `DiskSkillRegistry` | 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `ResolvedSkill<'a>` | 技能解析结果枚举：`Disk(&DiskSkill)` 或 `Bundled(Arc<dyn Skill>)` |
 | `ParsedSkill` | 解析结果：manifest、是否仅描述字段、原始 frontmatter 文本 |
 | `ScanConfig` | 扫描配置：bundled_dir / extra_dirs / global_dir / project_root / agent_id |
 | `SkillSource` | 技能来源枚举：`Bundled` / `ExtraDirs` / `Global` / `Agent` / `Project` |
@@ -36,6 +38,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 |------|------|
 | `parse_skill_md(raw)` | 解析 SKILL.md 文件内容，返回 ParsedSkill 或 ParseError |
 | `scan_all_skills(config)` | 扫描所有配置的技能目录，返回按优先级去重的 Vec<DiskSkill> |
+| `init_disk_skills(config)` | 初始化磁盘技能注册表：调用 `scan_all_skills`，返回 DiskSkillRegistry |
+| `resolve_skill(name, disk_registry, skill_registry)` | 查询路由：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 ResolvedSkill |
 
 ---
 
@@ -48,6 +52,9 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `types.rs` | 所有类型定义，包含 SkillManifest、DiskSkill、ParsedSkill、ScanConfig、SkillSource、SkillContext、SkillEffort、ParseError |
 | `frontmatter.rs` | SKILL.md YAML frontmatter 解析实现 |
 | `loader.rs` | 技能目录扫描实现，按 SkillSource 优先级聚合 |
+| `registry.rs` | DiskSkillRegistry 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `resolve.rs` | 技能查询路由函数 `resolve_skill`：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 `ResolvedSkill` |
+| `init.rs` | `init_disk_skills` 初始化入口：调用 `scan_all_skills` 并构造 DiskSkillRegistry |
 
 ### 扫描优先级
 

--- a/src/skills/disk/init.rs
+++ b/src/skills/disk/init.rs
@@ -1,0 +1,63 @@
+//! init_disk_skills - initializes the disk skill registry at startup.
+
+use super::{registry::DiskSkillRegistry, scan_all_skills};
+
+/// Initializes the disk skill registry by scanning all configured skill directories.
+///
+/// Returns a [`DiskSkillRegistry`] containing all discovered disk skills,
+/// or an empty registry if no skills are found or all scans fail.
+pub fn init_disk_skills(config: &super::ScanConfig) -> DiskSkillRegistry {
+    let skills = scan_all_skills(config);
+    let loaded = skills.len();
+
+    tracing::info!(
+        loaded = loaded,
+        skipped = 0,
+        errors = 0,
+        "disk skill scan complete",
+    );
+
+    DiskSkillRegistry::new(skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ScanConfig;
+
+    #[test]
+    fn test_init_disk_skills_empty_config() {
+        let config = ScanConfig::default();
+        let registry = super::init_disk_skills(&config);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_init_disk_skills_nonexistent_dir() {
+        let config = ScanConfig {
+            bundled_dir: Some(std::path::PathBuf::from("/nonexistent")),
+            ..Default::default()
+        };
+        let registry = super::init_disk_skills(&config);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn test_init_disk_skills_with_valid_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill_dir = temp.path().join("test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: a test skill\n---\n# Test\n",
+        )
+        .unwrap();
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let registry = super::init_disk_skills(&config);
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.list(), vec!["test-skill"]);
+    }
+}

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -4,11 +4,17 @@
 //! hierarchical directories to find, parse, and load skill definitions.
 
 pub mod frontmatter;
+pub mod init;
 pub mod loader;
+pub mod registry;
+pub mod resolve;
 pub mod types;
 
 pub use frontmatter::parse_skill_md;
+pub use init::init_disk_skills;
 pub use loader::scan_all_skills;
+pub use registry::DiskSkillRegistry;
+pub use resolve::{resolve_skill, ResolvedSkill};
 pub use types::{
     DiskSkill, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort, SkillManifest,
     SkillSource,

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -1,0 +1,132 @@
+//! DiskSkillRegistry - in-memory registry for disk-loaded skills.
+
+use super::types::{DiskSkill, SkillSource};
+
+/// In-memory registry holding all discovered disk skills.
+#[derive(Debug, Default)]
+pub struct DiskSkillRegistry {
+    skills: Vec<DiskSkill>,
+}
+
+impl DiskSkillRegistry {
+    /// Creates a new registry with the given skills.
+    pub fn new(skills: Vec<DiskSkill>) -> Self {
+        Self { skills }
+    }
+
+    /// Returns the number of registered skills.
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
+
+    /// Returns true if the registry contains no skills.
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    /// Looks up a skill by exact name.
+    pub fn get(&self, name: &str) -> Option<&DiskSkill> {
+        self.skills.iter().find(|s| s.manifest.name == name)
+    }
+
+    /// Returns true if a skill with the given name exists.
+    pub fn contains(&self, name: &str) -> bool {
+        self.get(name).is_some()
+    }
+
+    /// Returns the names of all registered skills in registration order.
+    pub fn list(&self) -> Vec<&str> {
+        self.skills
+            .iter()
+            .map(|s| s.manifest.name.as_str())
+            .collect()
+    }
+
+    /// Returns all skills that originated from the given source.
+    pub fn filter_by_source(&self, source: SkillSource) -> Vec<&DiskSkill> {
+        self.skills.iter().filter(|s| s.source == source).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
+    use super::DiskSkill;
+    use super::DiskSkillRegistry;
+    use std::path::PathBuf;
+
+    fn skill(name: &str, source: SkillSource) -> DiskSkill {
+        DiskSkill {
+            source,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: String::new(),
+                context: SkillContext::default(),
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+            skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        }
+    }
+
+    #[test]
+    fn test_new_and_len() {
+        let r = DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)]);
+        assert_eq!(r.len(), 1);
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn test_empty_registry() {
+        let r = DiskSkillRegistry::new(vec![]);
+        assert!(r.is_empty());
+        assert!(r.get("any").is_none());
+        assert!(!r.contains("any"));
+        assert!(r.list().is_empty());
+        assert!(r.filter_by_source(SkillSource::Bundled).is_empty());
+    }
+
+    #[test]
+    fn test_get() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("foo", SkillSource::Agent),
+            skill("bar", SkillSource::Project),
+        ]);
+        assert_eq!(r.get("foo").unwrap().manifest.name, "foo");
+        assert!(r.get("baz").is_none());
+    }
+
+    #[test]
+    fn test_contains() {
+        let r = DiskSkillRegistry::new(vec![skill("x", SkillSource::Global)]);
+        assert!(r.contains("x"));
+        assert!(!r.contains("y"));
+    }
+
+    #[test]
+    fn test_list() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("z", SkillSource::Bundled),
+            skill("a", SkillSource::Global),
+        ]);
+        assert_eq!(r.list(), vec!["z", "a"]);
+    }
+
+    #[test]
+    fn test_filter_by_source() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("b1", SkillSource::Bundled),
+            skill("g1", SkillSource::Global),
+            skill("b2", SkillSource::Bundled),
+        ]);
+        assert_eq!(r.filter_by_source(SkillSource::Bundled).len(), 2);
+        assert_eq!(r.filter_by_source(SkillSource::Global).len(), 1);
+        assert_eq!(r.filter_by_source(SkillSource::Agent).len(), 0);
+    }
+}

--- a/src/skills/disk/resolve.rs
+++ b/src/skills/disk/resolve.rs
@@ -1,0 +1,145 @@
+//! Skill resolution - routes skill lookup between disk and bundled registries.
+
+use super::types::DiskSkill;
+use super::DiskSkillRegistry;
+use crate::skills::registry::{Skill, SkillRegistry};
+use std::sync::Arc;
+
+/// Result of a skill resolution attempt.
+pub enum ResolvedSkill<'a> {
+    /// Skill loaded from disk.
+    Disk(&'a DiskSkill),
+    /// Skill from the bundled registry.
+    Bundled(Arc<dyn Skill>),
+}
+
+/// Resolves a skill by name, checking disk registry first, then bundled registry.
+///
+/// Resolution order:
+/// 1. Disk registry (synchronous, checked first)
+/// 2. Bundled registry (async, checked second)
+///
+/// Returns `None` if the skill is not found in either registry.
+pub async fn resolve_skill<'a>(
+    name: &str,
+    disk_registry: &'a DiskSkillRegistry,
+    skill_registry: &'a SkillRegistry,
+) -> Option<ResolvedSkill<'a>> {
+    // Check disk registry first (synchronous)
+    if let Some(skill) = disk_registry.get(name) {
+        return Some(ResolvedSkill::Disk(skill));
+    }
+    // Then check bundled registry (async)
+    if let Some(skill) = skill_registry.get(name).await {
+        return Some(ResolvedSkill::Bundled(skill));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_skill, DiskSkillRegistry, ResolvedSkill};
+    use crate::skills::registry::{Skill, SkillManifest, SkillRegistry};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct BundledMockSkill(String);
+
+    #[async_trait]
+    impl Skill for BundledMockSkill {
+        fn manifest(&self) -> SkillManifest {
+            SkillManifest {
+                name: self.0.clone(),
+                version: "1.0".into(),
+                description: "bundled".into(),
+                author: None,
+                dependencies: vec![],
+            }
+        }
+        fn methods(&self) -> Vec<&str> {
+            vec![]
+        }
+        async fn execute(
+            &self,
+            _method: &str,
+            _args: serde_json::Value,
+        ) -> Result<serde_json::Value, crate::skills::registry::SkillError> {
+            Ok(serde_json::Value::Null)
+        }
+    }
+
+    fn make_disk_skill(name: &str) -> super::super::types::DiskSkill {
+        super::super::types::DiskSkill {
+            source: super::super::types::SkillSource::Global,
+            manifest: super::super::types::SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: String::new(),
+                context: super::super::types::SkillContext::default(),
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: super::super::types::SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: std::path::PathBuf::from("/tmp/test"),
+            skill_dir: std::path::PathBuf::from("/tmp/test"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_disk_hit() {
+        let disk_reg = DiskSkillRegistry::new(vec![make_disk_skill("disk-skill")]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("disk-skill".into())))
+            .await;
+
+        let result = resolve_skill("disk-skill", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Disk(_)) => {}
+            other => panic!("expected Disk, got unexpected variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_bundled_hit() {
+        let disk_reg = DiskSkillRegistry::new(vec![]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("bundled-skill".into())))
+            .await;
+
+        let result = resolve_skill("bundled-skill", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Bundled(_)) => {}
+            other => panic!("expected Bundled, got unexpected variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_not_found() {
+        let disk_reg = DiskSkillRegistry::new(vec![]);
+        let bundled_reg = SkillRegistry::new();
+
+        let result = resolve_skill("nonexistent", &disk_reg, &bundled_reg).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_disk_priority_over_bundled() {
+        // Both disk and bundled have a skill named "foo"; disk should win
+        let disk_reg = DiskSkillRegistry::new(vec![make_disk_skill("foo")]);
+        let mut bundled_reg = SkillRegistry::new();
+        bundled_reg
+            .register(Arc::new(BundledMockSkill("foo".into())))
+            .await;
+
+        let result = resolve_skill("foo", &disk_reg, &bundled_reg).await;
+        match result {
+            Some(ResolvedSkill::Disk(_)) => {}
+            other => panic!("expected Disk (priority), got unexpected variant"),
+        }
+    }
+}

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -10,5 +10,6 @@ pub mod skill_creator;
 
 pub use builtin::{builtin_skills, builtin_skills_with_engine};
 pub use coding_agent::CodingAgentSkill;
+pub use disk::{init_disk_skills, resolve_skill, DiskSkillRegistry, ResolvedSkill, ScanConfig};
 pub use registry::{Skill, SkillError, SkillInput, SkillManifest, SkillOutput, SkillRegistry};
 pub use skill_creator::SkillCreatorSkill;

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -228,8 +228,10 @@ mod tests {
     use super::super::sections::Section;
     use super::super::sections::{clear_append_section, set_append_section};
     use super::*;
+    use crate::skills::DiskSkillRegistry;
     use crate::tools::builtin::register_builtin_tools;
     use crate::tools::ToolRegistry;
+    use std::sync::Arc;
 
     #[test]
     fn test_build_system_prompt_with_override() {
@@ -315,7 +317,8 @@ mod tests {
     #[tokio::test]
     async fn test_build_tools_section_returns_tools_section() {
         let registry = ToolRegistry::new();
-        register_builtin_tools(&registry).await;
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry).await;
         let ctx = crate::tools::ToolContext {
             agent_id: "test".to_string(),
             workdir: None,
@@ -330,7 +333,8 @@ mod tests {
     #[tokio::test]
     async fn test_build_tools_section_contains_group_headers() {
         let registry = ToolRegistry::new();
-        register_builtin_tools(&registry).await;
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry).await;
         let ctx = crate::tools::ToolContext {
             agent_id: "test".to_string(),
             workdir: None,
@@ -352,7 +356,8 @@ mod tests {
     #[tokio::test]
     async fn test_build_tools_section_contains_tool_names() {
         let registry = ToolRegistry::new();
-        register_builtin_tools(&registry).await;
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry).await;
         let ctx = crate::tools::ToolContext {
             agent_id: "test".to_string(),
             workdir: None,
@@ -384,7 +389,8 @@ mod tests {
     #[tokio::test]
     async fn test_build_tools_section_respects_max_length() {
         let registry = ToolRegistry::new();
-        register_builtin_tools(&registry).await;
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry).await;
         let ctx = crate::tools::ToolContext {
             agent_id: "test".to_string(),
             workdir: None,

--- a/src/tools/SPEC.md
+++ b/src/tools/SPEC.md
@@ -9,7 +9,7 @@
 - `ToolRegistry` 是并发安全的注册中心，内部用 `tokio::sync::RwLock` 包裹 `HashMap<String, Arc<dyn Tool>>`
 - `ToolDescriptor` 仅含 name / group / summary / is_deferred，用于 system prompt 一级索引
 - 工具 detail 和 input_schema 按需通过 `ToolSearch` 触发注入，不在一级索引展开
-- `builtin` 子模块提供 5 个 file_ops 工具、2 个 meta 工具、5 个 git_ops 工具和 2 个 stub 工具，全部通过 `register_builtin_tools()` 一键注册
+- `builtin` 子模块提供 5 个 file_ops 工具、2 个 meta 工具、5 个 git_ops 工具、1 个 SkillTool 和 2 个 stub 工具，全部通过 `register_builtin_tools()` 一键注册
 - System prompt 集成：builder.rs 提供 `build_tools_section(registry, ctx)` async 函数，返回 `Section::ToolsSection`；`build_from_workspace` 中预埋 `Section::ToolsSection(String::new())` 占位符（位于 RoleSection 之后 MemorySection 之前）。当前 `build_tools_section` 尚未在 sync 路径中与 `build_from_workspace` 打通，内容通过 dynamic_sections 外部传入
 
 边界：builtin tools 不依赖 `crate::skills` 模块；`ToolRegistry` 依赖 `tokio`（异步运行时）。
@@ -20,11 +20,15 @@
 
 ### 核心类型（mod.rs）
 
-- `Tool` trait — 工具核心接口，6 个方法：name / group / summary / detail / input_schema / flags
+- `Tool` trait — 工具核心接口，6 个方法：name / group / summary / detail / input_schema / flags；第 7 个方法 call() 用于执行（默认返回 NotImplemented）
 - `ToolFlags` — bitflags 风格运行时标记（is_concurrency_safe / is_read_only / is_destructive / is_expensive / is_deferred_by_default）
 - `ToolContext` — 运行时上下文（agent_id + workdir）
 - `ToolDescriptor` — 一级摘要数据（name / group / summary / is_deferred）
 - `ToolError` — 工具层错误类型，用 thiserror 定义（NotFound / AlreadyRegistered / Serialization / Io）
+- `ToolCallError` — 工具执行错误（NotFound / PermissionDenied / InvalidArgs / ExecutionFailed / NotImplemented）
+- `ToolMessage` — 注入上下文的元消息（content + is_meta）
+- `ContextModifier` — 上下文修改器（allowed_tools 列表）
+- `ToolResult` — 工具执行结果（data + new_messages + context_modifier）
 
 ### 注册中心（registry.rs）
 
@@ -37,7 +41,8 @@
 
 ### 内建工具（builtin/）
 
-- `register_builtin_tools(registry)` — 将全部 14 个内建工具注册到指定注册表
+- `SkillTool` — skills 组，从 DiskSkillRegistry 查找 skill 并注入 SKILL.md 内容到 agent 上下文；group = "skills"，is_deferred_by_default = false；输入参数 skill_name（必填）和 args（可选）
+- `register_builtin_tools(registry, disk_registry)` — 将全部 16 个内建工具注册到指定注册表
 - `ReadTool` / `WriteTool` / `EditTool` / `GrepTool` / `LsTool` — file_ops 组，group = "file_ops"
 - `ToolSearchTool` / `PermissionQueryTool` — meta 组，group = "meta"，is_deferred_by_default = false
 - `GitStatusTool` / `GitLogTool` / `GitCommitTool` / `GitPushTool` / `GitPullTool` — git_ops 组，group = "git_ops"；GitStatusTool/GitLogTool 标记 is_read_only，GitCommitTool/GitPushTool/GitPullTool 标记 is_destructive
@@ -55,11 +60,12 @@ tools/
 ├── mod.rs              # Tool trait、ToolFlags、ToolContext、ToolDescriptor、ToolError
 ├── registry.rs         # ToolRegistry 并发注册中心 + build_tools_section
 └── builtin/
-    ├── mod.rs          # register_builtin_tools 统一入口（14 个工具）
+    ├── mod.rs          # register_builtin_tools 统一入口（15 个工具）
     ├── file_ops.rs     # Read / Write / Edit / Grep / Ls
     ├── git_ops.rs      # GitStatus / GitLog / GitCommit / GitPush / GitPull
     ├── coding_agent.rs # CodingAgentTool (stub)
     ├── skill_creator.rs # SkillCreatorTool (stub)
+    ├── skill_tool.rs   # SkillTool
     ├── search.rs       # ToolSearchTool
     └── permission.rs   # PermissionQueryTool
 ```

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -9,6 +9,7 @@ pub mod git_ops;
 pub mod permission;
 pub mod search;
 pub mod skill_creator;
+pub mod skill_tool;
 
 pub use coding_agent::CodingAgentTool;
 pub use file_ops::{EditTool, GrepTool, LsTool, ReadTool, WriteTool};
@@ -16,10 +17,15 @@ pub use git_ops::{GitCommitTool, GitLogTool, GitPullTool, GitPushTool, GitStatus
 pub use permission::PermissionQueryTool;
 pub use search::ToolSearchTool;
 pub use skill_creator::SkillCreatorTool;
+pub use skill_tool::SkillTool;
+
+use std::sync::Arc;
+
+use crate::skills::DiskSkillRegistry;
 
 /// Registers all built-in tools with the given registry.
 ///
-/// Currently registers 14 tools:
+/// Currently registers 15 tools:
 ///
 /// 5 file_ops tools:
 /// - [`ReadTool`]
@@ -39,10 +45,14 @@ pub use skill_creator::SkillCreatorTool;
 /// - [`GitPushTool`]
 /// - [`GitPullTool`]
 ///
-/// 2 stub tools:
+/// 3 stub tools:
 /// - [`CodingAgentTool`]
 /// - [`SkillCreatorTool`]
-pub async fn register_builtin_tools(registry: &crate::tools::ToolRegistry) {
+/// - [`SkillTool`]
+pub async fn register_builtin_tools(
+    registry: &crate::tools::ToolRegistry,
+    disk_registry: Arc<DiskSkillRegistry>,
+) {
     // file_ops
     registry.register(ReadTool::new()).await.ok();
     registry.register(WriteTool::new()).await.ok();
@@ -61,4 +71,6 @@ pub async fn register_builtin_tools(registry: &crate::tools::ToolRegistry) {
     // stub
     registry.register(CodingAgentTool::new()).await.ok();
     registry.register(SkillCreatorTool::new()).await.ok();
+    // skills
+    registry.register(SkillTool::new(disk_registry)).await.ok();
 }

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -1,0 +1,330 @@
+//! Built-in tool — SkillTool
+//!
+//! Invokes a disk-based skill by looking it up in the [`DiskSkillRegistry`],
+//! reading its SKILL.md file, and returning the content as a meta message
+//! to be injected into the agent context.
+
+use crate::skills::disk::DiskSkillRegistry;
+use crate::tools::{
+    ContextModifier, Tool, ToolCallError, ToolContext, ToolFlags, ToolMessage, ToolResult,
+};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// SkillTool
+// ---------------------------------------------------------------------------
+
+/// Tool that loads and executes a disk-based skill.
+///
+/// When called, `SkillTool` looks up the named skill in the
+/// [`DiskSkillRegistry`], reads its SKILL.md file, and injects the
+/// content as a meta message into the agent context.
+pub struct SkillTool {
+    registry: Arc<DiskSkillRegistry>,
+}
+
+impl SkillTool {
+    /// Creates a new `SkillTool` backed by the given registry.
+    pub fn new(registry: Arc<DiskSkillRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillTool {
+    fn name(&self) -> &str {
+        "SkillTool"
+    }
+
+    fn group(&self) -> &str {
+        "skills"
+    }
+
+    fn summary(&self) -> String {
+        "Load and execute a disk-based skill".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Loads a skill definition from the disk-based skill registry and \
+         makes it available to the agent. Call this tool with `skill_name` \
+         (required) to retrieve the skill's SKILL.md content, which will be \
+         injected as a meta message. The `args` field (optional) can pass \
+         additional context to the skill."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the skill to load (e.g. 'clawhub')"
+                },
+                "args": {
+                    "type": "object",
+                    "description": "Optional arguments to pass to the skill"
+                }
+            },
+            "required": ["skill_name"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: false,
+            ..Default::default()
+        }
+    }
+
+    async fn call(&self, args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        // Extract skill_name from args
+        let skill_name = args
+            .get("skill_name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolCallError::InvalidArgs("skill_name is required".to_string()))?;
+
+        // Look up the skill in the registry
+        let skill = self
+            .registry
+            .get(skill_name)
+            .ok_or_else(|| ToolCallError::NotFound(skill_name.to_string()))?;
+
+        // Read the SKILL.md file
+        let readme_content = tokio::fs::read_to_string(&skill.readme_path)
+            .await
+            .map_err(|e| {
+                ToolCallError::ExecutionFailed(format!(
+                    "failed to read {}: {}",
+                    skill.readme_path.display(),
+                    e
+                ))
+            })?;
+
+        // Build context_modifier from manifest.allowed_tools
+        let context_modifier = if skill.manifest.allowed_tools.is_empty() {
+            None
+        } else {
+            Some(ContextModifier {
+                allowed_tools: skill.manifest.allowed_tools.clone(),
+            })
+        };
+
+        Ok(ToolResult {
+            data: serde_json::json!({
+                "skill_name": skill_name,
+                "status": "loaded"
+            }),
+            new_messages: vec![ToolMessage {
+                content: readme_content,
+                is_meta: true,
+            }],
+            context_modifier,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::disk::types::{
+        DiskSkill, SkillContext, SkillEffort, SkillManifest, SkillSource,
+    };
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn make_skill(
+        name: &str,
+        allowed_tools: Vec<String>,
+        readme_path: std::path::PathBuf,
+    ) -> DiskSkill {
+        DiskSkill {
+            source: SkillSource::Bundled,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("A test skill named {}", name),
+                allowed_tools,
+                when_to_use: String::new(),
+                context: SkillContext::Inline,
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: SkillEffort::Small,
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path,
+            skill_dir: std::path::PathBuf::new(),
+        }
+    }
+
+    fn new_ctx() -> ToolContext {
+        ToolContext {
+            agent_id: "test-agent".to_string(),
+            workdir: None,
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Metadata tests
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_skill_tool_name() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        assert_eq!(tool.name(), "SkillTool");
+    }
+
+    #[test]
+    fn test_skill_tool_group() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        assert_eq!(tool.group(), "skills");
+    }
+
+    #[test]
+    fn test_skill_tool_summary_length() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let summary = tool.summary();
+        assert!(
+            summary.len() <= 50,
+            "summary '{}' exceeds 50 chars",
+            summary
+        );
+    }
+
+    #[test]
+    fn test_skill_tool_flags_is_deferred_false() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let flags = tool.flags();
+        assert!(!flags.is_deferred_by_default);
+    }
+
+    #[test]
+    fn test_skill_tool_input_schema_contains_skill_name() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let schema = tool.input_schema();
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("skill_name"));
+        assert!(props.contains_key("args"));
+        let required = schema.get("required").unwrap().as_array().unwrap();
+        assert!(required.contains(&serde_json::json!("skill_name")));
+    }
+
+    // -----------------------------------------------------------------
+    // call() — error cases
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_call_skill_not_found() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let result = tool
+            .call(serde_json::json!({"skill_name": "nonexistent"}), &new_ctx())
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ToolCallError::NotFound(_)));
+        let ToolCallError::NotFound(name) = err else {
+            unreachable!()
+        };
+        assert_eq!(name, "nonexistent");
+    }
+
+    #[tokio::test]
+    async fn test_call_missing_skill_name() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let result = tool.call(serde_json::json!({}), &new_ctx()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ToolCallError::InvalidArgs(_)));
+    }
+
+    #[tokio::test]
+    async fn test_call_skill_name_wrong_type() {
+        let registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let tool = SkillTool::new(registry);
+        let result = tool
+            .call(serde_json::json!({"skill_name": 123}), &new_ctx())
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ToolCallError::InvalidArgs(_)));
+    }
+
+    #[tokio::test]
+    async fn test_call_readme_file_not_found() {
+        let skill = make_skill(
+            "orphan",
+            vec![],
+            std::path::PathBuf::from("/nonexistent/path/SKILL.md"),
+        );
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry);
+        let result = tool
+            .call(serde_json::json!({"skill_name": "orphan"}), &new_ctx())
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(result, Err(ToolCallError::ExecutionFailed(_))));
+    }
+
+    // -----------------------------------------------------------------
+    // call() — normal cases
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_call_normal_with_empty_allowed_tools() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content =
+            "---\ndescription: A test skill\n---\n\n# Test Skill\n\nSome skill content here.\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let skill = make_skill("testskill", vec![], readme_path);
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result.data["skill_name"], "testskill");
+        assert_eq!(result.data["status"], "loaded");
+        assert_eq!(result.new_messages.len(), 1);
+        assert!(result.new_messages[0].is_meta);
+        assert_eq!(result.new_messages[0].content, skill_content);
+        assert!(result.context_modifier.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_call_normal_with_allowed_tools() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content = "---\ndescription: Skill with allowed tools\n---\n\n# My Skill\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let skill = make_skill(
+            "tooled",
+            vec!["ReadTool".into(), "WriteTool".into()],
+            readme_path,
+        );
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "tooled"}), &new_ctx())
+            .await
+            .unwrap();
+
+        assert!(result.context_modifier.is_some());
+        let cm = result.context_modifier.unwrap();
+        assert_eq!(cm.allowed_tools, vec!["ReadTool", "WriteTool"]);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -16,6 +16,7 @@ pub mod registry;
 
 pub use registry::ToolRegistry;
 
+use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
 
@@ -104,6 +105,68 @@ pub enum ToolError {
 }
 
 // ---------------------------------------------------------------------------
+// ToolCallError —工具执行错误
+// ---------------------------------------------------------------------------
+
+/// Errors raised during tool execution.
+#[derive(Debug, Error, Clone)]
+pub enum ToolCallError {
+    #[error("skill not found: {0}")]
+    NotFound(String),
+
+    #[error("permission denied for skill: {0}")]
+    PermissionDenied(String),
+
+    #[error("invalid arguments: {0}")]
+    InvalidArgs(String),
+
+    #[error("execution failed: {0}")]
+    ExecutionFailed(String),
+
+    #[error("call not implemented for this tool")]
+    NotImplemented,
+}
+
+// ---------------------------------------------------------------------------
+// ToolMessage —注入上下文的消息
+// ---------------------------------------------------------------------------
+
+/// A message to be injected into the agent context.
+#[derive(Debug, Clone)]
+pub struct ToolMessage {
+    /// The content of the message.
+    pub content: String,
+    /// Whether this message is metadata (not from a real user).
+    pub is_meta: bool,
+}
+
+// ---------------------------------------------------------------------------
+// ContextModifier —上下文修改器
+// ---------------------------------------------------------------------------
+
+/// Modifies the agent session context after tool execution.
+#[derive(Debug, Clone)]
+pub struct ContextModifier {
+    /// List of tools the agent is allowed to use.
+    pub allowed_tools: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ToolResult —工具执行结果
+// ---------------------------------------------------------------------------
+
+/// Result of a tool call.
+#[derive(Debug, Clone)]
+pub struct ToolResult {
+    /// The structured result data (JSON value).
+    pub data: Value,
+    /// Messages to inject into the agent context.
+    pub new_messages: Vec<ToolMessage>,
+    /// Optional context modifier.
+    pub context_modifier: Option<ContextModifier>,
+}
+
+// ---------------------------------------------------------------------------
 // Tool —核心 trait
 // ---------------------------------------------------------------------------
 
@@ -111,6 +174,7 @@ pub enum ToolError {
 ///
 /// Each tool is a named, grouped capability that the LLM can invoke.
 /// Implementations must be `Send + Sync + 'static`.
+#[async_trait]
 pub trait Tool: Send + Sync {
     /// Returns the unique name of this tool.
     fn name(&self) -> &str;
@@ -130,6 +194,13 @@ pub trait Tool: Send + Sync {
 
     /// Returns the JSON Schema for this tool's input parameters.
     fn input_schema(&self) -> Value;
+
+    /// Call the tool with the given arguments and runtime context.
+    ///
+    /// Default implementation returns `ToolCallError::NotImplemented`.
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
 
     /// Returns this tool's runtime flags.
     fn flags(&self) -> ToolFlags;


### PR DESCRIPTION
## What

Implement SkillTool — a tool registered to ToolRegistry that lets LLM execute disk skills by calling SkillTool.

## How

- Define `ToolResult`, `ToolMessage`, `ContextModifier`, `ToolCallError` types in `src/tools/mod.rs`
- Add `async fn call()` default method to `Tool` trait (returns `NotImplemented` by default)
- Implement `SkillTool` in `src/tools/builtin/skill_tool.rs`:
  - Holds `Arc<DiskSkillRegistry>`
  - `call()` looks up skill from registry, reads SKILL.md, injects as meta message, injects `allowed_tools` via `context_modifier`
- Register `SkillTool` in `register_builtin_tools()`

## Testing

- `cargo build` ✓
- `cargo test` ✓
- `cargo clippy -- -D warnings` ✓
- `cargo fmt --check` ✓

Source: issue #459
Type: feat