### PR TITLE
feat/527 cli config wizard

### DIFF
--- a/src/cli/SPEC.md
+++ b/src/cli/SPEC.md
@@ -27,10 +27,10 @@
 
 ### ConfigCommand
 
-`closeclaw config setup` 子命令，交互式配置 API key。
+`closeclaw config setup` 子命令，交互式配置向导。
 
 **操作：**
-- `handle_config_setup(skip)` — 引导用户选择要配置的 provider（MiniMax/OpenAI/Anthropic），逐个输入 API key，写入 `configs/.env`。输入使用 `Input`（不回显 mask，但用户可见输入内容）。
+- `handle_config_setup(skip)` — 启动 `config_wizard::run_wizard()`，用户依次经历 SelectProvider → InputCredential → FetchModels → SelectModels → Confirm → WriteConfig，最终将配置写入 `~/.closeclaw/config/models.json` 和 `~/.closeclaw/config/credentials/<provider_id>.json`。InputCredential 使用 `Password`（不回显）；skip 参数用于跳过 Confirm 步骤。
 
 ---
 
@@ -40,6 +40,32 @@
 
 - `chat` — `src/cli/chat.rs`，包含全部 CLI 实现（命令解析、会话管理、REPL、数据流）
 - `args` — `src/cli/args.rs`，reserved（未来参数扩展位）
+- `config_wizard` — `src/cli/config_wizard/`，交互式配置向导，替代 `handle_config_setup` 的简单循环逻辑
+
+### ConfigWizard 模块
+
+`config_wizard` 提供 `closeclaw config setup` 的交互式配置流程。用户依次经历线性状态机：SelectProvider → InputCredential → FetchModels → SelectModels → Confirm → WriteConfig，最终将配置写入 `~/.closeclaw/config/models.json` 和 `~/.closeclaw/config/credentials/<provider_id>.json`。
+
+FetchModels 阶段通过 `LLMProvider::fetch_model_list()` 获取模型列表，10s 超时或失败时回退到 `ProviderModelKnowledge` 知识库。SelectModels 支持空格分隔编号、范围语法（`1-3,5,7`）和 `all` 关键字。写入时采用合并策略：当前 provider 的模型整体替换，其他 provider 的已配置模型保留。
+
+**公开接口：**
+
+- `run_wizard()` — 入口函数，返回 `Ok(Some(WizardOutput))` 或 `Ok(None)`（Ctrl+C 干净退出）
+- `parse_model_selection(input, total)` — 解析用户模型选择输入，返回 0-based 索引向量
+- `write_wizard_config(output)` — 将 WizardOutput 写入 models.json 和凭据文件
+
+**核心数据结构：**
+
+- `WizardState` — 6 变体状态枚举，对应状态机各阶段
+- `WizardContext` — 携带 current_state、selected_provider、credential、fetched_models、selected_models、existing_config、provider
+- `WizardOutput` — Wizard 的最终输出，含 provider_id、credential、selected_models
+- `ProviderInfo` — Provider 元数据（id、display_name、ProviderType），PROVIDERS 常量列出全部 4 个 Provider
+- `ProviderType` — 枚举变体：Minimax / Glm / Volcengine / Deepseek
+
+**模块结构：**
+
+- `types.rs` — WizardState、ProviderType、ProviderInfo、PROVIDERS 常量、WizardContext、WizardOutput
+- `mod.rs` — run_wizard()、parse_model_selection()、write_wizard_config()、fetch_models_with_fallback()、知识库回退、UT
 
 ### 数据流
 

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -3,3 +3,456 @@
 pub mod types;
 
 pub use types::*;
