### PR TITLE
fix(config): change watch() return type to Result<WatcherHandle, ConfigError>

### DIFF
--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -225,7 +225,7 @@ impl<P: ConfigProvider + Send + 'static> ConfigReloadManager<P> {
     /// Start watching config files for changes using notify.
     /// This spawns a background task that handles file change events.
     /// Returns a handle that can be used to stop watching.
-    pub fn watch(&mut self, paths: Vec<PathBuf>) -> Result<(), ConfigError> {
+    pub fn watch(&mut self, paths: Vec<PathBuf>) -> Result<WatcherHandle, ConfigError> {
         self.watched_paths = paths.clone();
 
         let provider = Arc::clone(&self.provider);


### PR DESCRIPTION
The watch() function was declared as returning Result<(), ConfigError> but
actually returned Ok(WatcherHandle { watcher }), causing E0308 (mismatched
types) and E0599 (.stop() method not found) compilation errors.

Source: Fixes #545
Type: fix
