### PR TITLE
fix(glm): use dynamic next_block_index instead of hardcoded 0

### DIFF
--- a/src/llm/SPEC.md
+++ b/src/llm/SPEC.md
@@ -85,7 +85,7 @@ LLM 模块为 CloseClaw 提供统一的多 Provider LLM 调用抽象。通过 `L
 ### 具体 Protocol 实现
 
 - **`OpenAiProtocol`** — OpenAI 兼容协议，用于 OpenAI、MiniMax、VolcEngine、DeepSeek。Bearer token 认证，SSE 解析 `choices[0].delta` 格式，文本流式输出 `delta.content`；流式 tool_calls 解析 `delta.tool_calls` 数组，产出完整工具调用事件序列（`BlockStart(ToolUse)` + `ToolUseId` + `ToolUseName` + `ToolUseInputChunk` + `BlockEnd(ToolUse)`）。Block 转换时（Text/Thinking → ToolUse）自动结束前一 block；`finish_reason: "tool_calls"` 触发 `BlockEnd(ToolUse)` + `MessageEnd { finish_reason: "tool_calls" }`。使用 `next_block_index` 计数器保证多 block 场景下 index 唯一递增。
-- **`GlmProtocol`** — 智谱 GLM 系列协议。Bearer token 认证，`parse_response` 优先 `content` 兜底 `reasoning_content`，SSE 解析 `reasoning_content` 优先 `content`；流式 tool_calls 解析 `delta.tool_calls` 数组（路径同 OpenAI，`choices[0].delta.tool_calls`），Block 转换时自动结束前一 block；`finish_reason: "tool_calls"` 触发 `BlockEnd(ToolUse)` + `MessageEnd { finish_reason: "tool_calls" }`。注：当前 GLM 实现使用固定 block index（所有 block 均用 index 0），与 OpenAiProtocol 的递增 index 策略不同，混用时需注意。
+- **`GlmProtocol`** — 智谱 GLM 系列协议。Bearer token 认证，`parse_response` 优先 `content` 兜底 `reasoning_content`，SSE 解析 `reasoning_content` 优先 `content`；流式 tool_calls 解析 `delta.tool_calls` 数组（路径同 OpenAI，`choices[0].delta.tool_calls`），Block 转换时自动结束前一 block；`finish_reason: "tool_calls"` 触发 `BlockEnd(ToolUse)` + `MessageEnd { finish_reason: "tool_calls" }`。使用 `next_block_index` 计数器，与 OpenAiProtocol 一致的动态递增策略，保证多 tool_calls 场景下各 block index 唯一递增。
 - **`AnthropicProtocol`** — Anthropic `/v1/messages` stub。`x-api-key` + `anthropic-version` header，`parse_response` 解析 `content[].text` 数组，SSE 流式暂未实现
 
 ### 数据类型（模型元数据）

--- a/src/llm/protocol/glm.rs
+++ b/src/llm/protocol/glm.rs
@@ -151,6 +151,7 @@ impl ChatProtocol for GlmProtocol {
             let mut stream = incoming;
             let mut current_block_index: Option<usize> = None;
             let mut current_block_type: Option<ContentBlockType> = None;
+            let mut next_block_index: usize = 0;
 
             while let Some(chunk) = stream.next().await {
                 let data = chunk.data.trim();
@@ -194,7 +195,8 @@ impl ChatProtocol for GlmProtocol {
                             } else {
                                 ContentBlockType::Text
                             };
-                            let idx = 0;
+                            let idx = next_block_index;
+                            next_block_index += 1;
                             current_block_index = Some(idx);
                             current_block_type = Some(btype);
                             yield StreamEvent::BlockStart { index: idx, block_type: btype };
@@ -228,7 +230,8 @@ impl ChatProtocol for GlmProtocol {
                     for tc in tool_calls.iter() {
                         if let Some(tc_id) = tc.get("id").and_then(|v| v.as_str()) {
                             // Start new tool block
-                            let idx = 0;
+                            let idx = next_block_index;
+                            next_block_index += 1;
                             current_block_index = Some(idx);
                             current_block_type = Some(ContentBlockType::ToolUse);
                             yield StreamEvent::BlockStart { index: idx, block_type: ContentBlockType::ToolUse };


### PR DESCRIPTION
- Replace hardcoded `let idx = 0;` in tool_calls and text/thinking blocks
  with `next_block_index` counter for unique incremental indices
- Ensures multi tool_calls scenarios don't overwrite each other's blocks
- Aligns GLM behavior with OpenAI protocol's dynamic index strategy

Source: issue #602
Type: fix
