### PR TITLE
feat(session): add LLM execution and summary parsing to Session Compaction

### DIFF
--- a/src/session/SPEC.md
+++ b/src/session/SPEC.md
@@ -66,6 +66,10 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
 | `CompactionService::token_warning_state(&self, used_tokens: usize, model: &str) -> TokenWarningState` | 返回分级警告状态（Normal / Warning / AutoCompactTriggered / Blocking） |
 | `CompactionService::record_failure(&mut self)` | 记录压缩失败，递增连续失败计数 |
 | `CompactionService::record_success(&mut self)` | 记录压缩成功，重置连续失败计数 |
+| `build_compact_prompt(custom_instructions: Option<&str>) -> String` | 构建 LLM 压缩 prompt（NO_TOOLS 约束 + 9 项摘要结构 + 可选保留指令） |
+| `extract_summary(response: &str) -> Option<String>` | 从 LLM 响应中提取 `<summary>` 内容（丢弃 `<analysis>` 草稿） |
+| `format_boundary_message(summary: &str, is_auto: bool) -> String` | 格式化压缩边界系统消息（标记"自动压缩"/"手动压缩"） |
+| `execute_compact(messages, llm, model_name, custom_instructions, is_auto) -> Result<CompactionResult, CompactionError>` | 异步执行会话压缩：构建 prompt → 调用 LLM → 解析摘要 → 格式化结果 |
 
 ### 查询
 
@@ -118,7 +122,8 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
 | `UserIntent` | 解析后的用户意图（raw_input/parsed_goal/entities） |
 | `RecoveryReport` | 恢复结果报告（recovered/failed 列表 + is_full_success/total） |
 | `CompactConfig` | compaction 配置（chars_per_token=0.25 / auto_compact_buffer_tokens=13_000 / max_consecutive_failures=3） |
-| `CompactionResult` | 压缩结果（是否执行 / 原 token 数 / 压缩后 token 数 / 消息） |
+| `CompactionResult` | 压缩结果（含 performed / original_tokens / compacted_tokens / message / before_char_count / after_char_count / before_token_count / after_token_count / boundary_message / is_auto） |
+| `CompactionError` | 压缩执行错误（LLMCallFailed / SummaryParseFailed / EmptyMessages） |
 | `TokenWarningState` | 分级警告状态枚举（Normal / Warning / AutoCompactTriggered / Blocking） |
 
 ---

--- a/src/session/compaction.rs
+++ b/src/session/compaction.rs
@@ -4,6 +4,7 @@
 //! for LLM context window management.
 
 use crate::llm::Message;
+use crate::llm::{ChatRequest, LLMProvider};
 
 /// Configuration for compaction behavior.
 #[derive(Debug, Clone)]
@@ -37,9 +38,152 @@ pub struct CompactionResult {
     pub compacted_tokens: usize,
     /// Human-readable message describing the outcome.
     pub message: String,
+    /// Character count before compaction.
+    pub before_char_count: usize,
+    /// Character count after compaction.
+    pub after_char_count: usize,
+    /// Token count before compaction.
+    pub before_token_count: usize,
+    /// Token count after compaction.
+    pub after_token_count: usize,
+    /// Boundary system message containing the summary.
+    pub boundary_message: String,
+    /// Whether this compaction was triggered automatically.
+    pub is_auto: bool,
 }
 
