### PR TITLE
feat(session): integrate CompactConfig into SessionConfig and KV cache consistency UT

### DIFF
--- a/src/config/SPEC.md
+++ b/src/config/SPEC.md
@@ -33,7 +33,8 @@
 | `ConfigValidationError` | 配置验证错误（path + message） |
 | `write_atomically` | 原子写入函数（写临时文件 + fsync + rename） |
 | `PerAgentSessionConfig` | 单个 agent-role 的 session 配置（idle_minutes / purge_after_minutes） |
-| `SessionConfig` | 完整 session 配置容器（defaults / agents / sweeper_interval_secs） |
+| `CompactConfig` | compaction 配置（chars_per_token / auto_compact_buffer_tokens / max_consecutive_failures），从 `crate::session::compaction` re-exported |
+| `SessionConfig` | 完整 session 配置容器（defaults / agents / sweeper_interval_secs / compact） |
 | `SessionConfigProvider` | Trait，获取 per-agent session 配置和 sweeper 间隔 |
 | `JsonSessionConfigProvider` | JSON 文件实现的 SessionConfigProvider |
 | `AgentRole` | Agent 角色枚举（MainAgent / SubAgent），imported from `crate::session::persistence` |
@@ -94,12 +95,13 @@ pub enum ConfigError {
 
 **数据结构**：
 - `PerAgentSessionConfig`：单个 agent-role 的配置（idle_minutes、purge_after_minutes）
-- `SessionConfig`：完整配置容器（defaults: BTreeMap<AgentRole, PerAgentSessionConfig>、agents: BTreeMap<agent_id, BTreeMap<AgentRole, PerAgentSessionConfig>>、sweeper_interval_secs）
+- `SessionConfig`：完整配置容器（defaults: BTreeMap<AgentRole, PerAgentSessionConfig>、agents: BTreeMap<agent_id, BTreeMap<AgentRole, PerAgentSessionConfig>>、sweeper_interval_secs、compact: Option<CompactConfig>）
 
 **Trait `SessionConfigProvider`**（Send + Sync）：
 - `session_config_for(agent_id, role)` — 按 agent/role 查询配置，使用 fallback 链：per-agent override → defaults → hardcoded defaults
 - `sweeper_interval_secs()` — sweeper 轮询间隔
 - `list_agents()` — 所有配置了 per-agent override 的 agent_id 列表
+- `compact_config()` — compaction 配置，JSON 中无 `compact` 字段时返回 `CompactConfig::default()`
 
 **`JsonSessionConfigProvider`** 构造与行为：
 - `new(path)` — 读取 JSON 文件

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ pub use manager::{
     ConfigWriteError, SafeBackupManager,
 };
 
+pub use crate::session::compaction::CompactConfig;
 pub use agents::{AgentDirectoryEntry, AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
 pub use migration::{migrate_if_needed, ConfigMigrationError};
 pub use providers::{

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -11,7 +11,12 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::config::providers::ConfigError;
+use crate::session::compaction::CompactConfig;
 use crate::session::persistence::AgentRole;
+
+#[cfg(test)]
+#[path = "session_compact_tests.rs"]
+mod session_compact_tests;
 
 /// Default idle time in minutes before a session is considered idle
 pub const DEFAULT_IDLE_MINUTES: i64 = 30;
@@ -66,6 +71,9 @@ pub struct SessionConfig {
     /// Sweeper interval in seconds (default: 5 minutes)
     #[serde(default = "default_sweeper_interval")]
     pub sweeper_interval_secs: u64,
+    /// Compaction configuration (optional, falls back to CompactConfig::default())
+    #[serde(default)]
+    pub compact: Option<CompactConfig>,
 }
 
 fn default_sweeper_interval() -> u64 {
@@ -78,6 +86,7 @@ impl Default for SessionConfig {
             defaults: BTreeMap::new(),
             agents: BTreeMap::new(),
             sweeper_interval_secs: DEFAULT_SWEEPER_INTERVAL_SECS,
+            compact: None,
         }
     }
 }
@@ -92,6 +101,9 @@ pub trait SessionConfigProvider: Send + Sync {
 
     /// List all agent IDs that have per-agent overrides
     fn list_agents(&self) -> Vec<String>;
+
+    /// Get compaction configuration
+    fn compact_config(&self) -> CompactConfig;
 }
 
 /// JSON-based session configuration provider
@@ -223,6 +235,13 @@ impl SessionConfigProvider for JsonSessionConfigProvider {
         self.config
             .as_ref()
             .map(|c| c.agents.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn compact_config(&self) -> CompactConfig {
+        self.config
+            .as_ref()
+            .and_then(|c| c.compact.clone())
             .unwrap_or_default()
     }
 }

--- a/src/config/session_compact_tests.rs
+++ b/src/config/session_compact_tests.rs
@@ -1,0 +1,79 @@
+//! Integration tests for session config compact functionality
+
+use tempfile::TempDir;
+
+use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
+use crate::session::compaction::CompactConfig;
+
+/// Minimal valid session config JSON with given defaults, agents, and sweeper interval.
+fn valid_config_json(defaults: &str, agents: &str, sweeper_interval_secs: u64) -> String {
+    format!(
+        r#"{{"defaults":{},"agents":{},"sweeperIntervalSecs":{}}}"#,
+        defaults, agents, sweeper_interval_secs
+    )
+}
+
+/// Write JSON content to a temp file and return its path.
+fn write_temp_json(content: &str) -> (TempDir, std::path::PathBuf) {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("session_config.json");
+    std::fs::write(&path, content).unwrap();
+    (temp, path)
+}
+
+#[test]
+fn test_compact_config_parsed_when_present() {
+    let json = r#"{"defaults":{"mainAgent":{"idleMinutes":10,"purgeAfterMinutes":60}},"agents":{},"sweeperIntervalSecs":300,"compact":{"charsPerToken":0.3,"autoCompactBufferTokens":15000,"maxConsecutiveFailures":5}}"#.to_string();
+    let (_temp, path) = write_temp_json(&json);
+
+    let provider = JsonSessionConfigProvider::new(&path).unwrap();
+    let compact = provider.compact_config();
+
+    assert_eq!(compact.chars_per_token, 0.3);
+    assert_eq!(compact.auto_compact_buffer_tokens, 15000);
+    assert_eq!(compact.max_consecutive_failures, 5);
+}
+
+#[test]
+fn test_compact_config_returns_default_when_absent() {
+    let json = valid_config_json(
+        r#"{"mainAgent":{"idleMinutes":10,"purgeAfterMinutes":60}}"#,
+        "{}",
+        300,
+    );
+    let (_temp, path) = write_temp_json(&json);
+
+    let provider = JsonSessionConfigProvider::new(&path).unwrap();
+    let compact = provider.compact_config();
+    let default_compact = CompactConfig::default();
+
+    assert_eq!(compact.chars_per_token, default_compact.chars_per_token);
+    assert_eq!(
+        compact.auto_compact_buffer_tokens,
+        default_compact.auto_compact_buffer_tokens
+    );
+    assert_eq!(
+        compact.max_consecutive_failures,
+        default_compact.max_consecutive_failures
+    );
+}
+
+#[test]
+fn test_compact_config_fallback_when_no_config_file() {
+    let temp = TempDir::new().unwrap();
+    let nonexistent = temp.path().join("nonexistent.json");
+    let provider = JsonSessionConfigProvider::new(&nonexistent).unwrap();
+
+    let compact = provider.compact_config();
+    let default_compact = CompactConfig::default();
+
+    assert_eq!(compact.chars_per_token, default_compact.chars_per_token);
+    assert_eq!(
+        compact.auto_compact_buffer_tokens,
+        default_compact.auto_compact_buffer_tokens
+    );
+    assert_eq!(
+        compact.max_consecutive_failures,
+        default_compact.max_consecutive_failures
+    );
+}

--- a/src/session/SPEC.md
+++ b/src/session/SPEC.md
@@ -17,7 +17,7 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
   - `context` — BootstrapContext 元数据容器
   - `types` — BootstrapRegion 标记结构、错误类型
 - `checkpoint_manager` — Checkpoint 持久化管理器（save/load/archive/restore/purge）
-- `compaction` — Token 估算、自动压缩阈值检测、分级警告、Circuit Breaker；为 LLM 压缩执行（#505）和 Session 集成（#507/#508）提供基础接口
+- `compaction` — Token 估算、自动压缩阈值检测、分级警告、Circuit Breaker；JSON 配置集成（#508）；为 LLM 压缩执行（#505）和 Session 集成（#507/#508）提供基础接口
 - `persistence` — Checkpoint 数据结构 + 持久化服务接口 + 本地缓存管理器
 - `events` — Checkpoint 触发时机定义（模式切换/消息发送/网关关闭/compaction）
 - `recovery` — 网关启动时从存储恢复会话

--- a/src/session/bootstrap/loader.rs
+++ b/src/session/bootstrap/loader.rs
@@ -230,4 +230,74 @@ mod tests {
         assert!(!minimal.contains(&"HEARTBEAT.md"));
         assert!(!full.contains(&"HEARTBEAT.md"));
     }
+
+    #[test]
+    fn test_bootstrap_kv_cache_consistency() {
+        // 文件内容不变时，两次加载结果应完全一致
+        let tmp = TempDir::new().unwrap();
+        create_test_files(
+            tmp.path(),
+            &["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md", "TOOLS.md"],
+        );
+
+        let result1 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+        let result2 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+
+        assert_eq!(
+            result1, result2,
+            "same files should produce identical results"
+        );
+        assert_eq!(result1.len(), 5);
+        for (name, content) in &result1 {
+            assert_eq!(
+                *content,
+                format!("content of {}", name),
+                "content should match expected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bootstrap_content_changed() {
+        // 文件被修改后，再次加载结果应不同
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("AGENTS.md"), "original content").unwrap();
+
+        let result1 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+        let original_content = result1.get("AGENTS.md").unwrap().clone();
+
+        // 修改文件内容
+        std::fs::write(tmp.path().join("AGENTS.md"), "modified content").unwrap();
+
+        let result2 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+        let modified_content = result2.get("AGENTS.md").unwrap();
+
+        assert_ne!(
+            original_content.as_str(),
+            modified_content.as_str(),
+            "modified file should produce different content"
+        );
+        assert_eq!(modified_content, "modified content");
+    }
+
+    #[test]
+    fn test_bootstrap_file_deleted() {
+        // 文件被删除后，加载结果应缺少该文件
+        let tmp = TempDir::new().unwrap();
+        create_test_files(tmp.path(), &["AGENTS.md", "SOUL.md"]);
+
+        let result1 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+        assert!(result1.contains_key("AGENTS.md"));
+        assert!(result1.contains_key("SOUL.md"));
+
+        // 删除文件
+        std::fs::remove_file(tmp.path().join("AGENTS.md")).unwrap();
+
+        let result2 = load_bootstrap_files(tmp.path(), BootstrapMode::Minimal).unwrap();
+        assert!(
+            !result2.contains_key("AGENTS.md"),
+            "deleted file should not appear in results"
+        );
+        assert!(result2.contains_key("SOUL.md"), "other files should remain");
+    }
 }

--- a/src/session/compaction.rs
+++ b/src/session/compaction.rs
@@ -3,11 +3,14 @@
 //! Provides token estimation, auto-compaction threshold detection, and circuit breaker
 //! for LLM context window management.
 
+use serde::{Deserialize, Serialize};
+
 use crate::llm::Message;
 use crate::llm::{ChatRequest, LLMProvider};
 
 /// Configuration for compaction behavior.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompactConfig {
     /// Characters per token (linear estimation coefficient).
     pub chars_per_token: f64,

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -366,6 +366,10 @@ mod tests {
         fn list_agents(&self) -> Vec<String> {
             self.agents.lock().unwrap().clone()
         }
+
+        fn compact_config(&self) -> crate::session::CompactConfig {
+            crate::session::CompactConfig::default()
+        }
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
- Add Serialize/Deserialize to CompactConfig with camelCase naming
- Add compact: Option<CompactConfig> field to SessionConfig with serde(default)
- Extend SessionConfigProvider trait with compact_config() method
- JsonSessionConfigProvider implements compact_config() with default fallback
- Add session_compact_tests module with 3 integration tests
- Add bootstrap KV cache consistency tests in loader.rs

Source: issue #508
Type: feat
