### PR TITLE
feat(tools): inject eager tool detail into first-level index

### DIFF
--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -164,7 +164,7 @@ use crate::tools::{ToolContext, ToolRegistry};
 /// Build the Tools section content from a registry.
 ///
 /// Groups tools by their group name, formats each group with a header and
-/// tool list, then truncates at `TOOLS_SECTION_MAX_LEN` (1500 chars) if needed.
+/// tool list, then truncates at `TOOLS_SECTION_MAX_LEN` (15000 chars) if needed.
 pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> Section {
     let content = registry.build_tools_section(ctx).await;
     Section::ToolsSection(content)
@@ -458,9 +458,9 @@ mod tests {
             Section::ToolsSection(c) => c,
             _ => panic!("expected ToolsSection"),
         };
-        // With 7 tools the section should be well under 1500 chars
+        // With all builtin tools + detail the section should be well under 15000 chars
         assert!(
-            content.chars().count() <= 1500,
+            content.chars().count() <= 15000,
             "section too long: {}",
             content
         );

--- a/src/tools/SPEC.md
+++ b/src/tools/SPEC.md
@@ -8,7 +8,8 @@
 - `Tool` trait 定义工具的核心接口，所有工具必须实现 `Send + Sync + 'static`
 - `ToolRegistry` 是并发安全的注册中心，内部用 `tokio::sync::RwLock` 包裹 `HashMap<String, Arc<dyn Tool>>`
 - `ToolDescriptor` 仅含 name / group / summary / is_deferred，用于 system prompt 一级索引
-- 工具 detail 和 input_schema 按需通过 `ToolSearch` 触发注入，不在一级索引展开
+- `ToolRegistry::build_tools_section` 将 eager 工具的 detail 注入一级索引；deferred 工具仅显示名称；group header 在组内存在 eager 工具时附加 `(always loaded)` 标记；按 group 排序，组内按 name 排序；总长不超过 15000 字符，超长截断（不做任何提示文字）
+- 工具 detail 和 input_schema 完整内容通过 `ToolSearch` 触发注入
 - `builtin` 子模块提供 5 个 file_ops 工具、2 个 meta 工具、5 个 git_ops 工具、1 个 SkillTool 和 2 个 stub 工具，全部通过 `register_builtin_tools()` 一键注册
 - System prompt 集成：builder.rs 提供 `build_tools_section(registry, ctx)` async 函数，返回 `Section::ToolsSection`；`build_from_workspace` 中预埋 `Section::ToolsSection(String::new())` 占位符（位于 RoleSection 之后 MemorySection 之前）。当前 `build_tools_section` 尚未在 sync 路径中与 `build_from_workspace` 打通，内容通过 dynamic_sections 外部传入
 
@@ -37,7 +38,7 @@
 - `ToolRegistry::list_descriptors(ctx)` — 列出所有 ToolDescriptor，按 ctx 过滤
 - `ToolRegistry::get_detail(name)` — 获取指定工具的 detail 字符串，不存在返回 `NotFound`
 - `ToolRegistry::list_by_group(group)` — 列出指定分组下的所有工具名
-- `ToolRegistry::build_tools_section(ctx)` — 生成分组索引字符串，超 1500 字符截断
+- `ToolRegistry::build_tools_section(ctx)` — 生成分组索引字符串，eager 工具显示 `**{name}**: {detail}`，deferred 工具仅显示名称；总长不超过 15000 字符，超长截断
 
 ### 内建工具（builtin/）
 
@@ -58,7 +59,7 @@
 ```
 tools/
 ├── mod.rs              # Tool trait、ToolFlags、ToolContext、ToolDescriptor、ToolError
-├── registry.rs         # ToolRegistry 并发注册中心 + build_tools_section
+├── registry.rs         # ToolRegistry 并发注册中心 + ToolInfo + build_tools_section
 └── builtin/
     ├── mod.rs          # register_builtin_tools 统一入口（15 个工具）
     ├── file_ops.rs     # Read / Write / Edit / Grep / Ls
@@ -72,7 +73,7 @@ tools/
 
 ### 两级设计
 
-**一级索引**（`ToolRegistry::build_tools_section` 输出）：按 group 聚合，展示 `**{group}** — (always loaded)` 标题 + 工具名列表（中文顿号分隔、按名称排序），供 LLM 了解可用工具范围。总长不超过 1500 字符，超长截断并附加 `... (N more tools, use ToolSearch to explore)` 提示。
+**一级索引**（`ToolRegistry::build_tools_section` 输出）：按 group 排序，eager 工具展示 `**{name}**: {detail}`，deferred 工具仅显示名称；group header 在组内存在 eager 工具时附加 `(always loaded)` 标记。总长不超过 15000 字符，超长截断。
 
 **二级详情**（`get_detail` 返回）：完整 detail 描述 + input_schema JSON，通过 `ToolSearch` 按关键词或精确名触发注入。
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -6,8 +6,42 @@ use std::sync::Arc;
 
 use crate::tools::{Tool, ToolContext, ToolDescriptor, ToolError};
 
+use serde_json::Value;
+
+/// Internal tool info carrier for `build_tools_section`.
+struct ToolInfo {
+    name: String,
+    group: String,
+    detail: String,
+    #[allow(dead_code)]
+    input_schema: Value,
+    is_deferred: bool,
+    #[allow(dead_code)]
+    is_read_only: bool,
+    #[allow(dead_code)]
+    is_destructive: bool,
+    #[allow(dead_code)]
+    is_expensive: bool,
+}
+
+impl ToolInfo {
+    fn from_tool(tool: &Arc<dyn Tool>) -> Self {
+        let flags = tool.flags();
+        Self {
+            name: tool.name().to_string(),
+            group: tool.group().to_string(),
+            detail: tool.detail(),
+            input_schema: tool.input_schema(),
+            is_deferred: flags.is_deferred_by_default,
+            is_read_only: flags.is_read_only,
+            is_destructive: flags.is_destructive,
+            is_expensive: flags.is_expensive,
+        }
+    }
+}
+
 /// Maximum length of the first-level tools section (in characters).
-const TOOLS_SECTION_MAX_LEN: usize = 1500;
+const TOOLS_SECTION_MAX_LEN: usize = 15000;
 
 /// Thread-safe tool registry.
 ///
@@ -32,40 +66,44 @@ impl Default for ToolRegistry {
 impl ToolRegistry {
     /// Format a single group into a section line, returning (output, new_total_len).
     /// Returns None if truncation was triggered.
+    ///
+    /// Output format:
+    /// - group header: `**{group}** — (always loaded)` if the group has eager tools
+    /// - eager tools: `  - **{name}**: {detail}`
+    /// - deferred tools: `  - {name}`
     fn format_group_line(
         group_name: &str,
-        tools: Vec<(String, bool)>,
+        tools: &[ToolInfo],
         total_len: usize,
         max_len: usize,
     ) -> Option<(String, usize)> {
-        let tag = if tools.iter().any(|(_, deferred)| !deferred) {
-            "(always loaded)"
-        } else {
-            ""
-        };
+        let has_eager = tools.iter().any(|t| !t.is_deferred);
+        let tag = if has_eager { "(always loaded)" } else { "" };
         let header = if tag.is_empty() {
             format!("**{}**", group_name)
         } else {
             format!("**{}** — {}", group_name, tag)
         };
-        let mut sorted_tools = tools;
-        sorted_tools.sort_by_key(|(n, _)| n.clone());
-        let tool_list: String = sorted_tools
-            .into_iter()
-            .map(|(n, _)| n)
-            .collect::<Vec<_>>()
-            .join("、");
-        let line = format!("{}\n- {}\n", header, tool_list);
-        let new_len = total_len + line.chars().count();
+
+        let mut sorted_tools: Vec<_> = tools.iter().collect();
+        sorted_tools.sort_by_key(|t| t.name.clone());
+
+        let mut lines = vec![header];
+        for tool in sorted_tools {
+            let line = if tool.is_deferred {
+                format!("  - {}", tool.name)
+            } else {
+                format!("  - **{}**: {}", tool.name, tool.detail)
+            };
+            lines.push(line);
+        }
+
+        let output = lines.join("\n") + "\n";
+        let new_len = total_len + output.chars().count();
         if new_len > max_len {
-            let overflow = new_len - max_len;
-            let exceeded = format!(
-                "... ({} more tools, use ToolSearch to explore)",
-                overflow / 10 + 1
-            );
-            Some((exceeded, new_len))
+            None
         } else {
-            Some((line, new_len))
+            Some((output, new_len))
         }
     }
 }
@@ -141,17 +179,17 @@ impl ToolRegistry {
     ///
     /// Groups tools by `group()`, formats each group with a header and tool
     /// list, then truncates at `TOOLS_SECTION_MAX_LEN` if needed.
-    pub async fn build_tools_section(&self, ctx: &ToolContext) -> String {
-        let descriptors = self.list_descriptors(ctx).await;
+    pub async fn build_tools_section(&self, _ctx: &ToolContext) -> String {
+        let guard = self.tools.read().await;
+
+        // Collect ToolInfo from all registered tools
+        let tool_infos: Vec<ToolInfo> = guard.values().map(|t| ToolInfo::from_tool(t)).collect();
 
         // Group by group name
-        let mut groups_map: std::collections::HashMap<String, Vec<(String, bool)>> =
+        let mut groups_map: std::collections::HashMap<String, Vec<ToolInfo>> =
             std::collections::HashMap::new();
-        for d in descriptors {
-            groups_map
-                .entry(d.group)
-                .or_default()
-                .push((d.name, d.is_deferred));
+        for info in tool_infos {
+            groups_map.entry(info.group.clone()).or_default().push(info);
         }
 
         let mut lines: Vec<String> = Vec::new();
@@ -162,7 +200,7 @@ impl ToolRegistry {
 
         for (group_name, tools) in sorted_groups {
             let Some((line, new_len)) =
-                Self::format_group_line(&group_name, tools, total_len, TOOLS_SECTION_MAX_LEN)
+                Self::format_group_line(&group_name, &tools, total_len, TOOLS_SECTION_MAX_LEN)
             else {
                 break;
             };
@@ -328,6 +366,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tool_info_from_tool() {
+        let reg = ToolRegistry::new();
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read files".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+
+        let guard = reg.tools.read().await;
+        let tool = guard.get("Read").unwrap();
+        let info = ToolInfo::from_tool(tool);
+        assert_eq!(info.name, "Read");
+        assert_eq!(info.group, "file_ops");
+        assert_eq!(info.detail, "detail for Read");
+        assert!(!info.is_deferred);
+        assert!(!info.is_read_only);
+        assert!(!info.is_destructive);
+        assert!(!info.is_expensive);
+    }
+
+    #[tokio::test]
     async fn test_build_tools_section() {
         let reg = ToolRegistry::new();
         reg.register(DummyTool {
@@ -350,9 +412,49 @@ mod tests {
         let ctx = make_ctx();
         let section = reg.build_tools_section(&ctx).await;
         assert!(section.contains("file_ops"));
-        assert!(section.contains("Read"));
+        assert!(section.contains("**Read**: detail for Read"));
         assert!(section.contains("meta"));
-        assert!(section.contains("ToolSearch"));
+        assert!(section.contains("**ToolSearch**: detail for ToolSearch"));
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_with_detail() {
+        let reg = ToolRegistry::new();
+        // Eager tool — should show detail
+        reg.register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read files".to_string(),
+            is_deferred: false,
+        })
+        .await
+        .unwrap();
+        // Deferred tool — should show name only
+        reg.register(DummyTool {
+            name: "Write".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Write files".to_string(),
+            is_deferred: true,
+        })
+        .await
+        .unwrap();
+
+        let ctx = make_ctx();
+        let section = reg.build_tools_section(&ctx).await;
+        // Eager: bold name + detail
+        assert!(
+            section.contains("**Read**: detail for Read"),
+            "eager tool should show detail, got: {section}"
+        );
+        // Deferred: name only, no bold/detail
+        assert!(
+            section.contains("  - Write"),
+            "deferred tool should show name only, got: {section}"
+        );
+        assert!(
+            !section.contains("**Write**:"),
+            "deferred tool should NOT have bold detail, got: {section}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

让 `build_tools_section` 从 `Arc<dyn Tool>` 实例中读取 `detail()` 并注入一级索引。

### Changes
- 新增 `ToolInfo` 内部结构体，从 `Arc<dyn Tool>` 一次性收集 detail + flags 元数据
- 重构 `build_tools_section`：eager 工具输出 `**name**: detail`，deferred 工具只输出名称
- `format_group_line` 改为接收 `&[ToolInfo]`
- `TOOLS_SECTION_MAX_LEN` 从 1500 调整为 15000
- 更新 `SPEC.md` 反映新输出格式
- 新增测试 `test_tool_info_from_tool` 和 `test_build_tools_section_with_detail`

### Test
1600 passed, 0 failed

Closes #652

Source: issue #652
Type: feat