-/// Token warning state for monitoring context window pressure.
+/// Errors that can occur during compaction.
+#[derive(Debug, thiserror::Error)]
+pub enum CompactionError {
+    /// LLM call failed.
+    #[error("LLM call failed: {0}")]
+    LLMCallFailed(#[from] crate::llm::LLMError),
+
+    /// Failed to parse summary from LLM response.
+    #[error("Failed to parse summary from LLM response")]
+    SummaryParseFailed,
+
+    /// No messages provided for compaction.
+    #[error("No messages provided for compaction")]
+    EmptyMessages,
+}
+
+/// No-tools preamble constant.
+const NO_TOOLS_PREAMBLE: &str = "You are a session summarizer. You must not call any tools or functions. You are analyzing a conversation session to create a summary. Output ONLY the <summary> tag with required content.";
+
+/// Base compact prompt with 9-item summary structure.
+const BASE_COMPACT_PROMPT: &str = "\n## Summary Structure\nYour summary must cover: 1) User Identity & Preferences, 2) Current Project & Context, 3) Key Decisions & Conclusions, 4) Open Questions & Unresolved Issues, 5) Technical State, 6) Conversation Flow, 7) Important Facts & References, 8) Agent Memory & Self-Knowledge, 9) Next Steps & Action Items.\n\n## Output Format\nWrite in English using bullet points. Be specific and concrete. Output ONLY: <summary>your summary here</summary>";
+
+const NO_TOOLS_TRAILER: &str =
+    "\n## Important\n- Do NOT call any tools. Output ONLY the <summary> tag.";
+
+/// Builds the compact prompt with optional custom instructions.
+pub fn build_compact_prompt(custom_instructions: Option<&str>) -> String {
+    let base = format!("{}\n{}", NO_TOOLS_PREAMBLE, BASE_COMPACT_PROMPT);
+    match custom_instructions {
+        Some(inst) if !inst.is_empty() => format!("{}\n\n保留 {}", base, inst),
+        _ => format!("{}{}", base, NO_TOOLS_TRAILER),
+    }
+}
+
+/// Extracts the `<summary>` content from an LLM response.
+pub fn extract_summary(response: &str) -> Option<String> {
+    let start_tag = "<summary>";
+    let end_tag = "</summary>";
+    let start = response.find(start_tag)?;
+    let end = response.find(end_tag)?;
+    if end <= start {
+        return None;
+    }
+    Some(response[start + start_tag.len()..end].to_string())
+}
+
+/// Formats a boundary system message containing the summary.
+pub fn format_boundary_message(summary: &str, is_auto: bool) -> String {
+    let trigger = if is_auto {
+        "自动压缩"
+    } else {
+        "手动压缩"
+    };
+    format!("[Session Compaction | {}]\n\n{}", trigger, summary)
+}
+
+/// Executes session compaction: builds prompt, calls LLM, parses summary, formats result.
+///
+/// # Arguments
+/// * `messages` - Session messages to compact
+/// * `llm` - LLM provider
+/// * `model_name` - Model name for the request
+/// * `custom_instructions` - Optional custom instructions appended to the prompt
+/// * `is_auto` - Whether this is an automatic compaction
+///
+/// # Errors
+/// * `EmptyMessages` - No messages provided
+/// * `LLMCallFailed` - LLM call returned an error
+/// * `SummaryParseFailed` - LLM response contains no `<summary>` tag
+pub async fn execute_compact(
+    messages: &[Message],
+    llm: &dyn LLMProvider,
+    model_name: &str,
+    custom_instructions: Option<&str>,
+    is_auto: bool,
+) -> Result<CompactionResult, CompactionError> {
+    if messages.is_empty() {
+        return Err(CompactionError::EmptyMessages);
+    }
+
+    let before_char_count: usize = messages.iter().map(|m| m.content.chars().count()).sum();
+    let before_token_count = estimate_messages_tokens(messages);
+
+    // Build system prompt with compaction instructions
+    let compact_prompt = build_compact_prompt(custom_instructions);
+    let system_message = Message {
+        role: "system".to_string(),
+        content: compact_prompt,
+    };
+
+    let request = ChatRequest {
+        model: model_name.to_string(),
+        messages: vec![system_message],
+        temperature: 0.3,
+        max_tokens: Some(8192),
+    };
+
+    let response = llm
+        .chat(request)
+        .await
+        .map_err(CompactionError::LLMCallFailed)?;
+
+    let summary = match extract_summary(&response.content) {
+        Some(s) => s,
+        None => return Err(CompactionError::SummaryParseFailed),
+    };
+
+    let boundary_message = format_boundary_message(&summary, is_auto);
+    let after_char_count = boundary_message.chars().count();
+    let after_token_count = estimate_tokens(&boundary_message);
+
+    Ok(CompactionResult {
+        performed: true,
+        original_tokens: before_token_count,
+        compacted_tokens: after_token_count,
+        message: format!(
+            "Compacted {} messages ({} chars, {} tokens) → {} chars, {} tokens",
+            messages.len(),
+            before_char_count,
+            before_token_count,
+            after_char_count,
+            after_token_count
+        ),
+        before_char_count,
+        after_char_count,
+        before_token_count,
+        after_token_count,
+        boundary_message,
+        is_auto,
+    })
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenWarningState {
     /// Normal state — plenty of context room.
@@ -160,194 +304,5 @@ impl CompactionService {
     /// Returns the number of consecutive compaction failures.
     pub fn consecutive_failures(&self) -> usize {
         self.consecutive_failures
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_estimate_tokens_english() {
-        // "hello" = 5 chars * 0.25 = 1.25 -> ceil = 2
-        let tokens = estimate_tokens("hello");
-        assert!(tokens >= 2 && tokens <= 5, "expected 2-5, got {}", tokens);
-    }
-
-    #[test]
-    fn test_estimate_tokens_chinese() {
-        // "你好" = 2 chars * 0.25 = 0.5 -> ceil = 1
-        let tokens = estimate_tokens("你好");
-        assert!(tokens >= 1 && tokens <= 4, "expected 1-4, got {}", tokens);
-    }
-
-    #[test]
-    fn test_estimate_tokens_empty() {
-        assert_eq!(estimate_tokens(""), 0);
-    }
-
-    #[test]
-    fn test_estimate_tokens_emoji() {
-        // "🎉🎊🔥" = 3 chars * 0.25 = 0.75 -> ceil = 1
-        let tokens = estimate_tokens("🎉🎊🔥");
-        assert!(tokens >= 1 && tokens <= 4, "expected 1-4, got {}", tokens);
-    }
-
-    #[test]
-    fn test_estimate_tokens_long_string() {
-        let s = "a".repeat(1000);
-        assert_eq!(estimate_tokens(&s), 250);
-    }
-
-    #[test]
-    fn test_get_context_window_minimax() {
-        assert_eq!(get_context_window("mini-max"), 1_000_000);
-    }
-
-    #[test]
-    fn test_get_context_window_glm() {
-        assert_eq!(get_context_window("glm-5.1"), 256_000);
-    }
-
-    #[test]
-    fn test_get_context_window_unknown() {
-        assert_eq!(get_context_window("unknown-model-xyz"), 128_000);
-    }
-
-    #[test]
-    fn test_should_auto_compact_below_threshold() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        let msgs = vec![Message {
-            role: "user".to_string(),
-            content: "short".to_string(),
-        }];
-        assert!(!service.should_auto_compact(&msgs, "mini-max"));
-    }
-
-    #[test]
-    fn test_should_auto_compact_circuit_breaker() {
-        let mut config = CompactConfig::default();
-        config.max_consecutive_failures = 3;
-        let mut service = CompactionService::new(config);
-        // Record failures up to max
-        service.record_failure();
-        service.record_failure();
-        service.record_failure();
-        let msgs = vec![Message {
-            role: "user".to_string(),
-            content: "x".repeat(900_000),
-        }];
-        // Circuit breaker should trip
-        assert!(!service.should_auto_compact(&msgs, "mini-max"));
-    }
-
-    #[test]
-    fn test_token_warning_state_normal() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        // 1,000,000 - 50,000 = 950,000 used -> 50,000 remaining > 20,000
-        assert_eq!(
-            service.token_warning_state(950_000, "mini-max"),
-            TokenWarningState::Normal
-        );
-    }
-
-    #[test]
-    fn test_token_warning_state_warning() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        // remaining = 20,000 -> Warning
-        assert_eq!(
-            service.token_warning_state(980_000, "mini-max"),
-            TokenWarningState::Warning
-        );
-    }
-
-    #[test]
-    fn test_token_warning_state_auto_compact() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        // remaining = 13,000 -> AutoCompactTriggered
-        assert_eq!(
-            service.token_warning_state(987_000, "mini-max"),
-            TokenWarningState::AutoCompactTriggered
-        );
-    }
-
-    #[test]
-    fn test_token_warning_state_blocking() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        // remaining = 3,000 -> Blocking
-        assert_eq!(
-            service.token_warning_state(997_000, "mini-max"),
-            TokenWarningState::Blocking
-        );
-    }
-
-    #[test]
-    fn test_percent_left_normal() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        assert_eq!(service.percent_left(500_000, "mini-max"), 50);
-    }
-
-    #[test]
-    fn test_percent_left_zero_used() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        assert_eq!(service.percent_left(0, "mini-max"), 100);
-    }
-
-    #[test]
-    fn test_percent_left_near_full() {
-        let config = CompactConfig::default();
-        let service = CompactionService::new(config);
-        assert_eq!(service.percent_left(999_000, "mini-max"), 0);
-    }
-
-    #[test]
-    fn test_record_failure_increments() {
-        let mut config = CompactConfig::default();
-        config.max_consecutive_failures = 3;
-        let mut service = CompactionService::new(config);
-        assert_eq!(service.consecutive_failures(), 0);
-        service.record_failure();
-        assert_eq!(service.consecutive_failures(), 1);
-        service.record_failure();
-        assert_eq!(service.consecutive_failures(), 2);
-    }
-
-    #[test]
-    fn test_record_success_resets() {
-        let mut config = CompactConfig::default();
-        config.max_consecutive_failures = 3;
-        let mut service = CompactionService::new(config);
-        service.record_failure();
-        service.record_failure();
-        assert_eq!(service.consecutive_failures(), 2);
-        service.record_success();
-        assert_eq!(service.consecutive_failures(), 0);
-    }
-
-    #[test]
-    fn test_should_auto_compact_recovers_after_success() {
-        let mut config = CompactConfig::default();
-        config.max_consecutive_failures = 3;
-        let mut service = CompactionService::new(config);
-        // Push to edge of circuit breaker (3 failures = trip)
-        service.record_failure();
-        service.record_failure();
-        service.record_failure(); // Now consecutive_failures=3 >= max=3, CB trips
-                                  // 4M chars -> 1M tokens, exceeds 987K threshold
-        let msgs = vec![Message {
-            role: "user".to_string(),
-            content: "x".repeat(4_000_000),
-        }];
-        assert!(!service.should_auto_compact(&msgs, "mini-max")); // CB trips
-                                                                  // Success resets
-        service.record_success();
-        assert!(service.should_auto_compact(&msgs, "mini-max")); // CB recovers
     }
 }

