### PR TITLE
feat(wizard): add retry with exponential backoff for model list fetch

### DIFF
--- a/src/cli/SPEC.md
+++ b/src/cli/SPEC.md
@@ -45,7 +45,13 @@
 
 `config_wizard` 提供 `closeclaw config setup` 的交互式配置流程。用户依次经历线性状态机：SelectProvider → InputCredential → FetchModels → SelectModels → Confirm → WriteConfig，最终将配置写入 `~/.closeclaw/config/models.json` 和 `~/.closeclaw/config/credentials/<provider_id>.json`。
 
-FetchModels 阶段通过 `LLMProvider::fetch_model_list()` 获取模型列表，10s 超时或失败时回退到 `ProviderModelKnowledge` 知识库。SelectModels 支持空格分隔编号、范围语法（`1-3,5,7`）和 `all` 关键字，每行显示列表时追加 `protocol: {proto} (recommended)` 标签。写入时采用合并策略：当前 provider 的模型整体替换，其他 provider 的已配置模型保留。`write_wizard_config()` 写入 `ProviderConfig.protocol` 字段，值为第一个选中模型的 `recommended_protocol`。
+FetchModels 阶段调用 `fetch_models_with_retry()` 获取模型列表，`fetch_models_with_retry()` 包装 `fetch_model_list()` 调用，最多重试 3 次。重试策略：
+- **Transient 错误**（429 / 5xx / 网络超时）→ 指数退避重试（1s~10s 上界），耗尽 3 次后回退到 `ProviderModelKnowledge` 知识库
+- **超时**（10s）→ 视为 Transient，一同参与指数退避重试
+- **Auth / Billing / InvalidRequest** → 立即回退到知识库，不重试
+- 重试延迟使用 `crate::llm::retry::backoff_delay()` 计算（1s base，10s 上界）
+
+SelectModels 支持空格分隔编号，范围语法（`1-3,5,7`）和 `all` 关键字，每行显示列表时追加 `protocol: {proto} (recommended)` 标签。写入时采用合并策略：当前 provider 的模型整体替换，其他 provider 的已配置模型保留。`write_wizard_config()` 写入 `ProviderConfig.protocol` 字段，值为第一个选中模型的 `recommended_protocol`。
 
 **公开接口：**
 

