### PR TITLE
fix(llm): resolve CI compile errors in minimax stream tests

### DIFF
--- a/src/llm/minimax_stream.rs
+++ b/src/llm/minimax_stream.rs
@@ -34,72 +34,74 @@ pub(crate) struct MiniMaxStreamRequest<'a> {
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamChunk {
     #[serde(default)]
-    choices: Option<Vec<MiniMaxStreamChoice>>,
+    pub(crate) choices: Option<Vec<MiniMaxStreamChoice>>,
     #[serde(default)]
-    usage: Option<MiniMaxStreamUsage>,
+    pub(crate) usage: Option<MiniMaxStreamUsage>,
     #[serde(default)]
-    model: String,
+    pub(crate) model: String,
     #[serde(default)]
-    base_resp: Option<MiniMaxStreamBaseResp>,
+    pub(crate) base_resp: Option<MiniMaxStreamBaseResp>,
     #[serde(default)]
-    object: String,
+    pub(crate) object: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamChoice {
     #[serde(default)]
-    index: u32,
+    pub(crate) index: u32,
     #[serde(default)]
-    delta: Option<MiniMaxStreamDelta>,
+    pub(crate) delta: Option<MiniMaxStreamDelta>,
     #[serde(default)]
-    finish_reason: Option<String>,
+    pub(crate) finish_reason: Option<String>,
     /// Final chunk has message instead of delta
     #[serde(default)]
-    message: Option<MiniMaxStreamMessage>,
+    pub(crate) message: Option<MiniMaxStreamMessage>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamDelta {
     #[serde(default)]
-    role: Option<String>,
+    pub(crate) role: Option<String>,
     #[serde(default)]
-    content: Option<String>,
+    pub(crate) content: Option<String>,
     #[serde(default)]
-    reasoning_content: Option<String>,
+    pub(crate) reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamMessage {
     #[serde(default)]
-    role: String,
+    pub(crate) role: String,
     #[serde(default)]
-    content: Option<String>,
+    pub(crate) content: Option<String>,
     #[serde(default)]
-    reasoning_content: Option<String>,
+    pub(crate) reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamUsage {
     #[serde(default)]
-    prompt_tokens: u32,
+    pub(crate) prompt_tokens: u32,
     #[serde(default)]
-    completion_tokens: u32,
+    pub(crate) completion_tokens: u32,
     #[serde(default)]
-    total_tokens: u32,
+    pub(crate) total_tokens: u32,
     #[serde(default)]
-    completion_tokens_details: Option<MiniMaxStreamCompletionTokensDetails>,
+    pub(crate) completion_tokens_details: Option<MiniMaxStreamCompletionTokensDetails>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamCompletionTokensDetails {
     #[serde(default)]
-    reasoning_tokens: Option<u32>,
+    pub(crate) reasoning_tokens: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamBaseResp {
-    status_code: i32,
-    status_msg: String,
+    #[serde(default)]
+    pub(crate) status_code: i32,
+    #[serde(default)]
+    pub(crate) status_msg: String,
 }
 
 /// Send a streaming chat request to MiniMax.

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -7,9 +7,9 @@ mod tests {
     use crate::llm::{
         minimax::minimax_stream::{
             extract_message_text, parse_sse_line, parse_stream_chunk, process_buffer,
-            process_chunk, ChatStreamChunk, MiniMaxStreamChunk, MiniMaxStreamMessage,
+            process_chunk, MiniMaxStreamChunk, MiniMaxStreamMessage,
         },
-        LLMError, MiniMaxProvider,
+        ChatStreamChunk, LLMError, MiniMaxProvider,
     };
 
     // --- SSE line parsing ---


### PR DESCRIPTION
Add pub(crate) visibility to MiniMaxStreamChunk and sub-struct fields, and fix ChatStreamChunk import path from private re-export to crate::llm.

Source: CI run 25393058397