### PR TITLE
feat(renderer): define Renderer trait and FeishuRenderer implementation

### DIFF
--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -119,7 +119,12 @@ async fn test_processor_chain_bypass_no_registry() {
 async fn test_processor_chain_bypass_empty_registry() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(&config, None));
-    let registry = ProcessorChainLoader::load(&ProcessorChainConfig { inbound: vec![] }).unwrap();
+    let (registry, _renderer) = ProcessorChainLoader::load(&ProcessorChainConfig {
+        inbound: vec![],
+        outbound: vec![],
+        renderer: None,
+    })
+    .unwrap();
     let gw = crate::gateway::Gateway::with_processor_registry(
         config,
         Arc::clone(&sm),
@@ -149,8 +154,10 @@ async fn test_processor_chain_applies_processors() {
             dir: tmp.path().to_path_buf(),
             retention_days: 7,
         }],
+        outbound: vec![],
+        renderer: None,
     };
-    let registry = ProcessorChainLoader::load(&proc_config).unwrap();
+    let (registry, _renderer) = ProcessorChainLoader::load(&proc_config).unwrap();
     let gw = crate::gateway::Gateway::with_processor_registry(
         config,
         Arc::clone(&sm),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod mode;
 pub mod permission;
 pub mod platform;
 pub mod processor_chain;
+pub mod renderer;
 pub mod session;
 pub mod skills;
 pub mod system_prompt;

--- a/src/processor_chain/loader.rs
+++ b/src/processor_chain/loader.rs
@@ -9,6 +9,9 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 
+use crate::renderer::feishu::FeishuRenderer;
+use crate::renderer::{RenderedOutput, Renderer};
+
 use super::dsl_parser::DslParser;
 use super::error::ProcessError;
 use super::markdown_normalizer::MarkdownNormalizer;
@@ -30,6 +33,21 @@ pub struct ProcessorChainConfig {
     /// Ordered list of outbound processor configurations.
     #[serde(default)]
     pub outbound: Vec<ProcessorConfig>,
+
+    /// Renderer configuration. When present, a [`Renderer`] is returned
+    /// from [`ProcessorChainLoader::load`].
+    #[serde(default)]
+    pub renderer: Option<RendererConfig>,
+}
+
+/// Configuration for a platform renderer.
+///
+/// Each variant corresponds to one concrete [`Renderer`] implementation.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RendererConfig {
+    /// Feishu platform renderer.
+    Feishu,
 }
 
 /// Configuration for a single processor.
@@ -74,7 +92,8 @@ fn default_retention_days() -> u32 {
     7
 }
 
-/// Loads a [`ProcessorRegistry`] from a [`ProcessorChainConfig`].
+/// Loads a [`ProcessorRegistry`] and optionally a [`Renderer`] from a
+/// [`ProcessorChainConfig`].
 ///
 /// Processors are instantiated according to their [`ProcessorConfig`] variant,
 /// then registered to the registry in the order they appear in the config.
