### PR TITLE
feat(session): add llm_busy state and pending_messages queue

### DIFF
--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -107,9 +107,19 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 - **`CapturedRequest`** — `FakeProvider` 捕获的请求记录（model、messages）
 - **`Builder`** — `FakeProvider` 的 Builder，支持 `.then_ok()`、`.then_err()`、`.then_delay()`、`.or_else()`、`.stub()` 等 API
 
+### Session 管理与队列
+
+- **`ChatSession`**（trait）— LLM 对话会话抽象 trait，定义会话状态查询和操作接口。所有实现必须 `Send + Sync`
+- **`ConversationSession`** — `ChatSession` 的内存实现，持有消息历史、turn 计数、系统 prompt、`llm_busy` 状态和 `pending_messages` 队列
+- **`ChatSession::is_llm_busy`** — 查询 LLM 是否处于 busy 状态（是否有进行中的 LLM 调用）
+- **`ConversationSession::set_llm_busy`** — 设置 LLM busy 状态（`Arc<AtomicBool>`，线程安全）
+- **`ConversationSession::push_pending`** — 将 `PendingMessage` 压入 pending 队列（FIFO）
+- **`ConversationSession::pop_pending`** — 弹出并返回最早的 pending 消息（无则返回 None）
+- **`ConversationSession::has_pending`** — 查询 pending 队列是否非空
+- **`ConversationSession::pending_count`** — 返回 pending 消息数量
+
 ### 构造
 
-- **`LegacyProviderAdapter::new`** — 构造桥接器，将旧 `LLMProvider` 适配到新 `Provider` trait；参数包括 inner provider、base_url、api_key、supported_protocols、http_client、default_headers
 - **`LegacySessionAdapter::from_legacy_messages`** — 从旧 `Vec<Message>` 构造新 `ChatSession` 适配器（模型名 + 消息历史）
 - **`LLMRegistry::new`** — 创建空注册中心
 

--- a/src/llm/adapter/legacy_session.rs
+++ b/src/llm/adapter/legacy_session.rs
@@ -5,6 +5,8 @@
 //! through the [`ChatSession`] trait.
 
 use chrono::Utc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use crate::llm::session::{ChatSession, SessionMessage};
 use crate::llm::turn::TurnCounter;
@@ -21,6 +23,7 @@ pub struct LegacySessionAdapter {
     system_prompt: Option<String>,
     model: String,
     turn_counter: TurnCounter,
+    is_llm_busy: Arc<AtomicBool>,
 }
 
 impl LegacySessionAdapter {
@@ -43,6 +46,7 @@ impl LegacySessionAdapter {
             system_prompt: None,
             model,
             turn_counter: TurnCounter::new(),
+            is_llm_busy: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -134,6 +138,10 @@ impl ChatSession for LegacySessionAdapter {
             stream: false,
             extra_body: Default::default(),
         }
+    }
+
+    fn is_llm_busy(&self) -> bool {
+        self.is_llm_busy.load(Ordering::SeqCst)
     }
 }
 

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -5,6 +5,9 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use crate::llm::turn::TurnCounter;
 use crate::llm::types::{ContentBlock, InternalMessage, InternalRequest, UnifiedResponse};
@@ -53,6 +56,9 @@ pub trait ChatSession: Send + Sync {
     /// Includes system prompt (if set), all messages, model, temperature
     /// and max_tokens.
     fn build_api_request(&self) -> InternalRequest;
+
+    /// Returns whether the LLM is currently busy (processing a request).
+    fn is_llm_busy(&self) -> bool;
 }
 
 /// A simple in-memory implementation of `ChatSession`.
@@ -65,6 +71,8 @@ pub struct ConversationSession {
     turn_counter: TurnCounter,
     model: String,
     compaction_state: Option<String>,
+    is_llm_busy: Arc<AtomicBool>,
+    pending_messages: VecDeque<crate::session::persistence::PendingMessage>,
 }
 
 impl ConversationSession {
@@ -77,6 +85,8 @@ impl ConversationSession {
             turn_counter: TurnCounter::new(),
             model,
             compaction_state: None,
+            is_llm_busy: Arc::new(AtomicBool::new(false)),
+            pending_messages: VecDeque::new(),
         }
     }
 
@@ -93,6 +103,31 @@ impl ConversationSession {
             content_blocks,
             timestamp: Utc::now(),
         });