--- a/src/cli/config_wizard/fetch.rs
+++ b/src/cli/config_wizard/fetch.rs
@@ -1,0 +1,159 @@
+//! Model fetching logic with retry and fallback
+use crate::llm::retry::backoff_delay;
+use crate::llm::{ErrorKind, LLMProvider, ModelInfo, ProviderModelKnowledge};
+use std::sync::Arc;
+use std::time::Duration;
+
+const FETCH_MAX_RETRIES: u32 = 3;
+
+/// Fetch model list with retry and exponential backoff for transient errors.
+///
+/// - Transient errors (429, 5xx, timeout, network) → retry up to 3 times with backoff
+/// - Auth / Billing / InvalidRequest → immediately fallback to knowledge base
+/// - After exhausting retries → fallback to knowledge base
+pub async fn fetch_models_with_retry(
+    provider: &Arc<dyn LLMProvider>,
+    credential: &str,
+) -> Vec<ModelInfo> {
+    // Show spinner while fetching
+    print!("Fetching models from provider...");
+    std::io::Write::flush(&mut std::io::stdout()).ok();
+
+    for attempt in 1..=FETCH_MAX_RETRIES {
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            provider.fetch_model_list(credential),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(model_infos)) => {
+                println!(" done");
+                return model_infos;
+            }
+            Ok(Err(err)) => {
+                let kind = err.kind();
+                match kind {
+                    ErrorKind::Transient | ErrorKind::Unknown => {
+                        if attempt < FETCH_MAX_RETRIES {
+                            let delay = backoff_delay(
+                                attempt,
+                                Duration::from_secs(1),
+                                Duration::from_secs(10),
+                            );
+                            println!(
+                                "\n[Retry {}] {} ({}), retrying in {:?}...",
+                                attempt,
+                                kind_str(&kind),
+                                err,
+                                delay
+                            );
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        }
+                        println!(
+                            "\n[Warning] API fetch failed after {} attempts ({}), falling back to knowledge base",
+                            FETCH_MAX_RETRIES, err
+                        );
+                        return knowledge_fallback(provider.name()).await;
+                    }
+                    ErrorKind::Auth | ErrorKind::Billing | ErrorKind::InvalidRequest => {
+                        println!(
+                            "\n[Warning] API fetch failed ({}), falling back to knowledge base",
+                            err
+                        );
+                        return knowledge_fallback(provider.name()).await;
+                    }
+                }
+            }
+            Err(_) => {
+                // Timeout is treated as transient error
+                if attempt < FETCH_MAX_RETRIES {
+                    let delay = backoff_delay(
+                        attempt,
+                        Duration::from_secs(1),
+                        Duration::from_secs(10),
+                    );
+                    println!(
+                        "\n[Retry {}] API fetch timed out (10s), retrying in {:?}...",
+                        attempt, delay
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                println!("\n[Warning] API fetch timed out after {} attempts, falling back to knowledge base", FETCH_MAX_RETRIES);
+                return knowledge_fallback(provider.name()).await;
+            }
+        }
+    }
+
+    // Unreachable because we return on the last attempt
+    unreachable!()
+}
+
+/// Helper to convert ErrorKind to user-friendly string
+fn kind_str(kind: &ErrorKind) -> &str {
+    match kind {
+        ErrorKind::Transient => "Transient error",
+        ErrorKind::Auth => "Authentication error",
+        ErrorKind::Billing => "Billing error",
+        ErrorKind::InvalidRequest => "Invalid request",
+        ErrorKind::Unknown => "Unknown error",
+    }
+}
+
+/// Fetch model list with a 10-second timeout.
+/// On timeout or error, falls back to `ProviderModelKnowledge`.
+pub async fn fetch_models_with_fallback(
+    provider: &Arc<dyn LLMProvider>,
+    credential: &str,
+) -> Vec<ModelInfo> {
+    // Show spinner while fetching
+    print!("Fetching models from provider...");
+    std::io::Write::flush(&mut std::io::stdout()).ok();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        provider.fetch_model_list(credential),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(model_infos)) => {
+            println!(" done");
+            model_infos
+        }
+        Ok(Err(err)) => {
+            println!(
+                "\n[Warning] API fetch failed ({}), falling back to knowledge base",
+                err
+            );
+            knowledge_fallback(provider.name()).await
+        }
+        Err(_) => {
+            println!("\n[Warning] API fetch timed out (10s), falling back to knowledge base");
+            knowledge_fallback(provider.name()).await
+        }
+    }
+}
+
+/// Return model list from `ProviderModelKnowledge` for the given provider name.
+pub async fn knowledge_fallback(provider_name: &str) -> Vec<ModelInfo> {
+    let kb = ProviderModelKnowledge::new();
+    let model_ids = kb.all_models(provider_name);
+    model_ids
+        .into_iter()
+        .map(|id| {
+            let params = kb.find(provider_name, id).unwrap();
+            ModelInfo {
+                id: id.to_string(),
+                name: id.to_string(),
+                context_window: params.context_window,
+                max_tokens: params.max_tokens,
+                default_temperature: Some(params.default_temperature),
+                reasoning: params.reasoning,
+                input_types: params.input_types,
+            }
+        })
+        .collect()
+}

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -1,17 +1,22 @@
 //! Config Wizard - interactive CLI configuration flow
 
 pub mod types;
+pub mod fetch;
 
 pub use types::*;
+pub use fetch::*;
 
 use crate::config::providers::{
     credentials::{AnyProviderCredentials, ApiKeyCredentials},
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
+use crate::llm::retry::backoff_delay;
 use crate::llm::{
-    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelInfo, ProviderModelKnowledge,
-    VolcEngineProvider,
+    DeepSeekProvider, ErrorKind, GlmProvider, LLMProvider, MiniMaxProvider, ModelInfo,
+    ProviderModelKnowledge, VolcEngineProvider,
 };
+#[cfg(test)]
+use crate::llm::LLMError;
 use dialoguer::{Input, Select};
 
 use std::panic;
@@ -214,62 +219,6 @@ fn build_provider(info: &ProviderInfo, credential: &str) -> Arc<dyn LLMProvider>
     }
 }
 