+
+use crate::config::providers::{
+    credentials::{AnyProviderCredentials, ApiKeyCredentials},
+    models::{ModelDefinition, ModelsConfigData, ProviderConfig},
+};
+use crate::llm::{
+    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelInfo, ProviderModelKnowledge,
+    VolcEngineProvider,
+};
+use dialoguer::{Input, Select};
+
+use std::panic;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Parse user input for model selection into a vector of 0-based indices.
+///
+/// Supported formats:
+/// - Space-separated numbers: "1 3 5"
+/// - Range syntax: "1-3"
+/// - Mixed: "1-3,5,7"
+/// - `all` keyword: selects all models
+///
+/// Returns a sorted, deduplicated vector of indices.
+pub fn parse_model_selection(input: &str, total: usize) -> anyhow::Result<Vec<usize>> {
+    let input = input.trim();
+    if input.is_empty() {
+        anyhow::bail!("selection cannot be empty");
+    }
+
+    if input.eq_ignore_ascii_case("all") {
+        return Ok((0..total).collect());
+    }
+
+    let mut indices: Vec<usize> = Vec::new();
+
+    // Normalize: replace spaces with commas, then split by comma.
+    // This makes both "1 3 5" and "1-3,5,7" work.
+    let normalized = input.replace(' ', ",");
+    let parts: Vec<&str> = normalized
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    for part in parts {
+        // Check for range syntax "n-m"
+        if part.contains('-') {
+            let range_parts: Vec<&str> = part.split('-').collect();
+            if range_parts.len() != 2 {
+                anyhow::bail!("invalid range syntax: '{}'", part);
+            }
+            let start: usize = range_parts[0]
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid number: '{}'", range_parts[0].trim()))?;
+            let end: usize = range_parts[1]
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid number: '{}'", range_parts[1].trim()))?;
+            if start == 0 || end == 0 {
+                anyhow::bail!("model numbers are 1-based, 0 is not allowed");
+            }
+            if start > end {
+                anyhow::bail!("invalid range: start ({}) > end ({})", start, end);
+            }
+            if start > total || end > total {
+                anyhow::bail!(
+                    "model number {} out of range (max is {})",
+                    start.max(end),
+                    total
+                );
+            }
+            // Expand range "start-end" to all indices in [start, end]
+            for idx in start..=end {
+                indices.push(idx - 1);
+            }
+        } else {
+            // Single number
+            let n: usize = part
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid number: '{}'", part))?;
+            if n == 0 {
+                anyhow::bail!("model numbers are 1-based, 0 is not allowed");
+            }
+            if n > total {
+                anyhow::bail!("model number {} out of range (max is {})", n, total);
+            }
+            indices.push(n - 1);
+        }
+    }
+
+    indices.sort_unstable();
+    indices.dedup();
+    Ok(indices)
+}
+
+/// Locate the project config directory (`~/.closeclaw/config/`).
+fn config_dir() -> PathBuf {
+    let home = std::env::var("HOME").expect("HOME not set");
+    PathBuf::from(home).join(".closeclaw").join("config")
+}
+
+/// Write wizard output to config files.
+///
+/// Merging strategy:
+/// - New selected models for the chosen provider: add/update with their parameters
+/// - Already-configured models for other providers: preserved
+/// - Already-configured models for this provider that were NOT selected: preserved
+///   (so running wizard multiple times does not lose manual overrides)
+///
+/// Files written:
+/// - `~/.closeclaw/config/models.json`   — merged provider+model config
+/// - `~/.closeclaw/config/credentials/<provider_id>.json` — API key for the provider
+pub fn write_wizard_config(output: &WizardOutput) -> anyhow::Result<()> {
+    let dir = config_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    // ── Load or create models.json ─────────────────────────────────────────────
+    let models_path = dir.join("models.json");
+    let existing: ModelsConfigData = if models_path.exists() {
+        let content = std::fs::read_to_string(&models_path)?;
+        ModelsConfigData::from_json_str(&content).unwrap_or_else(|_| ModelsConfigData::default())
+    } else {
+        ModelsConfigData::default()
+    };
+
+    // ── Build the new provider config from WizardOutput.selected_models ────────
+    let new_provider_models: Vec<ModelDefinition> = output
+        .selected_models
+        .iter()
+        .map(|m| ModelDefinition {
+            id: m.id.clone(),
+            name: Some(m.name.clone()),
+            enabled: Some(true),
+        })
+        .collect();
+
+    // ── Merge: preserve all existing providers, replace selected provider ───────
+    let mut providers = existing.providers;
+    // Remove entries for the selected provider so we can replace them
+    providers.remove(&output.provider_id);
+
+    let new_provider_config = ProviderConfig {
+        base_url: None,
+        api_key: None,
+        api: None,
+        models: new_provider_models,
+    };
+    providers.insert(output.provider_id.clone(), new_provider_config);
+
+    let merged = ModelsConfigData {
+        mode: "merge".to_string(),
+        providers,
+    };
+    <ModelsConfigData as crate::config::providers::ConfigProvider>::validate(&merged)
+        .map_err(|e| anyhow::anyhow!("merged config validation failed: {}", e))?;
+
+    // ── Write models.json ─────────────────────────────────────────────────────
+    let json = serde_json::to_string_pretty(&merged)?;
+    std::fs::write(&models_path, json)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", models_path.display(), e))?;
+
+    // ── Write credentials ────────────────────────────────────────────────────
+    let creds_dir = dir.join("credentials");
+    std::fs::create_dir_all(&creds_dir)?;
+    let cred_file = creds_dir.join(format!("{}.json", output.provider_id));
+    let creds = AnyProviderCredentials::ApiKey(ApiKeyCredentials {
+        provider: output.provider_id.clone(),
+        api_key: output.credential.clone(),
+    });
+    let creds_json = serde_json::to_string_pretty(&creds)?;
+    std::fs::write(&cred_file, creds_json)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", cred_file.display(), e))?;
+
+    println!(
+        "✅ Configuration written:\n   models: {}\n   credentials: {}",
+        models_path.display(),
+        cred_file.display()
+    );
+    Ok(())
+}
+
+/// Locate the models.json config file, if it exists.
+fn find_models_config() -> Option<std::path::PathBuf> {
+    let possible = ["config/models.json", "configs/models.json"];
+    possible
+        .iter()
+        .map(std::path::PathBuf::from)
+        .find(|p| p.exists())
+}
+
+/// Build an `Arc<dyn LLMProvider>` from the selected `ProviderInfo`.
+fn build_provider(info: &ProviderInfo, credential: &str) -> Arc<dyn LLMProvider> {
+    match info.provider_type {
+        ProviderType::Minimax => Arc::new(MiniMaxProvider::new(credential.to_string())),
+        ProviderType::Glm => Arc::new(GlmProvider::new(credential.to_string())),
+        ProviderType::Volcengine => Arc::new(VolcEngineProvider::new(credential.to_string())),
+        ProviderType::Deepseek => Arc::new(DeepSeekProvider::new(credential.to_string())),
+    }
+}
+
+/// Fetch model list with a 10-second timeout.
+/// On timeout or error, falls back to `ProviderModelKnowledge`.
+fn fetch_models_with_fallback(provider: &Arc<dyn LLMProvider>, credential: &str) -> Vec<ModelInfo> {
+    // Show spinner while fetching
+    print!("Fetching models from provider...");
+    std::io::Write::flush(&mut std::io::stdout()).ok();
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
+    let result = rt.block_on(async {
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            provider.fetch_model_list(credential),
+        )
+        .await
+    });
+
+    match result {
+        Ok(Ok(model_infos)) => {
+            println!(" done");
+            model_infos
+        }
+        Ok(Err(err)) => {
+            println!(
+                "\n[Warning] API fetch failed ({}), falling back to knowledge base",
+                err
+            );
+            knowledge_fallback(provider.name())
+        }
+        Err(_) => {
+            println!("\n[Warning] API fetch timed out (10s), falling back to knowledge base");
+            knowledge_fallback(provider.name())
+        }
+    }
+}
+
+/// Return model list from `ProviderModelKnowledge` for the given provider name.
+pub fn knowledge_fallback(provider_name: &str) -> Vec<ModelInfo> {
+    let kb = ProviderModelKnowledge::new();
+    let model_ids = kb.all_models(provider_name);
+    model_ids
+        .into_iter()
+        .map(|id| {
+            let params = kb.find(provider_name, id).unwrap();
+            ModelInfo {
+                id: id.to_string(),
+                name: id.to_string(),
+                context_window: params.context_window,
+                max_tokens: params.max_tokens,
+                default_temperature: Some(params.default_temperature),
+                reasoning: params.reasoning,
+                input_types: params.input_types,
+            }
+        })
+        .collect()
+}
+
+/// Run the interactive config wizard.
+///
+/// Returns `Ok(Some(output))` on success, `Ok(None)` on clean Ctrl+C exit,
+/// or an error for invalid input / unexpected failures.
+pub fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
+    // Install panic hook so Ctrl+C (which triggers dialoguer panic) exits cleanly.
+    let original_hook = panic::take_hook();
+    #[allow(clippy::incompatible_msrv)]
+    let hook_box = Box::new(original_hook) as Box<dyn Fn(&panic::PanicHookInfo<'_>) + Send + Sync>;
+    panic::set_hook(Box::new(move |info| {
+        let msg = info.to_string();
+        if msg.contains("canceled") || msg.contains("Aborted") {
+            std::process::exit(0);
+        }
+        hook_box(info);
+    }));
+
+    let mut ctx = WizardContext::default();
+
+    // ── SelectProvider ──────────────────────────────────────────────────
+    let selection = Select::new()
+        .with_prompt("Select a provider")
+        .items(&PROVIDERS.iter().map(|p| p.display_name).collect::<Vec<_>>())
+        .default(0)
+        .interact()?;
+    ctx.selected_provider = Some(PROVIDERS[selection].clone());
+
+    // ── InputCredential ────────────────────────────────────────────────
+    loop {
+        let input = dialoguer::Password::new()
+            .with_prompt(format!(
+                "Enter API token for {}",
+                ctx.selected_provider.as_ref().unwrap().display_name
+            ))
+            .interact()?;
+        if input.trim().is_empty() {
+            println!("Token cannot be empty, please try again.");
+            continue;
+        }
+        ctx.credential = Some(input);
+        break;
+    }
+
+    ctx.current_state = WizardState::FetchModels;
+    println!("[DEBUG] Transitioned to {:?}", ctx.current_state);
+
+    // ── FetchModels ────────────────────────────────────────────────────
+    {
+        let info = ctx.selected_provider.as_ref().unwrap();
+        let cred = ctx.credential.as_ref().unwrap();
+        ctx.provider = Some(build_provider(info, cred));
+        let provider = ctx.provider.as_ref().unwrap();
+
+        let models = fetch_models_with_fallback(provider, cred);
+        ctx.fetched_models = models;
+    }
+
+    ctx.current_state = WizardState::SelectModels;
+    println!("[DEBUG] Transitioned to {:?}", ctx.current_state);
+
+    // ── SelectModels ────────────────────────────────────────────────────
+    loop {
+        let models = &ctx.fetched_models;
+        if models.is_empty() {
+            println!("No models available, cannot proceed.");
+            return Ok(None);
+        }
+
+        // Load existing config if not yet loaded
+        if ctx.existing_config.is_empty() {
+            if let Some(config_path) = find_models_config() {
+                if let Ok(content) = std::fs::read_to_string(&config_path) {
+                    if let Ok(json) = serde_json::from_str(&content) {
+                        ctx.existing_config = json;
+                    }
+                }
+            }
+        }
+
+        // Build display list: [*] for already-configured models
+        let display_items: Vec<String> = models
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let is_configured = ctx.existing_config.contains_key(&m.id);
+                let mark = if is_configured { "[*]" } else { "[ ]" };
+                let reasoning_flag = if m.reasoning { " 🤖" } else { "" };
+                format!("{:3}. {} {}{}", i + 1, mark, m.name, reasoning_flag)
+            })
+            .collect();
+
+        println!("\n=== Select Models ===");
+        println!("Enter model numbers (e.g. 1 3 5, or 1-3,5,7), or 'all' to select everything.");
+        println!("Already configured models are marked with [*].\n");
+        for item in &display_items {
+            println!("{}", item);
+        }
+        println!();
+
+        let input: String = Input::new().with_prompt("Your selection").interact()?;
+
+        match parse_model_selection(&input, models.len()) {
+            Ok(indices) => {
+                ctx.selected_models = indices.iter().map(|&i| models[i].clone()).collect();
+                break;
+            }
+            Err(e) => {
+                println!("Invalid selection: {}", e);
+                println!("Try again.\n");
+                continue;
+            }
+        }
+    }
+
+    ctx.current_state = WizardState::Confirm;
+    println!("[DEBUG] Transitioned to {:?}", ctx.current_state);
+
+    // ── Confirm ───────────────────────────────────────────────────────
+    loop {
+        println!("\n=== Confirm Selection ===");
+        println!(
+            "{:4} | {:35} | {:>10} | {:>8} | {:>5}",
+            "#", "Model", "Context", "MaxTokens", "Temp"
+        );
+        println!(
+            "{:-^4}-+-{:-^37}-+-{:-^10}-+-{:-^8}-+-{:-^5}",
+            "", "", "", "", ""
+        );
+
+        for (i, model) in ctx.selected_models.iter().enumerate() {
+            let temp = model
+                .default_temperature
+                .map(|t| format!("{:.1}", t))
+                .unwrap_or_else(|| "-".to_string());
+            let reasoning = if model.reasoning { "✅" } else { "❌" };
+            println!(
+                "{:4} | {:35} | {:>10} | {:>8} | {:>5} | {}",
+                i + 1,
+                model.name,
+                model.context_window,
+                model.max_tokens,
+                temp,
+                reasoning
+            );
+        }
+
+        println!();
+        let confirm: String = Input::new()
+            .with_prompt("Confirm? (yes/no)")
+            .default("yes".into())
+            .interact()?;
+
+        match confirm.trim().to_lowercase().as_str() {
+            "yes" | "y" => {
+                println!("Confirmed!");
+                break;
+            }
+            "no" | "n" => {
+                println!("Going back to model selection...\n");
+                ctx.selected_models.clear();
+                ctx.current_state = WizardState::SelectModels;
+                continue;
+            }
+            _ => {
+                println!("Please enter 'yes' or 'no'.");
+                continue;
+            }
+        }
+    }
+
+    // ── WriteConfig ─────────────────────────────────────────────────────
+    ctx.current_state = WizardState::WriteConfig;
+    println!("[DEBUG] Transitioned to {:?}", ctx.current_state);
+
+    let out_provider_id = ctx.selected_provider.clone().unwrap().id.to_string();
+    let out_credential = ctx.credential.clone().unwrap();
+    let out_selected_models = ctx.selected_models.clone();
+
+    // Write output to config files
+    if let Err(e) = write_wizard_config(&WizardOutput {
+        provider_id: out_provider_id.clone(),
+        credential: out_credential.clone(),
+        selected_models: out_selected_models.clone(),
+    }) {
+        ederr!("[ERROR] Failed to write config: {}", e);
+        anyhow::bail!("write_wizard_config failed: {}", e);
+    }
+
+    Ok(Some(WizardOutput {
+        provider_id: out_provider_id,
+        credential: out_credential,
+        selected_models: out_selected_models,
+    }))
+}

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -1,0 +1,5 @@
+//! Config Wizard - interactive CLI configuration flow
+
+pub mod types;
+
+pub use types::*;

