### PR TITLE
feat(llm): add GLM protocol implementation with tests

### DIFF
--- a/src/llm/protocol/glm.rs
+++ b/src/llm/protocol/glm.rs
@@ -1,0 +1,260 @@
+//! GLM (Zhipu AI) ChatProtocol implementation.
+//!
+//! GLM uses a wire format similar to OpenAI Chat Completions but has some
+//! notable differences:
+//!   - `reasoning_content` field carries chain-of-thought / thinking content
+//!   - Error responses use a nested `{error: {code, message}}` structure
+//!   - SSE streaming prioritises `reasoning_content` delta over `content` delta
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+
+use crate::llm::types::{
+    ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
+    RawContentBlock, RawUsage, SseStateMachine, StreamEvent,
+};
+
+use crate::llm::protocol::{
+    ChatProtocol, IncomingSseStream, OutgoingEventStream, ProtocolError, Result,
+};
+
+const PATH: &str = "/api/paas/v4/chat/completions";
+
+/// GLM protocol implementation.
+#[derive(Debug, Clone)]
+pub struct GlmProtocol {
+    id: ProtocolId,
+}
+
+impl GlmProtocol {
+    pub fn new() -> Self {
+        Self {
+            id: ProtocolId::new("glm"),
+        }
+    }
+}
+
+impl Default for GlmProtocol {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn build_message(msg: &InternalMessage) -> serde_json::Value {
+    serde_json::json!({
+        "role": msg.role,
+        "content": msg.content,
+    })
+}
+
+#[async_trait]
+impl ChatProtocol for GlmProtocol {
+    fn protocol_id(&self) -> &ProtocolId {
+        &self.id
+    }
+    fn path(&self) -> &str {
+        PATH
+    }
+
+    fn build_request(&self, request: &InternalRequest) -> Result<serde_json::Value> {
+        // GLM uses the same request format as OpenAI.
+        let mut body = serde_json::json!({
+            "model": request.model,
+            "messages": request.messages.iter().map(build_message).collect::<Vec<_>>(),
+            "temperature": request.temperature,
+            "stream": request.stream,
+        });
+
+        if let Some(max_tokens) = request.max_tokens {
+            body.as_object_mut()
+                .unwrap()
+                .insert("max_tokens".to_string(), serde_json::json!(max_tokens));
+        }
+
+        for (key, value) in &request.extra_body {
+            body.as_object_mut()
+                .unwrap()
+                .insert(key.clone(), value.clone());
+        }
+
+        Ok(body)
+    }
+
+    fn parse_response(&self, body: serde_json::Value) -> Result<InternalResponse> {
+        // GLM may return `reasoning_content` alongside `content`.
+        // Prefer `content` if present; fall back to `reasoning_content` if not.
+        let choices = body
+            .get("choices")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|choice| choice.get("message"));
+
+        let text = choices
+            .and_then(|msg| msg.get("content"))
+            .and_then(|c| c.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        let reasoning = choices
+            .and_then(|msg| msg.get("reasoning_content"))
+            .and_then(|c| c.as_str())
+            .map(|s| s.to_string());
+
+        let finish_reason = body
+            .get("choices")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|choice| choice.get("finish_reason"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let usage = parse_usage(&body);
+
+        let content_blocks = match (text, reasoning) {
+            (Some(t), _) => vec![RawContentBlock::Text(t)],
+            (_, Some(r)) => vec![RawContentBlock::Thinking(r)],
+            (None, None) => vec![],
+        };
+
+        Ok(InternalResponse {
+            content_blocks,
+            usage,
+            finish_reason,
+        })
+    }
+
+    fn decorate_headers(&self, headers: &mut HeaderMap) -> Result<()> {
+        // GLM uses the same Bearer token format as OpenAI.
+        let api_key = std::env::var("GLM_API_KEY").unwrap_or_default();
+        let bearer = format!("Bearer {api_key}");
+        let auth_value = HeaderValue::from_str(&bearer)
+            .map_err(|e| ProtocolError::HeaderDecorate(e.to_string()))?;
+        headers.insert(AUTHORIZATION, auth_value);
+
+        let ct_value = HeaderValue::from_static("application/json");
+        headers.insert(CONTENT_TYPE, ct_value);
+
+        Ok(())
+    }
+
+    fn create_sse_machine(&self) -> SseStateMachine {
+        SseStateMachine::new()
+    }
+
+    async fn parse_sse_stream(
+        &self,
+        incoming: IncomingSseStream,
+        _machine: SseStateMachine,
+    ) -> OutgoingEventStream {
+        Box::pin(async_stream::try_stream! {
+            let mut stream = incoming;
+            let mut current_block_index: Option<usize> = None;
+            let mut current_block_type: Option<ContentBlockType> = None;
+
+            while let Some(chunk) = stream.next().await {
+                let data = chunk.data.trim();
+
+                if data.is_empty() || data == "[DONE]" {
+                    break;
+                }
+
+                let parsed: serde_json::Value = match serde_json::from_str(data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                // GLM SSE delta is in choices[0].delta.
+                let delta = match parsed
+                    .get("choices")
+                    .and_then(|v| v.as_array())
+                    .and_then(|arr| arr.first())
+                    .and_then(|c| c.get("delta"))
+                {
+                    Some(d) => d,
+                    None => continue,
+                };
+
+                // GLM may emit `reasoning_content` delta or `content` delta.
+                // Prefer `reasoning_content` first, then fall back to `content`.
+                let (text_delta, thinking_delta) = (
+                    delta.get("content").and_then(|v| v.as_str()),
+                    delta.get("reasoning_content").and_then(|v| v.as_str()),
+                );
+
+                let content_to_yield = thinking_delta.or(text_delta);
+
+                if let Some(text) = content_to_yield {
+                    let (idx, btype) = match current_block_index {
+                        Some(i) => (i, current_block_type.unwrap()),
+                        None => {
+                            // First delta — emit BlockStart.
+                            let btype = if thinking_delta.is_some() {
+                                ContentBlockType::Thinking
+                            } else {
+                                ContentBlockType::Text
+                            };
+                            let idx = 0;
+                            current_block_index = Some(idx);
+                            current_block_type = Some(btype);
+                            yield StreamEvent::BlockStart { index: idx, block_type: btype };
+                            (idx, btype)
+                        }
+                    };
+
+                    let delta = match btype {
+                        ContentBlockType::Thinking => {
+                            ContentDelta::Thinking { thinking: text.to_string() }
+                        }
+                        _ => ContentDelta::Text { text: text.to_string() },
+                    };
+
+                    yield StreamEvent::BlockDelta { index: idx, delta };
+                }
+            }
+
+            if let Some(idx) = current_block_index {
+                if let Some(btype) = current_block_type {
+                    yield StreamEvent::BlockEnd { index: idx, block_type: btype };
+                }
+            }
+
+            yield StreamEvent::MessageEnd {
+                usage: None,
+                finish_reason: Some("stop".to_string()),
+            };
+        })
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn parse_usage(body: &serde_json::Value) -> RawUsage {
+    let usage_obj = body.get("usage");
+
+    let prompt_tokens = usage_obj
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let completion_tokens = usage_obj
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    let total_tokens = usage_obj
+        .and_then(|u| u.get("total_tokens"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+
+    RawUsage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    include!("glm_test.rs");
+}

--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -1,0 +1,277 @@
+use super::*;
+use crate::llm::types::{InternalMessage, RawSseChunk};
+
+fn make_request() -> InternalRequest {
+    InternalRequest {
+        model: "glm-4".to_string(),
+        messages: vec![InternalMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+        }],
+        temperature: 0.7,
+        max_tokens: Some(256),
+        stream: false,
+        extra_body: Default::default(),
+    }
+}
+
+// ── build_request tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_build_request_basic() {
+    let proto = GlmProtocol::new();
+    let request = make_request();
+    let body = proto.build_request(&request).unwrap();
+
+    assert_eq!(body.get("model").unwrap(), "glm-4");
+    assert!(body.get("messages").unwrap().is_array());
+    let temp_val = body.get("temperature").unwrap().as_f64().unwrap();
+    assert!((temp_val - 0.7).abs() < 1e-6);
+    assert_eq!(body.get("max_tokens").unwrap(), &serde_json::json!(256));
+    assert_eq!(body.get("stream").unwrap(), &serde_json::json!(false));
+}
+
+#[test]
+fn test_build_request_stream() {
+    let proto = GlmProtocol::new();
+    let mut request = make_request();
+    request.stream = true;
+    let body = proto.build_request(&request).unwrap();
+    assert_eq!(body.get("stream").unwrap(), &serde_json::json!(true));
+}
+
+// ── parse_response tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_parse_response_normal() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": { "content": "GLM reply" },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15
+        }
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == "GLM reply"));
+    assert_eq!(resp.usage.prompt_tokens, 10);
+    assert_eq!(resp.usage.completion_tokens, 5);
+    assert_eq!(resp.usage.total_tokens, Some(15));
+    assert_eq!(resp.finish_reason, Some("stop".to_string()));
+}
+
+#[test]
+fn test_parse_response_reasoning_content() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": "Let me think step by step..."
+            },
+            "finish_reason": "stop"
+        }]
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(
+        matches!(resp.content_blocks[0], RawContentBlock::Thinking(ref s) if s == "Let me think step by step...")
+    );
+}
+
+#[test]
+fn test_parse_response_reasoning_content_prefers_text() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "Final answer",
+                "reasoning_content": "Thinking trace"
+            },
+            "finish_reason": "stop"
+        }]
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == "Final answer"));
+}
+
+#[test]
+fn test_parse_response_error_format() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "error": {
+            "code": "invalid_api_key",
+            "message": "API key is invalid"
+        }
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert!(resp.content_blocks.is_empty());
+    assert_eq!(resp.usage.prompt_tokens, 0);
+    assert_eq!(resp.usage.completion_tokens, 0);
+    assert!(resp.finish_reason.is_none());
+}
+
+#[test]
+fn test_parse_response_empty_choices() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({ "choices": [] });
+    let resp = proto.parse_response(body).unwrap();
+    assert!(resp.content_blocks.is_empty());
+    assert_eq!(resp.usage.prompt_tokens, 0);
+}
+
+// ── decorate_headers tests ────────────────────────────────────────────────
+
+#[test]
+fn test_decorate_headers_bearer() {
+    std::env::remove_var("GLM_API_KEY");
+    let proto = GlmProtocol::new();
+    let mut headers = HeaderMap::new();
+    proto.decorate_headers(&mut headers).unwrap();
+
+    let auth = headers.get(AUTHORIZATION).unwrap();
+    assert!(auth.to_str().unwrap().starts_with("Bearer "));
+}
+
+#[test]
+fn test_decorate_headers_content_type() {
+    let proto = GlmProtocol::new();
+    let mut headers = HeaderMap::new();
+    proto.decorate_headers(&mut headers).unwrap();
+
+    assert_eq!(
+        headers.get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+        "application/json"
+    );
+}
+
+// ── SSE parsing tests ──────────────────────────────────────────────────────
+
+fn make_sse_chunk(data: &str) -> RawSseChunk {
+    RawSseChunk {
+        event_type: "message".to_string(),
+        data: data.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn test_parse_sse_reasoning_content_delta() {
+    let proto = GlmProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(r#"{"choices":[{"delta":{"reasoning_content":"step 1"}}]}"#),
+        make_sse_chunk(r#"{"choices":[{"delta":{"reasoning_content":"step 2"}}]}"#),
+        make_sse_chunk("[DONE]"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    let evt1 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt1,
+        StreamEvent::BlockStart {
+            block_type: ContentBlockType::Thinking,
+            ..
+        }
+    ));
+
+    let evt2 = stream.next().await.unwrap().unwrap();
+    assert!(
+        matches!(evt2, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == "step 1")
+    );
+
+    let evt3 = stream.next().await.unwrap().unwrap();
+    assert!(
+        matches!(evt3, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == "step 2")
+    );
+
+    let evt4 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt4,
+        StreamEvent::BlockEnd {
+            block_type: ContentBlockType::Thinking,
+            ..
+        }
+    ));
+
+    let evt5 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt5, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_parse_sse_content_delta_fallback() {
+    let proto = GlmProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(r#"{"choices":[{"delta":{"content":"Hello"}}]}"#),
+        make_sse_chunk(r#"{"choices":[{"delta":{"content":" world"}}]}"#),
+        make_sse_chunk("[DONE]"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    let evt1 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt1,
+        StreamEvent::BlockStart {
+            block_type: ContentBlockType::Text,
+            ..
+        }
+    ));
+
+    let evt2 = stream.next().await.unwrap().unwrap();
+    assert!(
+        matches!(evt2, StreamEvent::BlockDelta { delta: ContentDelta::Text { text: s }, .. } if s == "Hello")
+    );
+
+    let evt3 = stream.next().await.unwrap().unwrap();
+    assert!(
+        matches!(evt3, StreamEvent::BlockDelta { delta: ContentDelta::Text { text: s }, .. } if s == " world")
+    );
+
+    let evt4 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt4,
+        StreamEvent::BlockEnd {
+            block_type: ContentBlockType::Text,
+            ..
+        }
+    ));
+
+    let evt5 = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt5, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_parse_sse_empty_chunk_breaks() {
+    let proto = GlmProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(""),
+        make_sse_chunk("[DONE]"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
+}


### PR DESCRIPTION
- Add `GlmProtocol` implementing `ChatProtocol` for Zhipu AI GLM series
- Support `reasoning_content` field for chain-of-thought
- SSE streaming prioritizes `reasoning_content` delta over `content` delta
- Unit tests for build_request, parse_response, decorate_headers, SSE streaming
- Tests extracted to `glm_test.rs` via `include!` to stay under 500-line limit

Part of #549 (GLM was split out from #563 due to file size limit)