### PR TITLE
fix(llm): fix module path for openai_tests

### DIFF
--- a/src/llm/protocol/openai.rs
+++ b/src/llm/protocol/openai.rs
@@ -266,4 +266,5 @@ fn parse_usage(body: &serde_json::Value) -> RawUsage {
 }
 
 #[cfg(test)]
+#[path = "openai_tests.rs"]
 mod openai_tests; // extracted to stay under 500-line limit

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -1,8 +1,10 @@
 //! Tests for OpenAI protocol — extracted to stay under 500-line limit.
 use super::{
-    ContentBlockType, ContentDelta, IncomingSseStream, InternalRequest, OpenAiProtocol, StreamEvent,
+    ChatProtocol, ContentBlockType, ContentDelta, IncomingSseStream, InternalRequest,
+    OpenAiProtocol, StreamEvent,
 };
 use crate::llm::types::RawSseChunk;
+use futures::StreamExt;
 
 fn make_request() -> InternalRequest {
     InternalRequest {


### PR DESCRIPTION
Rust compiler was resolving 'mod openai_tests' as a subdirectory
(openai/openai_tests.rs) instead of the sibling file. Added explicit
#[path = "openai_tests.rs"] attribute to resolve the correct file.

Source: CI
Type: fix
