### PR TITLE
fix(session): add missing with_agent_id/with_role builders and new_with_identity

### DIFF
--- a/src/session/checkpoint_manager.rs
+++ b/src/session/checkpoint_manager.rs
@@ -1,0 +1,172 @@
+//! Checkpoint Manager — manages session checkpoint save/restore with local cache
+//!
+//! Provides optional identity auto-filling: if created with [`new_with_identity`],
+//! every checkpoint saved through this manager will have its `agent_id` and `role`
+//! fields automatically set (overriding any existing values).
+
+use super::{AgentRole, PersistenceError, PersistenceService, SessionCheckpoint};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Checkpoint Manager — saves and restores session state with optional identity
+pub struct CheckpointManager<S: PersistenceService> {
+    storage: Arc<S>,
+    /// Local cache to reduce storage access
+    local_cache: RwLock<HashMap<String, SessionCheckpoint>>,
+    /// Identity fields for auto-filling (None when not configured)
+    identity: Option<(String, AgentRole)>,
+}
+
+impl<S: PersistenceService + 'static> CheckpointManager<S> {
+    /// Create a new CheckpointManager with the given storage
+    pub fn new(storage: Arc<S>) -> Self {
+        Self {
+            storage,
+            local_cache: RwLock::new(HashMap::new()),
+            identity: Some((String::new(), AgentRole::MainAgent)),
+        }
+    }
+
+    /// Create a CheckpointManager with identity for automatic filling
+    ///
+    /// Every checkpoint saved through this manager will have its `agent_id`
+    /// and `role` fields automatically set to the given values.
+    pub fn new_with_identity(storage: Arc<S>, agent_id: String, role: AgentRole) -> Self {
+        Self {
+            storage,
+            local_cache: RwLock::new(HashMap::new()),
+            identity: Some((agent_id, role)),
+        }
+    }
+
+    /// Get a reference to the underlying storage
+    pub fn storage(&self) -> &S {
+        &*self.storage
+    }
+
+    /// Apply identity fields to a checkpoint (if identity is configured)
+    fn apply_identity(&self, mut checkpoint: SessionCheckpoint) -> SessionCheckpoint {
+        if let Some((ref agent_id, ref role)) = self.identity {
+            checkpoint.agent_id = Some(agent_id.clone());
+            checkpoint.role = Some(*role);
+        }
+        checkpoint
+    }
+
+    /// Save checkpoint (async write, does not block main flow)
+    pub async fn save(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
+        let checkpoint = self.apply_identity(checkpoint);
+        let session_id = checkpoint.session_id.clone();
+
+        {
+            let mut cache = self.local_cache.write().await;
+            cache.insert(session_id.clone(), checkpoint.clone());
+        }
+
+        let storage = Arc::clone(&self.storage);
+        tokio::spawn(async move {
+            if let Err(e) = storage.save_checkpoint(&checkpoint).await {
+                tracing::error!(session_id = %checkpoint.session_id, "Failed to save checkpoint: {}", e);
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Save checkpoint (sync write, used when gateway shuts down)
+    pub async fn save_sync(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
+        let checkpoint = self.apply_identity(checkpoint);
+        let session_id = checkpoint.session_id.clone();
+
+        {
+            let mut cache = self.local_cache.write().await;
+            cache.insert(session_id.clone(), checkpoint.clone());
+        }
+
+        self.storage.save_checkpoint(&checkpoint).await
+    }
+
+    /// Load checkpoint (local cache first)
+    pub async fn load(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        {
+            let cache = self.local_cache.read().await;
+            if let Some(cp) = cache.get(session_id) {
+                return Ok(Some(cp.clone()));
+            }
+        }
+
+        let cp = self.storage.load_checkpoint(session_id).await?;
+
+        if let Some(ref checkpoint) = cp {
+            let mut cache = self.local_cache.write().await;
+            cache.insert(session_id.to_string(), checkpoint.clone());
+        }
+
+        Ok(cp)
+    }
+
+    /// Delete checkpoint
+    pub async fn delete(&self, session_id: &str) -> Result<(), PersistenceError> {
+        {
+            let mut cache = self.local_cache.write().await;
+            cache.remove(session_id);
+        }
+
+        self.storage.delete_checkpoint(session_id).await
+    }
+
+    /// Clear local cache
+    pub async fn clear_cache(&self) {
+        let mut cache = self.local_cache.write().await;
+        cache.clear();
+    }
+
+    /// Get cached session ids
+    pub async fn cached_session_ids(&self) -> Vec<String> {
+        let cache = self.local_cache.read().await;
+        cache.keys().cloned().collect()
+    }
+
+    /// Archive checkpoint
+    pub async fn archive(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
+        let checkpoint = self.apply_identity(checkpoint);
+        self.storage.archive_checkpoint(&checkpoint).await?;
+        {
+            let mut cache = self.local_cache.write().await;
+            cache.remove(&checkpoint.session_id);
+        }
+        self.storage
+            .delete_checkpoint(&checkpoint.session_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Restore archived checkpoint
+    pub async fn restore(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        let cp = self.storage.restore_checkpoint(session_id).await?;
+        if let Some(ref checkpoint) = cp {
+            self.storage.save_checkpoint(checkpoint).await?;
+            self.storage.purge_checkpoint(session_id).await?;
+            let mut cache = self.local_cache.write().await;
+            cache.insert(session_id.to_string(), checkpoint.clone());
+        }
+        Ok(cp)
+    }
+
+    /// Permanently delete archived checkpoint
+    pub async fn purge(&self, session_id: &str) -> Result<(), PersistenceError> {
+        self.storage.purge_checkpoint(session_id).await
+    }
+
+    /// List archived session ids
+    pub async fn archived_session_ids(&self) -> Result<Vec<String>, PersistenceError> {
+        self.storage.list_archived_sessions().await
+    }
+}

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -63,6 +63,7 @@ impl SessionCheckpoint {
             channel: None,
             chat_id: None,
             agent_id: None,
+            role: None,
         }
     }
 
@@ -123,6 +124,18 @@ impl SessionCheckpoint {
     /// Update the chat ID
     pub fn with_chat_id(mut self, chat_id: String) -> Self {
         self.chat_id = Some(chat_id);
+        self
+    }
+
+    /// Update the agent ID
+    pub fn with_agent_id(mut self, agent_id: String) -> Self {
+        self.agent_id = Some(agent_id);
+        self
+    }
+
+    /// Update the role
+    pub fn with_role(mut self, role: AgentRole) -> Self {
+        self.role = Some(role);
         self
     }
 
@@ -352,149 +365,5 @@ pub trait PersistenceService: Send + Sync {
     }
 }
 
-/// Checkpoint 管理器 — 负责保存和恢复 Session 状态
-pub struct CheckpointManager<S: PersistenceService> {
-    storage: Arc<S>,
-    /// 本地缓存（减少对存储的访问）
-    local_cache: RwLock<HashMap<String, SessionCheckpoint>>,
-}
-
-impl<S: PersistenceService + 'static> CheckpointManager<S> {
-    /// Create a new CheckpointManager with the given storage
-    pub fn new(storage: Arc<S>) -> Self {
-        Self {
-            storage,
-            local_cache: RwLock::new(HashMap::new()),
-        }
-    }
-
-    /// Get a reference to the underlying storage
-    pub fn storage(&self) -> &S {
-        &*self.storage
-    }
-
-    /// 保存 Checkpoint（异步写入，不阻塞主流程）
-    pub async fn save(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
-        let session_id = checkpoint.session_id.clone();
-
-        // 先更新本地缓存
-        {
-            let mut cache = self.local_cache.write().await;
-            cache.insert(session_id.clone(), checkpoint.clone());
-        }
-
-        // 异步保存到存储后端
-        let storage = Arc::clone(&self.storage);
-        tokio::spawn(async move {
-            if let Err(e) = storage.save_checkpoint(&checkpoint).await {
-                tracing::error!(session_id = %checkpoint.session_id, "Failed to save checkpoint: {}", e);
-            }
-        });
-
-        Ok(())
-    }
-
-    /// 保存 Checkpoint（同步写入，用于网关关闭时）
-    pub async fn save_sync(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
-        let session_id = checkpoint.session_id.clone();
-
-        // 先更新本地缓存
-        {
-            let mut cache = self.local_cache.write().await;
-            cache.insert(session_id.clone(), checkpoint.clone());
-        }
-
-        // 同步保存到存储后端
-        self.storage.save_checkpoint(&checkpoint).await
-    }
-
-    /// 加载 Checkpoint（优先本地缓存）
-    pub async fn load(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-        // 先查本地缓存
-        {
-            let cache = self.local_cache.read().await;
-            if let Some(cp) = cache.get(session_id) {
-                return Ok(Some(cp.clone()));
-            }
-        }
-
-        // 缓存未命中，从存储加载
-        let cp = self.storage.load_checkpoint(session_id).await?;
-
-        if let Some(ref checkpoint) = cp {
-            // 更新本地缓存
-            let mut cache = self.local_cache.write().await;
-            cache.insert(session_id.to_string(), checkpoint.clone());
-        }
-
-        Ok(cp)
-    }
-
-    /// 删除 Checkpoint
-    pub async fn delete(&self, session_id: &str) -> Result<(), PersistenceError> {
-        // 删除本地缓存
-        {
-            let mut cache = self.local_cache.write().await;
-            cache.remove(session_id);
-        }
-
-        // 删除存储中的数据
-        self.storage.delete_checkpoint(session_id).await
-    }
-
-    /// 清空本地缓存
-    pub async fn clear_cache(&self) {
-        let mut cache = self.local_cache.write().await;
-        cache.clear();
-    }
-
-    /// 获取缓存中所有 session_id
-    pub async fn cached_session_ids(&self) -> Vec<String> {
-        let cache = self.local_cache.read().await;
-        cache.keys().cloned().collect()
-    }
-
-    /// 归档 Checkpoint
-    pub async fn archive(&self, checkpoint: SessionCheckpoint) -> Result<(), PersistenceError> {
-        self.storage.archive_checkpoint(&checkpoint).await?;
-        // 从本地缓存和活跃存储中移除
-        {
-            let mut cache = self.local_cache.write().await;
-            cache.remove(&checkpoint.session_id);
-        }
-        self.storage
-            .delete_checkpoint(&checkpoint.session_id)
-            .await?;
-        Ok(())
-    }
-
-    /// 恢复已归档的 Checkpoint
-    pub async fn restore(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-        let cp = self.storage.restore_checkpoint(session_id).await?;
-        if let Some(ref checkpoint) = cp {
-            // 恢复到活跃存储
-            self.storage.save_checkpoint(checkpoint).await?;
-            self.storage.purge_checkpoint(session_id).await?;
-            // 更新本地缓存
-            let mut cache = self.local_cache.write().await;
-            cache.insert(session_id.to_string(), checkpoint.clone());
-        }
-        Ok(cp)
-    }
-
-    /// 永久删除已归档的 Checkpoint
-    pub async fn purge(&self, session_id: &str) -> Result<(), PersistenceError> {
-        self.storage.purge_checkpoint(session_id).await
-    }
-
-    /// 列出已归档的 Session ID
-    pub async fn archived_session_ids(&self) -> Result<Vec<String>, PersistenceError> {
-        self.storage.list_archived_sessions().await
-    }
-}
+pub mod checkpoint_manager;
+pub use checkpoint_manager::CheckpointManager;


### PR DESCRIPTION
## Description

PR #501 merged agent_id/role fields to SessionCheckpoint but was missing:
- with_agent_id/with_role builder methods
- new_with_identity constructor on CheckpointManager
- CheckpointManager.new() was not setting default identity

This PR adds the missing pieces and splits CheckpointManager into its own file to stay under 500-line limit.

Source: issue #499