### PR TITLE
fix(test): update SessionManager::new call to match 4-arg signature

### DIFF
--- a/tests/im_inbound_e2e_tests.rs
+++ b/tests/im_inbound_e2e_tests.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use closeclaw::gateway::{DmScope, GatewayConfig, SessionManager};
 use closeclaw::im::processor::{ProcessError, ProcessorRegistry};
+use closeclaw::session::bootstrap::BootstrapMode;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,6 +26,8 @@ fn test_session_manager() -> Arc<SessionManager> {
             dm_scope: DmScope::PerChannelPeer,
         },
         None,
+        None,
+        BootstrapMode::Full,
     ))
 }
 


### PR DESCRIPTION
## Source
CI — Master 编译失败

## Problem
`tests/im_inbound_e2e_tests.rs:20` 调用 `SessionManager::new` 缺少两个参数（`Option<PathBuf>` 和 `BootstrapMode`），导致编译失败。

CI run: 25755157434

## Fix
- 添加 `use closeclaw::session::bootstrap::BootstrapMode;` 导入
- 补充 `None`（workspace_dir）和 `BootstrapMode::Full` 参数

## Testing
- `cargo test --test im_inbound_e2e_tests` ✅ (2 tests passed)
- `cargo build` ✅

## Plan
`plan/2026-05-13-03-24-ci.md`

## 进度

| | Step | Subagent Time | Subagent Tokens | Main Context |
|------|------|---------------|-----------------|--------------|
| ✅ | 1.1 | 37s | ~17.6k | |
| ✅ | 2：代码 Review | — | — | 主脑直接 review |
| ✅ | 3：测试 | — | — | 主脑直接测试 |
| skip | 4：SPEC | — | — | 仅测试文件改动 |
| skip | 5：SPEC Review | — | — | 仅测试文件改动 |
| → | 6：PR | | | |
| skip | 7：Issue | — | — | CI 修复 |