@@ -83,14 +102,17 @@ fn default_retention_days() -> u32 {
 pub struct ProcessorChainLoader;
 
 impl ProcessorChainLoader {
-    /// Constructs a [`ProcessorRegistry`] from `config`.
+    /// Constructs a [`ProcessorRegistry`] and optional [`Renderer`] from `config`.
     ///
     /// Returns an empty registry when `config.inbound` is empty.
+    /// The renderer is `None` when `config.renderer` is `None`.
     ///
     /// # Errors
     ///
     /// Returns [`ProcessError::ChainFailed`] if a processor cannot be constructed.
-    pub fn load(config: &ProcessorChainConfig) -> Result<ProcessorRegistry, ProcessError> {
+    pub fn load(
+        config: &ProcessorChainConfig,
+    ) -> Result<(ProcessorRegistry, Option<Arc<dyn Renderer>>), ProcessError> {
         let mut registry = ProcessorRegistry::new();
         for processor_config in &config.inbound {
             let processor = Self::build_processor(processor_config)?;
@@ -100,7 +122,17 @@ impl ProcessorChainLoader {
             let processor = Self::build_processor(processor_config)?;
             registry.register(processor);
         }
-        Ok(registry)
+
+        let renderer = Self::build_renderer(config.renderer.as_ref());
+        Ok((registry, renderer))
+    }
+
+    /// Builds a renderer from its configuration, or `None` if no renderer is configured.
+    fn build_renderer(config: Option<&RendererConfig>) -> Option<Arc<dyn Renderer>> {
+        match config {
+            Some(RendererConfig::Feishu) => Some(Arc::new(FeishuRenderer::new())),
+            None => None,
+        }
     }
 
     /// Builds a concrete processor from its configuration variant.
@@ -136,10 +168,12 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![],
             outbound: vec![],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 0);
         assert_eq!(registry.outbound_len(), 0);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -152,9 +186,11 @@ mod tests {
                 retention_days: 7,
             }],
             outbound: vec![],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 1);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -162,9 +198,11 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![ProcessorConfig::MessageCleaner],
             outbound: vec![],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 1);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -172,9 +210,11 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![ProcessorConfig::MarkdownNormalizer],
             outbound: vec![],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 1);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -191,9 +231,11 @@ mod tests {
                 ProcessorConfig::MarkdownNormalizer,
             ],
             outbound: vec![],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 3);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -201,9 +243,11 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![],
             outbound: vec![ProcessorConfig::DslParser],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.outbound_len(), 1);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -211,9 +255,11 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![],
             outbound: vec![ProcessorConfig::MarkdownToCard],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.outbound_len(), 1);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -221,10 +267,12 @@ mod tests {
         let config = ProcessorChainConfig {
             inbound: vec![ProcessorConfig::MessageCleaner],
             outbound: vec![ProcessorConfig::DslParser, ProcessorConfig::MarkdownToCard],
+            renderer: None,
         };
-        let registry = ProcessorChainLoader::load(&config).unwrap();
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
         assert_eq!(registry.inbound_len(), 1);
         assert_eq!(registry.outbound_len(), 2);
+        assert!(renderer.is_none());
     }
 
     #[test]
@@ -282,6 +330,50 @@ mod tests {
         match config {
             ProcessorConfig::MarkdownToCard => {}
             _ => panic!("expected MarkdownToCard variant"),
+        }
+    }
+
+    #[test]
+    fn test_load_with_feishu_renderer() {
+        let config = ProcessorChainConfig {
+            inbound: vec![],
+            outbound: vec![],
+            renderer: Some(RendererConfig::Feishu),
+        };
+        let (registry, renderer) = ProcessorChainLoader::load(&config).unwrap();
+        assert_eq!(registry.inbound_len(), 0);
+        assert!(renderer.is_some());
+        let r = renderer.unwrap();
+        assert_eq!(r.platform(), "feishu");
+    }
+
+    #[test]
+    fn test_load_without_renderer() {
+        let config = ProcessorChainConfig {
+            inbound: vec![],
+            outbound: vec![],
+            renderer: None,
+        };
+        let (_, renderer) = ProcessorChainLoader::load(&config).unwrap();
+        assert!(renderer.is_none());
+    }
+
+    #[test]
+    fn test_processor_chain_config_without_renderer_field() {
+        // When renderer field is absent (serde default), it should deserialize to None.
+        let json = r#"{"inbound":[]}"#;
+        let config: ProcessorChainConfig = serde_json::from_str(json).unwrap();
+        assert!(config.renderer.is_none());
+        let (_, renderer) = ProcessorChainLoader::load(&config).unwrap();
+        assert!(renderer.is_none());
+    }
+
+    #[test]
+    fn test_renderer_config_feishu_deserialization() {
+        let json = r#"{"type":"feishu"}"#;
+        let config: RendererConfig = serde_json::from_str(json).unwrap();
+        match config {
+            RendererConfig::Feishu => {}
         }
     }
 }

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -23,7 +23,7 @@ pub mod registry;
 pub mod registry_tests;
 
 pub use dsl_parser::{DslInstruction, DslParseResult, DslParser};
-pub use loader::{ProcessorChainConfig, ProcessorChainLoader, ProcessorConfig};
+pub use loader::{ProcessorChainConfig, ProcessorChainLoader, ProcessorConfig, RendererConfig};
 pub use registry::ProcessorRegistry;
 
 pub use context::{MessageContext, ProcessedMessage, RawMessage, RawMessageLog};

