### PR TITLE
feat(skill,system-prompt): inject skill listing at session bootstrap

### DIFF
--- a/src/skills/SPEC.md
+++ b/src/skills/SPEC.md
@@ -117,6 +117,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `DiskSkillRegistry::list()` | DiskSkillRegistry | 列出所有磁盘技能名称 |
 | `DiskSkillRegistry::contains(name)` | DiskSkillRegistry | 检查磁盘技能是否存在 |
 | `DiskSkillRegistry::filter_by_source(source)` | DiskSkillRegistry | 按来源过滤磁盘技能 |
+| `DiskSkillRegistry::generate_listing(agent_id)` | DiskSkillRegistry | 生成格式化 skill listing 字符串，含优先级排序和 agent_id 过滤 |
 | `DiskSkillRegistry::len()` | DiskSkillRegistry | 返回已注册技能数量 |
 | `resolve_skill(name, disk_registry, skill_registry)` | disk | 查询路由：先查 disk registry，未命中再查 bundled registry |
 | `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -46,6 +46,54 @@ impl DiskSkillRegistry {
     pub fn filter_by_source(&self, source: SkillSource) -> Vec<&DiskSkill> {
         self.skills.iter().filter(|s| s.source == source).collect()
     }
+
+    /// Generates a formatted skill listing string for the given agent_id.
+    ///
+    /// - Sorts by SkillSource priority (Bundled > ExtraDirs > Global > Agent > Project)
+    /// - Within the same priority, sorts by name alphabetically
+    /// - Filters: only includes skills where `agent_id` is empty or matches the given agent_id
+    /// - Format: `- **{name}**: {description}` + optionally ` — {when_to_use}`
+    /// - Returns empty string if no skills match
+    pub fn generate_listing(&self, agent_id: Option<&str>) -> String {
+        let mut filtered: Vec<&DiskSkill> = self
+            .skills
+            .iter()
+            .filter(|s| {
+                s.manifest.agent_id.is_empty()
+                    || agent_id.map_or(true, |id| s.manifest.agent_id == id)
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            return String::new();
+        }
+
+        // Sort by source priority (lower is higher priority), then by name
+        filtered.sort_by(|a, b| {
+            let src_cmp = a.source.cmp(&b.source);
+            if src_cmp != std::cmp::Ordering::Equal {
+                return src_cmp;
+            }
+            a.manifest.name.cmp(&b.manifest.name)
+        });
+
+        let lines: Vec<String> = filtered
+            .iter()
+            .map(|s| {
+                let when = if s.manifest.when_to_use.is_empty() {
+                    String::new()
+                } else {
+                    format!(" — {}", s.manifest.when_to_use)
+                };
+                format!(
+                    "- **{}**: {}{}",
+                    s.manifest.name, s.manifest.description, when
+                )
+            })
+            .collect();
+
+        lines.join("\n")
+    }
 }
 
 #[cfg(test)]
@@ -128,5 +176,109 @@ mod tests {
         assert_eq!(r.filter_by_source(SkillSource::Bundled).len(), 2);
         assert_eq!(r.filter_by_source(SkillSource::Global).len(), 1);
         assert_eq!(r.filter_by_source(SkillSource::Agent).len(), 0);
+    }
+
+    fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskSkill {
+        DiskSkill {
+            source,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: String::new(),
+                context: SkillContext::default(),
+                agent: String::new(),
+                agent_id: agent_id.into(),
+                effort: SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+            skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        }
+    }
+
+    fn skill_with_when_to_use(name: &str, source: SkillSource, when_to_use: &str) -> DiskSkill {
+        DiskSkill {
+            source,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("desc of {}", name),
+                allowed_tools: vec![],
+                when_to_use: when_to_use.into(),
+                context: SkillContext::default(),
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: SkillEffort::default(),
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+            skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        }
+    }
+
+    #[test]
+    fn test_generate_listing_empty() {
+        let r = DiskSkillRegistry::new(vec![]);
+        assert_eq!(r.generate_listing(None), "");
+        assert_eq!(r.generate_listing(Some("agent1")), "");
+    }
+
+    #[test]
+    fn test_generate_listing_single() {
+        let r = DiskSkillRegistry::new(vec![skill("foo", SkillSource::Bundled)]);
+        let listing = r.generate_listing(None);
+        assert!(listing.contains("**foo**"));
+        assert!(listing.contains("desc of foo"));
+    }
+
+    #[test]
+    fn test_generate_listing_sorted_by_priority_and_name() {
+        let r = DiskSkillRegistry::new(vec![
+            skill("z_bundled", SkillSource::Bundled),
+            skill("a_bundled", SkillSource::Bundled),
+            skill("z_global", SkillSource::Global),
+            skill("a_global", SkillSource::Global),
+            skill("z_agent", SkillSource::Agent),
+            skill("a_agent", SkillSource::Agent),
+        ]);
+        let listing = r.generate_listing(None);
+        let lines: Vec<&str> = listing.lines().collect();
+        assert_eq!(lines.len(), 6);
+        // Bundled before Global before Agent
+        assert!(listing.find("**a_bundled**").unwrap() < listing.find("**a_global**").unwrap());
+        assert!(listing.find("**a_global**").unwrap() < listing.find("**a_agent**").unwrap());
+        // Within Bundled, alphabetical order
+        assert!(listing.find("**a_bundled**").unwrap() < listing.find("**z_bundled**").unwrap());
+    }
+
+    #[test]
+    fn test_generate_listing_agent_id_filter() {
+        let r = DiskSkillRegistry::new(vec![
+            skill_with_agent_id("skill_a", SkillSource::Agent, "agent1"),
+            skill_with_agent_id("skill_b", SkillSource::Agent, "agent2"),
+            skill_with_agent_id("skill_c", SkillSource::Agent, ""), // no restriction
+        ]);
+        // None = no filter, all 3 returned
+        assert_eq!(r.generate_listing(None).lines().count(), 3);
+        // agent1 filter = skill_a (matches) + skill_c (no restriction)
+        let listing = r.generate_listing(Some("agent1"));
+        assert!(listing.contains("**skill_a**"));
+        assert!(listing.contains("**skill_c**"));
+        assert!(!listing.contains("**skill_b**"));
+    }
+
+    #[test]
+    fn test_generate_listing_when_to_use() {
+        let r = DiskSkillRegistry::new(vec![
+            skill_with_when_to_use("foo", SkillSource::Bundled, "Use when you need foo"),
+            skill("bar", SkillSource::Bundled), // no when_to_use
+        ]);
+        let listing = r.generate_listing(None);
+        assert!(listing.contains(" — Use when you need foo"));
+        // bar should NOT have the dash separator
+        let bar_line = listing.lines().find(|l| l.contains("**bar**")).unwrap();
+        assert!(!bar_line.contains(" — "));
     }
 }

--- a/src/system_prompt/SPEC.md
+++ b/src/system_prompt/SPEC.md
@@ -21,7 +21,7 @@
 | 接口 | 功能 |
 |------|------|
 | `build_system_prompt` | 组装完整 system prompt，按覆盖链优先级拼接各 section |
-| `build_from_workspace(workspace_root, dynamic_sections, mode)` | 从 workspace 路径按 `BootstrapMode` 加载 bootstrap 文件（Minimal/Full）构建 prompt |
+| `build_from_workspace(workspace_root, dynamic_sections, skill_info)` | 从 workspace 路径加载 bootstrap 文件（IDENTITY.md / SOUL.md / MEMORY.md）构建 prompt，skill_info 为 `Some((registry, agent_id))` 时注入 SkillListingSection |
 | `set_override_prompt` | 设置最高优先级覆盖 prompt |
 | `set_agent_prompt` | 设置 agent 级 prompt（覆盖链第二层） |
 | `set_custom_prompt` | 设置用户自定义 prompt（覆盖链第三层） |
@@ -79,8 +79,10 @@
 
 ### Section 分类
 
-- **静态（缓存）**：RoleSection、WorkspaceSection、ToolsSection、MemorySection、HeartbeatSection
+- **静态（缓存）**：RoleSection、WorkspaceSection、ToolsSection、MemorySection、HeartbeatSection、SkillListingSection
 - **动态（每次重建）**：ChannelContext、SessionState、AppendSection、GitStatus
+
+`SkillListingSection` 在 `build_from_workspace` 中从 `DiskSkillRegistry::generate_listing` 注入，位于 ToolsSection 之后、dynamic_sections 之前；内容为空时不渲染。
 
 ### 覆盖优先级（从高到低）
 

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -6,6 +6,7 @@ use super::sections::{
     get_append_section, get_cached_section, invalidate_all_sections, invalidate_section,
     load_cached_file_section, read_file_section, Section,
 };
+use crate::skills::DiskSkillRegistry;
 use std::path::Path;
 use std::sync::RwLock;
 
@@ -177,9 +178,13 @@ pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> 
 ///
 /// Reads IDENTITY.md, SOUL.md, and MEMORY.md from the workspace root
 /// and assembles them with the provided dynamic sections.
+///
+/// The `skill_info` parameter, when provided as `Some((registry, agent_id))`,
+/// injects a `SkillListingSection` after the ToolsSection for skill discovery.
 pub fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     dynamic_sections: Vec<Section>,
+    skill_info: Option<(&DiskSkillRegistry, &str)>,
 ) -> String {
     let root = workspace_root.as_ref();
     let mut sections: Vec<Section> = Vec::new();
@@ -216,6 +221,14 @@ pub fn build_from_workspace<P: AsRef<Path>>(
 
     // Tools section — inserted between RoleSection and MemorySection
     sections.push(Section::ToolsSection(String::new()));
+
+    // Skill listing section — injected after ToolsSection, before dynamic_sections
+    if let Some((registry, agent_id)) = skill_info {
+        let listing = registry.generate_listing(Some(agent_id));
+        if !listing.is_empty() {
+            sections.push(Section::SkillListingSection(listing));
+        }
+    }
 
     // Dynamic sections
     sections.extend(dynamic_sections);

--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -22,6 +22,7 @@ pub enum Section {
     ToolsSection(String),
     MemorySection(String),
     HeartbeatSection(String),
+    SkillListingSection(String),
     // --- Dynamic sections (always rebuilt) ---
     ChannelContext {
         chat_name: String,
@@ -46,6 +47,7 @@ impl Section {
                 | Section::ToolsSection(_)
                 | Section::MemorySection(_)
                 | Section::HeartbeatSection(_)
+                | Section::SkillListingSection(_)
         )
     }
 
@@ -57,6 +59,7 @@ impl Section {
             Section::ToolsSection(_) => "tools",
             Section::MemorySection(_) => "memory",
             Section::HeartbeatSection(_) => "heartbeat",
+            Section::SkillListingSection(_) => "skill_listing",
             Section::ChannelContext { .. } => "channel_context",
             Section::SessionState { .. } => "session_state",
             Section::AppendSection(_) => "append",
@@ -97,6 +100,13 @@ impl Section {
             }
             Section::HeartbeatSection(content) => {
                 format!("## Heartbeat Context\n{}\n", content)
+            }
+            Section::SkillListingSection(content) => {
+                if content.is_empty() {
+                    String::new()
+                } else {
+                    format!("## Available Skills\n\n{}\n", content)
+                }
             }
             Section::ChannelContext {
                 chat_name,
@@ -372,6 +382,39 @@ mod tests {
         std::fs::write(&file_path, "updated content").unwrap();
         let result3 = load_cached_file_section("test", &file_path);
         assert_eq!(result3, Some("updated content".to_string()));
+    }
+
+    #[test]
+    fn test_skill_listing_section_is_cacheable() {
+        let s = Section::SkillListingSection("some skills".to_string());
+        assert!(s.is_cacheable());
+    }
+
+    #[test]
+    fn test_skill_listing_section_name() {
+        let s = Section::SkillListingSection("some skills".to_string());
+        assert_eq!(s.name(), "skill_listing");
+    }
+
+    #[test]
+    fn test_skill_listing_section_render_format() {
+        let s = Section::SkillListingSection(
+            "- **foo**: desc — use when needed
+- **bar**: desc"
+                .to_string(),
+        );
+        let rendered = s.render();
+        assert!(rendered.starts_with("## Available Skills\n\n"));
+        assert!(rendered.contains("**foo**"));
+        assert!(rendered.contains("**bar**"));
+        assert!(rendered.contains(" — use when needed"));
+        assert!(rendered.ends_with("\n"));
+    }
+
+    #[test]
+    fn test_skill_listing_section_render_empty() {
+        let s = Section::SkillListingSection(String::new());
+        assert_eq!(s.render(), "");
     }
 
     #[test]

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -1,0 +1,99 @@
+//! Tests for builder skill listing injection (src/system_prompt/builder.rs)
+
+use closeclaw::skills::disk::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
+use closeclaw::skills::disk::DiskSkill;
+use closeclaw::skills::DiskSkillRegistry;
+use closeclaw::system_prompt::builder::build_from_workspace;
+use std::path::PathBuf;
+
+fn make_test_skill(name: &str, description: &str, when_to_use: &str, agent_id: &str) -> DiskSkill {
+    DiskSkill {
+        source: SkillSource::Bundled,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: description.into(),
+            allowed_tools: vec![],
+            when_to_use: when_to_use.into(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: agent_id.into(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+#[test]
+fn test_build_from_workspace_skill_listing_injected() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
+    std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
+    std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
+
+    let skill = make_test_skill("testskill", "A test skill", "Use when testing", "eda");
+    let registry = DiskSkillRegistry::new(vec![skill]);
+
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+
+    assert!(
+        result.contains("## Available Skills"),
+        "skill listing should appear in prompt: {}",
+        result
+    );
+    assert!(
+        result.contains("**testskill**"),
+        "skill name should appear: {}",
+        result
+    );
+    assert!(
+        result.contains("Use when testing"),
+        "when_to_use should appear: {}",
+        result
+    );
+}
+
+#[test]
+fn test_build_from_workspace_no_skill_info_no_section() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
+    std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
+    std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
+
+    let result = build_from_workspace(dir.path(), vec![], None);
+    assert!(!result.contains("## Available Skills"));
+}
+
+#[test]
+fn test_build_from_workspace_empty_listing_no_section() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
+    std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
+    std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
+
+    let registry = DiskSkillRegistry::new(vec![]);
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+    assert!(!result.contains("## Available Skills"));
+}
+
+#[test]
+fn test_build_from_workspace_skill_section_not_duplicated() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
+    std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
+    std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
+
+    let skill = make_test_skill("unique_skill", "desc", "", "eda");
+    let registry = DiskSkillRegistry::new(vec![skill]);
+
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+
+    let count = result.matches("## Available Skills").count();
+    assert_eq!(
+        count, 1,
+        "skill_listing should appear exactly once in: {}",
+        result
+    );
+}


### PR DESCRIPTION
- Add DiskSkillRegistry::generate_listing() for formatted skill list
- Add SkillListingSection enum variant in system prompt sections
- Inject skill listing in build_from_workspace after ToolsSection
- Add UTs for all new code

Source: issue #489
Type: feat