+    }
+
+    /// Sets the LLM busy state.
+    pub fn set_llm_busy(&self, busy: bool) {
+        self.is_llm_busy.store(busy, Ordering::SeqCst);
+    }
+
+    /// Pushes a pending message onto the queue.
+    pub fn push_pending(&mut self, msg: crate::session::persistence::PendingMessage) {
+        self.pending_messages.push_back(msg);
+    }
+
+    /// Pops the oldest pending message, if any.
+    pub fn pop_pending(&mut self) -> Option<crate::session::persistence::PendingMessage> {
+        self.pending_messages.pop_front()
+    }
+
+    /// Returns whether there are any pending messages.
+    pub fn has_pending(&self) -> bool {
+        !self.pending_messages.is_empty()
+    }
+
+    /// Returns the number of pending messages.
+    pub fn pending_count(&self) -> usize {
+        self.pending_messages.len()
     }
 }
 
@@ -167,12 +202,100 @@ impl ChatSession for ConversationSession {
             extra_body: Default::default(),
         }
     }
+
+    fn is_llm_busy(&self) -> bool {
+        self.is_llm_busy.load(Ordering::SeqCst)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::llm::types::UnifiedUsage;
+    use crate::session::persistence::PendingMessage;
+    use std::sync::Arc;
+    use std::thread;
+
+    // ── llm_busy state ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_llm_busy_default_false() {
+        let session = ConversationSession::new("sess_busy".into(), "gpt-4o".into());
+        assert!(!session.is_llm_busy());
+    }
+
+    #[test]
+    fn test_set_llm_busy_true() {
+        let session = ConversationSession::new("sess_busy".into(), "gpt-4o".into());
+        session.set_llm_busy(true);
+        assert!(session.is_llm_busy());
+    }
+
+    #[test]
+    fn test_set_llm_busy_false_recovers() {
+        let session = ConversationSession::new("sess_busy".into(), "gpt-4o".into());
+        session.set_llm_busy(true);
+        session.set_llm_busy(false);
+        assert!(!session.is_llm_busy());
+    }
+
+    #[test]
+    fn test_set_llm_busy_concurrent_no_panic() {
+        let session = Arc::new(ConversationSession::new(
+            "sess_concurrent".into(),
+            "gpt-4o".into(),
+        ));
+        let handles: Vec<_> = (0..4)
+            .map(|i| {
+                let s = Arc::clone(&session);
+                thread::spawn(move || {
+                    s.set_llm_busy(i % 2 == 0);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread panicked");
+        }
+    }
+
+    // ── pending_messages queue ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_pending_initial_state() {
+        let session = ConversationSession::new("sess_pending".into(), "gpt-4o".into());
+        assert_eq!(session.pending_count(), 0);
+        assert!(!session.has_pending());
+    }
+
+    #[test]
+    fn test_push_pending_sets_has_pending_and_increments_count() {
+        let mut session = ConversationSession::new("sess_pending".into(), "gpt-4o".into());
+        assert_eq!(session.pending_count(), 0);
+        session.push_pending(PendingMessage::new("msg_1".into(), "hello".into()));
+        assert!(session.has_pending());
+        assert_eq!(session.pending_count(), 1);
+        session.push_pending(PendingMessage::new("msg_2".into(), "world".into()));
+        assert_eq!(session.pending_count(), 2);
+    }
+
+    #[test]
+    fn test_pop_pending_fifo_order() {
+        let mut session = ConversationSession::new("sess_fifo".into(), "gpt-4o".into());
+        session.push_pending(PendingMessage::new("msg_A".into(), "first".into()));
+        session.push_pending(PendingMessage::new("msg_B".into(), "second".into()));
+        let first = session.pop_pending();
+        assert!(first.is_some());
+        assert_eq!(first.unwrap().message_id, "msg_A");
+        let second = session.pop_pending();
+        assert!(second.is_some());
+        assert_eq!(second.unwrap().message_id, "msg_B");
+    }
+
+    #[test]
+    fn test_pop_pending_returns_none_when_empty() {
+        let mut session = ConversationSession::new("sess_empty".into(), "gpt-4o".into());
+        assert!(session.pop_pending().is_none());
+    }
 
     // ── SessionMessage serde roundtrip ────────────────────────────────────────
 


### PR DESCRIPTION
- ChatSession trait adds is_llm_busy() method
- ConversationSession implements llm_busy: Arc<AtomicBool> with set_llm_busy()
- ConversationSession adds pending_messages: VecDeque with push/pop/has/count
- LegacySessionAdapter also implements is_llm_busy for adapter parity
- UT covers all new logic branches

Source: issue #572
Type: feat
