### PR TITLE
fix(system-prompt): remove global APPEND_SECTION from build_system_prompt

### DIFF
--- a/src/system_prompt/SPEC.md
+++ b/src/system_prompt/SPEC.md
@@ -10,7 +10,7 @@
 
 覆盖链（override → agent → custom → default）加 append 始终追加在最末。静态 section 基于 mtime 被动失效（无主动文件监听）；动态 section 每次请求重新渲染。Workspace 路径下 IDENTITY.md/SOUL.md/MEMORY.md 自动参与 RoleSection 拼接。
 
-权限校验由调用方负责；不主动监听文件变化；append 内容请求结束后自动清除。
+`build_system_prompt` 和 `build_from_workspace` 显式接收 `append_section: Option<String>` 参数，`append_append_section` 为纯函数，不再从全局读取——彻底消除并行测试时的状态竞争。
 
 ---
 
@@ -20,8 +20,8 @@
 
 | 接口 | 功能 |
 |------|------|
-| `build_system_prompt` | 组装完整 system prompt，按覆盖链优先级拼接各 section |
-| `build_from_workspace(workspace_root, dynamic_sections, skill_info)` | 从 workspace 路径加载 bootstrap 文件（IDENTITY.md / SOUL.md / MEMORY.md）构建 prompt，skill_info 为 `Some((registry, agent_id))` 时注入 SkillListingSection |
+| `build_system_prompt(sections, append_section)` | 组装完整 system prompt，按覆盖链优先级拼接各 section，append_section 追加在最末 |
+| `build_from_workspace(workspace_root, dynamic_sections, skill_info, append_section)` | 从 workspace 路径加载 bootstrap 文件构建 prompt，skill_info 为 `Some((registry, agent_id))` 时注入 SkillListingSection，append_section 追加在最末 |
 | `set_override_prompt` | 设置最高优先级覆盖 prompt |
 | `set_agent_prompt` | 设置 agent 级 prompt（覆盖链第二层） |
 | `set_custom_prompt` | 设置用户自定义 prompt（覆盖链第三层） |

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -3,8 +3,8 @@
 //! Orchestrates section assembly and renders the final system prompt string.
 
 use super::sections::{
-    get_append_section, get_cached_section, invalidate_all_sections, invalidate_section,
-    load_cached_file_section, read_file_section, Section,
+    get_cached_section, invalidate_all_sections, invalidate_section, load_cached_file_section,
+    read_file_section, Section,
 };
 use crate::skills::DiskSkillRegistry;
 use std::path::Path;
