### PR TITLE
feat(llm): add ModelInfo data types and embedded knowledge base

### DIFF
--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -4,6 +4,8 @@
 
 LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `LLMProvider` trait + `LLMRegistry` 实现插件式架构，支持同时注册多个 Provider（MiniMax、OpenAI、Anthropic、Stub）。核心设计：Provider 只负责 HTTP 调用和响应解析，错误分类由 `ErrorKind` 统一处理；重试和 fallback 逻辑由 `FallbackClient` 包装，对调用方透明。
 
+`model_info.rs` 定义模型元数据类型（`ModelInfo`、`InputType`），承载模型标识、上下文窗口、温度等元数据。`knowledge.rs` 提供内嵌知识库（`ProviderModelKnowledge`），手填 MiniMax、GLM、VolcEngine、DeepSeek 四个 Provider 的推荐参数，供 Model Discovery & Auto-Config Wizard 使用。
+
 边界：模块不负责 prompt 工程、不做缓存、不做 token 估算（Usage 数字由 Provider 透传）。冷却状态通过 `CooldownManager` 持久化到 `~/.closeclaw/llm_cooldowns.json`。
 
 ---
@@ -24,6 +26,15 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 - **`Scenario`** — `FakeProvider` 场景枚举：Ok（成功响应）、Err（错误响应）、Delay（sleep 后执行内部场景，内部场景可为 Ok/Err/另一个 Delay，嵌套递归解析）
 - **`StreamingResponse`** — 流式聊天响应接收器，`tokio::sync::mpsc::Receiver<ChatStreamChunk>`，调用方通过 `recv().await` 逐块消费
 - **`ChatStreamChunk`** — 流式响应中的单个 chunk：`Text(String)`（文本片段）、`Done { model, usage }`（流结束元数据）、`Error(LLMError)`（流式过程中的错误）
+
+### 数据类型（模型元数据）
+
+- **`InputType`** — 模型支持的输入模态：Text（纯文本）、Image（多模态图文）
+- **`ModelInfo`** — 模型元数据（id、name、context_window、max_tokens、default_temperature、reasoning、input_types），可从 `"provider/model_id"` 字符串解析（实现 `FromStr`）
+- **`ParseModelInfoError`** — `ModelInfo` 解析错误（格式非法时返回）
+- **`ReasoningLevels`** — 模型支持的思考强度级别：None（不支持）、Toggle { on }（GLM 开关式）、Levels { off, base, reasoner }（DeepSeek 多档）
+- **`ModelRecommendParams`** — 知识库中单模型的推荐参数（context_window、max_tokens、default_temperature、reasoning、reasoning_levels、input_types）
+- **`ProviderModelKnowledge`** — 内嵌知识库，按 provider 存储多模型推荐参数；支持 `find(provider, model_id)` 查询和 `all_models(provider)` 列表
 
 ### 数据类型（Provider 注册与管理）
 
@@ -100,6 +111,8 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 | 文件 | 职责 |
 |------|------|
 | `mod.rs` | 类型定义（Message、ChatRequest、ErrorKind 等）、LLMRegistry、LLMProvider trait、re-export 所有 Provider |
+| `model_info.rs` | 模型元数据类型：`InputType`（Text/Image 模态枚举）、`ModelInfo`（模型元数据 struct，含 `FromStr` 从 `"provider/model_id"` 解析）、`ParseModelInfoError` |
+| `knowledge.rs` | 内嵌知识库：`ReasoningLevels`（思考强度枚举）、`ModelRecommendParams`（推荐参数）、`ProviderModelKnowledge`（知识库，含 `find` 和 `all_models` 查询接口）；覆盖 MiniMax、GLM、VolcEngine、DeepSeek 四个 Provider |
 | `minimax.rs` | MiniMax Chat Completions API adapter。推理模型（M2.5/M2.7）用户可见回复在 `reasoning_content` 字段，`content` 为空时做兜底提取；业务错误码通过 `base_resp.status_code` 返回（非零即失败），区别于 HTTP 状态码；`completion_tokens_details.reasoning_tokens` 在内部解析（unit test 覆盖），暂未通过 `Usage` 暴露给调用方。 |
 | `glm/mod.rs` | 智谱 GLM 系列模型（glm-5.1、glm-4.7、glm-4.5-air 等）adapter。错误格式为 top-level `error`（code 为字符串），code "1211" → ModelNotFound、"1214" → InvalidRequest；推理模型 `content` 为空时提取 `reasoning_content`；`usage` 中含 `prompt_tokens_details.cached_tokens` 和 `completion_tokens_details.reasoning_tokens`。非流式 chat、流式 streaming、Usage API 均通过 mockito Mock Server 覆盖完整 HTTP 全链路（`glm/tests/mock_integration.rs` 13 个非流式用例 + `glm/tests/mock_extra.rs` 3 个非流式用例含错误场景 + `glm_stream/tests/mock_integration.rs` 3 个流式用例 + `glm/tests/mock_usage.rs` 3 个 Usage 用例）。 |
 | `minimax_stream.rs` | MiniMax 流式接口：SSE 解析、delta 提取、流式错误处理 |