--- a/src/session/compaction_tests.rs
+++ b/src/session/compaction_tests.rs
@@ -1,0 +1,437 @@
+//! Tests for compaction module
+
+#[cfg(test)]
+mod tests {
+    use crate::llm::Message;
+    use crate::session::compaction::{
+        build_compact_prompt, estimate_messages_tokens, estimate_tokens, extract_summary,
+        format_boundary_message, get_context_window, CompactConfig, CompactionError,
+        CompactionService, TokenWarningState,
+    };
+
+    #[test]
+    fn test_estimate_tokens_english() {
+        // "hello" = 5 chars * 0.25 = 1.25 -> ceil = 2
+        let tokens = estimate_tokens("hello");
+        assert!(tokens >= 2 && tokens <= 5, "expected 2-5, got {}", tokens);
+    }
+
+    #[test]
+    fn test_estimate_tokens_chinese() {
+        // "你好" = 2 chars * 0.25 = 0.5 -> ceil = 1
+        let tokens = estimate_tokens("你好");
+        assert!(tokens >= 1 && tokens <= 4, "expected 1-4, got {}", tokens);
+    }
+
+    #[test]
+    fn test_estimate_tokens_empty() {
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn test_estimate_tokens_emoji() {
+        // "🎉🎊🔥" = 3 chars * 0.25 = 0.75 -> ceil = 1
+        let tokens = estimate_tokens("🎉🎊🔥");
+        assert!(tokens >= 1 && tokens <= 4, "expected 1-4, got {}", tokens);
+    }
+
+    #[test]
+    fn test_estimate_tokens_long_string() {
+        let s = "a".repeat(1000);
+        assert_eq!(estimate_tokens(&s), 250);
+    }
+
+    #[test]
+    fn test_get_context_window_minimax() {
+        assert_eq!(get_context_window("mini-max"), 1_000_000);
+    }
+
+    #[test]
+    fn test_get_context_window_glm() {
+        assert_eq!(get_context_window("glm-5.1"), 256_000);
+    }
+
+    #[test]
+    fn test_get_context_window_unknown() {
+        assert_eq!(get_context_window("unknown-model-xyz"), 128_000);
+    }
+
+    #[test]
+    fn test_should_auto_compact_below_threshold() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        let msgs = vec![Message {
+            role: "user".to_string(),
+            content: "short".to_string(),
+        }];
+        assert!(!service.should_auto_compact(&msgs, "mini-max"));
+    }
+
+    #[test]
+    fn test_should_auto_compact_circuit_breaker() {
+        let mut config = CompactConfig::default();
+        config.max_consecutive_failures = 3;
+        let mut service = CompactionService::new(config);
+        // Record failures up to max
+        service.record_failure();
+        service.record_failure();
+        service.record_failure();
+        let msgs = vec![Message {
+            role: "user".to_string(),
+            content: "x".repeat(900_000),
+        }];
+        // Circuit breaker should trip
+        assert!(!service.should_auto_compact(&msgs, "mini-max"));
+    }
+
+    #[test]
+    fn test_token_warning_state_normal() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        // 1,000,000 - 50,000 = 950,000 used -> 50,000 remaining > 20,000
+        assert_eq!(
+            service.token_warning_state(950_000, "mini-max"),
+            TokenWarningState::Normal
+        );
+    }
+
+    #[test]
+    fn test_token_warning_state_warning() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        // remaining = 20,000 -> Warning
+        assert_eq!(
+            service.token_warning_state(980_000, "mini-max"),
+            TokenWarningState::Warning
+        );
+    }
+
+    #[test]
+    fn test_token_warning_state_auto_compact() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        // remaining = 13,000 -> AutoCompactTriggered
+        assert_eq!(
+            service.token_warning_state(987_000, "mini-max"),
+            TokenWarningState::AutoCompactTriggered
+        );
+    }
+
+    #[test]
+    fn test_token_warning_state_blocking() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        // remaining = 3,000 -> Blocking
+        assert_eq!(
+            service.token_warning_state(997_000, "mini-max"),
+            TokenWarningState::Blocking
+        );
+    }
+
+    #[test]
+    fn test_percent_left_normal() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        assert_eq!(service.percent_left(500_000, "mini-max"), 50);
+    }
+
+    #[test]
+    fn test_percent_left_zero_used() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        assert_eq!(service.percent_left(0, "mini-max"), 100);
+    }
+
+    #[test]
+    fn test_percent_left_near_full() {
+        let config = CompactConfig::default();
+        let service = CompactionService::new(config);
+        assert_eq!(service.percent_left(999_000, "mini-max"), 0);
+    }
+
+    #[test]
+    fn test_record_failure_increments() {
+        let mut config = CompactConfig::default();
+        config.max_consecutive_failures = 3;
+        let mut service = CompactionService::new(config);
+        assert_eq!(service.consecutive_failures(), 0);
+        service.record_failure();
+        assert_eq!(service.consecutive_failures(), 1);
+        service.record_failure();
+        assert_eq!(service.consecutive_failures(), 2);
+    }
+
+    #[test]
+    fn test_record_success_resets() {
+        let mut config = CompactConfig::default();
+        config.max_consecutive_failures = 3;
+        let mut service = CompactionService::new(config);
+        service.record_failure();
+        service.record_failure();
+        assert_eq!(service.consecutive_failures(), 2);
+        service.record_success();
+        assert_eq!(service.consecutive_failures(), 0);
+    }
+
+    #[test]
+    fn test_should_auto_compact_recovers_after_success() {
+        let mut config = CompactConfig::default();
+        config.max_consecutive_failures = 3;
+        let mut service = CompactionService::new(config);
+        service.record_failure();
+        service.record_failure();
+        service.record_failure();
+        let msgs = vec![Message {
+            role: "user".to_string(),
+            content: "x".repeat(4_000_000),
+        }];
+        assert!(!service.should_auto_compact(&msgs, "mini-max"));
+        service.record_success();
+        assert!(service.should_auto_compact(&msgs, "mini-max"));
+    }
+
+    // Step 1.2 tests: Prompt template and summary extraction
+    #[test]
+    fn test_build_compact_prompt_none() {
+        let prompt = build_compact_prompt(None);
+        assert!(prompt.contains("You must not call any tools"));
+    }
+
+    #[test]
+    fn test_build_compact_prompt_with_instructions() {
+        let prompt = build_compact_prompt(Some("xxx"));
+        assert!(prompt.contains("保留 xxx"));
+    }
+
+    #[test]
+    fn test_build_compact_prompt_empty() {
+        let p1 = build_compact_prompt(None);
+        let p2 = build_compact_prompt(Some(""));
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_extract_summary_simple() {
+        assert_eq!(extract_summary("hello"), None);
+        assert_eq!(
+            extract_summary("<summary>test</summary>"),
+            Some("test".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_summary_with_analysis() {
+        let r = extract_summary("<analysis>draft</analysis><summary>content</summary>");
+        assert_eq!(r, Some("content".to_string()));
+    }
+
+    #[test]
+    fn test_extract_summary_empty() {
+        assert_eq!(extract_summary("<summary></summary>"), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_extract_summary_no_tags() {
+        assert_eq!(extract_summary("no tags"), None);
+    }
+
+    #[test]
+    fn test_extract_summary_unclosed() {
+        assert_eq!(extract_summary("<summary>unclosed"), None);
+    }
+
+    #[test]
+    fn test_format_boundary_message_auto() {
+        let msg = format_boundary_message("summary", true);
+        assert!(msg.contains("自动压缩"));
+    }
+
+    #[test]
+    fn test_format_boundary_message_manual() {
+        let msg = format_boundary_message("summary", false);
+        assert!(msg.contains("手动压缩"));
+    }
+
+    // Step 1.4 tests: Complete UT coverage
+
+    // build_compact_prompt tests - additional coverage
+    #[test]
+    fn test_build_compact_prompt_with_custom_full() {
+        let prompt = build_compact_prompt(Some("保留 xxx"));
+        assert!(prompt.contains("保留 xxx"));
+        assert!(prompt.contains("You must not call any tools"));
+    }
+
+    // extract_summary tests - additional coverage
+    #[test]
+    fn test_extract_summary_with_whitespace() {
+        let r = extract_summary("<summary>\n  item1\n  item2\n</summary>");
+        assert_eq!(r, Some("\n  item1\n  item2\n".to_string()));
+    }
+
+    #[test]
+    fn test_extract_summary_wrong_order() {
+        // end tag before start tag
+        assert_eq!(
+            extract_summary("</summary><summary>content</summary>"),
+            None
+        );
+    }
+
+    // format_boundary_message tests - additional coverage
+    #[test]
+    fn test_format_boundary_message_auto_full() {
+        let msg = format_boundary_message("summary text", true);
+        assert!(msg.contains("[Session Compaction | 自动压缩]"));
+        assert!(msg.contains("summary text"));
+    }
+
+    #[test]
+    fn test_format_boundary_message_manual_full() {
+        let msg = format_boundary_message("summary text", false);
+        assert!(msg.contains("[Session Compaction | 手动压缩]"));
+        assert!(msg.contains("summary text"));
+    }
+
+    // CompactionError Display tests
+    #[test]
+    fn test_compaction_error_display() {
+        // LLMCallFailed
+        let err_llm = CompactionError::LLMCallFailed(crate::llm::LLMError::RateLimitExceeded);
+        assert!(err_llm.to_string().contains("LLM call failed"));
+
+        // SummaryParseFailed
+        let err_parse = CompactionError::SummaryParseFailed;
+        assert!(err_parse.to_string().contains("Failed to parse summary"));
+
+        // EmptyMessages
+        let err_empty = CompactionError::EmptyMessages;
+        assert!(err_empty.to_string().contains("No messages"));
+    }
+}
+
+#[cfg(all(test, feature = "fake-llm"))]
+mod async_tests {
+    use crate::llm::fake::{FakeProvider, Scenario};
+    use crate::llm::Message;
+    use crate::session::compaction::{execute_compact, CompactionError, CompactionResult};
+
+    #[tokio::test]
+    async fn test_execute_compact_success() {
+        let provider = FakeProvider::builder()
+            .then_ok("<summary>Compacted summary content</summary>", "glm-5.1")
+            .build();
+
+        let messages = vec![
+            Message {
+                role: "user".to_string(),
+                content: "Hello, this is a test message".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "Hi! How can I help you?".to_string(),
+            },
+        ];
+
+        let result = execute_compact(&messages, &provider, "glm-5.1", None, false).await;
+
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert!(r.performed);
+        assert!(r.boundary_message.contains("Compacted summary content"));
+        assert!(r.boundary_message.contains("手动压缩"));
+        assert!(r.message.contains("2 messages"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_compact_empty_messages() {
+        let provider = FakeProvider::builder()
+            .then_ok("<summary>content</summary>", "glm-5.1")
+            .build();
+
+        let messages: Vec<Message> = vec![];
+
+        let result = execute_compact(&messages, &provider, "glm-5.1", None, true).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(CompactionError::EmptyMessages)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_compact_llm_failure() {
+        let provider = FakeProvider::builder()
+            .then_err(crate::llm::LLMError::RateLimitExceeded)
+            .build();
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: "test".to_string(),
+        }];
+
+        let result = execute_compact(&messages, &provider, "glm-5.1", None, false).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(CompactionError::LLMCallFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_execute_compact_no_summary() {
+        let provider = FakeProvider::builder()
+            .then_ok("No summary tag in response", "glm-5.1")
+            .build();
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: "test".to_string(),
+        }];
+
+        let result = execute_compact(&messages, &provider, "glm-5.1", None, true).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(CompactionError::SummaryParseFailed)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_compact_with_custom_instructions() {
+        let provider = FakeProvider::builder()
+            .then_ok("<summary>Test summary</summary>", "glm-5.1")
+            .build();
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: "Test".to_string(),
+        }];
+
+        let result = execute_compact(
+            &messages,
+            &provider,
+            "glm-5.1",
+            Some("重点保留用户名"),
+            true,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert!(r.boundary_message.contains("Test summary"));
+        assert!(r.boundary_message.contains("自动压缩"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_compact_auto_trigger() {
+        let provider = FakeProvider::builder()
+            .then_ok("<summary>Auto summary</summary>", "glm-5.1")
+            .build();
+
+        let messages = vec![Message {
+            role: "user".to_string(),
+            content: "test".to_string(),
+        }];
+
+        let result = execute_compact(&messages, &provider, "glm-5.1", None, true).await;
+
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert!(r.is_auto);
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -13,6 +13,8 @@
 pub mod bootstrap;
 pub mod checkpoint_manager;
 pub mod compaction;
+#[cfg(test)]
+pub mod compaction_tests;
 pub mod events;
 pub mod persistence;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds LLM-based session compaction execution to the Session Compaction module (issue #505):

-  - Builds prompt with NO_TOOLS preamble and 9-item summary structure
-  - Parses  XML blocks from LLM responses  
-  - Formats compaction boundary system messages
-  - Async function orchestrating prompt → LLM → parse → format

Also extends:
-  with before/after char/token counts and boundary_message
-  enum with LLM call failed, parse failed, and empty messages variants

Moves tests to  to comply with the 500-line file limit.

## Changes

- : New functions and types (under 500 lines)
- : Unit tests (new file)
- : Added test module declaration
- : Updated compaction module documentation

## Testing

- All compaction tests pass (36 tests)
- cargo check passes