@@ -59,10 +59,10 @@ pub fn set_custom_prompt(prompt: Option<String>) {
 ///  3. CustomSystemPrompt (if set)
 ///  4. defaultSystemPrompt
 ///  5. appendSection (always appended last)
-pub fn build_system_prompt(sections: Vec<Section>) -> String {
+pub fn build_system_prompt(sections: Vec<Section>, append_section: Option<String>) -> String {
     // Check priority prompts first (early return)
     if let Some(prompt) = get_priority_prompt() {
-        return append_append_section(prompt);
+        return append_append_section(prompt, append_section);
     }
 
     // Render sections
@@ -73,7 +73,7 @@ pub fn build_system_prompt(sections: Vec<Section>) -> String {
         rendered.join("\n")
     };
 
-    append_append_section(base)
+    append_append_section(base, append_section)
 }
 
 /// Get the highest-priority prompt that is set
@@ -147,8 +147,8 @@ fn render_section(section: Section) -> String {
 }
 
 /// Append the current append_section to a base prompt
-fn append_append_section(base: String) -> String {
-    if let Some(append) = get_append_section() {
+fn append_append_section(base: String, append: Option<String>) -> String {
+    if let Some(append) = append {
         format!("{}\n\n## Append\n{}\n", base, append)
     } else {
         base
@@ -185,6 +185,7 @@ pub fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     dynamic_sections: Vec<Section>,
     skill_info: Option<(&DiskSkillRegistry, &str)>,
+    append_section: Option<String>,
 ) -> String {
     let root = workspace_root.as_ref();
     let mut sections: Vec<Section> = Vec::new();
@@ -233,13 +234,12 @@ pub fn build_from_workspace<P: AsRef<Path>>(
     // Dynamic sections
     sections.extend(dynamic_sections);
 
-    build_system_prompt(sections)
+    build_system_prompt(sections, append_section)
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::sections::Section;
-    use super::super::sections::{clear_append_section, set_append_section};
     use super::*;
     use crate::skills::DiskSkillRegistry;
     use crate::tools::builtin::register_builtin_tools;
@@ -248,82 +248,116 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_with_override() {
-        clear_append_section();
         set_override_prompt(Some("override prompt".to_string()));
         let sections = vec![Section::RoleSection("should not appear".to_string())];
-        let result = build_system_prompt(sections);
+        let result = build_system_prompt(sections, None);
         assert!(result.contains("override prompt"));
         set_override_prompt(None);
     }
 
     #[test]
     fn test_build_system_prompt_with_agent_prompt() {
-        clear_append_section();
         set_agent_prompt(Some("agent prompt".to_string()));
         let sections = vec![];
-        let result = build_system_prompt(sections);
+        let result = build_system_prompt(sections, None);
         assert!(result.contains("agent prompt"));
         set_agent_prompt(None);
     }
 
     #[test]
     fn test_build_system_prompt_with_custom_prompt() {
-        clear_append_section();
         set_custom_prompt(Some("custom prompt".to_string()));
         let sections = vec![];
-        let result = build_system_prompt(sections);
+        let result = build_system_prompt(sections, None);
         assert!(result.contains("custom prompt"));
         set_custom_prompt(None);
     }
 
     #[test]
-
     fn test_build_system_prompt_default() {
         // Clear global state that could affect this test
-        clear_append_section();
         set_override_prompt(None);
         set_agent_prompt(None);
         set_custom_prompt(None);
         invalidate_all_sections();
 
         let sections = vec![Section::RoleSection("role content".to_string())];
-        let result = build_system_prompt(sections);
+        let result = build_system_prompt(sections, None);
         assert!(result.contains("role content"));
     }
 
     #[test]
-
-    fn test_build_append_section_appended() {
-        set_override_prompt(None);
-        clear_append_section();
-        set_append_section("extra notes".to_string());
-        let sections = vec![Section::RoleSection("base".to_string())];
-        let result = build_system_prompt(sections);
-        assert!(result.contains("base"));
+    fn test_build_system_prompt_with_override_and_append() {
+        set_override_prompt(Some("override prompt".to_string()));
+        let sections = vec![Section::RoleSection("should not appear".to_string())];
+        let result = build_system_prompt(sections, Some("extra notes".to_string()));
+        assert!(result.contains("override prompt"));
         assert!(result.contains("extra notes"));
-        clear_append_section();
+        assert!(result.contains("## Append"));
+        set_override_prompt(None);
     }
 
     #[test]
+    fn test_build_system_prompt_with_agent_prompt_and_append() {
+        set_agent_prompt(Some("agent prompt".to_string()));
+        let sections = vec![];
+        let result = build_system_prompt(sections, Some("append content".to_string()));
+        assert!(result.contains("agent prompt"));
+        assert!(result.contains("append content"));
+        assert!(result.contains("## Append"));
+        set_agent_prompt(None);
+    }
 
-    fn test_append_section_not_shown_when_empty() {
-        clear_append_section();
+    #[test]
+    fn test_build_system_prompt_with_custom_prompt_and_append() {
+        set_custom_prompt(Some("custom prompt".to_string()));
+        let sections = vec![];
+        let result = build_system_prompt(sections, Some("append notes".to_string()));
+        assert!(result.contains("custom prompt"));
+        assert!(result.contains("append notes"));
+        assert!(result.contains("## Append"));
+        set_custom_prompt(None);
+    }
+
+    #[test]
+    fn test_build_system_prompt_default_with_append() {
+        set_override_prompt(None);
+        set_agent_prompt(None);
+        set_custom_prompt(None);
+        invalidate_all_sections();
+
+        let sections = vec![Section::RoleSection("role content".to_string())];
+        let result = build_system_prompt(sections, Some("additional info".to_string()));
+        assert!(result.contains("role content"));
+        assert!(result.contains("additional info"));
+        assert!(result.contains("## Append"));
+    }
+
+    #[test]
+    fn test_build_append_section_appended() {
+        set_override_prompt(None);
         let sections = vec![Section::RoleSection("base".to_string())];
-        let result = build_system_prompt(sections);
+        let result = build_system_prompt(sections, Some("extra notes".to_string()));
+        assert!(result.contains("base"));
+        assert!(result.contains("extra notes"));
+    }
+
+    #[test]
+    fn test_append_section_not_shown_when_empty() {
+        let sections = vec![Section::RoleSection("base".to_string())];
+        let result = build_system_prompt(sections, None);
         // append section should not appear at all
         assert!(!result.contains("## Append"));
-        clear_append_section();
     }
 
     #[test]
     fn test_dynamic_sections_not_cached() {
-        clear_append_section();
         let sections = vec![Section::SessionState {
             turn_count: 1,
             pending_tasks: vec![],
         }];
-        let result1 = build_system_prompt(sections.clone());
-        let result2 = build_system_prompt(sections);
+        let result1 = build_system_prompt(sections.clone(), None);
+        let result2 = build_system_prompt(sections, None);
         assert_eq!(result1, result2);
     }
 

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -36,7 +36,7 @@ fn test_build_from_workspace_skill_listing_injected() {
     let skill = make_test_skill("testskill", "A test skill", "Use when testing", "eda");
     let registry = DiskSkillRegistry::new(vec![skill]);
 
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
 
     assert!(
         result.contains("## Available Skills"),
@@ -62,7 +62,7 @@ fn test_build_from_workspace_no_skill_info_no_section() {
     std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
     std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
 
-    let result = build_from_workspace(dir.path(), vec![], None);
+    let result = build_from_workspace(dir.path(), vec![], None, None);
     assert!(!result.contains("## Available Skills"));
 }
 
@@ -74,7 +74,7 @@ fn test_build_from_workspace_empty_listing_no_section() {
     std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
 
     let registry = DiskSkillRegistry::new(vec![]);
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
     assert!(!result.contains("## Available Skills"));
 }
 
@@ -88,7 +88,7 @@ fn test_build_from_workspace_skill_section_not_duplicated() {
     let skill = make_test_skill("unique_skill", "desc", "", "eda");
     let registry = DiskSkillRegistry::new(vec![skill]);
 
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")));
+    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
 
     let count = result.matches("## Available Skills").count();
     assert_eq!(


### PR DESCRIPTION
- Add append_section: Option<String> parameter to build_system_prompt
- Make append_append_section a pure function
- Update build_from_workspace to pass through the parameter
- Update tests to use explicit parameters instead of global state

Source: issue #518
Type: fix