-/// Fetch model list with a 10-second timeout.
-/// On timeout or error, falls back to `ProviderModelKnowledge`.
-async fn fetch_models_with_fallback(
-    provider: &Arc<dyn LLMProvider>,
-    credential: &str,
-) -> Vec<ModelInfo> {
-    // Show spinner while fetching
-    print!("Fetching models from provider...");
-    std::io::Write::flush(&mut std::io::stdout()).ok();
-
-    let result = tokio::time::timeout(
-        Duration::from_secs(10),
-        provider.fetch_model_list(credential),
-    )
-    .await;
-
-    match result {
-        Ok(Ok(model_infos)) => {
-            println!(" done");
-            model_infos
-        }
-        Ok(Err(err)) => {
-            println!(
-                "\n[Warning] API fetch failed ({}), falling back to knowledge base",
-                err
-            );
-            knowledge_fallback(provider.name()).await
-        }
-        Err(_) => {
-            println!("\n[Warning] API fetch timed out (10s), falling back to knowledge base");
-            knowledge_fallback(provider.name()).await
-        }
-    }
-}
-
-/// Return model list from `ProviderModelKnowledge` for the given provider name.
-async fn knowledge_fallback(provider_name: &str) -> Vec<ModelInfo> {
-    let kb = ProviderModelKnowledge::new();
-    let model_ids = kb.all_models(provider_name);
-    model_ids
-        .into_iter()
-        .map(|id| {
-            let params = kb.find(provider_name, id).unwrap();
-            ModelInfo {
-                id: id.to_string(),
-                name: id.to_string(),
-                context_window: params.context_window,
-                max_tokens: params.max_tokens,
-                default_temperature: Some(params.default_temperature),
-                reasoning: params.reasoning,
-                input_types: params.input_types,
-            }
-        })
-        .collect()
-}
-
 /// Run the interactive config wizard.
 ///
 /// Returns `Ok(Some(output))` on success, `Ok(None)` on clean Ctrl+C exit,
@@ -335,7 +284,7 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         ctx.provider = Some(build_provider(info, cred));
         let provider = ctx.provider.as_ref().unwrap();
 
-        let models = fetch_models_with_fallback(provider, cred).await;
+        let models = fetch_models_with_retry(provider, cred).await;
         ctx.fetched_models = models;
     }
 

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -2,6 +2,173 @@
 
 use super::*;
 