--- a/src/renderer/SPEC.md
+++ b/src/renderer/SPEC.md
@@ -1,0 +1,126 @@
+# renderer 子模块规格说明书
+
+> 本文件按 SPEC_CONVENTION.md v3 标准编写，描述模块的实际行为，以代码为准。
+
+## 1. 模块概述
+
+`renderer` 子模块定义 Rendering Layer 的基础设施，将 LLM 输出的 markdown 内容渲染为平台特定的格式。核心抽象为 `Renderer` trait 和 `RenderedOutput` 类型。
+
+第一个平台实现 `FeishuRenderer` 将 markdown（及可选的 DSL 指令）渲染为飞书交互卡片或纯文本消息。渲染决策完全由内容本身决定：空内容或纯文本返回 text 类型，含富格式/换行/DSL 时返回 interactive 类型。
+
+`ProcessorChainConfig` 新增 `renderer` 配置字段，`ProcessorChainLoader::load()` 返回 `Option<Arc<dyn Renderer>>`，与 Processor 链解耦。
+
+**文件**：
+- `src/renderer/mod.rs` — `RenderedOutput`、`Renderer` trait
+- `src/renderer/feishu.rs` — `FeishuRenderer` 实现
+- `src/processor_chain/loader.rs` — `ProcessorChainConfig` renderer 字段及 loader 集成
+
+## 2. 公开接口
+
+### 2.1 Renderer trait
+
+| 接口 | 功能 |
+|------|------|
+| `Renderer::platform` | 返回平台名称，如 `"feishu"` |
+| `Renderer::render` | 将 markdown 内容渲染为 `RenderedOutput`；`dsl_result` 为 `None` 时正常渲染不报错 |
+
+> `Renderer` trait bound: `Send + Sync`（允许跨 async context 共享）
+
+### 2.2 RenderedOutput
+
+| 字段 | 说明 |
+|------|------|
+| `msg_type: String` | 消息类型，`"text"` 或 `"interactive"` |
+| `payload: serde_json::Value` | 平台相关 payload JSON |
+
+### 2.3 FeishuRenderer
+
+| 接口 | 功能 |
+|------|------|
+| `FeishuRenderer::new` | 创建实例 |
+| `Renderer` impl | 实现 `platform() -> "feishu"` 和 `render()` |
+
+渲染规则（`render()` 决策逻辑）：
+
+| 输入 | 输出 |
+|------|------|
+| 空 content | `msg_type: "text"`，空文本 JSON |
+| 纯文本（无 markdown 富格式、无换行、无 `#`、无 DSL） | `msg_type: "text"` |
+| 含 `# Title`（标题后有正文内容） | 提取为 `header.title`（template `"blue"`），正文部分按内容类型决定是否 card |
+| 含 `---` | 转为 `hr` element |
+| 含 DSL 按钮指令 | 渲染为 `action` element；第一个按钮为 `primary`，其余为 `default` |
+| 含换行/富格式（`**`、`__`、`*`、`_`、`\``、`[](`） | `msg_type: "interactive"` |
+
+### 2.4 ProcessorChainLoader 配置集成
+
+| 配置类型 | 说明 |
+|------|------|
+| `ProcessorChainConfig.renderer: Option<RendererConfig>` | YAML 中可选字段，默认为 `None` |
+| `RendererConfig::Feishu` | 飞书平台 renderer，serde tag `"type": "feishu"` |
+
+| 接口 | 功能 |
+|------|------|
+| `ProcessorChainLoader::load` | 返回 `(ProcessorRegistry, Option<Arc<dyn Renderer>>)`；无 renderer 配置时返回 `None` |
+
+## 3. 架构/结构
+
+### 3.1 子模块划分
+
+- `renderer/mod.rs` — 核心 trait 和类型定义，`pub mod feishu`
+- `renderer/feishu.rs` — `FeishuRenderer` 实现，自含 Card 相关类型（`CardPayload`、`Card`、`CardHeader`、`CardElement`、`CardAction`、`CardText`）
+
+> 注：FeishuRenderer 卡片类型独立定义于 `feishu.rs` 内，未从 `MarkdownToCard` 复用。
+
+### 3.2 数据流
+
+```
+LLM markdown 输出
+    │
+    ▼
+FeishuRenderer::render(content, dsl_result)
+    │
+    ├─ 空 content → build_text("")
+    │
+    ├─ 不需要 card（纯文本无格式）→ build_text(content)
+    │
+    └─ 需要 card
+         ├─ extract_header → 提取 # Title 为 header
+         ├─ to_elements → 换行分割，--- → hr element
+         ├─ render_buttons → DSL 按钮转为 action element
+         └─ build_card → RenderedOutput { msg_type: "interactive", payload }
+    │
+    ▼
+RenderedOutput { msg_type, payload }
+```
+
+### 3.3 ProcessorChainLoader 中的集成
+
+```
+ProcessorChainConfig { inbound, outbound, renderer: Option<RendererConfig> }
+    │
+    ▼
+ProcessorChainLoader::load()
+    ├─ 构建 ProcessorRegistry（inbound + outbound processors）
+    └─ build_renderer(config.renderer.as_ref())
+         ├─ Some(RendererConfig::Feishu) → Some(Arc::new(FeishuRenderer::new()))
+         └─ None → None
+    │
+    ▼
+(ProcessorRegistry, Option<Arc<dyn Renderer>>)
+```
+
+### 3.4 FeishuRenderer 卡片结构
+
+```json
+{
+  "msg_type": "interactive",
+  "card": {
+    "header": { "title": "...", "template": "blue" },
+    "elements": [
+      { "tag": "markdown", "content": "..." },
+      { "tag": "hr" },
+      { "tag": "action", "actions": [{ "tag": "button", "text": { "tag": "plain_text", "content": "..." }, "type": "primary" }] }
+    ]
+  }
+}
+```

