### PR TITLE
fix(config-wizard): replace undefined ederr! macro with eprintln!

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -446,7 +446,7 @@ pub fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         credential: out_credential.clone(),
         selected_models: out_selected_models.clone(),
     }) {
-        ederr!("[ERROR] Failed to write config: {}", e);
+        eprintln!("[ERROR] Failed to write config: {}", e);
         anyhow::bail!("write_wizard_config failed: {}", e);
     }
 


### PR DESCRIPTION
## Summary
Replaces undefined `ederr!` macro with `eprintln!` in `src/cli/config_wizard/mod.rs:449`.

## Source
CI build failure on master commit e8d32eb (PR #539)