+use async_trait::async_trait;
+
+use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Arc;
+
+// ─────────────────────────────────────────────────────────────────
+// Mock LLMProvider for testing fetch_models_with_retry
+// ─────────────────────────────────────────────────────────────────
+
+struct MockProvider {
+    name: String,
+    // What the fetch_model_list call should return
+    result: std::sync::Mutex<
+        std::sync::Arc<dyn Fn(&str) -> Result<Vec<ModelInfo>, LLMError> + Send + Sync>,
+    >,
+}
+
+impl MockProvider {
+    fn new(
+        name: &str,
+        f: impl Fn(&str) -> Result<Vec<ModelInfo>, LLMError> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            result: std::sync::Mutex::new(std::sync::Arc::new(f)),
+        }
+    }
+
+    fn returning(result: impl Into<Result<Vec<ModelInfo>, LLMError>>) -> Self {
+        let result = result.into();
+        Self::new("mock", move |_| result.clone())
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MockProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn chat(
+        &self,
+        _request: crate::llm::ChatRequest,
+    ) -> Result<crate::llm::ChatResponse, LLMError> {
+        Err(LLMError::ApiError("mock not implemented".to_string()))
+    }
+
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        let f = self.result.lock().unwrap();
+        f(bearer_token)
+    }
+
+    fn models(&self) -> Vec<&str> {
+        vec![]
+    }
+}
+
+fn model_infos() -> Vec<ModelInfo> {
+    vec![
+        ModelInfo {
+            id: "gpt-4".to_string(),
+            name: "GPT-4".to_string(),
+            context_window: 8192,
+            max_tokens: 8192,
+            default_temperature: None,
+            reasoning: false,
+            input_types: vec![],
+        },
+        ModelInfo {
+            id: "gpt-3.5-turbo".to_string(),
+            name: "GPT-3.5 Turbo".to_string(),
+            context_window: 4096,
+            max_tokens: 4096,
+            default_temperature: None,
+            reasoning: false,
+            input_types: vec![],
+        },
+    ]
+}
+
+fn transient_err(msg: &str) -> LLMError {
+    LLMError::ApiError(msg.to_string())
+}
+
+fn auth_err(msg: &str) -> LLMError {
+    LLMError::AuthFailed(msg.to_string())
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Tests for fetch_models_with_retry
+// ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod fetch_models_with_retry_tests {
+    use super::*;
+
+    /// Scenario: Provider returns models successfully on first call — no retry needed.
+    #[tokio::test]
+    async fn success_no_retry() {
+        let provider: Arc<dyn LLMProvider> = Arc::new(MockProvider::returning(Ok(model_infos())));
+        let cred = "test-token";
+        let result = fetch_models_with_retry(&provider, cred).await;
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "gpt-4");
+        assert_eq!(result[1].id, "gpt-3.5-turbo");
+    }
+
+    /// Scenario: Transient error on first call, succeeds on second call — one retry.
+    #[tokio::test]
+    async fn transient_retry_succeeds() {
+        let attempt = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempt);
+        let provider: Arc<dyn LLMProvider> = Arc::new(MockProvider::new("minimax", move |_| {
+            let n = counter.fetch_add(1, atomic::Ordering::SeqCst);
+            if n == 0 {
+                Err(transient_err("500 internal error"))
+            } else {
+                Ok(model_infos())
+            }
+        }));
+        let result = fetch_models_with_retry(&provider, "token").await;
+        // Should have retried once and succeeded — 2 total calls
+        let attempts = attempt.load(atomic::Ordering::SeqCst);
+        assert_eq!(
+            attempts, 2,
+            "Expected 2 attempts (fail then success), got {}",
+            attempts
+        );
+        assert_eq!(result.len(), 2);
+    }
+
+    /// Scenario: All attempts return transient errors — falls back to knowledge base.
+    #[tokio::test]
+    async fn transient_exhausted_fallback() {
+        let attempt = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempt);
+        let provider: Arc<dyn LLMProvider> = Arc::new(MockProvider::new("minimax", move |_| {
+            counter.fetch_add(1, atomic::Ordering::SeqCst);
+            Err(transient_err("500 internal error"))
+        }));
+        let result = fetch_models_with_retry(&provider, "token").await;
+        // All 3 attempts exhausted, fallback to knowledge base — result comes from minimax KB
+        let attempts = attempt.load(atomic::Ordering::SeqCst);
+        assert_eq!(attempts, 3, "Expected 3 attempts, got {}", attempts);
+        assert!(!result.is_empty());
+    }
+
+    /// Scenario: Auth error — immediately falls back to knowledge base (no retry).
+    #[tokio::test]
+    async fn auth_error_no_retry_immediate_fallback() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&call_count);
+        let provider: Arc<dyn LLMProvider> = Arc::new(MockProvider::new("minimax", move |_| {
+            counter.fetch_add(1, atomic::Ordering::SeqCst);
+            Err(auth_err("invalid api key"))
+        }));
+        let result = fetch_models_with_retry(&provider, "token").await;
+        let count = call_count.load(atomic::Ordering::SeqCst);
+        assert_eq!(
+            count, 1,
+            "Auth error should not retry — only 1 call expected, got {}",
+            count
+        );
+        assert!(!result.is_empty());
+    }
+}
+
 #[cfg(test)]
 mod parse_model_selection_tests {
     use super::parse_model_selection;


### PR DESCRIPTION
Fixes #583

This PR adds exponential backoff retry for model list fetch in the config wizard:
- Transient errors (429/5xx/timeout/network) retry up to 3 times with backoff
- Auth/Billing/InvalidRequest immediately fallback to knowledge base
- After exhausting retries → fallback to knowledge base