### PR TITLE
refactor(processor_chain): migrate DslParser from im/processor to processor_chain

### DIFF
--- a/src/im/processor/mod.rs
+++ b/src/im/processor/mod.rs
@@ -4,11 +4,9 @@
 //! - `mod.rs` — `ProcessPhase`, `MessageProcessor` trait, `MessageContext`,
 //!   `ProcessError`, `ProcessorRegistry`, `ProcessedMessage`
 //! - `cleaner.rs` — `FeishuMessageCleaner` (inbound processor) + cleaning logic
-//! - `dsl_parser.rs` — `DslParser` (outbound processor) + DSL types
 //! - `session_router.rs` — `SessionRouter` (inbound, priority 20) + session routing
 
 mod cleaner;
-mod dsl_parser;
 mod session_router;
 
 use async_trait::async_trait;
@@ -17,9 +15,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::gateway::SessionManager;
+use crate::processor_chain::{DslInstruction, DslParseResult};
 
 pub use cleaner::FeishuMessageCleaner;
-pub use dsl_parser::{DslInstruction, DslParseResult, DslParser};
 use serde_json::Value;
 pub use session_router::SessionRouter;
 
@@ -124,12 +122,11 @@ impl ProcessorRegistry {
     /// Create a new registry with default processors registered:
     /// - [`SessionRouter`] (inbound, priority 20) — resolves session IDs
     /// - [`FeishuMessageCleaner`] (inbound, priority 30)
-    /// - [`DslParser`] (outbound, priority 10)
+    /// - [`FeishuMessageCleaner`] (inbound, priority 30)
     pub fn new(session_manager: Arc<SessionManager>) -> Self {
         let mut registry = Self::default();
         registry.register(SessionRouter::new(session_manager));
         registry.register(FeishuMessageCleaner);
-        registry.register(DslParser);
         registry
     }
 
@@ -338,10 +335,8 @@ mod tests {
     async fn test_registry_default_has_all_processors() {
         let mgr = test_session_manager();
         let registry = ProcessorRegistry::new(mgr);
-        // SessionRouter (inbound, prio 20) + FeishuMessageCleaner (inbound, prio 30)
+        // FeishuMessageCleaner (inbound, prio 30)
         assert!(!registry.inbound.is_empty());
-        // DslParser (outbound, prio 10)
-        assert!(!registry.outbound.is_empty());
     }
 
     #[tokio::test]
@@ -417,70 +412,4 @@ mod tests {
         assert_eq!(result.content, expected.content);
     }
 
-    // --- Outbound chain end-to-end ---
-
-    #[tokio::test]
-    async fn test_outbound_chain_no_dsl() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
-        let msg = serde_json::json!({"content": "Hello, this is a normal message."});
-
-        let result = registry.process_outbound(&msg).await.unwrap();
-        // DslParser removes DSL lines; since there are none, content is unchanged
-        assert_eq!(result.content, "Hello, this is a normal message.");
-        // dsl_result metadata should be present with empty instructions
-        let dsl_result_json = result.metadata.get("dsl_result").unwrap();
-        let dsl_result: DslParseResult = serde_json::from_str(dsl_result_json).unwrap();
-        assert!(dsl_result.instructions.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_outbound_chain_with_dsl() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
-        let content = [
-            "Hello world",
-            "::button[label:Click Me;action:navigate;value:/home]",
-            "Goodbye",
-        ]
-        .join("\n");
-        let msg = serde_json::json!({"content": content});
-
-        let result = registry.process_outbound(&msg).await.unwrap();
-        assert_eq!(result.content, "Hello world\nGoodbye");
-
-        let dsl_result_json = result.metadata.get("dsl_result").unwrap();
-        let dsl_result: DslParseResult = serde_json::from_str(dsl_result_json).unwrap();
-        assert_eq!(dsl_result.instructions.len(), 1);
-        match &dsl_result.instructions[0] {
-            DslInstruction::Button {
-                label,
-                action,
-                value,
-            } => {
-                assert_eq!(label, "Click Me");
-                assert_eq!(action, "navigate");
-                assert_eq!(value, "/home");
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_outbound_chain_multiple_dsl() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
-        let content = [
-            "::button[label:Yes;action:confirm;value:1]",
-            "::button[label:No;action:cancel;value:0]",
-        ]
-        .join("\n");
-        let msg = serde_json::json!({"content": content});
-
-        let result = registry.process_outbound(&msg).await.unwrap();
-        assert_eq!(result.content, ""); // all lines are DSL
-
-        let dsl_result_json = result.metadata.get("dsl_result").unwrap();
-        let dsl_result: DslParseResult = serde_json::from_str(dsl_result_json).unwrap();
-        assert_eq!(dsl_result.instructions.len(), 2);
-    }
 }

--- a/src/processor_chain/SPEC.md
+++ b/src/processor_chain/SPEC.md
@@ -51,15 +51,15 @@ Inbound 链接收平台原始消息（`RawMessage`），经多个处理器顺序
 
 | 文件 | 职责 |
 |------|------|
-| `error.rs` | `ProcessError` 枚举及构造函数 |
 | `context.rs` | `RawMessage / MessageContext / ProcessedMessage / RawMessageLog` + 单元测试 |
-| `processor.rs` | `ProcessPhase` 枚举 + `MessageProcessor` trait |
-| `registry.rs` | `ProcessorRegistry` 实现 + 单元测试 |
-| `raw_log_processor.rs` | `RawLogProcessor`（入站处理器），Debug 模式或 enabled=true 时将 `RawMessage` 写入 JSON 日志文件，启动时清理超过 `retention_days` 的旧日志 |
-| `message_cleaner.rs` | `MessageCleaner`（入站处理器，priority=30），提取纯文本内容（text 类型直接取 text 字段，post 类型展开为 markdown），将 thread_id/root_id/parent_id 写入 metadata 的 `feishu_thread_id` 字段 |
-| `markdown_normalizer.rs` | `MarkdownNormalizer`（入站处理器，priority=40），标准化 markdown 内容后再送 LLM：压缩连续空行、去除每行尾随空格、为裸 URL 补全 https:// 前缀、为无语言标识的代码块补全 ` ```text` 标记 |
+| `dsl_parser.rs` | `DslParser`（出站处理器，priority=10），解析 `::button[...]` DSL，从 markdown 中移除 DSL 行并将解析结果存入 metadata 的 `dsl_result` 键 |
+| `error.rs` | `ProcessError` 枚举及构造函数 |
 | `loader.rs` | `ProcessorChainLoader`，根据 YAML/TOML 配置构造 processor 实例并注册到 `ProcessorRegistry` |
-| `mod.rs` | 模块入口，re-export 公开类型 |
+| `markdown_normalizer.rs` | `MarkdownNormalizer`（入站处理器，priority=40），标准化 markdown 内容后再送 LLM：压缩连续空行、去除每行尾随空格、为裸 URL 补全 https:// 前缀、为无语言标识的代码块补全 ` ```text` 标记 |
+| `message_cleaner.rs` | `MessageCleaner`（入站处理器，priority=30），提取纯文本内容（text 类型直接取 text 字段，post 类型展开为 markdown），将 thread_id/root_id/parent_id 写入 metadata 的 `feishu_thread_id` 字段 |
+| `processor.rs` | `ProcessPhase` 枚举 + `MessageProcessor` trait |
+| `raw_log_processor.rs` | `RawLogProcessor`（入站处理器），Debug 模式或 enabled=true 时将 `RawMessage` 写入 JSON 日志文件，启动时清理超过 `retention_days` 的旧日志 |
+| `registry.rs` | `ProcessorRegistry` 实现 + 单元测试 |
 
 ### 数据流
 
@@ -70,7 +70,7 @@ Inbound:
 Outbound:
   ProcessedMessage (from LLM)
     → synthetic RawMessage
-    → [Processor sorted by priority asc]
+    → [dsl_parser (priority=10, parses ::button[...] DSL, removes DSL lines, writes dsl_result to metadata), ...other processors sorted by priority asc]
     → ProcessedMessage
 ```
 

--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::{MessageContext, MessageProcessor, ProcessError, ProcessPhase};
-use serde_json::Value;
 
 // ---------------------------------------------------------------------------
 // DSL data types
@@ -130,7 +129,11 @@ fn parse_dsl_line(line: &str) -> Option<DslInstruction> {
 
 #[async_trait]
 impl MessageProcessor for DslParser {
-    fn priority(&self) -> i32 {
+    fn name(&self) -> &str {
+        "DslParser"
+    }
+
+    fn priority(&self) -> u8 {
         10
     }
 
@@ -141,21 +144,21 @@ impl MessageProcessor for DslParser {
     async fn process(
         &self,
         ctx: &MessageContext,
-        msg: &Value,
-    ) -> Result<super::ProcessedMessage, ProcessError> {
-        // Expect `msg` to be a JSON object with a "content" string field (LLM output)
-        let content = msg.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    ) -> Result<Option<super::ProcessedMessage>, ProcessError> {
+        let content = &ctx.content;
 
         let result = self.parse(content);
-        let json = serde_json::to_string(&result)?;
+        let json = serde_json::to_string(&result)
+            .map_err(|e| ProcessError::processor_failed("DslParser", e))?;
 
         let mut metadata = ctx.metadata.clone();
-        metadata.insert("dsl_result".to_string(), json);
+        metadata.insert("dsl_result".to_string(), serde_json::Value::String(json));
 
-        Ok(super::ProcessedMessage {
+        Ok(Some(super::ProcessedMessage {
             content: result.clean_content,
             metadata,
-        })
+            suppress: false,
+        }))
     }
 }
 
@@ -287,6 +290,4 @@ mod tests {
         assert_eq!(result.instructions.len(), 3);
         assert_eq!(result.clean_content, "Text A\nText B");
     }
-
-    // No helper needed — fields accessed via direct match in each test
 }

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -11,6 +11,7 @@
 //! - [`ProcessError`] — error types
 
 pub mod context;
+pub mod dsl_parser;
 pub mod error;
 pub mod loader;
 pub mod markdown_normalizer;
@@ -20,6 +21,7 @@ pub mod raw_log_processor;
 pub mod registry;
 pub mod registry_tests;
 
+pub use dsl_parser::{DslInstruction, DslParseResult, DslParser};
 pub use loader::{ProcessorChainConfig, ProcessorChainLoader, ProcessorConfig};
 pub use registry::ProcessorRegistry;
 


### PR DESCRIPTION
## Summary

Re-implements  against the   trait (Outbound, priority=10).

## Changes

- Re-implement  at  implementing  trait
-  and  logic identical to original
-  reads from , writes  JSON to metadata  key
-  and  re-exported from 
- Delete original 
- Remove  registration from  in 
- Update  to reflect  in submodule table

## Source

issue #465