### PR TITLE
test(llm): add multi tool_calls SSE stream test for GLM protocol

### DIFF
--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -364,6 +364,37 @@ async fn test_parse_sse_tool_calls_basic() {
 }
 
 #[tokio::test]
+async fn test_parse_sse_multi_tool_calls() {
+    let p = GlmProtocol::new();
+    let inc: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(
+            r#"{"choices":[{"delta":{"tool_calls":[{"id":"c1","type":"function","function":{"name":"f1","arguments":""}},{"id":"c2","type":"function","function":{"name":"f2","arguments":""}}]}}]}"#,
+        ),
+        make_sse_chunk(r#"{"choices":[{"finish_reason":"tool_calls"}]}"#),
+    ]));
+    let mut s = p.parse_sse_stream(inc, p.create_sse_machine()).await;
+    let e = s.next().await.unwrap().unwrap();
+    let i0 = match &e {
+        StreamEvent::BlockStart { index, .. } => *index,
+        _ => panic!("{e:?}"),
+    };
+    s.next().await.unwrap().unwrap();
+    s.next().await.unwrap().unwrap();
+    let e = s.next().await.unwrap().unwrap();
+    let i1 = match &e {
+        StreamEvent::BlockStart { index, .. } => *index,
+        _ => panic!("{e:?}"),
+    };
+    assert_eq!(i0, 0);
+    assert_eq!(i1, 1);
+    assert_ne!(i0, i1);
+    for _ in 0..4 {
+        s.next().await.unwrap().unwrap();
+    }
+    assert!(s.next().await.is_none());
+}
+
+#[tokio::test]
 async fn test_parse_sse_reasoning_then_tool_calls() {
     let proto = GlmProtocol::new();
     let machine = proto.create_sse_machine();


### PR DESCRIPTION
## 目的

补充 PR #605（修复 GLM 协议多 tool_calls 场景 block index 硬编码问题）缺失的单元测试。

## 改动

- `src/llm/protocol/glm_test.rs`: 新增 `test_parse_sse_multi_tool_calls` 测试用例
  - 构造包含两个 tool_calls 的 SSE 流
  - 验证每个 tool_call 获得独立的递增 block index（0 和 1）
  - 验证完整的事件序列和流结束

## 测试

- `cargo test --lib` 全部通过（1581 tests）

Source: issue #606