### PR TITLE
fix(test): complete SessionManager::new 4-arg migration in outbound tests

### DIFF
--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -6,6 +6,7 @@ use closeclaw::im::{AdapterError, IMAdapter};
 use closeclaw::processor_chain::{
     MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage,
 };
+use closeclaw::session::bootstrap::BootstrapMode;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -98,7 +99,12 @@ pub(crate) fn make_outbound_message(to: &str, content: &str) -> Message {
 }
 
 pub(crate) fn make_outbound_gw(config: GatewayConfig) -> (Gateway, Arc<SessionManager>) {
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let gw = Gateway::new(config, Arc::clone(&sm));
     (gw, sm)
 }
@@ -121,7 +127,12 @@ async fn test_send_outbound_no_registry_bypass() {
 #[tokio::test]
 async fn test_send_outbound_text_path() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -146,7 +157,12 @@ async fn test_send_outbound_text_path() {
 #[tokio::test]
 async fn test_send_outbound_interactive_path() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -181,7 +197,12 @@ async fn test_send_outbound_interactive_path() {
 #[tokio::test]
 async fn test_send_outbound_suppress() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {

--- a/tests/gateway_send_outbound_renderer.rs
+++ b/tests/gateway_send_outbound_renderer.rs
@@ -9,6 +9,7 @@ use closeclaw::processor_chain::{
     dsl_parser::DslParseResult, MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage,
 };
 use closeclaw::renderer::{RenderedOutput, Renderer};
+use closeclaw::session::bootstrap::BootstrapMode;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -130,7 +131,12 @@ use gateway_send_outbound_basic::{make_config, make_outbound_gw, make_outbound_m
 #[tokio::test]
 async fn test_send_outbound_with_renderer_text() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -169,7 +175,12 @@ async fn test_send_outbound_with_renderer_text() {
 #[tokio::test]
 async fn test_send_outbound_with_renderer_interactive() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -203,7 +214,12 @@ async fn test_send_outbound_with_renderer_interactive() {
 #[tokio::test]
 async fn test_send_outbound_with_renderer_dsl_result_passed() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let dsl_json = serde_json::to_string(&DslParseResult {
         clean_content: "Clean content".to_string(),
         instructions: vec![],
@@ -245,7 +261,12 @@ async fn test_send_outbound_with_renderer_dsl_result_passed() {
 #[tokio::test]
 async fn test_send_outbound_no_renderer_fallback_text() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -294,7 +315,12 @@ async fn test_send_outbound_no_renderer_no_registry_bypass() {
 #[tokio::test]
 async fn test_send_outbound_renderer_with_suppress() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let registry = Arc::new({
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
@@ -329,7 +355,12 @@ async fn test_send_outbound_renderer_with_suppress() {
 #[tokio::test]
 async fn test_send_outbound_renderer_requires_registry() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(&config, None));
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ));
     let renderer = Arc::new(MockRenderer::new(
         "text",
         serde_json::json!({"msg_type": "text", "content": {"text": "x"}}),


### PR DESCRIPTION
## Summary

PR #645 partially updated `SessionManager::new` calls for the new 4-arg signature but missed 10 call sites in outbound test files.

## Changes

- `tests/gateway_send_outbound_basic.rs`: 4 call sites + import
- `tests/gateway_send_outbound_renderer.rs`: 6 call sites + import
- All calls updated to `SessionManager::new(&config, None, None, BootstrapMode::Minimal)`

## Test

All 21 tests in both files pass.

Source: CI-25757444702
Type: fix