--- a/src/renderer/feishu.rs
+++ b/src/renderer/feishu.rs
@@ -1,0 +1,327 @@
+//! Feishu renderer — renders LLM output as Feishu card or text payloads.
+//!
+//! This module implements the [`Renderer`] trait for the Feishu platform,
+//! converting markdown content (with optional DSL buttons) into Feishu
+//! interactive card payloads or plain text messages.
+
+use serde::Serialize;
+
+use crate::processor_chain::dsl_parser::{DslInstruction, DslParseResult};
+
+use super::{RenderedOutput, Renderer};
+
+// ---------------------------------------------------------------------------
+// Card types (reused from MarkdownToCard)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CardPayload {
+    pub msg_type: String,
+    pub card: Card,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Card {
+    pub header: Option<CardHeader>,
+    pub elements: Vec<CardElement>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CardHeader {
+    pub title: String,
+    pub template: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "tag")]
+pub enum CardElement {
+    #[serde(rename = "markdown")]
+    Markdown { content: String },
+    #[serde(rename = "hr")]
+    Hr,
+    #[serde(rename = "action")]
+    Action { actions: Vec<CardAction> },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CardAction {
+    pub tag: String,
+    pub text: CardText,
+    #[serde(rename = "type")]
+    pub action_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CardText {
+    pub tag: String,
+    pub content: String,
+}
+
+// ---------------------------------------------------------------------------
+// FeishuRenderer
+// ---------------------------------------------------------------------------
+
+/// Renderer implementation for Feishu.
+#[derive(Debug, Clone, Default)]
+pub struct FeishuRenderer;
+
+impl FeishuRenderer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Returns true when content needs a card (has DSL, header, newlines, or inline formatting).
+    fn should_use_card(content: &str, has_dsl: bool) -> bool {
+        let md = content.trim();
+        if md.is_empty() {
+            return false;
+        }
+        if has_dsl || md.starts_with('#') || md.contains('\n') {
+            return true;
+        }
+        contains_inline(md)
+    }
+
+    /// Extracts `# Title` from first line.
+    fn extract_header(content: &str) -> (Option<String>, String) {
+        let trimmed = content.trim_start();
+        if !trimmed.starts_with("# ") {
+            return (None, content.to_string());
+        }
+        let end = trimmed.find('\n').unwrap_or(trimmed.len());
+        let title = trimmed[2..end].trim().to_string();
+        let rest = if end < trimmed.len() {
+            trimmed[end + 1..].trim_end().to_string()
+        } else {
+            String::new()
+        };
+        (Some(title), rest)
+    }
+
+    /// Converts markdown to card elements.
+    fn to_elements(content: &str) -> Vec<CardElement> {
+        let mut els = Vec::new();
+        for line in content.lines() {
+            let l = line.trim_end();
+            if l.is_empty() {
+                continue;
+            }
+            if l == "---" {
+                els.push(CardElement::Hr);
+            } else {
+                els.push(CardElement::Markdown {
+                    content: l.to_string(),
+                });
+            }
+        }
+        els
+    }
+
+    /// Renders DSL instructions as buttons.
+    fn render_buttons(instructions: &[DslInstruction]) -> Vec<CardElement> {
+        if instructions.is_empty() {
+            return Vec::new();
+        }
+        let has_primary = instructions
+            .iter()
+            .any(|i| matches!(i, DslInstruction::Button { .. }));
+        let mut actions = Vec::new();
+        let mut seen = false;
+
+        for inst in instructions {
+            let DslInstruction::Button { label, .. } = inst;
+            let bt = if has_primary && !seen {
+                seen = true;
+                "primary"
+            } else {
+                "default"
+            };
+            actions.push(CardAction {
+                tag: "button".into(),
+                text: CardText {
+                    tag: "plain_text".into(),
+                    content: label.clone(),
+                },
+                action_type: bt.into(),
+                url: None,
+            });
+        }
+        vec![CardElement::Action { actions }]
+    }
+
+    /// Builds an interactive card [`RenderedOutput`].
+    fn build_card(title: Option<String>, elements: Vec<CardElement>) -> RenderedOutput {
+        let header = title.map(|t| CardHeader {
+            title: t,
+            template: "blue".into(),
+        });
+        let card = Card { header, elements };
+        let payload = CardPayload {
+            msg_type: "interactive".into(),
+            card,
+        };
+        RenderedOutput {
+            msg_type: "interactive".into(),
+            payload: serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null),
+        }
+    }
+
+    /// Returns a plain text [`RenderedOutput`].
+    fn build_text(content: &str) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({
+                "msg_type": "text",
+                "content": { "text": content }
+            }),
+        }
+    }
+}
+
+fn contains_inline(s: &str) -> bool {
+    s.contains("**")
+        || s.contains("__")
+        || s.contains('*')
+        || s.contains('_')
+        || s.contains('`')
+        || (s.contains('[') && s.contains("]("))
+}
+
+impl Renderer for FeishuRenderer {
+    fn platform(&self) -> &str {
+        "feishu"
+    }
+
+    fn render(&self, content: &str, dsl_result: Option<&DslParseResult>) -> RenderedOutput {
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return Self::build_text("");
+        }
+
+        let has_dsl = dsl_result
+            .as_ref()
+            .is_some_and(|r| !r.instructions.is_empty());
+
+        if !Self::should_use_card(trimmed, has_dsl) {
+            return Self::build_text(trimmed);
+        }
+
+        let (title, body) = Self::extract_header(trimmed);
+        let elements = Self::to_elements(&body);
+        let mut all = elements;
+
+        if let Some(r) = dsl_result {
+            all.extend(Self::render_buttons(&r.instructions));
+        }
+
+        Self::build_card(title, all)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::processor_chain::dsl_parser::DslParseResult;
+
+    fn btn(label: &str, action: &str, value: &str) -> DslInstruction {
+        DslInstruction::Button {
+            label: label.into(),
+            action: action.into(),
+            value: value.into(),
+        }
+    }
+
+    #[test]
+    fn test_platform() {
+        let r = FeishuRenderer::new();
+        assert_eq!(r.platform(), "feishu");
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let r = FeishuRenderer::new();
+        let out = r.render("", None);
+        assert_eq!(out.msg_type, "text");
+        assert_eq!(out.payload["content"]["text"], "");
+    }
+
+    #[test]
+    fn test_plain_text() {
+        let r = FeishuRenderer::new();
+        let out = r.render("hello world", None);
+        assert_eq!(out.msg_type, "text");
+        assert_eq!(out.payload["content"]["text"], "hello world");
+    }
+
+    #[test]
+    fn test_rich_formatting() {
+        let r = FeishuRenderer::new();
+        let out = r.render("**bold** and _italic_", None);
+        assert_eq!(out.msg_type, "interactive");
+    }
+
+    #[test]
+    fn test_multiline() {
+        let r = FeishuRenderer::new();
+        let out = r.render("Line 1\nLine 2", None);
+        assert_eq!(out.msg_type, "interactive");
+    }
+
+    #[test]
+    fn test_header_extraction() {
+        let r = FeishuRenderer::new();
+        let out = r.render("# My Title\nBody content", None);
+        assert_eq!(out.msg_type, "interactive");
+        assert_eq!(out.payload["card"]["header"]["title"], "My Title");
+        assert_eq!(out.payload["card"]["header"]["template"], "blue");
+    }
+
+    #[test]
+    fn test_hr_element() {
+        let r = FeishuRenderer::new();
+        let out = r.render("Before\n---\nAfter", None);
+        let els = out.payload["card"]["elements"].as_array().unwrap();
+        assert!(els.iter().any(|e| e["tag"] == "hr"));
+    }
+
+    #[test]
+    fn test_dsl_button() {
+        let r = FeishuRenderer::new();
+        let dsl = DslParseResult {
+            clean_content: "Hi".into(),
+            instructions: vec![btn("Yes", "y", "1")],
+        };
+        let out = r.render("Hello", Some(&dsl));
+        assert_eq!(out.msg_type, "interactive");
+        let els = out.payload["card"]["elements"].as_array().unwrap();
+        let action = els.iter().find(|e| e["tag"] == "action").unwrap();
+        assert_eq!(action["actions"][0]["type"], "primary");
+    }
+
+    #[test]
+    fn test_dsl_multi_buttons() {
+        let r = FeishuRenderer::new();
+        let dsl = DslParseResult {
+            clean_content: "Hi".into(),
+            instructions: vec![btn("A", "a", "1"), btn("B", "b", "2")],
+        };
+        let out = r.render("Hello", Some(&dsl));
+        let els = out.payload["card"]["elements"].as_array().unwrap();
+        let action = els.iter().find(|e| e["tag"] == "action").unwrap();
+        assert_eq!(action["actions"][0]["type"], "primary");
+        assert_eq!(action["actions"][1]["type"], "default");
+    }
+
+    #[test]
+    fn test_no_dsl_none() {
+        let r = FeishuRenderer::new();
+        let out = r.render("No DSL here", None);
+        assert_eq!(out.msg_type, "text");
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,0 +1,53 @@
+//! Renderer — rendering layer infrastructure.
+//!
+//! This module provides the core types and trait for rendering LLM output
+//! to platform-specific formats:
+//! - [`RenderedOutput`] — output type from a renderer
+//! - [`Renderer`] — trait for platform-specific renderers
+//!
+//! # Example
+//! ```
+//! use closeclaw::renderer::{Renderer, RenderedOutput};
+//! use closeclaw::renderer::feishu::FeishuRenderer;
+//!
+//! let renderer = FeishuRenderer::new();
+//! let output = renderer.render("Hello **world**", None);
+//! assert_eq!(output.msg_type, "text");
+//! ```
+
+pub mod feishu;
+
+use serde::{Deserialize, Serialize};
+
+use crate::processor_chain::DslParseResult;
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Output produced by a [`Renderer`] after rendering LLM content.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RenderedOutput {
+    /// Message type, e.g. `"text"` or `"interactive"`.
+    pub msg_type: String,
+    /// Platform-specific payload JSON.
+    pub payload: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Renderer trait
+// ---------------------------------------------------------------------------
+
+/// Trait for rendering LLM output to a platform-specific format.
+///
+/// Implementors must be `Send + Sync` to allow sharing across async contexts.
+pub trait Renderer: Send + Sync {
+    /// Returns the platform name, e.g. `"feishu"` or `"wecom"`.
+    fn platform(&self) -> &str;
+
+    /// Renders `content` (markdown text from LLM) to a platform-specific output.
+    ///
+    /// `dsl_result` carries parsed DSL instructions from the processor chain
+    /// and may be `None` when no DSL was extracted.
+    fn render(&self, content: &str, dsl_result: Option<&DslParseResult>) -> RenderedOutput;
+}


### PR DESCRIPTION
## Summary

Define Rendering Layer infrastructure:
- `Renderer` trait and `RenderedOutput` type in `src/renderer/mod.rs`
- `FeishuRenderer` implementation in `src/renderer/feishu.rs`
- ProcessorChainLoader configuration integration in `src/processor_chain/loader.rs`

## Changes

- Empty content / plain text → `msg_type: "text"`
- Rich format / newlines / DSL → `msg_type: "interactive"` card with header, hr, action elements
- `ProcessorChainConfig` gains optional `renderer` field
- `ProcessorChainLoader::load()` returns `(ProcessorRegistry, Option\<Arc\<dyn Renderer\>>)`

## Testing

- Unit tests cover all rendering branches: empty, plain, rich, header extraction, hr, DSL buttons, multi-button primary/default

Closes #559