### PR TITLE
fix(scripts): count both #[test] and #[tokio::test] in collect_code_stats

### DIFF
--- a/scripts/collect_code_stats.py
+++ b/scripts/collect_code_stats.py
@@ -135,7 +135,7 @@ def count_stats(commit):
                 elif s.startswith("//"):
                     continue
                 else:
-                    if s.startswith("#[test"):
+                    if s.startswith("#[test") or s.startswith("#[tokio::test"):
                         test_count += 1
                     total_loc += 1
             else:


### PR DESCRIPTION
修复 collect_code_stats.py 只统计 #[test] 漏统计 #[tokio::test] 的问题，测试数从 903 修正为 1306（与 cargo test --list 结果一致）。

Source: user
Type: fix