### PR TITLE
test(outbound): add e2e test coverage for outbound chain

### DIFF
--- a/src/processor_chain/SPEC.md
+++ b/src/processor_chain/SPEC.md
@@ -63,6 +63,19 @@ Inbound 链接收平台原始消息（`RawMessage`），经多个处理器顺序
 | `registry.rs` | `ProcessorRegistry` 实现 + 单元测试 |
 | `registry_tests.rs` | `ProcessorRegistry` 的集成测试（通过 `#[cfg(test)] mod tests` 间接测试） |
 
+### Outbound Fixtures
+
+| 文件 | 场景 |
+|------|------|
+| `tests/fixtures/outbound/fixture_E1.json` | 纯文本 → text 消息 |
+| `tests/fixtures/outbound/fixture_E2.json` | 加粗/斜体/行内代码 → interactive card |
+| `tests/fixtures/outbound/fixture_E3.json` | DSL 按钮 → 卡片 action 按钮 |
+| `tests/fixtures/outbound/fixture_E4.json` | 标题提取（`# 标题`）→ header.title |
+| `tests/fixtures/outbound/fixture_E5.json` | 分割线 `---` → hr 元素 |
+| `tests/fixtures/outbound/fixture_E6.json` | 代码块 → card code 元素 |
+| `tests/fixtures/outbound/fixture_E7.json` | 混合格式（含标题+分割线+代码块）→ interactive card |
+| `tests/fixtures/outbound/fixture_E8.json` | 无 markdown 纯文本 → text 消息（边界）|
+
 ### 数据流
 
 ```

--- a/tests/fixtures/outbound/fixture_E1.json
+++ b/tests/fixtures/outbound/fixture_E1.json
@@ -1,0 +1,10 @@
+{
+  "name": "E1: plain text",
+  "description": "纯文本消息，无任何格式或特殊元素，直接作为 text 消息发出",
+  "input": {
+    "content": "Hello world"
+  },
+  "expected": {
+    "msg_type": "text"
+  }
+}

--- a/tests/fixtures/outbound/fixture_E2.json
+++ b/tests/fixtures/outbound/fixture_E2.json
@@ -1,0 +1,10 @@
+{
+  "name": "E2: bold markdown",
+  "description": "包含加粗格式的 markdown，预期渲染为 interactive card（飞书消息卡片）",
+  "input": {
+    "content": "**粗体** 和普通文本"
+  },
+  "expected": {
+    "msg_type": "interactive"
+  }
+}

--- a/tests/fixtures/outbound/fixture_E3.json
+++ b/tests/fixtures/outbound/fixture_E3.json
@@ -1,0 +1,25 @@
+{
+  "name": "E3: DSL button",
+  "description": "包含 DSL 按钮（::button）的 markdown，预期渲染为带 primary 按钮的 interactive card",
+  "input": {
+    "content": "::button[label:发送;action:send]"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "elements": [
+        {
+          "tag": "button",
+          "action": {
+            "type": "click",
+            "value": "send"
+          },
+          "text": {
+            "tag": "lark_md",
+            "content": "发送"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/outbound/fixture_E4.json
+++ b/tests/fixtures/outbound/fixture_E4.json
@@ -1,0 +1,26 @@
+{
+  "name": "E4: pure button card",
+  "description": "纯按钮卡片，无 content header（无标题、无正文），只有按钮的卡片",
+  "input": {
+    "content": "::button[label:确认;action:confirm]"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "header": null,
+      "elements": [
+        {
+          "tag": "button",
+          "action": {
+            "type": "click",
+            "value": "confirm"
+          },
+          "text": {
+            "tag": "lark_md",
+            "content": "确认"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/outbound/fixture_E5.json
+++ b/tests/fixtures/outbound/fixture_E5.json
@@ -1,0 +1,15 @@
+{
+  "name": "E5: title + content",
+  "description": "以 # 开头的标题行 + 正文内容，预期提取为 card header.title",
+  "input": {
+    "content": "# 文档标题\n\n这是正文内容"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": "文档标题"
+      }
+    }
+  }
+}

--- a/tests/fixtures/outbound/fixture_E6.json
+++ b/tests/fixtures/outbound/fixture_E6.json
@@ -1,0 +1,17 @@
+{
+  "name": "E6: horizontal rule",
+  "description": "包含 --- 分割线的 markdown 内容，预期 card elements 中包含 hr 元素",
+  "input": {
+    "content": "第一段\n\n---\n\n第二段"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "elements": [
+        {
+          "tag": "hr"
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/outbound/fixture_E7.json
+++ b/tests/fixtures/outbound/fixture_E7.json
@@ -1,0 +1,18 @@
+{
+  "name": "E7: code block",
+  "description": "包含代码块的 markdown，预期 card 中包含代码块相关元素",
+  "input": {
+    "content": "```rust\nfn hello() {\n    println!(\"world\");\n}\n```"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "elements": [
+        {
+          "tag": "markdown",
+          "content": "```rust\nfn hello() {\n    println!(\"world\");\n}\n```"
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/outbound/fixture_E8.json
+++ b/tests/fixtures/outbound/fixture_E8.json
@@ -1,0 +1,32 @@
+{
+  "name": "E8: mixed format",
+  "description": "混合格式：标题 + 加粗 + 斜体 + DSL 按钮，预期完整渲染为含 header、markdown、按钮的 card",
+  "input": {
+    "content": "# 标题\n\n**粗体** + *斜体*\n\n::button[label:发送;action:send]"
+  },
+  "expected": {
+    "msg_type": "interactive",
+    "card": {
+      "header": {
+        "title": "标题"
+      },
+      "elements": [
+        {
+          "tag": "markdown",
+          "content": "**粗体** + *斜体*"
+        },
+        {
+          "tag": "button",
+          "action": {
+            "type": "click",
+            "value": "send"
+          },
+          "text": {
+            "tag": "lark_md",
+            "content": "发送"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/outbound_e2e_tests.rs
+++ b/tests/outbound_e2e_tests.rs
@@ -1,0 +1,172 @@
+//! Outbound e2e tests — DslParser → MarkdownToCard full链路.
+//
+//! Covers: text path, interactive card, DSL buttons, title extraction, full chain.
+
+use std::sync::Arc;
+
+use closeclaw::processor_chain::{
+    dsl_parser::DslParser, markdown_to_card::MarkdownToCard, registry::ProcessorRegistry,
+    ProcessedMessage,
+};
+
+/// Helper: build registry with DslParser + MarkdownToCard in outbound chain.
+fn build_registry() -> ProcessorRegistry {
+    let mut reg = ProcessorRegistry::new();
+    reg.register(Arc::new(DslParser));
+    reg.register(Arc::new(MarkdownToCard));
+    reg
+}
+
+/// Helper: parse outbound result JSON and extract msg_type.
+fn msg_type(result: &ProcessedMessage) -> serde_json::Value {
+    serde_json::from_str(&result.content).expect("output must be valid JSON")
+}
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+fn pm(content: &str) -> ProcessedMessage {
+    ProcessedMessage {
+        content: content.to_string(),
+        metadata: serde_json::Map::new(),
+        suppress: false,
+    }
+}
+
+// ── E1: plain text → text msg_type ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_text_path() {
+    // Plain text has no DSL / header / newlines / inline → falls through to text.
+    let reg = build_registry();
+    let result = reg.process_outbound(pm("Hello world")).await.unwrap();
+    let v = msg_type(&result);
+    assert_eq!(v["msg_type"], "text", "plain text should stay as text type");
+}
+
+// ── E2: bold markdown → interactive card ────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_interactive_with_formatting() {
+    // Bold inline triggers should_use_card → interactive card.
+    let reg = build_registry();
+    let result = reg
+        .process_outbound(pm("**粗体** 和普通文本"))
+        .await
+        .unwrap();
+    let v = msg_type(&result);
+    assert_eq!(
+        v["msg_type"], "interactive",
+        "bold should produce interactive card"
+    );
+    let elements = v["card"]["elements"]
+        .as_array()
+        .expect("card must have elements");
+    assert!(!elements.is_empty(), "card must have at least one element");
+}
+
+// ── E3 / E4: DSL button rendering ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_dsl_button_rendering() {
+    // E3: markdown text + DSL button → first button primary, rest default.
+    let reg = build_registry();
+    let input = "请确认：\n::button[label:发送;action:send;value:1]\n::button[label:取消;action:cancel;value:0]";
+    let result = reg.process_outbound(pm(input)).await.unwrap();
+    let v = msg_type(&result);
+    assert_eq!(
+        v["msg_type"], "interactive",
+        "DSL buttons should produce interactive card"
+    );
+
+    // Find Action element with buttons.
+    let actions: Vec<_> = v["card"]["elements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["tag"] == "action")
+        .collect();
+    assert!(
+        !actions.is_empty(),
+        "card must contain at least one action element"
+    );
+
+    let buttons = &actions[0]["actions"];
+    let btns = buttons.as_array().expect("action must have buttons array");
+    assert!(btns.len() >= 2, "expected at least 2 buttons");
+
+    // First button is primary, rest are default.
+    assert_eq!(btns[0]["type"], "primary", "first button should be primary");
+    for btn in btns.iter().skip(1) {
+        assert_eq!(
+            btn["type"], "default",
+            "subsequent buttons should be default"
+        );
+    }
+}
+
+// ── E5: title extraction ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_card_header_extraction() {
+    // "# Title\nBody" → card header.title = "Title".
+    let reg = build_registry();
+    let result = reg
+        .process_outbound(pm("# 文档标题\n\n这是正文内容"))
+        .await
+        .unwrap();
+    let v = msg_type(&result);
+    assert_eq!(
+        v["msg_type"], "interactive",
+        "header markdown should produce interactive card"
+    );
+
+    let header = v["card"]["header"]
+        .as_object()
+        .expect("card must have header");
+    assert_eq!(
+        header["title"], "文档标题",
+        "header title should be extracted correctly"
+    );
+}
+
+// ── E8: full chain ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_outbound_full_chain() {
+    // "# 标题\n\n**粗体** + *斜体*\n\n::button[label:发送;action:send]"
+    // → header.title + markdown elements + buttons.
+    let reg = build_registry();
+    let input = "# 标题\n\n**粗体** + *斜体*\n\n::button[label:发送;action:send]";
+    let result = reg.process_outbound(pm(input)).await.unwrap();
+    let v = msg_type(&result);
+
+    assert_eq!(
+        v["msg_type"], "interactive",
+        "full chain should produce interactive card"
+    );
+
+    // Header extracted.
+    let header = v["card"]["header"]
+        .as_object()
+        .expect("card must have header");
+    assert_eq!(header["title"], "标题", "header title should be '标题'");
+
+    // Elements present (markdown + action).
+    let elements = v["card"]["elements"]
+        .as_array()
+        .expect("card must have elements");
+    assert!(!elements.is_empty(), "card must have elements");
+
+    // At least one markdown element with bold content.
+    let has_markdown = elements
+        .iter()
+        .any(|e| e["tag"] == "markdown" && e["content"].as_str().unwrap().contains("**粗体**"));
+    assert!(has_markdown, "elements should contain bold markdown");
+
+    // Action element with button exists.
+    let has_action = elements.iter().any(|e| e["tag"] == "action");
+    assert!(
+        has_action,
+        "elements should contain action element with button"
+    );
+}


### PR DESCRIPTION
- Add 8 outbound fixture JSON files covering text, formatting, DSL buttons, headers, dividers, code blocks
- Implement outbound_e2e_tests.rs with 5 test scenarios: text path, interactive with formatting, DSL button rendering, card header extraction, full chain
- Update processor_chain SPEC with outbound fixtures table

Source: issue #470
Type: test
