### PR TITLE
feat(tools): add deferred tag and danger marks to build_tools_section

### DIFF
--- a/src/tools/SPEC.md
+++ b/src/tools/SPEC.md
@@ -8,7 +8,7 @@
 - `Tool` trait 定义工具的核心接口，所有工具必须实现 `Send + Sync + 'static`
 - `ToolRegistry` 是并发安全的注册中心，内部用 `tokio::sync::RwLock` 包裹 `HashMap<String, Arc<dyn Tool>>`
 - `ToolDescriptor` 仅含 name / group / summary / is_deferred，用于 system prompt 一级索引
-- `ToolRegistry::build_tools_section` 将 eager 工具的 detail 注入一级索引；deferred 工具仅显示名称；group header 在组内存在 eager 工具时附加 `(always loaded)` 标记；按 group 排序，组内按 name 排序；总长不超过 15000 字符，超长截断（不做任何提示文字）
+- `ToolRegistry::build_tools_section` 将 eager 工具以 `**{name}**{danger}: {detail}` 格式注入一级索引；deferred 工具以 `  - {name}{danger}` 格式仅显示名称；纯 deferred 组 header 显示 `(deferred)`，含 eager 工具的组显示 `(always loaded)`；danger 根据 `is_read_only`/`is_destructive` 标记为 `(read-only)` 或 `(destructive)`；按 group 排序，组内按 name 排序；总长不超过 15000 字符，超长截断（不做任何提示文字）
 - 工具 detail 和 input_schema 完整内容通过 `ToolSearch` 触发注入
 - `builtin` 子模块提供 5 个 file_ops 工具、2 个 meta 工具、5 个 git_ops 工具、1 个 SkillTool 和 2 个 stub 工具，全部通过 `register_builtin_tools()` 一键注册
 - System prompt 集成：builder.rs 提供 `build_tools_section(registry, ctx)` async 函数，返回 `Section::ToolsSection`；`build_from_workspace` 中预埋 `Section::ToolsSection(String::new())` 占位符（位于 RoleSection 之后 MemorySection 之前）。当前 `build_tools_section` 尚未在 sync 路径中与 `build_from_workspace` 打通，内容通过 dynamic_sections 外部传入
@@ -38,12 +38,12 @@
 - `ToolRegistry::list_descriptors(ctx)` — 列出所有 ToolDescriptor，按 ctx 过滤
 - `ToolRegistry::get_detail(name)` — 获取指定工具的 detail 字符串，不存在返回 `NotFound`
 - `ToolRegistry::list_by_group(group)` — 列出指定分组下的所有工具名
-- `ToolRegistry::build_tools_section(ctx)` — 生成分组索引字符串，eager 工具显示 `**{name}**: {detail}`，deferred 工具仅显示名称；总长不超过 15000 字符，超长截断
+- `ToolRegistry::build_tools_section(ctx)` — 生成分组索引字符串，按 group 分组输出；纯 deferred 组 header 显示 `(deferred)`，含 eager 工具的组显示 `(always loaded)`；eager 工具显示 `**{name}**{danger}: {detail}`，deferred 工具显示 `  - {name}{danger}`；danger 根据 `is_read_only`/`is_destructive` 标记为 `(read-only)` 或 `(destructive)`；总长不超过 15000 字符，超长截断
 
 ### 内建工具（builtin/）
 
 - `SkillTool` — skills 组，从 DiskSkillRegistry 查找 skill 并注入 SKILL.md 内容到 agent 上下文；group = "skills"，is_deferred_by_default = false；输入参数 skill_name（必填）和 args（可选）
-- `register_builtin_tools(registry, disk_registry)` — 将全部 16 个内建工具注册到指定注册表
+- `register_builtin_tools(registry, disk_registry)` — 将全部 15 个内建工具注册到指定注册表
 - `ReadTool` / `WriteTool` / `EditTool` / `GrepTool` / `LsTool` — file_ops 组，group = "file_ops"
 - `ToolSearchTool` / `PermissionQueryTool` — meta 组，group = "meta"，is_deferred_by_default = false
 - `GitStatusTool` / `GitLogTool` / `GitCommitTool` / `GitPushTool` / `GitPullTool` — git_ops 组，group = "git_ops"；GitStatusTool/GitLogTool 标记 is_read_only，GitCommitTool/GitPushTool/GitPullTool 标记 is_destructive
