### PR TITLE
feat(skill): add skill hot reload on file change (phase 2)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4,6 +4,7 @@
 //! Handles graceful shutdown via ShutdownCoordinator.
 
 pub mod shutdown;
+pub mod skill_reload;
 
 use crate::audit::{AuditEventBuilder, AuditEventType, AuditLogger, AuditResult};
 use crate::chat::ChatServer;
@@ -18,10 +19,10 @@ use crate::permission::{Defaults, PermissionEngine, RuleSet};
 use crate::session::persistence::PersistenceService;
 use crate::session::storage::SqliteStorage;
 use crate::session::sweeper::ArchiveSweeper;
+use crate::skills::{DiskSkillRegistry, SkillWatcherHandle};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
-use tokio::sync::RwLock;
 use tracing::info;
 
 /// Load key=value pairs from a .env file and set them as environment variables.
@@ -58,6 +59,10 @@ pub struct Daemon {
     pub storage: Arc<SqliteStorage>,
     /// Shutdown sender for ArchiveSweeper
     pub sweeper_shutdown_tx: watch::Sender<()>,
+    /// Shared skill registry, updated on hot reload
+    pub skill_registry: Arc<RwLock<Option<DiskSkillRegistry>>>,
+    /// Skill file watcher handle (RAII: stops on drop)
+    _skill_watcher: Option<SkillWatcherHandle>,
 }
 
 // --- Lifecycle: start, run ---
@@ -181,6 +186,10 @@ impl Daemon {
         // Spawn the background flush task for the (possibly injected) audit logger
         Self::spawn_audit_background_tasks(Arc::clone(&audit_logger));
 
+        // Initialize skill hot reload system
+        let (skill_registry, skill_watcher) =
+            skill_reload::init_skill_hot_reload(config_dir).await?;
+
         info!(
             "CloseClaw daemon started successfully (v{})",
             env!("CARGO_PKG_VERSION")
@@ -195,6 +204,8 @@ impl Daemon {
             audit_logger,
             storage,
             sweeper_shutdown_tx: sweeper_tx,
+            skill_registry,
+            _skill_watcher: Some(skill_watcher),
         })
     }
 

--- a/src/daemon/skill_reload.rs
+++ b/src/daemon/skill_reload.rs
@@ -1,0 +1,61 @@
+//! Skill Hot Reload Initialization
+//!
+//! Initializes the skill registry and file watcher at daemon startup.
+
+use crate::skills::{
+    init_disk_skills, start_skill_watcher, DiskSkillRegistry, ScanConfig, SkillWatcherHandle,
+};
+use crate::system_prompt::sections::invalidate_skill_listing;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use tracing::info;
+
+/// Initialize skill hot reload system.
+///
+/// Scans configured skill directories and starts a file watcher.
+/// When skill files change, the registry is re-scanned and cached
+/// listings are invalidated.
+///
+/// Returns the shared skill registry and the watcher handle
+/// (RAII: stops on drop).
+pub(crate) async fn init_skill_hot_reload(
+    config_dir: &str,
+) -> anyhow::Result<(Arc<RwLock<Option<DiskSkillRegistry>>>, SkillWatcherHandle)> {
+    let skill_dir = std::path::Path::new(config_dir).join("skills");
+    let skill_dirs: Vec<PathBuf> = vec![skill_dir.clone()];
+
+    let scan_config = ScanConfig {
+        bundled_dir: Some(skill_dir),
+        ..Default::default()
+    };
+
+    // Initialize shared registry state
+    let registry = init_disk_skills(&scan_config);
+    let registry_len = registry.len();
+    let registry_arc = Arc::new(RwLock::new(Some(registry)));
+    let registry_for_watcher = Arc::clone(&registry_arc);
+
+    info!(loaded = registry_len, "skill registry initialized");
+
+    // Start watcher — re-scan uses the same ScanConfig as initial scan
+    let watcher_config = scan_config.clone();
+    let watcher = start_skill_watcher(
+        skill_dirs,
+        Box::new(move || {
+            let new_registry = init_disk_skills(&watcher_config);
+
+            // Update shared state
+            if let Ok(mut guard) = registry_for_watcher.write() {
+                *guard = Some(new_registry);
+            }
+
+            // Invalidate cache so next build picks up new listing
+            invalidate_skill_listing();
+
+            tracing::info!("skill registry reloaded after file change");
+        }),
+    )?;
+
+    info!("skill hot reload initialized");
+    Ok((registry_arc, watcher))
+}

