### PR TITLE
feat(skills): add conditional skill activation by file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "flume",
+ "glob",
  "hex",
  "libc",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 # For getting home directory
 dirs = "5"
 
+# Glob pattern matching (for conditional skill activation)
+glob = "0.3"
+
 
 [dev-dependencies]
 # Testing

--- a/src/skills/disk/SPEC.md
+++ b/src/skills/disk/SPEC.md
@@ -22,7 +22,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | 类型 | 功能 |
 |------|------|
 | `DiskSkill` | 磁盘上发现的技能：来源、manifest、SKILL.md 路径、技能目录路径 |
-| `DiskSkillRegistry` | 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `DiskSkillRegistry` | 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` / `conditional_skills` / `matches_paths` / `generate_listing` |
+| `PathMatcher` | glob pattern 匹配引擎：`new(patterns)` 编译 patterns，`matches(path)` 判断路径是否匹配 |
 | `ResolvedSkill<'a>` | 技能解析结果枚举：`Disk(&DiskSkill)` 或 `Bundled(Arc<dyn Skill>)` |
 | `ParsedSkill` | 解析结果：manifest、是否仅描述字段、原始 frontmatter 文本 |
 | `ScanConfig` | 扫描配置：bundled_dir / extra_dirs / global_dir / project_root / agent_id |
@@ -55,7 +56,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 | `types.rs` | 所有类型定义，包含 SkillManifest、DiskSkill、ParsedSkill、ScanConfig、SkillSource、SkillContext、SkillEffort、ParseError |
 | `frontmatter.rs` | SKILL.md YAML frontmatter 解析实现 |
 | `loader.rs` | 技能目录扫描实现，按 SkillSource 优先级聚合 |