@@ -73,7 +73,7 @@ tools/
 
 ### 两级设计
 
-**一级索引**（`ToolRegistry::build_tools_section` 输出）：按 group 排序，eager 工具展示 `**{name}**: {detail}`，deferred 工具仅显示名称；group header 在组内存在 eager 工具时附加 `(always loaded)` 标记。总长不超过 15000 字符，超长截断。
+**一级索引**（`ToolRegistry::build_tools_section` 输出）：按 group 排序，eager 工具展示 `**{name}**{danger}: {detail}`，deferred 工具仅显示 `  - {name}{danger}`；纯 deferred 组 header 显示 `(deferred)`，含 eager 工具的组显示 `(always loaded)`；危险度标记：`is_read_only` → `(read-only)`，`is_destructive` → `(destructive)`。总长不超过 15000 字符，超长截断。
 
 **二级详情**（`get_detail` 返回）：完整 detail 描述 + input_schema JSON，通过 `ToolSearch` 按关键词或精确名触发注入。
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -16,9 +16,7 @@ struct ToolInfo {
     #[allow(dead_code)]
     input_schema: Value,
     is_deferred: bool,
-    #[allow(dead_code)]
     is_read_only: bool,
-    #[allow(dead_code)]
     is_destructive: bool,
     #[allow(dead_code)]
     is_expensive: bool,
@@ -68,9 +66,9 @@ impl ToolRegistry {
     /// Returns None if truncation was triggered.
     ///
     /// Output format:
-    /// - group header: `**{group}** — (always loaded)` if the group has eager tools
-    /// - eager tools: `  - **{name}**: {detail}`
-    /// - deferred tools: `  - {name}`
+    /// - group header: `**{group}** — (always loaded)` if the group has eager tools, else `**{group}** — (deferred)`
+    /// - eager tools: `  - **{name}**{(read-only)}: {detail}` or `  - **{name}**{(destructive)}: {detail}`
+    /// - deferred tools: `  - {name}{(read-only)}` or `  - {name}{(destructive)}`
     fn format_group_line(
         group_name: &str,
         tools: &[ToolInfo],
@@ -78,22 +76,29 @@ impl ToolRegistry {
         max_len: usize,
     ) -> Option<(String, usize)> {
         let has_eager = tools.iter().any(|t| !t.is_deferred);
-        let tag = if has_eager { "(always loaded)" } else { "" };
-        let header = if tag.is_empty() {
-            format!("**{}**", group_name)
+        let tag = if has_eager {
+            "(always loaded)"
         } else {
-            format!("**{}** — {}", group_name, tag)
+            "(deferred)"
         };
+        let header = format!("**{}** — {}", group_name, tag);
 
         let mut sorted_tools: Vec<_> = tools.iter().collect();
         sorted_tools.sort_by_key(|t| t.name.clone());
 
         let mut lines = vec![header];
         for tool in sorted_tools {
-            let line = if tool.is_deferred {
-                format!("  - {}", tool.name)
+            let danger_mark = if tool.is_destructive {
+                " (destructive)"
+            } else if tool.is_read_only {
+                " (read-only)"
             } else {
-                format!("  - **{}**: {}", tool.name, tool.detail)
+                ""
+            };
+            let line = if tool.is_deferred {
+                format!("  - {}{}", tool.name, danger_mark)
+            } else {
+                format!("  - **{}**{}: {}", tool.name, danger_mark, tool.detail)
             };
             lines.push(line);
         }
@@ -213,255 +218,5 @@ impl ToolRegistry {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tools::ToolFlags;
-
-    struct DummyTool {
-        name: String,
-        group: String,
-        summary_text: String,
-        is_deferred: bool,
-    }
-
-    impl Tool for DummyTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-        fn group(&self) -> &str {
-            &self.group
-        }
-        fn summary(&self) -> String {
-            self.summary_text.clone()
-        }
-        fn detail(&self) -> String {
-            format!("detail for {}", self.name)
-        }
-        fn input_schema(&self) -> serde_json::Value {
-            serde_json::json!({ "type": "object", "properties": {} })
-        }
-        fn flags(&self) -> ToolFlags {
-            let mut f = ToolFlags::default();
-            f.is_deferred_by_default = self.is_deferred;
-            f
-        }
-    }
-
-    fn make_ctx() -> ToolContext {
-        ToolContext {
-            agent_id: "test-agent".to_string(),
-            workdir: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn test_register_and_get_detail() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read file contents".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-
-        let detail = reg.get_detail("Read").await.unwrap();
-        assert!(detail.contains("Read"));
-    }
-
-    #[tokio::test]
-    async fn test_register_not_found() {
-        let reg = ToolRegistry::new();
-        let err = reg.get_detail("NonExistent").await.unwrap_err();
-        assert!(matches!(err, ToolError::NotFound(_)));
-    }
-
-    #[tokio::test]
-    async fn test_register_duplicate() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-
-        let err = reg
-            .register(DummyTool {
-                name: "Read".to_string(),
-                group: "file_ops".to_string(),
-                summary_text: "Read again".to_string(),
-                is_deferred: false,
-            })
-            .await
-            .unwrap_err();
-        assert!(matches!(err, ToolError::AlreadyRegistered(_)));
-    }
-
-    #[tokio::test]
-    async fn test_list_descriptors() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read files".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-        reg.register(DummyTool {
-            name: "Write".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Write files".to_string(),
-            is_deferred: true,
-        })
-        .await
-        .unwrap();
-
-        let ctx = make_ctx();
-        let descriptors = reg.list_descriptors(&ctx).await;
-        assert_eq!(descriptors.len(), 2);
-        let read_desc = descriptors.iter().find(|d| d.name == "Read").unwrap();
-        assert_eq!(read_desc.group, "file_ops");
-        assert!(!read_desc.is_deferred);
-        let write_desc = descriptors.iter().find(|d| d.name == "Write").unwrap();
-        assert!(write_desc.is_deferred);
-    }
-
-    #[tokio::test]
-    async fn test_list_by_group() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "R".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-        reg.register(DummyTool {
-            name: "ToolSearch".to_string(),
-            group: "meta".to_string(),
-            summary_text: "T".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-
-        let file_ops = reg.list_by_group("file_ops").await;
-        assert_eq!(file_ops, vec!["Read"]);
-
-        let meta = reg.list_by_group("meta").await;
-        assert_eq!(meta, vec!["ToolSearch"]);
-    }
-
-    #[tokio::test]
-    async fn test_list_by_group_empty() {
-        let reg = ToolRegistry::new();
-        let result = reg.list_by_group("nonexistent").await;
-        assert!(result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_tool_info_from_tool() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read files".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-
-        let guard = reg.tools.read().await;
-        let tool = guard.get("Read").unwrap();
-        let info = ToolInfo::from_tool(tool);
-        assert_eq!(info.name, "Read");
-        assert_eq!(info.group, "file_ops");
-        assert_eq!(info.detail, "detail for Read");
-        assert!(!info.is_deferred);
-        assert!(!info.is_read_only);
-        assert!(!info.is_destructive);
-        assert!(!info.is_expensive);
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section() {
-        let reg = ToolRegistry::new();
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read files".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-        reg.register(DummyTool {
-            name: "ToolSearch".to_string(),
-            group: "meta".to_string(),
-            summary_text: "Search tools".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-
-        let ctx = make_ctx();
-        let section = reg.build_tools_section(&ctx).await;
-        assert!(section.contains("file_ops"));
-        assert!(section.contains("**Read**: detail for Read"));
-        assert!(section.contains("meta"));
-        assert!(section.contains("**ToolSearch**: detail for ToolSearch"));
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_with_detail() {
-        let reg = ToolRegistry::new();
-        // Eager tool — should show detail
-        reg.register(DummyTool {
-            name: "Read".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Read files".to_string(),
-            is_deferred: false,
-        })
-        .await
-        .unwrap();
-        // Deferred tool — should show name only
-        reg.register(DummyTool {
-            name: "Write".to_string(),
-            group: "file_ops".to_string(),
-            summary_text: "Write files".to_string(),
-            is_deferred: true,
-        })
-        .await
-        .unwrap();
-
-        let ctx = make_ctx();
-        let section = reg.build_tools_section(&ctx).await;
-        // Eager: bold name + detail
-        assert!(
-            section.contains("**Read**: detail for Read"),
-            "eager tool should show detail, got: {section}"
-        );
-        // Deferred: name only, no bold/detail
-        assert!(
-            section.contains("  - Write"),
-            "deferred tool should show name only, got: {section}"
-        );
-        assert!(
-            !section.contains("**Write**:"),
-            "deferred tool should NOT have bold detail, got: {section}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_empty() {
-        let reg = ToolRegistry::new();
-        let ctx = make_ctx();
-        let section = reg.build_tools_section(&ctx).await;
-        assert!(section.is_empty());
-    }
-}
+#[path = "registry_tests.rs"]
+mod tests;

--- a/src/tools/registry_tests.rs
+++ b/src/tools/registry_tests.rs
@@ -1,0 +1,484 @@
+use super::*;
+use crate::tools::ToolFlags;
+
+struct DummyTool {
+    name: String,
+    group: String,
+    summary_text: String,
+    is_deferred: bool,
+    is_read_only: bool,
+    is_destructive: bool,
+}
+
+impl Tool for DummyTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn group(&self) -> &str {
+        &self.group
+    }
+    fn summary(&self) -> String {
+        self.summary_text.clone()
+    }
+    fn detail(&self) -> String {
+        format!("detail for {}", self.name)
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {} })
+    }
+    fn flags(&self) -> ToolFlags {
+        let mut f = ToolFlags::default();
+        f.is_deferred_by_default = self.is_deferred;
+        f.is_read_only = self.is_read_only;
+        f.is_destructive = self.is_destructive;
+        f
+    }
+}
+
+fn make_ctx() -> ToolContext {
+    ToolContext {
+        agent_id: "test-agent".to_string(),
+        workdir: None,
+    }
+}
+
+#[tokio::test]
+async fn test_register_and_get_detail() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read file contents".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let detail = reg.get_detail("Read").await.unwrap();
+    assert!(detail.contains("Read"));
+}
+
+#[tokio::test]
+async fn test_register_not_found() {
+    let reg = ToolRegistry::new();
+    let err = reg.get_detail("NonExistent").await.unwrap_err();
+    assert!(matches!(err, ToolError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn test_register_duplicate() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let err = reg
+        .register(DummyTool {
+            name: "Read".to_string(),
+            group: "file_ops".to_string(),
+            summary_text: "Read again".to_string(),
+            is_deferred: false,
+            is_read_only: false,
+            is_destructive: false,
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ToolError::AlreadyRegistered(_)));
+}
+
+#[tokio::test]
+async fn test_list_descriptors() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read files".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    reg.register(DummyTool {
+        name: "Write".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Write files".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let descriptors = reg.list_descriptors(&ctx).await;
+    assert_eq!(descriptors.len(), 2);
+    let read_desc = descriptors.iter().find(|d| d.name == "Read").unwrap();
+    assert_eq!(read_desc.group, "file_ops");
+    assert!(!read_desc.is_deferred);
+    let write_desc = descriptors.iter().find(|d| d.name == "Write").unwrap();
+    assert!(write_desc.is_deferred);
+}
+
+#[tokio::test]
+async fn test_list_by_group() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "R".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    reg.register(DummyTool {
+        name: "ToolSearch".to_string(),
+        group: "meta".to_string(),
+        summary_text: "T".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let file_ops = reg.list_by_group("file_ops").await;
+    assert_eq!(file_ops, vec!["Read"]);
+
+    let meta = reg.list_by_group("meta").await;
+    assert_eq!(meta, vec!["ToolSearch"]);
+}
+
+#[tokio::test]
+async fn test_list_by_group_empty() {
+    let reg = ToolRegistry::new();
+    let result = reg.list_by_group("nonexistent").await;
+    assert!(result.is_empty());
+}
+
+#[tokio::test]
+async fn test_tool_info_from_tool() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read files".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let guard = reg.tools.read().await;
+    let tool = guard.get("Read").unwrap();
+    let info = ToolInfo::from_tool(tool);
+    assert_eq!(info.name, "Read");
+    assert_eq!(info.group, "file_ops");
+    assert_eq!(info.detail, "detail for Read");
+    assert!(!info.is_deferred);
+    assert!(!info.is_read_only);
+    assert!(!info.is_destructive);
+    assert!(!info.is_expensive);
+}
+
+#[tokio::test]
+async fn test_build_tools_section() {
+    let reg = ToolRegistry::new();
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read files".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    reg.register(DummyTool {
+        name: "ToolSearch".to_string(),
+        group: "meta".to_string(),
+        summary_text: "Search tools".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    assert!(section.contains("file_ops"), "section: {section}");
+    assert!(
+        section.contains("**Read**: detail for Read"),
+        "section: {section}"
+    );
+    assert!(section.contains("meta"), "section: {section}");
+    assert!(
+        section.contains("**ToolSearch**: detail for ToolSearch"),
+        "section: {section}"
+    );
+    // All-eager group header should include "(always loaded)"
+    assert!(section.contains("(always loaded)"), "section: {section}");
+}
+
+#[tokio::test]
+async fn test_build_tools_section_with_detail() {
+    let reg = ToolRegistry::new();
+    // Eager tool — should show detail
+    reg.register(DummyTool {
+        name: "Read".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Read files".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    // Deferred tool — should show name only
+    reg.register(DummyTool {
+        name: "Write".to_string(),
+        group: "file_ops".to_string(),
+        summary_text: "Write files".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    // Eager: bold name + detail
+    assert!(
+        section.contains("**Read**: detail for Read"),
+        "eager tool should show detail, got: {section}"
+    );
+    // Deferred: name only, no bold/detail
+    assert!(
+        section.contains("  - Write"),
+        "deferred tool should show name only, got: {section}"
+    );
+    assert!(
+        !section.contains("**Write**:"),
+        "deferred tool should NOT have bold detail, got: {section}"
+    );
+    // Mixed eager+deferred group header is "(always loaded)"
+    assert!(section.contains("(always loaded)"), "section: {section}");
+}
+
+#[tokio::test]
+async fn test_build_tools_section_deferred_group() {
+    let reg = ToolRegistry::new();
+    // Pure deferred group
+    reg.register(DummyTool {
+        name: "SlowOp".to_string(),
+        group: "background".to_string(),
+        summary_text: "Slow async operation".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    reg.register(DummyTool {
+        name: "Cleanup".to_string(),
+        group: "background".to_string(),
+        summary_text: "Clean up temp files".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    // Deferred group header must show "(deferred)"
+    assert!(
+        section.contains("(deferred)"),
+        "deferred group should have '(deferred)' tag, got: {section}"
+    );
+    assert!(
+        !section.contains("(always loaded)"),
+        "pure deferred group should NOT have '(always loaded)', got: {section}"
+    );
+    // Deferred tools: no bold, no detail
+    assert!(
+        section.contains("  - SlowOp"),
+        "deferred tool name should appear, got: {section}"
+    );
+    assert!(
+        !section.contains("**SlowOp**"),
+        "deferred tool should NOT be bold, got: {section}"
+    );
+}
+
+#[tokio::test]
+async fn test_build_tools_section_danger_marks() {
+    let reg = ToolRegistry::new();
+    // Eager read-only tool
+    reg.register(DummyTool {
+        name: "Viewer".to_string(),
+        group: "review".to_string(),
+        summary_text: "View contents".to_string(),
+        is_deferred: false,
+        is_read_only: true,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    // Eager destructive tool
+    reg.register(DummyTool {
+        name: "Deleter".to_string(),
+        group: "review".to_string(),
+        summary_text: "Delete files".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: true,
+    })
+    .await
+    .unwrap();
+    // Eager tool with no danger mark
+    reg.register(DummyTool {
+        name: "Lister".to_string(),
+        group: "review".to_string(),
+        summary_text: "List everything".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    // Deferred read-only tool
+    reg.register(DummyTool {
+        name: "DReader".to_string(),
+        group: "lazy".to_string(),
+        summary_text: "Deferred read".to_string(),
+        is_deferred: true,
+        is_read_only: true,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    // Deferred destructive tool
+    reg.register(DummyTool {
+        name: "DDeleter".to_string(),
+        group: "lazy".to_string(),
+        summary_text: "Deferred delete".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: true,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    // Eager read-only: bold name + "(read-only)" + detail
+    assert!(
+        section.contains("**Viewer** (read-only): detail for Viewer"),
+        "expected eager read-only mark, got: {section}"
+    );
+    // Eager destructive: bold name + "(destructive)" + detail
+    assert!(
+        section.contains("**Deleter** (destructive): detail for Deleter"),
+        "expected eager destructive mark, got: {section}"
+    );
+    // Eager no mark: no suffix after bold name
+    assert!(
+        section.contains("**Lister**: detail for Lister"),
+        "expected eager no mark, got: {section}"
+    );
+    // Deferred read-only: name + "(read-only)"
+    assert!(
+        section.contains("  - DReader (read-only)"),
+        "expected deferred read-only mark, got: {section}"
+    );
+    // Deferred destructive: name + "(destructive)"
+    assert!(
+        section.contains("  - DDeleter (destructive)"),
+        "expected deferred destructive mark, got: {section}"
+    );
+}
+
+#[tokio::test]
+async fn test_build_tools_section_eager_and_deferred_group() {
+    let reg = ToolRegistry::new();
+    // Eager tool in one group
+    reg.register(DummyTool {
+        name: "Query".to_string(),
+        group: "data".to_string(),
+        summary_text: "Query data".to_string(),
+        is_deferred: false,
+        is_read_only: true,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+    // Deferred tool in the same group → mixed group
+    reg.register(DummyTool {
+        name: "Purge".to_string(),
+        group: "data".to_string(),
+        summary_text: "Purge old data".to_string(),
+        is_deferred: true,
+        is_read_only: false,
+        is_destructive: true,
+    })
+    .await
+    .unwrap();
+    // Pure eager group
+    reg.register(DummyTool {
+        name: "Compute".to_string(),
+        group: "math".to_string(),
+        summary_text: "Compute stuff".to_string(),
+        is_deferred: false,
+        is_read_only: false,
+        is_destructive: false,
+    })
+    .await
+    .unwrap();
+
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    // Mixed group (eager + deferred): should say "(always loaded)"
+    assert!(
+        section.contains("**data** — (always loaded)"),
+        "mixed group should have '(always loaded)' tag, got: {section}"
+    );
+    // Pure eager group: "(always loaded)"
+    assert!(
+        section.contains("**math** — (always loaded)"),
+        "pure eager group should have '(always loaded)' tag, got: {section}"
+    );
+    // Eager tool with read-only mark
+    assert!(
+        section.contains("**Query** (read-only): detail for Query"),
+        "expected eager read-only mark, got: {section}"
+    );
+    // Deferred tool with destructive mark
+    assert!(
+        section.contains("  - Purge (destructive)"),
+        "expected deferred destructive mark, got: {section}"
+    );
+}
+
+#[tokio::test]
+async fn test_build_tools_section_empty() {
+    let reg = ToolRegistry::new();
+    let ctx = make_ctx();
+    let section = reg.build_tools_section(&ctx).await;
+    assert!(section.is_empty());
+}


### PR DESCRIPTION
## Summary

Add deferred group tag `(deferred)` and tool danger marks `(read-only)` / `(destructive)` to the first-level tools section output.

## Changes

- **format_group_line**: Pure deferred groups now show `(deferred)` instead of no tag; eager/mixed groups continue to show `(always loaded)`
- **Danger marks**: Each tool line appends `(read-only)` or `(destructive)` based on ToolFlags
- **Eager format**: `  - **{name}**{danger}: {detail}`
- **Deferred format**: `  - {name}{danger}`
- **Tests extracted**: Moved registry tests to `registry_tests.rs` to stay under 500-line limit
- **Updated SPEC.md** to reflect new output format

## Related

Closes #653