### PR TITLE
feat(llm): define Provider and ChatProtocol traits for multi-Provider architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "flume",
+ "futures",
  "glob",
  "hex",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ fake-llm = []
 [dependencies]
 # Async runtime - pinned to older version to avoid edition2024 issues
 tokio = { version = "=1.35.0", features = ["full"] }
+futures = "0.3"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/chat/session_compaction_tests.rs
+++ b/src/chat/session_compaction_tests.rs
@@ -4,9 +4,10 @@
 mod compaction_tests {
     use super::*;
     use crate::chat::session::ChatSession;
+    use crate::llm::stub::StubProvider;
     use crate::{
         chat::protocol::ServerMessage,
-        llm::{LLMRegistry, Message, StubProvider},
+        llm::{LLMRegistry, Message},
         session::compaction::CompactionService,
     };
     use std::sync::Arc;

--- a/src/chat/session_multi_session_tests.rs
+++ b/src/chat/session_multi_session_tests.rs
@@ -5,7 +5,8 @@ mod multi_session_tests {
     use super::*;
     use crate::chat::protocol::ServerMessage;
     use crate::chat::session::ChatSession;
-    use crate::llm::{LLMRegistry, StubProvider};
+    use crate::llm::stub::StubProvider;
+    use crate::llm::LLMRegistry;
     use std::sync::Arc;
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},

--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -41,11 +41,27 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 
 ### 数据类型（Protocol 内部层）
 
+- **`ProtocolId`** — 协议标识符（newtype wrapper `String`），实现 `Display`、`From<&str>`、`From<String>`、`Hash`、`Clone`
+- **`InternalMessage`** — `InternalRequest` 中的单条消息（role + content）
+- **`InternalRequest`** — Protocol 内部请求结构（model、messages、temperature、max_tokens、stream、extra_body）
 - **`InternalResponse`** — Protocol 内部组装的原始响应（content_blocks + usage + finish_reason）
 - **`RawContentBlock`** — Protocol 内部原始内容块（结构同 ContentBlock，但不对外暴露）
 - **`RawUsage`** — Protocol 内部原始用量（prompt_tokens、completion_tokens、total_tokens）
 - **`RawSseChunk`** — Protocol 内部 SSE 原始 chunk（event_type + data）
 - **`SseStateMachine`** — SSE 流解析状态机（跟踪 current_block_index、block_type、pending_thinking、pending_signature）
+
+### Provider trait
+
+- **`Provider`**（trait）— LLM Provider 抽象，唯一职责是持有配置（URL、credentials、HTTP client）并执行实际的 HTTP 请求/响应周期。使用 `async_trait`，`Send + Sync`。配置访问器（`id`、`base_url`、`api_key`、`supported_protocols`、`http_client`、`default_headers`）均为同步；`send` 和 `send_streaming` 为异步
+- **`ProviderError`** — Provider 层错误：`Reqwest(reqwest::Error)`，HTTP 请求失败（网络错误、TLS 错误、超时、重定向限制、非成功状态码等）
+- **`SseStream`** — 流式响应通道类型，`tokio::sync::mpsc::Receiver<RawSseChunk>`，调用方通过 `recv().await` 逐块消费 SSE 原始 chunk
+
+### ChatProtocol trait
+
+- **`ChatProtocol`**（trait）— 请求/响应协议转换 trait，负责在 internal unified types 和具体 LLM API 协议（OpenAI、Anthropic、GLM 等）的 wire format 之间互转。使用 `async_trait`，`Send + Sync`。标识方法（`protocol_id`、`path`）同步；`build_request`、`parse_response`、`decorate_headers` 同步（纯序列化/header 操作）；`create_sse_machine` 是工厂方法；`parse_sse_stream` 异步 streaming
+- **`ProtocolError`** — Protocol 层错误：`RequestBuild`、`ResponseParse`、`HeaderDecorate`、`SseParse`
+- **`IncomingSseStream`** — 入站 SSE 流类型，`Pin<Box<dyn Stream<Item = RawSseChunk> + Send>>`
+- **`OutgoingEventStream`** — 出站事件流类型，`Pin<Box<dyn Stream<Item = Result<StreamEvent, ProtocolError>> + Send>>`
 
 ### 数据类型（模型元数据）
 
@@ -146,6 +162,8 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 | `glm_stream.rs` | GLM 流式接口：SSE 解析、delta 提取（`reasoning_content` 优先、`content` 兜底）、流式错误处理；`GlmProvider::chat_streaming()` override 实现 |
 | `openai.rs` | OpenAI Chat Completions API adapter |
 | `anthropic.rs` | Anthropic API adapter（当前为 stub） |
+| `provider.rs` | Provider trait：持有配置（URL、credentials、HTTP client），执行 HTTP 请求/响应周期；配置访问器同步，`send`/`send_streaming` 异步；`ProviderError`（Reqwest）；`SseStream`（mpsc channel） |
+| `protocol.rs` | ChatProtocol trait：请求/响应协议转换，负责在 internal unified types 和具体 LLM API wire format 之间互转；标识方法同步，`build_request`/`parse_response`/`decorate_headers` 同步，`parse_sse_stream` 异步 streaming；`ProtocolError`、`IncomingSseStream`、`OutgoingEventStream` |
 | `stub.rs` | 测试用固定响应 Provider |
 | `volcengine.rs` | VolcEngine（火山方舟）Chat Completions API adapter。`provider_display_name` 返回 "VolcEngine"；`fetch_model_list` GET `/models`（火山方舟格式），按 `domain=="LLM"` 且 `status` 非 Shutdown/Retiring 过滤，`reasoning` 保守设为 false。 |
 | `deepseek.rs` | DeepSeek Chat Completions API adapter。`provider_display_name` 返回 "DeepSeek"；`fetch_model_list` GET `/models`（OpenAI 兼容格式），按 `status` 非 deprecated/shutdown 过滤，`reasoning` 保守设为 false。 |

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -9,6 +9,8 @@ pub mod minimax;
 pub mod model_cache;
 pub mod model_info;
 pub mod openai;
+pub mod protocol;
+pub mod provider;
 pub mod retry;
 pub mod stub;
 pub mod types;
@@ -29,8 +31,13 @@ pub use minimax::MiniMaxProvider;
 pub use model_cache::{CacheEntry, ModelCache};
 pub use model_info::{InputType, ModelInfo};
 pub use openai::OpenAIProvider;
-pub use stub::StubProvider;
+pub use protocol::ChatProtocol;
+pub use provider::Provider;
 pub use volcengine::VolcEngineProvider;
+
+pub use stub::StubProvider;
+
+pub use types::{InternalRequest, ProtocolId};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -241,6 +248,7 @@ impl LLMRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::stub::StubProvider;
 
     #[test]
     fn test_message_serde() {
@@ -276,7 +284,8 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_model_list_default_returns_model_not_found() {
         let provider = StubProvider::new();
-        let result = provider.fetch_model_list("fake-token").await;
+        let result: Result<Vec<crate::llm::ModelInfo>, LLMError> =
+            provider.fetch_model_list("fake-token").await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, LLMError::ModelNotFound(_)));

--- a/src/llm/protocol.rs
+++ b/src/llm/protocol.rs
@@ -1,0 +1,146 @@
+//! LLM ChatProtocol abstraction — request building, response parsing, SSE parsing.
+//!
+//! This module defines the [`ChatProtocol`] trait, which is responsible for
+//! **protocol-level** transformations between the internal unified types and
+//! the wire format of a specific LLM API protocol (OpenAI, Anthropic, GLM, etc.).
+//!
+//! Specifically, a `ChatProtocol` implementation handles:
+//! - Serialising an [`InternalRequest`][crate::llm::InternalRequest] into a
+//!   protocol-specific HTTP request body (`serde_json::Value`).
+//! - Deserialising a protocol-specific HTTP response body into an
+//!   [`InternalResponse`][crate::llm::InternalResponse].
+//! - Decorating an HTTP request with protocol-specific headers.
+//! - Parsing raw SSE event streams into structured [`StreamEvent`][crate::llm::StreamEvent] values.
+//!
+//! One `ChatProtocol` exists per protocol variant (e.g. OpenAI, Anthropic).
+//! The appropriate protocol is selected at runtime by matching the
+//! [`ProtocolId`][crate::llm::ProtocolId] returned by a [`Provider`][crate::llm::Provider].
+
+use async_trait::async_trait;
+use futures::Stream;
+use reqwest::header::HeaderMap;
+use std::pin::Pin;
+
+use crate::llm::types::{
+    InternalRequest, InternalResponse, ProtocolId, RawSseChunk, SseStateMachine, StreamEvent,
+};
+
+/// Errors that can occur during protocol-level operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    /// Request serialization failed.
+    #[error("failed to serialise request: {0}")]
+    RequestBuild(#[from] serde_json::Error),
+    /// Response parsing failed.
+    #[error("failed to parse response: {0}")]
+    ResponseParse(String),
+    /// Header decoration failed.
+    #[error("failed to decorate headers: {0}")]
+    HeaderDecorate(String),
+    /// SSE stream parsing failed.
+    #[error("SSE stream parsing error: {0}")]
+    SseParse(String),
+}
+
+/// Result type alias for protocol operations.
+pub type Result<T> = std::result::Result<T, ProtocolError>;
+
+/// Incoming stream type — a [`Stream`] of [`RawSseChunk`] emitted by a provider.
+pub type IncomingSseStream = Pin<Box<dyn Stream<Item = RawSseChunk> + Send>>;
+
+/// Outgoing stream type — a [`Stream`] of parsed [`StreamEvent`] values.
+pub type OutgoingEventStream =
+    Pin<Box<dyn Stream<Item = std::result::Result<StreamEvent, ProtocolError>> + Send>>;
+
+/// LLM ChatProtocol trait — request/response protocol conversion.
+///
+/// Implementors translate between the internal unified types
+/// (`InternalRequest`, `InternalResponse`, `StreamEvent`) and the
+/// wire format of a specific LLM API protocol.
+///
+/// # Design contract
+///
+/// - All identifier/path accessors are **synchronous**.
+/// - `build_request`, `parse_response`, and `decorate_headers` are **synchronous**
+///   because they only perform serialisation / header manipulation with no I/O.
+/// - `create_sse_machine` is a **factory** that returns a fresh state machine.
+/// - `parse_sse_stream` is **asynchronous** and streaming; it consumes an
+///   [`IncomingSseStream`] (from a [`Provider`][crate::llm::Provider]'s
+///   [`send_streaming`][crate::llm::Provider::send_streaming]) and produces a
+///   stream of parsed [`StreamEvent`][crate::llm::StreamEvent] values.
+#[async_trait]
+pub trait ChatProtocol: Send + Sync {
+    // ── Identity ────────────────────────────────────────────────────────────
+
+    /// Returns the protocol identifier for this implementation.
+    ///
+    /// The returned value must match one of the [`ProtocolId`][crate::llm::ProtocolId]
+    /// values advertised by the [`Provider`][crate::llm::Provider] that hosts
+    /// this protocol.
+    fn protocol_id(&self) -> &ProtocolId;
+
+    /// Returns the API endpoint path for chat completions.
+    ///
+    /// This path is appended to the provider's `base_url` to form the full URL.
+    /// Example: `"/chat/completions"`.
+    fn path(&self) -> &str;
+
+    // ── Request / Response ──────────────────────────────────────────────────
+
+    /// Builds a protocol-specific HTTP request body from an internal request.
+    ///
+    /// The caller is responsible for calling
+    /// [`Provider::supported_protocols`][crate::llm::Provider::supported_protocols]
+    /// to obtain the protocol ID, then selecting the matching `ChatProtocol`
+    /// from the registry before invoking this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::RequestBuild`] if `request` cannot be serialised.
+    fn build_request(&self, request: &InternalRequest) -> Result<serde_json::Value>;
+
+    /// Parses a protocol-specific HTTP response body into an internal response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::ResponseParse`] if the response body cannot be
+    /// parsed into an [`InternalResponse`][crate::llm::InternalResponse].
+    fn parse_response(&self, body: serde_json::Value) -> Result<InternalResponse>;
+
+    // ── Header decoration ───────────────────────────────────────────────────
+
+    /// Decorates an HTTP request header map with protocol-specific headers.
+    ///
+    /// This method is called by the framework before sending any request.
+    /// Implementors may add protocol-specific headers (e.g. `Content-Type`,
+    /// custom vendor headers) to the provided map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProtocolError::HeaderDecorate`] if a header cannot be added.
+    fn decorate_headers(&self, headers: &mut HeaderMap) -> Result<()>;
+
+    // ── SSE parsing ────────────────────────────────────────────────────────
+
+    /// Creates a fresh SSE state machine for parsing a streaming response.
+    ///
+    /// A new state machine is required for each streaming request to ensure
+    /// no residual state leaks between unrelated streams.
+    fn create_sse_machine(&self) -> SseStateMachine;
+
+    /// Parses a stream of raw SSE chunks into a stream of structured events.
+    ///
+    /// This method consumes an [`IncomingSseStream`] (typically obtained from
+    /// [`Provider::send_streaming`][crate::llm::Provider::send_streaming]) and
+    /// returns an [`OutgoingEventStream`] that yields one [`StreamEvent`] per
+    /// parsed SSE event.  Internally it uses an [`SseStateMachine`] (created
+    /// via [`create_sse_machine`][ChatProtocol::create_sse_machine]) to
+    /// track incremental state.
+    ///
+    /// The stream terminates when the incoming SSE stream is exhausted.
+    async fn parse_sse_stream(
+        &self,
+        incoming: IncomingSseStream,
+        machine: SseStateMachine,
+    ) -> OutgoingEventStream;
+}

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -1,0 +1,236 @@
+//! LLM Provider abstraction — pure configuration and HTTP send interface.
+//!
+//! This module defines the [`Provider`] trait, which is the **sole interface**
+//! through which the LLM framework interacts with a concrete provider
+//! implementation (OpenAI, Anthropic, GLM, DeepSeek, etc.).
+//!
+//! A `Provider` is responsible only for **carrying configuration** (URL, credentials,
+//! HTTP client) and for **performing the actual HTTP request/response cycle**.
+//! All request building (`build_request`) and response parsing (`parse_response`,
+//! `parse_sse`) are handled by a [`ChatProtocol`][crate::llm::ChatProtocol]
+//! implementation, which is selected based on the `ProtocolId` returned by
+//! `supported_protocols()`.
+
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use tokio::sync::mpsc;
+
+use crate::llm::types::{InternalRequest, InternalResponse, ProtocolId, RawSseChunk};
+
+/// Errors that can occur during provider-level HTTP operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    /// HTTP request failed (network error, TLS error, timeout, etc.).
+    #[error("HTTP request failed: {0}")]
+    Reqwest(#[from] reqwest::Error),
+}
+
+/// Result type alias for provider operations.
+pub type Result<T> = std::result::Result<T, ProviderError>;
+
+/// SSE stream — a channel that delivers raw SSE chunks to the caller.
+///
+/// The channel is owned by the caller; the provider implementation sends
+/// [`RawSseChunk`] values into it until the response is fully consumed or
+/// an error occurs, at which point the channel is closed.
+pub type SseStream = mpsc::Receiver<RawSseChunk>;
+
+/// LLM provider trait — configuration + HTTP send.
+///
+/// Implementors hold the credentials, base URL, and HTTP client for
+/// a specific LLM API provider.  The trait is intentionally narrow: it
+/// does **not** know about model lists, retries, or fallback strategies.
+///
+/// # Design contract
+///
+/// - All configuration accessors (`id`, `base_url`, `api_key`, …) are **synchronous**
+///   because they only return values stored in `Self`.
+/// - `send` and `send_streaming` are **asynchronous** because they perform I/O.
+/// - `supported_protocols` returns the set of protocol IDs this provider can serve.
+///   The framework selects the matching [`ChatProtocol`][crate::llm::ChatProtocol]
+///   from the registry and calls `build_request` before invoking `send`.
+#[async_trait]
+pub trait Provider: Send + Sync {
+    // ── Configuration accessors ─────────────────────────────────────────────
+
+    /// Returns the unique identifier for this provider (e.g. `"openai"`, `"anthropic"`).
+    fn id(&self) -> &str;
+
+    /// Returns the base URL of the provider's API endpoint
+    /// (e.g. `"https://api.openai.com/v1"`).
+    fn base_url(&self) -> &str;
+
+    /// Returns the API key used for authentication.
+    fn api_key(&self) -> &str;
+
+    /// Returns the set of protocol IDs this provider supports.
+    fn supported_protocols(&self) -> &[ProtocolId];
+
+    /// Returns a reference to the underlying HTTP client.
+    fn http_client(&self) -> &Client;
+
+    /// Returns additional HTTP headers that should be sent with every request.
+    ///
+    /// This is additive to the authentication headers already managed internally.
+    fn default_headers(&self) -> &HeaderMap;
+
+    // ── Behaviour: HTTP send ─────────────────────────────────────────────────
+
+    /// Sends a structured request to the provider and returns the parsed response.
+    ///
+    /// The caller is responsible for calling
+    /// [`ChatProtocol::build_request`][crate::llm::ChatProtocol::build_request]
+    /// first to convert the [`InternalRequest`][crate::llm::InternalRequest] into a
+    /// `serde_json::Value` that is suitable for the provider's HTTP endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError`] if the HTTP request fails at the network or
+    /// protocol layer (TLS, redirect limits, non-success status codes, etc.).
+    async fn send(
+        &self,
+        request: InternalRequest,
+        body: serde_json::Value,
+    ) -> Result<InternalResponse>;
+
+    /// Sends a streaming request and returns an SSE event stream.
+    ///
+    /// The caller is responsible for calling
+    /// [`ChatProtocol::build_request`][crate::llm::ChatProtocol::build_request]
+    /// first, passing `stream: true` in the [`InternalRequest`][crate::llm::InternalRequest].
+    ///
+    /// The returned [`SseStream`] channel yields one [`RawSseChunk`] per
+    /// SSE event received from the wire.  The caller (typically
+    /// [`ChatProtocol::parse_sse_stream`][crate::llm::ChatProtocol::parse_sse_stream])
+    /// is responsible for converting these chunks into structured
+    /// [`StreamEvent`][crate::llm::StreamEvent] values.
+    ///
+    /// The channel is closed automatically when the response finishes or
+    /// when an error occurs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError`] if the underlying HTTP request cannot be issued.
+    /// Note that stream-level errors (malformed SSE, parse errors) are reported
+    /// by closing the channel and **not** as a top-level error.
+    async fn send_streaming(
+        &self,
+        request: InternalRequest,
+        body: serde_json::Value,
+    ) -> Result<SseStream>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::llm::types::{InternalMessage, InternalRequest, ProtocolId};
+
+    // ── ProtocolId tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_protocol_id_from_str() {
+        let id = ProtocolId::from("openai");
+        assert_eq!(id.as_str(), "openai");
+        assert_eq!(format!("{}", id), "openai");
+    }
+
+    #[test]
+    fn test_protocol_id_from_string() {
+        let id = ProtocolId::from(String::from("anthropic"));
+        assert_eq!(id.as_str(), "anthropic");
+        assert_eq!(format!("{}", id), "anthropic");
+    }
+
+    #[test]
+    fn test_protocol_id_display() {
+        let id = ProtocolId::new("test-provider");
+        assert_eq!(format!("{}", id), "test-provider");
+    }
+
+    #[test]
+    fn test_protocol_id_clone() {
+        let id = ProtocolId::new("clone-me");
+        assert_eq!(id.clone(), id);
+    }
+
+    #[test]
+    fn test_protocol_id_hash() {
+        use std::collections::HashSet;
+        let id1 = ProtocolId::new("hashed");
+        let id2 = ProtocolId::new("hashed");
+        let mut set = HashSet::new();
+        set.insert(id1);
+        set.insert(id2);
+        assert_eq!(set.len(), 1);
+    }
+
+    // ── InternalRequest serde roundtrip tests ────────────────────────────────
+
+    #[test]
+    fn test_internal_request_basic_roundtrip() {
+        let req = InternalRequest {
+            model: "gpt-4".into(),
+            messages: vec![InternalMessage {
+                role: "user".into(),
+                content: "hello".into(),
+            }],
+            temperature: 0.7,
+            max_tokens: Some(100),
+            stream: false,
+            extra_body: serde_json::Map::new(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: InternalRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(req.model, parsed.model);
+        assert_eq!(req.messages.len(), parsed.messages.len());
+        assert_eq!(req.temperature, parsed.temperature);
+        assert_eq!(req.max_tokens, parsed.max_tokens);
+        assert_eq!(req.stream, parsed.stream);
+    }
+
+    #[test]
+    fn test_internal_request_default_temperature_and_stream() {
+        let json = r#"{"model":"test","messages":[]}"#;
+        let req: InternalRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.temperature, 0.0);
+        assert!(!req.stream);
+    }
+
+    #[test]
+    fn test_internal_request_extra_body_roundtrip() {
+        use serde_json::Value;
+        let mut extra = serde_json::Map::new();
+        extra.insert("top_p".into(), Value::from(0.9));
+        extra.insert("presence_penalty".into(), Value::from(0.1));
+
+        let req = InternalRequest {
+            model: "test".into(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: true,
+            extra_body: extra.clone(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: InternalRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.extra_body.get("top_p"), Some(&Value::from(0.9)));
+        assert_eq!(
+            parsed.extra_body.get("presence_penalty"),
+            Some(&Value::from(0.1))
+        );
+    }
+
+    #[test]
+    fn test_internal_request_empty_extra_body_not_serialized() {
+        let req = InternalRequest {
+            model: "test".into(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("extra_body"));
+    }
+}

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -2,6 +2,9 @@
 //!
 //! This module defines the unified type layer used across all Providers and Protocols.
 
+use std::fmt::{self, Display};
+use std::hash::Hash;
+
 use serde::{Deserialize, Serialize};
 
 /// Content block type classification.
@@ -194,6 +197,87 @@ pub struct RawSseChunk {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Protocol identity and request types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Protocol identifier (e.g., "openai", "anthropic").
+///
+/// This is a newtype wrapper around `String` used to identify which
+/// protocol a `ChatProtocol` implementation targets.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ProtocolId(String);
+
+impl ProtocolId {
+    /// Creates a new `ProtocolId` from a string value.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying protocol identifier string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for ProtocolId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for ProtocolId {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<String> for ProtocolId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// A single message in an `InternalRequest`.
+///
+/// Contains the role and content of a chat message used internally
+/// by Protocol implementations when building provider requests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InternalMessage {
+    /// The role of the message sender (e.g., "user", "assistant").
+    pub role: String,
+    /// The content of the message.
+    pub content: String,
+}
+
+/// Internal request structure used by `ChatProtocol` implementations.
+///
+/// This is the protocol-level representation of a chat completion request,
+/// distinct from any provider-specific request types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InternalRequest {
+    /// The model identifier to use for this request.
+    pub model: String,
+    /// Ordered list of chat messages.
+    pub messages: Vec<InternalMessage>,
+    /// Sampling temperature (default 0.0).
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
+    /// Maximum number of tokens to generate (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Whether to stream responses (default false).
+    #[serde(default)]
+    pub stream: bool,
+    /// Additional provider-specific parameters.
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra_body: serde_json::Map<String, serde_json::Value>,
+}
+
+fn default_temperature() -> f32 {
+    0.0
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // SSE state machine for stream parsing
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -373,4 +457,6 @@ mod tests {
         assert_eq!(sm.pending_thinking, sm2.pending_thinking);
         assert_eq!(sm.pending_signature, sm2.pending_signature);
     }
+
+    // ── ProtocolId tests ──────────────────────────────────────────────────────
 }


### PR DESCRIPTION
## Summary

定义 LLM 多 Provider 架构的两个核心 trait（Issue 2/3），在 #558 核心类型基础上：

- **Provider trait** (`src/llm/provider.rs`) — 纯配置 trait，唯一行为是 HTTP 发送（`send`/`send_streaming`）
- **ChatProtocol trait** (`src/llm/protocol.rs`) — 协议 trait（请求序列化/响应解析/SSE 解析）
- **辅助类型** `ProtocolId`、`InternalMessage`、`InternalRequest` — 在 `types.rs` 中新增

## Changes

- `src/llm/types.rs` — 新增 `ProtocolId`（newtype wrapper）、`InternalMessage`、`InternalRequest`
- `src/llm/provider.rs` — `Provider` trait（id/base_url/api_key/supported_protocols/http_client/default_headers/send/send_streaming）
- `src/llm/protocol.rs` — `ChatProtocol` trait（protocol_id/path/build_request/parse_response/decorate_headers/create_sse_machine/parse_sse_stream）
- `src/llm/mod.rs` — re-export 新模块和类型
- `src/llm/SPEC.md` — 新增 Provider 和 ChatProtocol 接口描述

## Test

- ProtocolId 构造/Display/Clone/Hash 测试
- InternalRequest serde roundtrip 测试
- cargo test 全部通过

Closes #554

Source: issue #554
Type: feat