-| `registry.rs` | DiskSkillRegistry 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` |
+| `registry.rs` | DiskSkillRegistry 内存注册表：持有 `Vec<DiskSkill>`，提供 `get` / `list` / `contains` / `filter_by_source` / `len` / `is_empty` / `conditional_skills` / `matches_paths` / `generate_listing`（含 conditional 标注） |
+| `path_matcher.rs` | `PathMatcher` glob pattern 匹配引擎，用于条件技能激活 |
 | `resolve.rs` | 技能查询路由函数 `resolve_skill`：先查 DiskSkillRegistry（同步），未命中再查 SkillRegistry（async），返回 `ResolvedSkill` |
 | `init.rs` | `init_disk_skills` 初始化入口：调用 `scan_all_skills` 并构造 DiskSkillRegistry |
 | `hot_reload.rs` | 文件监听热重载，通过 notify 检测变更 → 300ms debounce → 触发回调 |
@@ -71,6 +73,8 @@ Disk Skill 模块提供基于文件系统的技能发现机制。扫描层级目
 ### 数据流
 
 `scan_all_skills` → `scan_layer`（每个来源）→ 读取 `SKILL.md` → `parse_skill_md` → `DiskSkill` → 按名称去重 → 返回有序列表
+
+`generate_listing`：对 `paths` 非空的 skill，追加 ` ⚡ auto-activates on: {patterns}` 标注
 
 ---
 

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -7,6 +7,7 @@ pub mod frontmatter;
 pub mod hot_reload;
 pub mod init;
 pub mod loader;
+pub mod path_matcher;
 pub mod registry;
 pub mod resolve;
 pub mod types;

--- a/src/skills/disk/path_matcher.rs
+++ b/src/skills/disk/path_matcher.rs
@@ -1,0 +1,99 @@
+//! PathMatcher — glob-based file path matching engine
+//!
+//! Wraps `glob::Pattern` to match file paths against a collection of
+//! glob patterns. Used for conditional skill activation based on the
+//! `paths` field in skill manifests.
+
+use std::path::Path;
+
+/// A collection of compiled glob patterns for matching file paths.
+///
+/// # Examples
+/// ```ignore
+/// let matcher = PathMatcher::new(&["**/*.rs".into()]).unwrap();
+/// assert!(matcher.matches(Path::new("src/main.rs")));
+/// ```
+#[derive(Debug, Clone)]
+pub struct PathMatcher {
+    patterns: Vec<glob::Pattern>,
+}
+
+impl PathMatcher {
+    /// Create a new PathMatcher from a slice of glob pattern strings.
+    ///
+    /// Returns an error if any pattern string is invalid glob syntax.
+    pub fn new(patterns: &[String]) -> Result<Self, glob::PatternError> {
+        let mut compiled = Vec::with_capacity(patterns.len());
+        for p in patterns {
+            compiled.push(glob::Pattern::new(p)?);
+        }
+        Ok(Self { patterns: compiled })
+    }
+
+    /// Check whether the given file path matches any of the stored patterns.
+    ///
+    /// Returns `false` when the pattern list is empty.
+    pub fn matches(&self, path: &Path) -> bool {
+        // Convert to string; glob::Pattern::matches works with &str.
+        let path_str = path.to_string_lossy();
+        self.patterns
+            .iter()
+            .any(|pattern| pattern.matches(&path_str))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positive_match_rs_glob() {
+        let matcher = PathMatcher::new(&["**/*.rs".into()]).unwrap();
+        assert!(matcher.matches(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn positive_match_cargo_toml_glob() {
+        let matcher = PathMatcher::new(&["**/Cargo.toml".into()]).unwrap();
+        assert!(matcher.matches(Path::new("Cargo.toml")));
+    }
+
+    #[test]
+    fn negative_match_rs_glob_against_ts() {
+        let matcher = PathMatcher::new(&["**/*.rs".into()]).unwrap();
+        assert!(!matcher.matches(Path::new("src/main.ts")));
+    }
+
+    #[test]
+    fn empty_patterns_returns_false() {
+        let matcher = PathMatcher::new(&[]).unwrap();
+        assert!(!matcher.matches(Path::new("src/main.rs")));
+        assert!(!matcher.matches(Path::new("any/path.txt")));
+    }
+
+    #[test]
+    fn invalid_pattern_returns_error() {
+        // Unmatched '[' is invalid glob syntax
+        let result = PathMatcher::new(&["[invalid".into()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn multi_pattern_match() {
+        let matcher = PathMatcher::new(&["**/*.rs".into(), "**/*.toml".into()]).unwrap();
+        // Matches via first pattern
+        assert!(matcher.matches(Path::new("src/main.rs")));
+        // Matches via second pattern
+        assert!(matcher.matches(Path::new("Cargo.toml")));
+        // Doesn't match any
+        assert!(!matcher.matches(Path::new("src/main.ts")));
+    }
+
+    #[test]
+    fn single_pattern_multiple_paths() {
+        let matcher = PathMatcher::new(&["docs/**/*.md".into()]).unwrap();
+        assert!(matcher.matches(Path::new("docs/README.md")));
+        assert!(matcher.matches(Path::new("docs/developer/style.md")));
+        assert!(!matcher.matches(Path::new("README.md")));
+    }
+}

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -1,5 +1,8 @@
 //! DiskSkillRegistry - in-memory registry for disk-loaded skills.
 
+use std::path::Path;
+
+use super::path_matcher::PathMatcher;
 use super::types::{DiskSkill, SkillSource};
 
 /// In-memory registry holding all discovered disk skills.
@@ -12,6 +15,42 @@ impl DiskSkillRegistry {
     /// Creates a new registry with the given skills.
     pub fn new(skills: Vec<DiskSkill>) -> Self {
         Self { skills }
+    }
+
+    /// Returns skills that have path-based conditional activation (`paths` is non-empty).
+    ///
+    /// These skills are only auto-activated when the current operation context
+    /// involves files matching one of their glob patterns.
+    pub fn conditional_skills(&self) -> Vec<&DiskSkill> {
+        self.skills
+            .iter()
+            .filter(|s| !s.manifest.paths.is_empty())
+            .collect()
+    }
+
+    /// Returns `true` if any path in `paths` matches one of the glob patterns
+    /// defined in the named skill's manifest `paths` field.
+    ///
+    /// Returns `false` when:
+    /// - The skill does not exist
+    /// - The skill has no paths conditions
+    /// - `paths` is empty
+    pub fn matches_paths(&self, skill_name: &str, paths: &[&Path]) -> bool {
+        if paths.is_empty() {
+            return false;
+        }
+        let skill = match self.get(skill_name) {
+            Some(s) => s,
+            None => return false,
+        };
+        if skill.manifest.paths.is_empty() {
+            return false;
+        }
+        let matcher = match PathMatcher::new(&skill.manifest.paths) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        paths.iter().any(|p| matcher.matches(p))
     }
 
     /// Returns the number of registered skills.
@@ -85,9 +124,14 @@ impl DiskSkillRegistry {
                 } else {
                     format!(" — {}", s.manifest.when_to_use)
                 };
+                let paths_anno = if s.manifest.paths.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ⚡ auto-activates on: {}", s.manifest.paths.join(", "))
+                };
                 format!(
-                    "- **{}**: {}{}",
-                    s.manifest.name, s.manifest.description, when
+                    "- **{}**: {}{}{}",
+                    s.manifest.name, s.manifest.description, when, paths_anno
                 )
             })
             .collect();
@@ -97,188 +141,5 @@ impl DiskSkillRegistry {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::super::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
-    use super::DiskSkill;
-    use super::DiskSkillRegistry;
-    use std::path::PathBuf;
-
-    fn skill(name: &str, source: SkillSource) -> DiskSkill {
-        DiskSkill {
-            source,
-            manifest: SkillManifest {
-                name: name.into(),
-                description: format!("desc of {}", name),
-                allowed_tools: vec![],
-                when_to_use: String::new(),
-                context: SkillContext::default(),
-                agent: String::new(),
-                agent_id: String::new(),
-                effort: SkillEffort::default(),
-                paths: vec![],
-                user_invocable: false,
-            },
-            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
-            skill_dir: PathBuf::from(format!("/skills/{}", name)),
-        }
-    }
-
-    #[test]
-    fn test_new_and_len() {
-        let r = DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)]);
-        assert_eq!(r.len(), 1);
-        assert!(!r.is_empty());
-    }
-
-    #[test]
-    fn test_empty_registry() {
-        let r = DiskSkillRegistry::new(vec![]);
-        assert!(r.is_empty());
-        assert!(r.get("any").is_none());
-        assert!(!r.contains("any"));
-        assert!(r.list().is_empty());
-        assert!(r.filter_by_source(SkillSource::Bundled).is_empty());
-    }
-
-    #[test]
-    fn test_get() {
-        let r = DiskSkillRegistry::new(vec![
-            skill("foo", SkillSource::Agent),
-            skill("bar", SkillSource::Project),
-        ]);
-        assert_eq!(r.get("foo").unwrap().manifest.name, "foo");
-        assert!(r.get("baz").is_none());
-    }
-
-    #[test]
-    fn test_contains() {
-        let r = DiskSkillRegistry::new(vec![skill("x", SkillSource::Global)]);
-        assert!(r.contains("x"));
-        assert!(!r.contains("y"));
-    }
-
-    #[test]
-    fn test_list() {
-        let r = DiskSkillRegistry::new(vec![
-            skill("z", SkillSource::Bundled),
-            skill("a", SkillSource::Global),
-        ]);
-        assert_eq!(r.list(), vec!["z", "a"]);
-    }
-
-    #[test]
-    fn test_filter_by_source() {
-        let r = DiskSkillRegistry::new(vec![
-            skill("b1", SkillSource::Bundled),
-            skill("g1", SkillSource::Global),
-            skill("b2", SkillSource::Bundled),
-        ]);
-        assert_eq!(r.filter_by_source(SkillSource::Bundled).len(), 2);
-        assert_eq!(r.filter_by_source(SkillSource::Global).len(), 1);
-        assert_eq!(r.filter_by_source(SkillSource::Agent).len(), 0);
-    }
-
-    fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskSkill {
-        DiskSkill {
-            source,
-            manifest: SkillManifest {
-                name: name.into(),
-                description: format!("desc of {}", name),
-                allowed_tools: vec![],
-                when_to_use: String::new(),
-                context: SkillContext::default(),
-                agent: String::new(),
-                agent_id: agent_id.into(),
-                effort: SkillEffort::default(),
-                paths: vec![],
-                user_invocable: false,
-            },
-            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
-            skill_dir: PathBuf::from(format!("/skills/{}", name)),
-        }
-    }
-
-    fn skill_with_when_to_use(name: &str, source: SkillSource, when_to_use: &str) -> DiskSkill {
-        DiskSkill {
-            source,
-            manifest: SkillManifest {
-                name: name.into(),
-                description: format!("desc of {}", name),
-                allowed_tools: vec![],
-                when_to_use: when_to_use.into(),
-                context: SkillContext::default(),
-                agent: String::new(),
-                agent_id: String::new(),
-                effort: SkillEffort::default(),
-                paths: vec![],
-                user_invocable: false,
-            },
-            readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
-            skill_dir: PathBuf::from(format!("/skills/{}", name)),
-        }
-    }
-
-    #[test]
-    fn test_generate_listing_empty() {
-        let r = DiskSkillRegistry::new(vec![]);
-        assert_eq!(r.generate_listing(None), "");
-        assert_eq!(r.generate_listing(Some("agent1")), "");
-    }
-
-    #[test]
-    fn test_generate_listing_single() {
-        let r = DiskSkillRegistry::new(vec![skill("foo", SkillSource::Bundled)]);
-        let listing = r.generate_listing(None);
-        assert!(listing.contains("**foo**"));
-        assert!(listing.contains("desc of foo"));
-    }
-
-    #[test]
-    fn test_generate_listing_sorted_by_priority_and_name() {
-        let r = DiskSkillRegistry::new(vec![
-            skill("z_bundled", SkillSource::Bundled),
-            skill("a_bundled", SkillSource::Bundled),
-            skill("z_global", SkillSource::Global),
-            skill("a_global", SkillSource::Global),
-            skill("z_agent", SkillSource::Agent),
-            skill("a_agent", SkillSource::Agent),
-        ]);
-        let listing = r.generate_listing(None);
-        let lines: Vec<&str> = listing.lines().collect();
-        assert_eq!(lines.len(), 6);
-        // Bundled before Global before Agent
-        assert!(listing.find("**a_bundled**").unwrap() < listing.find("**a_global**").unwrap());
-        assert!(listing.find("**a_global**").unwrap() < listing.find("**a_agent**").unwrap());
-        // Within Bundled, alphabetical order
-        assert!(listing.find("**a_bundled**").unwrap() < listing.find("**z_bundled**").unwrap());
-    }
-
-    #[test]
-    fn test_generate_listing_agent_id_filter() {
-        let r = DiskSkillRegistry::new(vec![
-            skill_with_agent_id("skill_a", SkillSource::Agent, "agent1"),
-            skill_with_agent_id("skill_b", SkillSource::Agent, "agent2"),
-            skill_with_agent_id("skill_c", SkillSource::Agent, ""), // no restriction
-        ]);
-        // None = no filter, all 3 returned
-        assert_eq!(r.generate_listing(None).lines().count(), 3);
-        // agent1 filter = skill_a (matches) + skill_c (no restriction)
-        let listing = r.generate_listing(Some("agent1"));
-        assert!(listing.contains("**skill_a**"));
-        assert!(listing.contains("**skill_c**"));
-        assert!(!listing.contains("**skill_b**"));
-    }
-
-    #[test]
-    fn test_generate_listing_when_to_use() {
-        let r = DiskSkillRegistry::new(vec![
-            skill_with_when_to_use("foo", SkillSource::Bundled, "Use when you need foo"),
-            skill("bar", SkillSource::Bundled), // no when_to_use
-        ]);
-        let listing = r.generate_listing(None);
-        assert!(listing.contains(" — Use when you need foo"));
-        // bar should NOT have the dash separator
-        let bar_line = listing.lines().find(|l| l.contains("**bar**")).unwrap();
-        assert!(!bar_line.contains(" — "));
-    }
-}
+#[path = "registry_tests.rs"]
+mod tests;

--- a/src/skills/disk/registry_tests.rs
+++ b/src/skills/disk/registry_tests.rs
@@ -1,0 +1,467 @@
+use super::super::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
+use super::DiskSkill;
+use super::DiskSkillRegistry;
+use std::path::{Path, PathBuf};
+
+fn skill(name: &str, source: SkillSource) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+#[test]
+fn test_new_and_len() {
+    let r = DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)]);
+    assert_eq!(r.len(), 1);
+    assert!(!r.is_empty());
+}
+
+#[test]
+fn test_empty_registry() {
+    let r = DiskSkillRegistry::new(vec![]);
+    assert!(r.is_empty());
+    assert!(r.get("any").is_none());
+    assert!(!r.contains("any"));
+    assert!(r.list().is_empty());
+    assert!(r.filter_by_source(SkillSource::Bundled).is_empty());
+}
+
+#[test]
+fn test_get() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Agent),
+        skill("bar", SkillSource::Project),
+    ]);
+    assert_eq!(r.get("foo").unwrap().manifest.name, "foo");
+    assert!(r.get("baz").is_none());
+}
+
+#[test]
+fn test_contains() {
+    let r = DiskSkillRegistry::new(vec![skill("x", SkillSource::Global)]);
+    assert!(r.contains("x"));
+    assert!(!r.contains("y"));
+}
+
+#[test]
+fn test_list() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("z", SkillSource::Bundled),
+        skill("a", SkillSource::Global),
+    ]);
+    assert_eq!(r.list(), vec!["z", "a"]);
+}
+
+#[test]
+fn test_filter_by_source() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("b1", SkillSource::Bundled),
+        skill("g1", SkillSource::Global),
+        skill("b2", SkillSource::Bundled),
+    ]);
+    assert_eq!(r.filter_by_source(SkillSource::Bundled).len(), 2);
+    assert_eq!(r.filter_by_source(SkillSource::Global).len(), 1);
+    assert_eq!(r.filter_by_source(SkillSource::Agent).len(), 0);
+}
+
+fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: agent_id.into(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+fn skill_with_when_to_use(name: &str, source: SkillSource, when_to_use: &str) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: when_to_use.into(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+#[test]
+fn test_generate_listing_empty() {
+    let r = DiskSkillRegistry::new(vec![]);
+    assert_eq!(r.generate_listing(None), "");
+    assert_eq!(r.generate_listing(Some("agent1")), "");
+}
+
+#[test]
+fn test_generate_listing_single() {
+    let r = DiskSkillRegistry::new(vec![skill("foo", SkillSource::Bundled)]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("desc of foo"));
+}
+
+#[test]
+fn test_generate_listing_sorted_by_priority_and_name() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("z_bundled", SkillSource::Bundled),
+        skill("a_bundled", SkillSource::Bundled),
+        skill("z_global", SkillSource::Global),
+        skill("a_global", SkillSource::Global),
+        skill("z_agent", SkillSource::Agent),
+        skill("a_agent", SkillSource::Agent),
+    ]);
+    let listing = r.generate_listing(None);
+    let lines: Vec<&str> = listing.lines().collect();
+    assert_eq!(lines.len(), 6);
+    // Bundled before Global before Agent
+    assert!(listing.find("**a_bundled**").unwrap() < listing.find("**a_global**").unwrap());
+    assert!(listing.find("**a_global**").unwrap() < listing.find("**a_agent**").unwrap());
+    // Within Bundled, alphabetical order
+    assert!(listing.find("**a_bundled**").unwrap() < listing.find("**z_bundled**").unwrap());
+}
+
+#[test]
+fn test_generate_listing_agent_id_filter() {
+    let r = DiskSkillRegistry::new(vec![
+        skill_with_agent_id("skill_a", SkillSource::Agent, "agent1"),
+        skill_with_agent_id("skill_b", SkillSource::Agent, "agent2"),
+        skill_with_agent_id("skill_c", SkillSource::Agent, ""), // no restriction
+    ]);
+    // None = no filter, all 3 returned
+    assert_eq!(r.generate_listing(None).lines().count(), 3);
+    // agent1 filter = skill_a (matches) + skill_c (no restriction)
+    let listing = r.generate_listing(Some("agent1"));
+    assert!(listing.contains("**skill_a**"));
+    assert!(listing.contains("**skill_c**"));
+    assert!(!listing.contains("**skill_b**"));
+}
+
+#[test]
+fn test_generate_listing_when_to_use() {
+    let r = DiskSkillRegistry::new(vec![
+        skill_with_when_to_use("foo", SkillSource::Bundled, "Use when you need foo"),
+        skill("bar", SkillSource::Bundled), // no when_to_use
+    ]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains(" — Use when you need foo"));
+    // bar should NOT have the dash separator
+    let bar_line = listing.lines().find(|l| l.contains("**bar**")).unwrap();
+    assert!(!bar_line.contains(" — "));
+}
+
+// --- helpers for conditional/ paths tests ---
+
+fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths,
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+// --- conditional_skills tests ---
+
+#[test]
+fn test_conditional_skills_returns_skills_with_paths() {
+    let r = DiskSkillRegistry::new(vec![
+        skill_with_paths("rs-tools", SkillSource::Bundled, vec!["**/*.rs".into()]),
+        skill_with_paths("toml-tools", SkillSource::Bundled, vec!["**/*.toml".into()]),
+        skill("no-cond", SkillSource::Bundled),
+    ]);
+    let cond = r.conditional_skills();
+    assert_eq!(cond.len(), 2);
+    let names: Vec<&str> = cond.iter().map(|s| s.manifest.name.as_str()).collect();
+    assert!(names.contains(&"rs-tools"));
+    assert!(names.contains(&"toml-tools"));
+    assert!(!names.contains(&"no-cond"));
+}
+
+#[test]
+fn test_conditional_skills_returns_empty_when_no_paths_defined() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("a", SkillSource::Bundled),
+        skill("b", SkillSource::Global),
+    ]);
+    assert!(r.conditional_skills().is_empty());
+}
+
+#[test]
+fn test_conditional_skills_returns_empty_for_empty_registry() {
+    let r = DiskSkillRegistry::new(vec![]);
+    assert!(r.conditional_skills().is_empty());
+}
+
+// --- matches_paths tests ---
+
+#[test]
+fn test_matches_paths_positive_match() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "rs-skill",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into()],
+    )]);
+    assert!(r.matches_paths("rs-skill", &[Path::new("src/main.rs")]));
+}
+
+#[test]
+fn test_matches_paths_negative_match() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "rs-skill",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into()],
+    )]);
+    assert!(!r.matches_paths("rs-skill", &[Path::new("src/main.ts")]));
+}
+
+#[test]
+fn test_matches_paths_multi_pattern_any_wins() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "multi",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into(), "**/*.toml".into()],
+    )]);
+    assert!(r.matches_paths("multi", &[Path::new("src/main.rs")]));
+    assert!(r.matches_paths("multi", &[Path::new("Cargo.toml")]));
+    assert!(!r.matches_paths("multi", &[Path::new("src/main.ts")]));
+}
+
+#[test]
+fn test_matches_paths_empty_paths_arg_returns_false() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "rs-skill",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into()],
+    )]);
+    assert!(!r.matches_paths("rs-skill", &[]));
+}
+
+#[test]
+fn test_matches_paths_nonexistent_skill_returns_false() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "rs-skill",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into()],
+    )]);
+    assert!(!r.matches_paths("no-such-skill", &[Path::new("src/main.rs")]));
+}
+
+#[test]
+fn test_matches_paths_skill_without_paths_returns_false() {
+    let r = DiskSkillRegistry::new(vec![skill("plain", SkillSource::Bundled)]);
+    assert!(!r.matches_paths("plain", &[Path::new("src/main.rs")]));
+}
+
+#[test]
+fn test_matches_paths_multiple_input_paths_any_match() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "multi-skill",
+        SkillSource::Bundled,
+        vec!["**/*.md".into()],
+    )]);
+    // One of the input paths matches
+    assert!(r.matches_paths(
+        "multi-skill",
+        &[Path::new("src/main.rs"), Path::new("docs/README.md")]
+    ));
+    // None match
+    assert!(!r.matches_paths(
+        "multi-skill",
+        &[Path::new("src/main.rs"), Path::new("src/lib.rs")]
+    ));
+}
+
+// --- generate_listing conditional annotation tests ---
+
+#[test]
+fn test_generate_listing_conditional_annotation_shown_for_paths() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "rs-skill",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into()],
+    )]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains("⚡ auto-activates on: **/*.rs"));
+}
+
+#[test]
+fn test_generate_listing_conditional_annotation_multi_patterns() {
+    let r = DiskSkillRegistry::new(vec![skill_with_paths(
+        "multi",
+        SkillSource::Bundled,
+        vec!["**/*.rs".into(), "**/*.toml".into()],
+    )]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains("⚡ auto-activates on: **/*.rs, **/*.toml"));
+}
+
+#[test]
+fn test_generate_listing_conditional_annotation_not_shown_without_paths() {
+    let r = DiskSkillRegistry::new(vec![skill("plain", SkillSource::Bundled)]);
+    let listing = r.generate_listing(None);
+    assert!(!listing.contains("⚡"));
+    assert!(!listing.contains("auto-activates"));
+}
+
+#[test]
+fn test_generate_listing_conditional_annotation_mixed() {
+    let r = DiskSkillRegistry::new(vec![
+        skill_with_paths("cond", SkillSource::ExtraDirs, vec!["**/*.rs".into()]),
+        skill("plain1", SkillSource::Bundled),
+        skill_with_paths("cond2", SkillSource::Global, vec!["**/*.md".into()]),
+        skill("plain2", SkillSource::Global),
+    ]);
+    let listing = r.generate_listing(None);
+    let lines: Vec<&str> = listing.lines().collect();
+    assert_eq!(lines.len(), 4, "all 4 skills should appear");
+    // cond has annotation, cond2 has annotation
+    let cond_line = lines.iter().find(|l| l.contains("**cond**")).unwrap();
+    assert!(cond_line.contains("⚡ auto-activates on: **/*.rs"));
+    let cond2_line = lines.iter().find(|l| l.contains("**cond2**")).unwrap();
+    assert!(cond2_line.contains("⚡ auto-activates on: **/*.md"));
+    // plain1 and plain2 no annotation
+    let plain1_line = lines.iter().find(|l| l.contains("**plain1**")).unwrap();
+    assert!(!plain1_line.contains("⚡"));
+    let plain2_line = lines.iter().find(|l| l.contains("**plain2**")).unwrap();
+    assert!(!plain2_line.contains("⚡"));
+}
+
+#[test]
+fn test_generate_listing_conditional_with_agent_id_filter() {
+    let s1 = DiskSkill {
+        source: SkillSource::Agent,
+        manifest: SkillManifest {
+            name: "agent1-cond".into(),
+            description: "desc".into(),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: "agent1".into(),
+            effort: SkillEffort::default(),
+            paths: vec!["**/*.rs".into()],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from("/skills/agent1-cond/SKILL.md"),
+        skill_dir: PathBuf::from("/skills/agent1-cond"),
+    };
+    let s2 = DiskSkill {
+        source: SkillSource::Agent,
+        manifest: SkillManifest {
+            name: "any-cond".into(),
+            description: "desc".into(),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec!["**/*.md".into()],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from("/skills/any-cond/SKILL.md"),
+        skill_dir: PathBuf::from("/skills/any-cond"),
+    };
+    let s3 = DiskSkill {
+        source: SkillSource::Agent,
+        manifest: SkillManifest {
+            name: "agent2-cond".into(),
+            description: "desc".into(),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: "agent2".into(),
+            effort: SkillEffort::default(),
+            paths: vec!["**/*.toml".into()],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from("/skills/agent2-cond/SKILL.md"),
+        skill_dir: PathBuf::from("/skills/agent2-cond"),
+    };
+    let s4 = DiskSkill {
+        source: SkillSource::Agent,
+        manifest: SkillManifest {
+            name: "plain".into(),
+            description: "desc".into(),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: false,
+        },
+        readme_path: PathBuf::from("/skills/plain/SKILL.md"),
+        skill_dir: PathBuf::from("/skills/plain"),
+    };
+
+    let r = DiskSkillRegistry::new(vec![s1, s2, s3, s4]);
+
+    // With agent1 filter: agent1-cond (matches agent1) + any-cond (no restriction) + plain (no restriction)
+    let listing = r.generate_listing(Some("agent1"));
+    assert!(listing.contains("**agent1-cond**"));
+    assert!(listing.contains("**any-cond**"));
+    assert!(listing.contains("**plain**"));
+    assert!(!listing.contains("**agent2-cond**"));
+    // agent1-cond has annotation
+    let agent1_line = listing
+        .lines()
+        .find(|l| l.contains("**agent1-cond**"))
+        .unwrap();
+    assert!(agent1_line.contains("⚡ auto-activates on: **/*.rs"));
+    // any-cond has annotation
+    let any_line = listing
+        .lines()
+        .find(|l| l.contains("**any-cond**"))
+        .unwrap();
+    assert!(any_line.contains("⚡ auto-activates on: **/*.md"));
+    // plain has no annotation
+    let plain_line = listing.lines().find(|l| l.contains("**plain**")).unwrap();
+    assert!(!plain_line.contains("⚡"));
+}


### PR DESCRIPTION
Closes #491

## Summary
Implement conditional skill activation: based on SKILL.md frontmatter `paths` glob patterns, the skill listing now displays `⚡ auto-activates on: ...` annotation so the model can see which skills are relevant to the current file context.

## Changes
- **path_matcher.rs**: New `PathMatcher` type using `glob::Pattern` for file path matching
- **registry.rs**: New `conditional_skills()` and `matches_paths()` methods on `DiskSkillRegistry`
- **generate_listing()**: Extended output with `⚡ auto-activates on:` annotation for skills with paths
- **Tests**: Comprehensive unit tests covering all new functionality

Source: issue #491
Type: feat