### PR TITLE
test(llm): replace timeout tests with deterministic MockTimeoutHttpClient

### DIFF
--- a/src/llm/glm/tests/mod.rs
+++ b/src/llm/glm/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the GLM provider.
 
 use super::*;
+use crate::llm::http_client::MockTimeoutHttpClient;
 use mockito::Server;
 
 // ---------------------------------------------------------------------------//
@@ -245,37 +246,17 @@ async fn test_fetch_model_list_success_mock() {
 }
 
 #[tokio::test]
-async fn test_fetch_model_list_timeout_mock() {
-    // Use an http_client with a very short reqwest timeout (1ms) so the
-    // HTTP send returns an error, which gets mapped to LLMError::NetworkError.
-    let mut server = mockito::Server::new_async().await;
-    let _m = server
-        .mock("GET", "/api/paas/v4/models")
-        .match_header(
-            "authorization",
-            mockito::Matcher::Regex(r"Bearer .+".to_string()),
-        )
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body_from_fn(|_w| {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            Ok(())
-        })
-        .create_async()
-        .await;
-
-    let http_client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_millis(1))
-        .build()
-        .unwrap();
-    let provider = GlmProvider {
-        api_key: "fake-key".into(),
-        base_url: format!("{}/api/coding/paas/v4/chat/completions", server.url()),
-        http_client: Arc::new(ReqwestHttpClient::with_client(http_client)),
-    };
+async fn test_glm_fetch_model_list_timeout_mock() {
+    // Use MockTimeoutHttpClient that always returns a timeout error,
+    // eliminating timing-dependent flakiness.
+    let http_client: Arc<dyn HttpClient> = Arc::new(MockTimeoutHttpClient::new());
+    let provider = GlmProvider::with_http_client(
+        "fake-key".into(),
+        "http://localhost/api/coding/paas/v4/chat/completions".into(),
+        http_client,
+    );
 
     let err = provider.fetch_model_list("fake-key").await.unwrap_err();
-
     assert!(matches!(err, LLMError::NetworkError(_)));
 }
 

--- a/src/llm/http_client.rs
+++ b/src/llm/http_client.rs
@@ -49,6 +49,54 @@ impl HttpClient for ReqwestHttpClient {
 }
 
 #[cfg(test)]
+pub use timeout_mock::MockTimeoutHttpClient;
+
+/// Test-only timeout mock module.
+#[cfg(test)]
+mod timeout_mock {
+    use super::*;
+
+    /// Mock HTTP client that always returns a timeout error.
+    pub struct MockTimeoutHttpClient;
+
+    impl MockTimeoutHttpClient {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+
+    impl Default for MockTimeoutHttpClient {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for MockTimeoutHttpClient {
+        async fn execute(
+            &self,
+            _request: reqwest::Request,
+        ) -> Result<reqwest::Response, reqwest::Error> {
+            // Build a client with zero timeout to always trigger a timeout error.
+            // reqwest::Error has no public constructor, so we use a 0-timeout client
+            // to reliably produce Kind::Timeout.
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(0))
+                .build()
+                .unwrap();
+            let req = reqwest::Request::new(
+                reqwest::Method::GET,
+                reqwest::Url::parse("http://localhost").unwrap(),
+            );
+            Err(client
+                .execute(req)
+                .await
+                .expect_err("expected timeout error"))
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -176,34 +176,13 @@ async fn test_fetch_model_list_auth_failure_mock() {
 }
 
 #[tokio::test]
-async fn test_fetch_model_list_timeout_mock() {
-    // Use an http_client with a very short reqwest timeout (1ms) so the
-    // HTTP send returns an error, which gets mapped to LLMError::NetworkError.
-    let mut server = mockito::Server::new_async().await;
-    let _m = server
-        .mock("GET", "/v1/models")
-        .match_header(
-            "Authorization",
-            mockito::Matcher::Regex(r"Bearer .+".to_string()),
-        )
-        .with_status(200)
-        .with_header("Content-Type", "application/json")
-        .with_body_from_fn(|_w| {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            Ok(())
-        })
-        .create_async()
-        .await;
+async fn test_minimax_fetch_model_list_timeout_mock() {
+    use crate::llm::http_client::MockTimeoutHttpClient;
 
     let provider = MiniMaxProvider::with_http_client(
         "test-key".into(),
-        server.url(),
-        Arc::new(ReqwestHttpClient::with_client(
-            reqwest::Client::builder()
-                .timeout(std::time::Duration::from_millis(1))
-                .build()
-                .unwrap(),
-        )),
+        "http://localhost/v1/models".into(),
+        Arc::new(MockTimeoutHttpClient::new()),
     );
 
     let err = provider.fetch_model_list("test-key").await.unwrap_err();


### PR DESCRIPTION
Replace timing-based timeout tests with deterministic MockTimeoutHttpClient.

Source: issue #640
Type: test