--- a/src/skills/SPEC.md
+++ b/src/skills/SPEC.md
@@ -14,6 +14,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 子模块：
 - `registry` — Skill trait + SkillRegistry 注册中心
 - `builtin` — 7 个内置技能实现（file_ops, git_ops, search, permission, discovery）
+- `disk` — 磁盘技能发现与加载（含 hot_reload 热重载）
 - `coding_agent` — 编码委托技能（stub）
 - `skill_creator` — 技能创建辅助技能
 
@@ -39,6 +40,8 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `SkillContext` | disk | 技能执行上下文：`Inline` 或 `Agent { agent_id }` |
 | `SkillEffort` | disk | 工作量估算：`Trivial` / `Small` / `Medium` / `Large` / `Unknown` |
 | `ParseError` | disk | 解析错误：`MissingDelimiter` / `InvalidYaml` / `MissingDescription` |
+| `SkillWatcherHandle` | disk | 文件监听 RAII 句柄，drop 时自动停止 watcher |
+| `HotReloadError` | disk | 热重载错误：`WatcherCreate` / `WatchPath` / `NoDirectories` |
 
 ### 构造
 
@@ -62,6 +65,8 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `parse_skill_md(raw)` | disk | 解析 SKILL.md YAML frontmatter |
 | `scan_all_skills(config)` | disk | 扫描所有技能目录，返回按优先级去重的技能列表 |
 | `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
+| `start_skill_watcher(skill_dirs, on_change)` | disk | 启动技能目录文件监听，300ms debounce 后触发回调，返回 `SkillWatcherHandle` |
+| `invalidate_skill_listing()` | sections | 使 skill_listing 缓存失效，下次 system prompt 构建时重新生成 |
 
 ### 内置类型
 
@@ -120,7 +125,6 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `DiskSkillRegistry::generate_listing(agent_id)` | DiskSkillRegistry | 生成格式化 skill listing 字符串，含优先级排序和 agent_id 过滤 |
 | `DiskSkillRegistry::len()` | DiskSkillRegistry | 返回已注册技能数量 |
 | `resolve_skill(name, disk_registry, skill_registry)` | disk | 查询路由：先查 disk registry，未命中再查 bundled registry |
-| `init_disk_skills(config)` | disk | 初始化磁盘技能注册表，扫描配置路径并加载所有磁盘技能 |
 | `Skill::manifest()` | Skill trait | 获取技能元数据 |
 | `Skill::methods()` | Skill trait | 列出技能支持的方法 |
 
@@ -146,6 +150,7 @@ Skills 模块为 Agent 提供可复用工具能力，采用插件化架构。所
 | `registry.rs` | DiskSkillRegistry 内存注册表 |
 | `resolve.rs` | 技能查询路由函数 resolve_skill |
 | `init.rs` | init_disk_skills 初始化入口 |
+| `hot_reload.rs` | 文件监听热重载，通过 notify 检测变更 → 300ms debounce → 触发回调 |
 
 ### 两套 Registry 并存架构
 

--- a/src/skills/disk/SPEC.md
+++ b/src/skills/disk/SPEC.md
@@ -31,6 +31,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `SkillEffort` | 工作量估算：`Trivial` / `Small` / `Medium` / `Large` / `Unknown` |
 | `SkillManifest` | 从 frontmatter 解析的技能元数据（name / description / allowed_tools / when_to_use / context / agent / agent_id / effort / paths / user_invocable） |
 | `ParseError` | 解析错误：`MissingDelimiter` / `InvalidYaml` / `MissingDescription` |
+| `SkillWatcherHandle` | 文件监听 RAII 句柄，drop 时自动停止 watcher |
+| `HotReloadError` | 热重载错误：`WatcherCreate` / `WatchPath` / `NoDirectories` |
 
 ### 入口函数
 
@@ -40,6 +42,7 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `scan_all_skills(config)` | 扫描所有配置的技能目录，返回按优先级去重的 Vec<DiskSkill> |
 | `init_disk_skills(config)` | 初始化磁盘技能注册表：调用 `scan_all_skills`，返回 DiskSkillRegistry |
 | `resolve_skill(name, disk_registry, skill_registry)` | 查询路由：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 ResolvedSkill |
+| `start_skill_watcher(skill_dirs, on_change)` | 启动技能目录文件监听，300ms debounce 后触发回调，返回 SkillWatcherHandle |
 
 ---
 
@@ -55,6 +58,7 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `registry.rs` | DiskSkillRegistry 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
 | `resolve.rs` | 技能查询路由函数 `resolve_skill`：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 `ResolvedSkill` |
 | `init.rs` | `init_disk_skills` 初始化入口：调用 `scan_all_skills` 并构造 DiskSkillRegistry |
+| `hot_reload.rs` | 文件监听热重载，通过 notify 检测变更 → 300ms debounce → 触发回调 |
 
 ### 扫描优先级
 

--- a/src/skills/disk/hot_reload.rs
+++ b/src/skills/disk/hot_reload.rs
@@ -1,0 +1,292 @@
+//! Skill Hot Reload - file system watcher for skill directory changes
+//!
+//! Watches skill directories and triggers a callback when files are added,
+//! modified, or removed. Uses 300ms debounce to coalesce rapid changes.
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use notify::{
+    Config as NotifyConfig, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Errors that can occur when starting the skill watcher.
+#[derive(Error, Debug)]
+pub enum HotReloadError {
+    #[error("failed to create watcher: {0}")]
+    WatcherCreate(#[from] notify::Error),
+
+    #[error("failed to watch path {path}: {source}")]
+    WatchPath {
+        path: PathBuf,
+        source: notify::Error,
+    },
+
+    #[error("no skill directories provided")]
+    NoDirectories,
+}
+
+/// Handle to the skill watcher. Dropping it stops the watcher.
+///
+/// # Examples
+///
+/// ```no_run
+/// use closeclaw::skills::disk::{start_skill_watcher, SkillWatcherHandle};
+/// use std::path::PathBuf;
+///
+/// let handle: SkillWatcherHandle = start_skill_watcher(
+///     vec![PathBuf::from("/path/to/skills")],
+///     Box::new(|| println!("skills changed")),
+/// )
+/// .unwrap();
+/// // Watcher is active while `handle` is alive.
+/// drop(handle); // watcher stops
+/// ```
+#[derive(Debug)]
+pub struct SkillWatcherHandle {
+    // Watcher is kept alive to continue watching; RAII drop stops it.
+    _watcher: RecommendedWatcher,
+}
+
+/// Start watching skill directories for file changes.
+///
+/// Returns `HotReloadError::NoDirectories` if `skill_dirs` is empty.
+/// Directories that do not exist are logged with a warning and skipped.
+/// File change events are debounced by 300ms before invoking `on_change`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use closeclaw::skills::disk::start_skill_watcher;
+/// use std::path::PathBuf;
+///
+/// let handle = start_skill_watcher(
+///     vec![PathBuf::from("/path/to/skills")],
+///     Box::new(|| println!("skill files changed")),
+/// )
+/// .unwrap();
+/// // handle drop stops the watcher
+/// ```
+pub fn start_skill_watcher(
+    skill_dirs: Vec<PathBuf>,
+    on_change: Box<dyn Fn() + Send + 'static>,
+) -> Result<SkillWatcherHandle, HotReloadError> {
+    if skill_dirs.is_empty() {
+        return Err(HotReloadError::NoDirectories);
+    }
+
+    // Filter to only directories that exist, warn on missing ones
+    let dirs_to_watch: Vec<PathBuf> = skill_dirs
+        .into_iter()
+        .filter(|p| {
+            if !p.exists() {
+                warn!(
+                    "skill watch directory does not exist, skipping: {}",
+                    p.display()
+                );
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if dirs_to_watch.is_empty() {
+        warn!("no valid skill directories to watch");
+        // Return a no-op handle rather than error, to allow graceful startup
+        return Ok(SkillWatcherHandle {
+            _watcher: RecommendedWatcher::new(
+                |_res: Result<Event, notify::Error>| {},
+                NotifyConfig::default(),
+            )?,
+        });
+    }
+
+    let (tx, rx) = mpsc::channel();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: Result<Event, notify::Error>| {
+            if let Ok(event) = res {
+                let _ = tx.send(event);
+            }
+        },
+        NotifyConfig::default(),
+    )?;
+
+    for dir in &dirs_to_watch {
+        watcher
+            .watch(dir, RecursiveMode::Recursive)
+            .map_err(|source| HotReloadError::WatchPath {
+                path: dir.clone(),
+                source,
+            })?;
+    }
+
+    std::thread::spawn(move || {
+        run_watch_loop(rx, on_change);
+    });
+
+    Ok(SkillWatcherHandle { _watcher: watcher })
+}
+
+/// Run the watch loop with 300ms debounce on the receiver.
+fn run_watch_loop(rx: mpsc::Receiver<Event>, on_change: Box<dyn Fn() + Send + 'static>) {
+    let debounce = Duration::from_millis(300);
+    let mut last_event_time: Option<Instant> = None;
+
+    for event in rx {
+        // Only act on create/modify/remove events
+        if !matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        ) {
+            continue;
+        }
+
+        let now = Instant::now();
+        if let Some(last) = last_event_time {
+            if now.duration_since(last) < debounce {
+                debug!("debouncing skill directory change event");
+                continue;
+            }
+        }
+        last_event_time = Some(now);
+
+        for path in &event.paths {
+            debug!("skill directory changed: {}", path.display());
+        }
+        on_change();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_no_directories_error() {
+        let called = Arc::new(Mutex::new(false));
+        let called_clone = Arc::clone(&called);
+        let cb = Box::new(move || {
+            *called_clone.lock().unwrap() = true;
+        });
+        let result = start_skill_watcher(vec![], cb);
+        assert!(matches!(result, Err(HotReloadError::NoDirectories)));
+        assert!(
+            !*called.lock().unwrap(),
+            "callback should not be called when no directories"
+        );
+    }
+
+    #[test]
+    fn test_nonexistent_directory_graceful() {
+        let called = Arc::new(Mutex::new(false));
+        let called_clone = Arc::clone(&called);
+        let fake_path = PathBuf::from("/this/path/does/not/exist at all");
+        let result = start_skill_watcher(
+            vec![fake_path],
+            Box::new(move || {
+                *called_clone.lock().unwrap() = true;
+            }),
+        );
+        // Should not panic, returns a handle even if dir doesn't exist
+        assert!(result.is_ok());
+        assert!(
+            !*called.lock().unwrap(),
+            "callback should not be called for nonexistent directory"
+        );
+    }
+
+    #[test]
+    fn test_callback_triggered_on_file_change() {
+        let called = Arc::new(Mutex::new(0));
+        let called_clone = Arc::clone(&called);
+        let tmpdir = TempDir::new().unwrap();
+        let dir = tmpdir.path().to_path_buf();
+
+        let on_change = Box::new(move || {
+            *called_clone.lock().unwrap() += 1;
+        });
+
+        let handle = start_skill_watcher(vec![dir.clone()], on_change).unwrap();
+
+        // Write a file to trigger the watcher
+        std::fs::write(dir.join("test_skill.md"), "# Test Skill").unwrap();
+
+        // Wait long enough for debounce to settle
+        std::thread::sleep(Duration::from_millis(400));
+
+        assert!(
+            *called.lock().unwrap() >= 1,
+            "callback should be triggered at least once after file change"
+        );
+
+        drop(handle);
+    }
+
+    #[test]
+    fn test_debounce_behavior() {
+        let call_count = Arc::new(Mutex::new(0));
+        let call_count_clone = Arc::clone(&call_count);
+        let tmpdir = TempDir::new().unwrap();
+        let dir = tmpdir.path().to_path_buf();
+
+        let on_change = Box::new(move || {
+            *call_count_clone.lock().unwrap() += 1;
+        });
+
+        let handle = start_skill_watcher(vec![dir.clone()], on_change).unwrap();
+
+        // Rapidly write multiple files
+        for i in 0..5 {
+            std::fs::write(dir.join(format!("skill_{}.md", i)), "# Skill").unwrap();
+        }
+
+        // Wait for debounce window to close
+        std::thread::sleep(Duration::from_millis(400));
+
+        // With 300ms debounce, rapid writes should result in only 1 callback
+        let count = *call_count.lock().unwrap();
+        assert!(
+            count <= 2,
+            "debounce should coalesce rapid writes, got {} calls",
+            count
+        );
+
+        drop(handle);
+    }
+
+    #[test]
+    fn test_watcher_handle_drop_stops_watcher() {
+        let tmpdir = TempDir::new().unwrap();
+        let dir = tmpdir.path().to_path_buf();
+
+        let called = Arc::new(Mutex::new(false));
+        let called_clone = Arc::clone(&called);
+
+        let handle = start_skill_watcher(
+            vec![dir.clone()],
+            Box::new(move || {
+                *called_clone.lock().unwrap() = true;
+            }),
+        )
+        .unwrap();
+
+        drop(handle);
+
+        // Write after dropping handle - callback should NOT fire
+        std::fs::write(dir.join("after_drop.md"), "# After").unwrap();
+        std::thread::sleep(Duration::from_millis(400));
+
+        assert!(
+            !*called.lock().unwrap(),
+            "callback should not fire after handle is dropped"
+        );
+    }
+}

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -4,6 +4,7 @@
 //! hierarchical directories to find, parse, and load skill definitions.
 
 pub mod frontmatter;
+pub mod hot_reload;
 pub mod init;
 pub mod loader;
 pub mod registry;
@@ -11,6 +12,7 @@ pub mod resolve;
 pub mod types;
 
 pub use frontmatter::parse_skill_md;
+pub use hot_reload::{start_skill_watcher, SkillWatcherHandle};
 pub use init::init_disk_skills;
 pub use loader::scan_all_skills;
 pub use registry::DiskSkillRegistry;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -10,6 +10,9 @@ pub mod skill_creator;
 
 pub use builtin::{builtin_skills, builtin_skills_with_engine};
 pub use coding_agent::CodingAgentSkill;
-pub use disk::{init_disk_skills, resolve_skill, DiskSkillRegistry, ResolvedSkill, ScanConfig};
+pub use disk::{
+    init_disk_skills, resolve_skill, start_skill_watcher, DiskSkillRegistry, ResolvedSkill,
+    ScanConfig, SkillWatcherHandle,
+};
 pub use registry::{Skill, SkillError, SkillInput, SkillManifest, SkillOutput, SkillRegistry};
 pub use skill_creator::SkillCreatorSkill;

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -3,12 +3,12 @@
 //! Orchestrates section assembly and renders the final system prompt string.
 
 use super::sections::{
-    get_cached_section, invalidate_all_sections, invalidate_section, load_cached_file_section,
-    read_file_section, Section,
+    get_cached_section, invalidate_all_sections, load_cached_file_section, read_file_section,
+    Section,
 };
 use crate::skills::DiskSkillRegistry;
 use std::path::Path;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 /// Static override: if set, replaces the entire prompt
 static OVERRIDE_PROMPT: RwLock<Option<String>> = RwLock::new(None);
@@ -179,12 +179,18 @@ pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> 
 /// Reads IDENTITY.md, SOUL.md, and MEMORY.md from the workspace root
 /// and assembles them with the provided dynamic sections.
 ///
-/// The `skill_info` parameter, when provided as `Some((registry, agent_id))`,
+/// The `skill_registry` parameter, when provided as `Some(Arc(...)`,
 /// injects a `SkillListingSection` after the ToolsSection for skill discovery.
+///
+/// When `skill_registry` is an `Arc<RwLock<Option<DiskSkillRegistry>>>`, the current
+/// registry value is read at build time and used to generate the listing.
+/// Callers should populate this shared registry at startup and update it via
+/// `invalidate_skill_listing()` + `start_skill_watcher` for hot-reload support.
 pub fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     dynamic_sections: Vec<Section>,
-    skill_info: Option<(&DiskSkillRegistry, &str)>,
+    skill_registry: Option<Arc<RwLock<Option<DiskSkillRegistry>>>>,
+    agent_id: Option<&str>,
     append_section: Option<String>,
 ) -> String {
     let root = workspace_root.as_ref();
@@ -224,10 +230,15 @@ pub fn build_from_workspace<P: AsRef<Path>>(
     sections.push(Section::ToolsSection(String::new()));
 
     // Skill listing section — injected after ToolsSection, before dynamic_sections
-    if let Some((registry, agent_id)) = skill_info {
-        let listing = registry.generate_listing(Some(agent_id));
-        if !listing.is_empty() {
-            sections.push(Section::SkillListingSection(listing));
+    // Uses cache if available; regenerated on cache invalidation
+    if let Some(registry_lock) = skill_registry {
+        if let Ok(guard) = registry_lock.read() {
+            if let Some(registry) = guard.as_ref() {
+                let listing = registry.generate_listing(agent_id);
+                if !listing.is_empty() {
+                    sections.push(Section::SkillListingSection(listing));
+                }
+            }
         }
     }
 

--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -189,6 +189,14 @@ pub fn invalidate_all_sections() {
     }
 }
 
+/// Invalidate the skill listing section cache.
+///
+/// Call this when skill files change so the next system prompt build
+/// regenerates the listing from the current registry state.
+pub fn invalidate_skill_listing() {
+    invalidate_section("skill_listing");
+}
+
 // ---------------------------------------------------------------------------
 // File-based section helpers
 // ---------------------------------------------------------------------------
@@ -424,5 +432,22 @@ mod tests {
         assert!(rendered.contains("## Git Status"));
         assert!(rendered.contains("On branch master"));
         assert!(!s.is_cacheable());
+    }
+
+    #[test]
+    fn test_invalidate_skill_listing() {
+        // Pre-populate the skill_listing cache with known content
+        put_cached_section("skill_listing", "old skill content".to_string(), Some(999));
+        // Verify it's cached
+        assert_eq!(
+            get_cached_section("skill_listing", Some(999)),
+            Some("old skill content".to_string())
+        );
+
+        // Invalidate via the public API
+        invalidate_skill_listing();
+
+        // Cache should be cleared
+        assert_eq!(get_cached_section("skill_listing", Some(999)), None);
     }
 }

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -4,7 +4,9 @@ use closeclaw::skills::disk::types::{SkillContext, SkillEffort, SkillManifest, S
 use closeclaw::skills::disk::DiskSkill;
 use closeclaw::skills::DiskSkillRegistry;
 use closeclaw::system_prompt::builder::build_from_workspace;
+use closeclaw::system_prompt::sections::invalidate_all_sections;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 fn make_test_skill(name: &str, description: &str, when_to_use: &str, agent_id: &str) -> DiskSkill {
     DiskSkill {
@@ -28,6 +30,8 @@ fn make_test_skill(name: &str, description: &str, when_to_use: &str, agent_id: &
 
 #[test]
 fn test_build_from_workspace_skill_listing_injected() {
+    invalidate_all_sections();
+
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
     std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
@@ -35,8 +39,9 @@ fn test_build_from_workspace_skill_listing_injected() {
 
     let skill = make_test_skill("testskill", "A test skill", "Use when testing", "eda");
     let registry = DiskSkillRegistry::new(vec![skill]);
+    let registry_arc = Arc::new(RwLock::new(Some(registry)));
 
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
+    let result = build_from_workspace(dir.path(), vec![], Some(registry_arc), Some("eda"), None);
 
     assert!(
         result.contains("## Available Skills"),
@@ -57,29 +62,36 @@ fn test_build_from_workspace_skill_listing_injected() {
 
 #[test]
 fn test_build_from_workspace_no_skill_info_no_section() {
+    invalidate_all_sections();
+
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
     std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
     std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
 
-    let result = build_from_workspace(dir.path(), vec![], None, None);
+    let result = build_from_workspace(dir.path(), vec![], None, None, None);
     assert!(!result.contains("## Available Skills"));
 }
 
 #[test]
 fn test_build_from_workspace_empty_listing_no_section() {
+    invalidate_all_sections();
+
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
     std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
     std::fs::write(dir.path().join("MEMORY.md"), "test memory").unwrap();
 
     let registry = DiskSkillRegistry::new(vec![]);
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
+    let registry_arc = Arc::new(RwLock::new(Some(registry)));
+    let result = build_from_workspace(dir.path(), vec![], Some(registry_arc), Some("eda"), None);
     assert!(!result.contains("## Available Skills"));
 }
 
 #[test]
 fn test_build_from_workspace_skill_section_not_duplicated() {
+    invalidate_all_sections();
+
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("IDENTITY.md"), "test identity").unwrap();
     std::fs::write(dir.path().join("SOUL.md"), "test soul").unwrap();
@@ -87,8 +99,9 @@ fn test_build_from_workspace_skill_section_not_duplicated() {
 
     let skill = make_test_skill("unique_skill", "desc", "", "eda");
     let registry = DiskSkillRegistry::new(vec![skill]);
+    let registry_arc = Arc::new(RwLock::new(Some(registry)));
 
-    let result = build_from_workspace(dir.path(), vec![], Some((&registry, "eda")), None);
+    let result = build_from_workspace(dir.path(), vec![], Some(registry_arc), Some("eda"), None);
 
     let count = result.matches("## Available Skills").count();
     assert_eq!(


### PR DESCRIPTION
Implement file watcher that detects SKILL.md changes and invalidates
the skill_listing section cache, so running sessions pick up skill
changes within seconds without restart.

- Add start_skill_watcher with notify debounce (300ms)
- Add SkillWatcherHandle for RAII watcher lifecycle
- Integrate watcher into daemon startup via skill_reload module
- Add invalidate_skill_listing() to system prompt sections
- Thread Arc<RwLock<Option<DiskSkillRegistry>>> through builder
- Update SPECs for new interfaces

Source: issue #490
Type: feat