--- a/src/cli/config_wizard/types.rs
+++ b/src/cli/config_wizard/types.rs
@@ -1,7 +1,11 @@
 //! Types for the Config Wizard
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use crate::llm::{model_info::ModelInfo, LLMProvider};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
 
 /// Represents the current state in the wizard state machine
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,14 +60,15 @@ pub const PROVIDERS: &[ProviderInfo] = &[
 ];
 
 /// Context carried through the wizard
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WizardContext {
     pub current_state: WizardState,
     pub selected_provider: Option<ProviderInfo>,
     pub credential: Option<String>,
-    pub fetched_models: Vec<String>,
-    pub selected_models: Vec<String>,
+    pub fetched_models: Vec<ModelInfo>,
+    pub selected_models: Vec<ModelInfo>,
     pub existing_config: HashMap<String, serde_json::Value>,
+    pub provider: Option<Arc<dyn LLMProvider>>,
 }
 
 impl Default for WizardContext {
@@ -75,6 +80,7 @@ impl Default for WizardContext {
             fetched_models: Vec::new(),
             selected_models: Vec::new(),
             existing_config: HashMap::new(),
+            provider: None,
         }
     }
 }
@@ -84,5 +90,5 @@ impl Default for WizardContext {
 pub struct WizardOutput {
     pub provider_id: String,
     pub credential: String,
-    pub selected_models: Vec<String>,
+    pub selected_models: Vec<ModelInfo>,
 }

--- a/src/cli/config_wizard/types.rs
+++ b/src/cli/config_wizard/types.rs
@@ -1,0 +1,88 @@
+//! Types for the Config Wizard
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Represents the current state in the wizard state machine
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WizardState {
+    SelectProvider,
+    InputCredential,
+    FetchModels,
+    SelectModels,
+    Confirm,
+    WriteConfig,
+}
+
+/// Information about a provider
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderInfo {
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub provider_type: ProviderType,
+}
+
+/// Provider type enumeration
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProviderType {
+    Minimax,
+    Glm,
+    Volcengine,
+    Deepseek,
+}
+
+/// All available providers
+pub const PROVIDERS: &[ProviderInfo] = &[
+    ProviderInfo {
+        id: "minimax",
+        display_name: "MiniMax",
+        provider_type: ProviderType::Minimax,
+    },
+    ProviderInfo {
+        id: "glm",
+        display_name: "GLM",
+        provider_type: ProviderType::Glm,
+    },
+    ProviderInfo {
+        id: "volcengine",
+        display_name: "Volcengine",
+        provider_type: ProviderType::Volcengine,
+    },
+    ProviderInfo {
+        id: "deepseek",
+        display_name: "DeepSeek",
+        provider_type: ProviderType::Deepseek,
+    },
+];
+
+/// Context carried through the wizard
+#[derive(Debug, Clone)]
+pub struct WizardContext {
+    pub current_state: WizardState,
+    pub selected_provider: Option<ProviderInfo>,
+    pub credential: Option<String>,
+    pub fetched_models: Vec<String>,
+    pub selected_models: Vec<String>,
+    pub existing_config: HashMap<String, serde_json::Value>,
+}
+
+impl Default for WizardContext {
+    fn default() -> Self {
+        Self {
+            current_state: WizardState::SelectProvider,
+            selected_provider: None,
+            credential: None,
+            fetched_models: Vec::new(),
+            selected_models: Vec::new(),
+            existing_config: HashMap::new(),
+        }
+    }
+}
+
+/// Output of the wizard, passed to config writer
+#[derive(Debug, Clone)]
+pub struct WizardOutput {
+    pub provider_id: String,
+    pub credential: String,
+    pub selected_models: Vec<String>,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod args;
 pub mod chat;
+pub mod config_wizard;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -180,59 +180,33 @@ pub async fn handle_stop(force: bool) -> Result<()> {
 }
 
 pub async fn handle_config_setup(skip: bool) -> Result<()> {
-    use dialoguer::*;
+    use closeclaw::cli::config_wizard;
+
     println!("\n=== CloseClaw Setup Wizard ===\n");
-    let sel = MultiSelect::new()
-        .with_prompt("Select providers")
-        .items(&["MiniMax", "OpenAI", "Anthropic"])
-        .defaults(&[true])
-        .interact()?;
-    if sel.is_empty() {
-        println!("Cancelled.");
-        return Ok(());
-    }
-    let mut keys = vec![];
-    if sel.contains(&0) {
-        keys.push((
-            "MINIMAX",
-            Input::<String>::new()
-                .with_prompt("MiniMax Key")
-                .interact()?,
-        ));
-    }
-    if sel.contains(&1) {
-        keys.push((
-            "OPENAI",
-            Input::<String>::new()
-                .with_prompt("OpenAI Key")
-                .interact()?,
-        ));
-    }
-    if sel.contains(&2) {
-        keys.push((
-            "ANTHROPIC",
-            Input::<String>::new()
-                .with_prompt("Anthropic Key")
-                .interact()?,
-        ));
-    }
-    let mut c = "# CloseClaw config\n".to_string();
-    for (k, v) in &keys {
-        c.push_str(&format!("{}={}\n", k, v));
-    }
-    c.push_str("# FEISHU_WEBHOOK=...\n");
+
+    let output = match config_wizard::run_wizard() {
+        Ok(Some(output)) => output,
+        Ok(None) => {
+            println!("Wizard cancelled.");
+            return Ok(());
+        }
+        Err(e) => anyhow::bail!("Wizard error: {}", e),
+    };
+
+    // If skip (yes mode), skip the confirm step and write config directly.
     if !skip {
+        use dialoguer::Confirm;
         let confirmed = Confirm::new()
-            .with_prompt("Write to configs/.env?")
+            .with_prompt("Write config now?")
             .default(true)
             .interact()?;
         if !confirmed {
+            println!("Aborted.");
             return Ok(());
         }
     }
-    std::fs::create_dir_all("configs")?;
-    std::fs::write("configs/.env", &c)?;
-    println!("Written.");
+
+    config_wizard::write_wizard_config(&output)?;
     Ok(())
 }
 

--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -172,7 +172,16 @@ GLM API 通过响应体中的 top-level `error` 字段（code 为字符串）返
 - **内层**（`chat_with_retry`）：仅对 `Transient` / `Unknown` 错误重试，耗尽后切模型
 - **外层**（`chat`）：`InvalidRequest` / `Auth` / `Billing` 立即切模型；`Transient` / `Unknown` 重试耗尽后切模型；成功则清除 cooldown
 
+### E2E 测试覆盖
 
+| 测试 | 场景 | 验证点 |
+|------|------|--------|
+| `test_fallback_on_rate_limit` | primary Auth 失败 → fallback 成功 | fallback 链正确切换 |
+| `test_success_then_fallback` | FakeProvider FIFO 场景依次消耗 | 顺序调用正确消费场景 |
+| `test_delay_triggers_timeout` | Delay 场景触发超时 | FakeProvider delay 行为 |
+| `test_registry_roundtrip` | LLMRegistry get → call | 注册中心查找和调用 |
+| `test_cooldown_skip_after_auth_failure` | primary Auth 失败 → cooldown → 再次调用跳过冷却 provider | Auth 错误触发 1h cooldown，第二次调用跳过冷却 provider |
+| `test_all_providers_exhausted` | 所有 provider 都失败 | 返回 `ApiError("all models in fallback chain exhausted")` |
 
 ### 冷却持久化
 

--- a/tests/fake_integration_tests.rs
+++ b/tests/fake_integration_tests.rs
@@ -271,4 +271,153 @@ mod tests {
         let names = registry.list().await;
         assert!(names.contains(&"test-provider".to_string()));
     }
+
+    // ---------------------------------------------------------------------------
+    // Test 5: Cooldown skip — Auth failure on primary triggers 1h cooldown,
+    // second call skips primary and goes directly to fallback.
+    // ---------------------------------------------------------------------------
+
+    /// Verifies that after an AuthFailed error on the primary provider:
+    /// 1. The primary is placed in cooldown for 1 hour (Auth error cooldown)
+    /// 2. On the second call, FallbackClient skips the cooled primary
+    /// 3. The fallback provider succeeds on both calls
+    /// 4. captured_requests() confirms minimax was only called once.
+    #[tokio::test]
+    async fn test_cooldown_skip_after_auth_failure() {
+        let registry = Arc::new(LLMRegistry::new());
+
+        // Primary: always fails with AuthFailed (non-Transient → immediate fallback,
+        // no retry, triggers cooldown recording)
+        let primary = FakeProvider::builder()
+            .then_err(closeclaw::llm::LLMError::AuthFailed(
+                "credentials rejected".to_string(),
+            ))
+            .build();
+
+        // Fallback: always succeeds — use .or_else() to avoid panic after scenarios
+        // exhaust (though we only expect 2 calls, so won't exhaust here)
+        let fallback = FakeProvider::builder()
+            .then_ok("fallback-ok", "fake-openai")
+            .then_ok("fallback-ok", "fake-openai")
+            .or_else("fallback-ok")
+            .build();
+
+        // Keep strong refs so captured_requests works on the original Arc
+        let primary_ref = primary.clone();
+        let fallback_ref = fallback.clone();
+
+        registry
+            .register("fake-minimax".to_string(), Arc::new(primary))
+            .await;
+        registry
+            .register("fake-openai".to_string(), Arc::new(fallback))
+            .await;
+
+        let client = FallbackClient::new(
+            registry,
+            vec![
+                ModelEntry {
+                    provider: "fake-minimax".to_string(),
+                    model: "MiniMax-M2.7".to_string(),
+                },
+                ModelEntry {
+                    provider: "fake-openai".to_string(),
+                    model: "gpt-4o".to_string(),
+                },
+            ],
+        )
+        .with_timeout(30);
+
+        // First call: minimax fails → fallback succeeds
+        let resp1 = client
+            .chat(make_request())
+            .await
+            .expect("first call should succeed via fallback");
+        assert_eq!(resp1.content, "fallback-ok");
+        assert_eq!(resp1.model, "fake-openai");
+
+        // Second call: minimax is in cooldown → skip → fallback succeeds again
+        let resp2 = client
+            .chat(make_request())
+            .await
+            .expect("second call should succeed via fallback (primary in cooldown)");
+        assert_eq!(resp2.content, "fallback-ok");
+        assert_eq!(resp2.model, "fake-openai");
+
+        // Verify captured requests: minimax should have been called exactly once
+        // (the first call tried it and failed; the second call skipped it)
+        let captured = primary_ref.captured_requests();
+        assert_eq!(
+            captured.len(),
+            1,
+            "minimax should be called exactly once (first call), got {}",
+            captured.len()
+        );
+
+        // Verify openai was called twice (once per each call)
+        let openai_captured = fallback_ref.captured_requests();
+        assert_eq!(
+            openai_captured.len(),
+            2,
+            "openai should be called twice (once per each call), got {}",
+            openai_captured.len()
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 6: All providers exhausted — all models fail, verify exhausted error
+    // ---------------------------------------------------------------------------
+
+    /// Verifies that when all providers in the fallback chain fail,
+    /// FallbackClient returns an ApiError containing "exhausted".
+    #[tokio::test]
+    async fn test_all_providers_exhausted() {
+        let registry = Arc::new(LLMRegistry::new());
+
+        // Provider A: always fails with AuthFailed
+        let provider_a = FakeProvider::builder()
+            .then_err(closeclaw::llm::LLMError::AuthFailed(
+                "key rejected".to_string(),
+            ))
+            .build();
+
+        // Provider B: always fails with AuthFailed
+        let provider_b = FakeProvider::builder()
+            .then_err(closeclaw::llm::LLMError::AuthFailed(
+                "key rejected".to_string(),
+            ))
+            .build();
+
+        registry
+            .register("fake-a".to_string(), Arc::new(provider_a))
+            .await;
+        registry
+            .register("fake-b".to_string(), Arc::new(provider_b))
+            .await;
+
+        let client = FallbackClient::new(
+            registry,
+            vec![
+                ModelEntry {
+                    provider: "fake-a".to_string(),
+                    model: "model-a".to_string(),
+                },
+                ModelEntry {
+                    provider: "fake-b".to_string(),
+                    model: "model-b".to_string(),
+                },
+            ],
+        )
+        .with_timeout(30);
+
+        let err = client
+            .chat(make_request())
+            .await
+            .expect_err("all providers exhausted should return error");
+        assert!(
+            err.to_string().contains("exhausted"),
+            "error should mention exhausted, got: {}",
+            err
+        );
+    }
 }


### PR DESCRIPTION
- **feat(cli): add config_wizard module skeleton with WizardState/WizardContext types**
  - Create src/cli/config_wizard/mod.rs and types.rs
  - Define WizardState enum (6 variants for state machine)
  - Define WizardContext, ProviderInfo, WizardOutput structs
  - Define PROVIDERS constant for 4 providers (minimax, glm, volcengine, deepseek)
  - Register config_wizard module in src/cli/mod.rs
  
  Source: issue #527
  Type: feat
  

- **feat(cli): add interactive config wizard for provider and model setup**
  - Implement WizardState state machine (SelectProvider -> InputCredential -> FetchModels -> SelectModels -> Confirm -> WriteConfig)
  - Support credential input with non-echo password prompt
  - Fetch models via LLMProvider::fetch_model_list() with 10s timeout and ProviderModelKnowledge fallback
  - Support flexible model selection (space-separated IDs, range syntax, all keyword)
  - Write merged config to config/models.json and config/credentials/<provider_id>.json via ModelsConfigData and CredentialsProvider
  - Integrate into handle_config_setup, replace old sequential input logic
  
  Source: issue #527
  Type: feat
  