### PR TITLE
feat(cli): add connect/read timeout safety net to start_session

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -6,8 +6,10 @@
 use anyhow::Context;
 use clap::Parser;
 use std::net::SocketAddr;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+use tokio::time::timeout;
 use tracing::info;
 
 const DEFAULT_CHAT_ADDR: &str = "127.0.0.1:18889";
@@ -64,15 +66,20 @@ impl ChatCommand {
 // --- Session lifecycle helpers ---
 
 impl ChatCommand {
-    /// Connect and start a chat session, returning the connected stream.
     /// Connect and start a chat session. Returns (stream, session_id).
     async fn start_session(
         addr: SocketAddr,
         agent_id: &str,
+        connect_timeout: Option<Duration>,
     ) -> anyhow::Result<(TcpStream, String)> {
-        let mut stream = TcpStream::connect(addr)
-            .await
-            .with_context(|| format!("cannot connect to {} — is the daemon running?", addr))?;
+        let mut stream = match connect_timeout {
+            Some(d) => tokio::time::timeout(d, TcpStream::connect(addr))
+                .await
+                .map_err(|_| anyhow::anyhow!("connect timeout after {}s", d.as_secs()))??,
+            None => TcpStream::connect(addr).await.map_err(|e| {
+                anyhow::anyhow!("cannot connect to {} — is the daemon running?: {}", addr, e)
+            })?,
+        };
 
         let request_id = uuid::Uuid::new_v4().to_string();
         let start_json = serde_json::json!({
@@ -82,7 +89,7 @@ impl ChatCommand {
         });
         send_json_line(&mut stream, &start_json).await?;
 
-        let resp = read_line(&mut stream).await?;
+        let resp = read_line_timeout(&mut stream, connect_timeout).await?;
         let resp_val: serde_json::Value = serde_json::from_str(&resp)?;
         if resp_val.get("type").and_then(|v| v.as_str()) != Some("chat.started") {
             anyhow::bail!("unexpected response to chat.start: {}", resp);
@@ -127,7 +134,8 @@ impl ChatCommand {
         agent_id: &str,
         message: &str,
     ) -> anyhow::Result<()> {
-        let (mut stream, _) = Self::start_session(addr, agent_id).await?;
+        let (mut stream, _) =
+            Self::start_session(addr, agent_id, Some(Duration::from_secs(30))).await?;
         Self::send_user_message(&mut stream, message).await?;
         Self::handle_single_response(&mut stream).await?;
         Self::send_stop(&mut stream).await?;
@@ -169,7 +177,8 @@ impl ChatCommand {
 impl ChatCommand {
     /// Connect and run an interactive REPL.
     async fn run_repl(&self, addr: SocketAddr, agent_id: &str) -> anyhow::Result<()> {
-        let (stream, session_id) = Self::start_session(addr, agent_id).await?;
+        let (stream, session_id) =
+            Self::start_session(addr, agent_id, Some(Duration::from_secs(30))).await?;
         info!(session_id = %session_id, "chat session started");
         println!("Connected to CloseClaw chat (session: {})", session_id);
         println!("Type your messages and press Enter to send. Type 'quit' or 'exit' to stop.\n");
@@ -305,6 +314,32 @@ async fn read_line(stream: &mut TcpStream) -> anyhow::Result<String> {
         .await?
         .ok_or_else(|| anyhow::anyhow!("server closed connection"))?;
     Ok(line)
+}
+
+/// Read a single newline-delimited JSON line from a stream, with optional timeout per read.
+async fn read_line_timeout(
+    stream: &mut TcpStream,
+    timeout: Option<Duration>,
+) -> anyhow::Result<String> {
+    match timeout {
+        Some(d) => {
+            let result = tokio::time::timeout(d, async {
+                let mut buf = tokio::io::BufReader::new(stream).lines();
+                match buf.next_line().await {
+                    Ok(Some(line)) => Ok(line),
+                    Ok(None) => Err(anyhow::anyhow!("server closed connection")),
+                    Err(e) => Err(anyhow::anyhow!("{}", e)),
+                }
+            })
+            .await;
+            match result {
+                Ok(Ok(line)) => Ok(line),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(anyhow::anyhow!("read timeout after {}s", d.as_secs())),
+            }
+        }
+        None => read_line(stream).await,
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -195,6 +195,22 @@ async fn start_session_success() {
 }
 
 #[tokio::test]
+async fn start_session_with_timeout_success() {
+    // timeout = Some but server responds normally — no timeout fired.
+    let (addr, h, ready_rx) = mock_server_seq(vec![
+        json!({"type":"chat.started","session_id":"s1","id":"r1"}),
+    ])
+    .await;
+    ready_rx.await.unwrap();
+    let (stream, sid) = ChatCommand::start_session(addr, "agent", Some(Duration::from_secs(5)))
+        .await
+        .unwrap();
+    assert_eq!(sid, "s1");
+    drop(stream);
+    h.await.unwrap();
+}
+
+#[tokio::test]
 async fn test_error_response_handling() {
     let (addr, h, ready_rx) = mock_server_seq(vec![
         json!({"type":"chat.error","message":"boom","id":"r1"}),

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -186,7 +186,9 @@ async fn start_session_success() {
     ])
     .await;
     ready_rx.await.unwrap();
-    let (stream, sid) = ChatCommand::start_session(addr, "agent").await.unwrap();
+    let (stream, sid) = ChatCommand::start_session(addr, "agent", None)
+        .await
+        .unwrap();
     assert_eq!(sid, "s1");
     drop(stream);
     h.await.unwrap();
@@ -199,28 +201,57 @@ async fn test_error_response_handling() {
     ])
     .await;
     ready_rx.await.unwrap();
-    assert!(ChatCommand::start_session(addr, "agent").await.is_err());
+    assert!(ChatCommand::start_session(addr, "agent", None)
+        .await
+        .is_err());
     h.await.unwrap();
 }
 
+// NOTE: Mock server accepts the connection but never sends chat.started.
+// start_session waits for the first line and should hit read_line_timeout.
 #[tokio::test]
-#[ignore = "depends on #478 read timeout mechanism"]
 async fn test_read_timeout_silent_server() {
-    // Mock server accepts but never responds.
-    // Will fully validate timeout behavior once #478 adds read_line_timeout.
     let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = l.local_addr().unwrap();
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
     let h = tokio::spawn(async move {
         let _ = ready_tx.send(());
-        let _ = l.accept().await;
-        // intentionally never write — simulates silent server
+        if let Ok((mut s, _)) = l.accept().await {
+            // Read the chat.start request but never respond.
+            let mut buf = [0u8; 1024];
+            let _ = s.read(&mut buf).await;
+            // Intentionally never write — simulates silent server.
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        }
     });
     ready_rx.await.unwrap();
-    // Without timeout, this would hang forever.
-    // After #478, start_session will return a timeout error.
-    let _ = ChatCommand::start_session(addr, "agent").await;
+    let result = ChatCommand::start_session(addr, "agent", Some(Duration::from_secs(1))).await;
+    assert!(result.is_err(), "expected timeout error, got {:?}", result);
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("read timeout"),
+        "error should mention 'read timeout', got: {}",
+        err
+    );
     h.abort();
+}
+
+#[tokio::test]
+async fn test_connect_timeout() {
+    // Non-routable address causes connect to time out (no ICMP, TCP SYN retransmits).
+    let addr: std::net::SocketAddr = "10.255.255.1:1".parse().unwrap();
+    let result = ChatCommand::start_session(addr, "agent", Some(Duration::from_secs(1))).await;
+    assert!(
+        result.is_err(),
+        "expected connect timeout error, got {:?}",
+        result
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("connect timeout"),
+        "error should mention 'connect timeout', got: {}",
+        err
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Add 30s timeout safety nets to the CLI's `start_session` function, covering both TCP connection and response read phases. When the daemon is unresponsive or non-existent, the CLI now fails fast with a clear error message instead of hanging indefinitely.

## Changes

### Core (`src/cli/chat.rs`)
- `start_session` accepts `timeout: Option<Duration>`
- Connect phase: `tokio::time::timeout` wraps `TcpStream::connect`
- Read phase: new `read_line_timeout` replaces `read_line` for per-read independent timers
- Error messages distinguish: `connect timeout after {n}s` vs `read timeout after {n}s`

### Entry points (`run_single`, `run_repl`)
- Both call `start_session` with `Some(Duration::from_secs(30))`

### Tests (`src/cli/chat_tests.rs`)
- `test_connect_timeout`: connects to a refuse-port address, expects connect timeout
- `test_read_timeout_silent_server`: previously `#[ignore]`, now enabled with silent server socket
- `test_start_session_with_timeout_success`: normal response path, no false timeout

## Test

```bash
cargo test
```

Source: issue #478
Type: feat