### PR TITLE
fix(test): use with_body_from_fn to ensure timeout mock tests are stable

### DIFF
--- a/src/llm/glm/tests/mod.rs
+++ b/src/llm/glm/tests/mod.rs
@@ -257,7 +257,10 @@ async fn test_fetch_model_list_timeout_mock() {
         )
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"data":[]}"#)
+        .with_body_from_fn(|_w| {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            Ok(())
+        })
         .create_async()
         .await;
 

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -188,7 +188,10 @@ async fn test_fetch_model_list_timeout_mock() {
         )
         .with_status(200)
         .with_header("Content-Type", "application/json")
-        .with_body(r#"{"data":[]}"#)
+        .with_body_from_fn(|_w| {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            Ok(())
+        })
         .create_async()
         .await;
 


### PR DESCRIPTION
## Summary

Fix flaky timeout mock tests in `llm::glm` and `llm::minimax` by replacing instant-response `.with_body()` with `.with_body_from_fn()` + `sleep(100ms)`, ensuring the reqwest 1ms timeout always fires before the mock server responds.

## Changes

- `src/llm/glm/tests/mod.rs`: `test_fetch_model_list_timeout_mock` — use `with_body_from_fn` + sleep
- `src/llm/minimax/tests.rs`: `test_fetch_model_list_timeout_mock` — use `with_body_from_fn` + sleep

## Test

All 1580 library unit tests pass (0 failures).

Closes #612