--- a/src/llm/knowledge.rs
+++ b/src/llm/knowledge.rs
@@ -1,0 +1,422 @@
+//! Embedded knowledge base of recommended model parameters.
+//!
+//! Sources:
+//! - MiniMax:实测 API 响应 + 官方文档
+//! - GLM: 实测 API 响应 + 官方文档 (bigmodel.cn)
+//! - VolcEngine: 火山引擎 ARTVC API 文档
+//! - DeepSeek: 实测 API 响应 + 官方文档 (deepseek.com)
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::model_info::InputType;
+
+// ---------------------------------------------------------------------------
+// ReasoningLevels
+// ---------------------------------------------------------------------------
+
+/// Levels of structured reasoning supported by a model.
+///
+/// Different providers use different schemes:
+/// - DeepSeek: `off` (no reasoning) / `base` / `reasoner`
+/// - GLM: `off` / `on` (toggle via enable_reaching in API request)
+/// - Others: `None` (not supported)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type", content = "value")]
+pub enum ReasoningLevels {
+    /// Provider does not support configurable reasoning levels.
+    None,
+    /// On/off toggle (GLM style).
+    Toggle { on: bool },
+    /// Multi-level reasoning (DeepSeek style).
+    Levels {
+        off: bool,
+        base: bool,
+        reasoner: bool,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// ModelRecommendParams
+// ---------------------------------------------------------------------------
+
+/// Recommended parameters for a specific model.
+/// These values come from 实测 API 响应 and official provider docs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRecommendParams {
+    /// Context window size in tokens.
+    pub context_window: u32,
+    /// Maximum output tokens the model can produce.
+    pub max_tokens: u32,
+    /// Default sampling temperature.
+    pub default_temperature: f32,
+    /// Whether the model supports structured reasoning / tool use.
+    pub reasoning: bool,
+    /// Supported reasoning level scheme.
+    pub reasoning_levels: ReasoningLevels,
+    /// Supported input modalities.
+    pub input_types: Vec<InputType>,
+}
+
+// ---------------------------------------------------------------------------
+// ProviderModelKnowledge
+// ---------------------------------------------------------------------------
+
+/// In-memory knowledge base of recommended model parameters.
+/// Maps provider_id -> (model_id -> ModelRecommendParams).
+pub struct ProviderModelKnowledge {
+    inner: HashMap<String, HashMap<&'static str, ModelRecommendParams>>,
+}
+
+impl ProviderModelKnowledge {
+    /// Create the knowledge base populated with all known providers.
+    pub fn new() -> Self {
+        let mut inner = HashMap::new();
+
+        // ──────────────────────────────────────────────────────────────────────
+        // MiniMax
+        // MiniMax 官方文档 + 实测 API 响应
+        // ──────────────────────────────────────────────────────────────────────
+        let mut minimax_models = HashMap::new();
+        minimax_models.insert(
+            "MiniMax-M2",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        minimax_models.insert(
+            "MiniMax-M2.1",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        minimax_models.insert(
+            "MiniMax-M2.5",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        minimax_models.insert(
+            "MiniMax-M2.7",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        inner.insert("minimax".to_string(), minimax_models);
+
+        // ──────────────────────────────────────────────────────────────────────
+        // GLM
+        // 实测 API 响应 + 官方文档 (bigmodel.cn)
+        // reasoning_content 字段表示支持思考内容
+        // ──────────────────────────────────────────────────────────────────────
+        let mut glm_models = HashMap::new();
+        glm_models.insert(
+            "GLM-4.5-Air",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        glm_models.insert(
+            "GLM-4.5-AirX",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text, InputType::Image],
+            },
+        );
+        glm_models.insert(
+            "glm-4.5-air",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        glm_models.insert(
+            "glm-4.5-airx",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text, InputType::Image],
+            },
+        );
+        glm_models.insert(
+            "glm-4.7",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::Toggle { on: false },
+                input_types: vec![InputType::Text],
+            },
+        );
+        glm_models.insert(
+            "glm-5.1",
+            ModelRecommendParams {
+                context_window: 128_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::Toggle { on: false },
+                input_types: vec![InputType::Text],
+            },
+        );
+        inner.insert("glm".to_string(), glm_models);
+
+        // ──────────────────────────────────────────────────────────────────────
+        // VolcEngine (火山引擎 ARTVC)
+        // 火山引擎 ARTVC API 文档
+        // ──────────────────────────────────────────────────────────────────────
+        let mut volcengine_models = HashMap::new();
+        volcengine_models.insert(
+            "doubao-1.5-pro",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        volcengine_models.insert(
+            "doubao-1.5-lite",
+            ModelRecommendParams {
+                context_window: 32_768,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::None,
+                input_types: vec![InputType::Text],
+            },
+        );
+        inner.insert("volcengine".to_string(), volcengine_models);
+
+        // ──────────────────────────────────────────────────────────────────────
+        // DeepSeek
+        // 实测 API 响应 + 官方文档 (deepseek.com)
+        // reasoning_levels 支持 off/base/reasoner 三档
+        // ──────────────────────────────────────────────────────────────────────
+        let mut deepseek_models = HashMap::new();
+        deepseek_models.insert(
+            "deepseek-v3-flash",
+            ModelRecommendParams {
+                context_window: 64_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::Levels {
+                    off: false,
+                    base: true,
+                    reasoner: true,
+                },
+                input_types: vec![InputType::Text],
+            },
+        );
+        deepseek_models.insert(
+            "deepseek-v3",
+            ModelRecommendParams {
+                context_window: 64_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: false,
+                reasoning_levels: ReasoningLevels::Levels {
+                    off: false,
+                    base: true,
+                    reasoner: true,
+                },
+                input_types: vec![InputType::Text],
+            },
+        );
+        deepseek_models.insert(
+            "deepseek-v4-flash",
+            ModelRecommendParams {
+                context_window: 64_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::Levels {
+                    off: false,
+                    base: true,
+                    reasoner: true,
+                },
+                input_types: vec![InputType::Text],
+            },
+        );
+        deepseek_models.insert(
+            "deepseek-v4",
+            ModelRecommendParams {
+                context_window: 64_000,
+                max_tokens: 8_192,
+                default_temperature: 0.7,
+                reasoning: true,
+                reasoning_levels: ReasoningLevels::Levels {
+                    off: false,
+                    base: true,
+                    reasoner: true,
+                },
+                input_types: vec![InputType::Text],
+            },
+        );
+        inner.insert("deepseek".to_string(), deepseek_models);
+
+        Self { inner }
+    }
+
+    /// Find recommended params for a specific provider + model.
+    pub fn find(&self, provider_id: &str, model_id: &str) -> Option<ModelRecommendParams> {
+        self.inner
+            .get(&provider_id.to_lowercase())
+            .and_then(|models| models.get(model_id).cloned())
+    }
+
+    /// List all model ids for a given provider.
+    pub fn all_models(&self, provider_id: &str) -> Vec<&'static str> {
+        self.inner
+            .get(&provider_id.to_lowercase())
+            .map(|models| models.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+}
+
+impl Default for ProviderModelKnowledge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kb() -> ProviderModelKnowledge {
+        ProviderModelKnowledge::new()
+    }
+
+    // ── find ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_find_hit() {
+        let kb = kb();
+        let params = kb.find("minimax", "MiniMax-M2.7");
+        assert!(params.is_some());
+        let p = params.unwrap();
+        assert_eq!(p.context_window, 32_768);
+        assert!(p.reasoning);
+        assert!(matches!(p.reasoning_levels, ReasoningLevels::None));
+    }
+
+    #[test]
+    fn test_find_miss_unknown_provider() {
+        let kb = kb();
+        assert!(kb.find("unknown", "model-x").is_none());
+    }
+
+    #[test]
+    fn test_find_miss_unknown_model() {
+        let kb = kb();
+        assert!(kb.find("minimax", "unknown-model").is_none());
+    }
+
+    #[test]
+    fn test_find_case_insensitive_provider() {
+        let kb = kb();
+        assert!(kb.find("MINIMAX", "MiniMax-M2").is_some());
+        assert!(kb.find("Glm", "glm-5.1").is_some());
+    }
+
+    // ── all_models ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_all_models_hit() {
+        let kb = kb();
+        let models = kb.all_models("minimax");
+        assert!(!models.is_empty());
+        assert!(models.contains(&"MiniMax-M2.7"));
+    }
+
+    #[test]
+    fn test_all_models_miss() {
+        let kb = kb();
+        let models = kb.all_models("nonexistent");
+        assert!(models.is_empty());
+    }
+
+    #[test]
+    fn test_all_models_all_providers() {
+        let kb = kb();
+        for p in &["minimax", "glm", "volcengine", "deepseek"] {
+            let models = kb.all_models(p);
+            assert!(!models.is_empty(), "provider {p} should have models");
+        }
+    }
+
+    // ── reasoning_levels ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_glm_reasoning_levels() {
+        let kb = kb();
+        let p = kb.find("glm", "glm-5.1").unwrap();
+        assert!(matches!(
+            p.reasoning_levels,
+            ReasoningLevels::Toggle { on: false }
+        ));
+    }
+
+    #[test]
+    fn test_deepseek_reasoning_levels() {
+        let kb = kb();
+        let p = kb.find("deepseek", "deepseek-v4-flash").unwrap();
+        assert!(matches!(
+            p.reasoning_levels,
+            ReasoningLevels::Levels {
+                off: false,
+                base: true,
+                reasoner: true
+            }
+        ));
+    }
+
+    #[test]
+    fn test_minimax_reasoning_levels_none() {
+        let kb = kb();
+        let p = kb.find("minimax", "MiniMax-M2.7").unwrap();
+        assert!(matches!(p.reasoning_levels, ReasoningLevels::None));
+    }
+}

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -4,7 +4,9 @@ pub mod anthropic;
 pub mod fallback;
 pub mod glm;
 pub mod glm_stream;
+pub mod knowledge;
 pub mod minimax;
+pub mod model_info;
 pub mod openai;
 pub mod retry;
 pub mod stub;
@@ -16,7 +18,9 @@ pub use fake::FakeProvider;
 
 pub use anthropic::AnthropicProvider;
 pub use glm::GlmProvider;
+pub use knowledge::{ModelRecommendParams, ProviderModelKnowledge, ReasoningLevels};
 pub use minimax::MiniMaxProvider;
+pub use model_info::{InputType, ModelInfo};
 pub use openai::OpenAIProvider;
 pub use stub::StubProvider;
 

--- a/src/llm/model_info.rs
+++ b/src/llm/model_info.rs
@@ -1,0 +1,177 @@
+//! Model metadata types for LLM Model Discovery & Auto-Config Wizard.
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use super::knowledge::ProviderModelKnowledge;
+
+/// Supported input types for a model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InputType {
+    /// Text-only input.
+    Text,
+    /// Image + text multimodal input.
+    Image,
+}
+
+/// Model metadata returned by the discovery wizard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInfo {
+    /// Provider-specific model identifier (e.g. "deepseek-v3-flash").
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// Context window size in tokens.
+    pub context_window: u32,
+    /// Maximum output tokens the model can produce.
+    pub max_tokens: u32,
+    /// Default sampling temperature, if known.
+    pub default_temperature: Option<f32>,
+    /// Whether the model supports structured reasoning / tool use.
+    pub reasoning: bool,
+    /// List of input modalities supported by this model.
+    pub input_types: Vec<InputType>,
+}
+
+impl ModelInfo {
+    /// Build a ModelInfo from a "provider/model_id" string by looking up
+    /// `ProviderModelKnowledge`. Fields not in the knowledge base get safe
+    /// defaults.
+    fn from_provider_model_str(s: &str) -> Result<Self, ParseModelInfoError> {
+        let (provider, model_id) = s
+            .split_once('/')
+            .ok_or(ParseModelInfoError(s.to_string()))?;
+
+        let kb = ProviderModelKnowledge::new();
+        let params = kb.find(provider, model_id);
+
+        let (context_window, max_tokens, default_temperature, reasoning, input_types) = match params
+        {
+            Some(p) => (
+                p.context_window,
+                p.max_tokens,
+                Some(p.default_temperature),
+                p.reasoning,
+                p.input_types.clone(),
+            ),
+            None => (32_768, 4_096, None, false, vec![InputType::Text]),
+        };
+
+        Ok(Self {
+            id: model_id.to_string(),
+            name: format_name(provider, model_id),
+            context_window,
+            max_tokens,
+            default_temperature,
+            reasoning,
+            input_types,
+        })
+    }
+}
+
+/// Parse error for ModelInfo.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseModelInfoError(String);
+
+impl std::fmt::Display for ParseModelInfoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid ModelInfo format: {}", self.0)
+    }
+}
+
+impl std::error::Error for ParseModelInfoError {}
+
+impl FromStr for ModelInfo {
+    type Err = ParseModelInfoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_provider_model_str(s)
+    }
+}
+
+/// Construct a human-readable display name from provider and model id.
+fn format_name(provider: &str, model_id: &str) -> String {
+    let lower = provider.to_lowercase();
+    let p = match lower.as_str() {
+        "minimax" => "MiniMax",
+        "glm" => "GLM",
+        "deepseek" => "DeepSeek",
+        "volcengine" => "VolcEngine",
+        other => other,
+    };
+    let capitalized = model_id
+        .split('-')
+        .map(word_capitalize)
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("{p} {capitalized}")
+}
+
+fn word_capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_input_type_serde() {
+        for ty in &[InputType::Text, InputType::Image] {
+            let json = serde_json::to_string(ty).unwrap();
+            let parsed: InputType = serde_json::from_str(&json).unwrap();
+            assert_eq!(*ty, parsed);
+        }
+    }
+
+    #[test]
+    fn test_model_info_serde() {
+        let model = ModelInfo {
+            id: "deepseek-v3-flash".to_string(),
+            name: "DeepSeek V3 Flash".to_string(),
+            context_window: 64_000,
+            max_tokens: 8_192,
+            default_temperature: Some(0.7),
+            reasoning: false,
+            input_types: vec![InputType::Text],
+        };
+        let json = serde_json::to_string(&model).unwrap();
+        let parsed: ModelInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "deepseek-v3-flash");
+        assert_eq!(parsed.context_window, 64_000);
+    }
+
+    #[test]
+    fn test_from_str_known_model() {
+        let model = ModelInfo::from_str("deepseek/deepseek-v4-flash").unwrap();
+        assert_eq!(model.id, "deepseek-v4-flash");
+        assert!(model.reasoning);
+        assert_eq!(model.context_window, 64_000);
+        assert_eq!(model.max_tokens, 8_192);
+        assert_eq!(model.default_temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_from_str_unknown_model() {
+        let model = ModelInfo::from_str("unknown/model").unwrap();
+        assert_eq!(model.id, "model");
+        assert!(!model.reasoning);
+        assert_eq!(model.context_window, 32_768);
+        assert_eq!(model.max_tokens, 4_096);
+        assert_eq!(model.default_temperature, None);
+        assert_eq!(model.input_types, vec![InputType::Text]);
+    }
+
+    #[test]
+    fn test_from_str_bad_format() {
+        let err = ModelInfo::from_str("no-slash-at-all").unwrap_err();
+        assert!(err.to_string().contains("invalid ModelInfo format"));
+    }
+}


### PR DESCRIPTION
- Define InputType enum (Text/Image) and ModelInfo struct for model metadata
- Add ProviderModelKnowledge with 4 providers (MiniMax, GLM, VolcEngine, DeepSeek)
- Implement find() and all_models() query interfaces
- Implement FromStr for ModelInfo from 'provider/model_id' format
- Update SPEC.md with new public interfaces

Source: issue #524
Type: feat
