### PR TITLE
feat(workspace): add workspace path auto-creation and traversal protection

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -11,6 +11,7 @@ use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
 use crate::session::persistence::{
     PendingMessage, PersistenceError, PersistenceService, SessionCheckpoint, SessionStatus,
 };
+use crate::session::workspace;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -219,6 +220,15 @@ impl SessionManager {
             }
         } else {
             // No archived session — create a brand-new Session
+
+            // Create workspace directory for this agent-user pair
+            if let Some(ref workspace_dir) = self.workspace_dir {
+                workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from)
+                    .map_err(|e| {
+                        ProcessError::ProcessingFailed(format!("workspace creation failed: {}", e))
+                    })?;
+            }
+
             sessions.insert(
                 session_id.clone(),
                 Session {

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -324,3 +324,98 @@ impl PersistenceService for MockPersistService {
         Ok(Vec::new())
     }
 }
+
+// ── Workspace creation tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_find_or_create_creates_workspace_directory() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let workspace_dir = Some(tmp.path().to_path_buf());
+    let mgr = SessionManager::new(
+        &test_config(),
+        None,
+        workspace_dir.clone(),
+        BootstrapMode::Full,
+    );
+    let msg = test_message();
+
+    let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+
+    // Verify workspace directory was created
+    let expected_workspace = workspace_dir
+        .unwrap()
+        .join("workspaces")
+        .join("agent-b")
+        .join("user-a");
+    assert!(
+        expected_workspace.exists(),
+        "workspace directory should be created at {:?}",
+        expected_workspace
+    );
+    assert!(expected_workspace.is_dir());
+}
+
+#[tokio::test]
+async fn test_find_or_create_workspace_idempotent() {
+    // Calling find_or_create twice should not fail (idempotent workspace creation)
+    let tmp = tempfile::TempDir::new().unwrap();
+    let workspace_dir = Some(tmp.path().to_path_buf());
+    let mgr = SessionManager::new(
+        &test_config(),
+        None,
+        workspace_dir.clone(),
+        BootstrapMode::Full,
+    );
+    let msg = test_message();
+
+    let session_id1 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    let session_id2 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+
+    assert_eq!(session_id1, session_id2);
+    let expected_workspace = workspace_dir
+        .unwrap()
+        .join("workspaces")
+        .join("agent-b")
+        .join("user-a");
+    assert!(expected_workspace.exists());
+}
+
+#[tokio::test]
+async fn test_find_or_create_no_workspace_dir_skipped() {
+    // When workspace_dir is None, workspace creation is skipped
+    let mgr = SessionManager::new(&test_config(), None, None, BootstrapMode::Full);
+    let msg = test_message();
+
+    let result = mgr.find_or_create("feishu", &msg, None).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_find_or_create_workspace_invalid_agent_id() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let workspace_dir = Some(tmp.path().to_path_buf());
+    let mgr = SessionManager::new(&test_config(), None, workspace_dir, BootstrapMode::Full);
+    let mut msg = test_message();
+    msg.to = "../etc".to_string();
+
+    let result = mgr.find_or_create("feishu", &msg, None).await;
+    assert!(
+        result.is_err(),
+        "invalid agent_id should fail workspace creation"
+    );
+}
+
+#[tokio::test]
+async fn test_find_or_create_workspace_invalid_user_id() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let workspace_dir = Some(tmp.path().to_path_buf());
+    let mgr = SessionManager::new(&test_config(), None, workspace_dir, BootstrapMode::Full);
+    let mut msg = test_message();
+    msg.from = r#"..\foo"#.to_string();
+
+    let result = mgr.find_or_create("feishu", &msg, None).await;
+    assert!(
+        result.is_err(),
+        "invalid user_id should fail workspace creation"
+    );
+}

--- a/src/session/SPEC.md
+++ b/src/session/SPEC.md
@@ -23,6 +23,7 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
 - `recovery` — 网关启动时从存储恢复会话
 - `storage/` — 可插拔存储后端（Memory/Redis/SqliteStorage）
 - `sweeper` — 后台任务，定时扫描 idle session 执行 archive，对超 TTL 的 archived session 执行 purge，支持 `tokio::sync::watch` 优雅退出
+- `workspace` — agent-user workspace 目录路径计算、校验和创建；路径格式 `{config_dir}/workspaces/{agent_id}/{user_id}/`；包含路径穿越防护（拒绝 `..`、`/`、`\`、`\0`、空字符串、`.` 和 `..`）
 
 ---
 
@@ -46,6 +47,8 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
 | `CheckpointManager::new_with_identity(Arc<S>, agent_id: String, role: AgentRole)` | 创建带存储后端且指定 identity 的 Checkpoint 管理器（保存时自动填充 checkpoint 的 agent_id/role） |
 | `ArchiveSweeper::run(&self, tokio::sync::watch::Receiver<()>)` | 启动 sweeper 主循环，固定调度时刻（首次延迟一个完整 interval），Unix 平台降 nice 为 10，监听 shutdown 信号优雅退出 |
 | `SessionRecoveryService::new(Arc<S>)` | 创建恢复服务 |
+| `validate_path_component(id: &str) -> Result<(), WorkspaceError>` | 校验路径组件（agent_id/user_id）安全性；拒绝空字符串、`..`、`/`、`\`、`\0`、`.`、`..` |
+| `ensure_workspace_dir(config_dir: &Path, agent_id: &str, user_id: &str) -> Result<PathBuf, WorkspaceError>` | 计算并创建 workspace 目录；路径格式 `{config_dir}/workspaces/{agent_id}/{user_id}/`；幂等安全 |
 
 ### 主操作
 
@@ -107,7 +110,7 @@ Session 模块负责 OpenClaw 会话的持久化恢复和 bootstrap 上下文保
 |------|------|
 | `BootstrapContext` | bootstrap 区域元数据容器，含 regions 列表和 integrity hash |
 | `BootstrapRegion` | 单个 bootstrap 文件的区域标记（含 hash 用于完整性校验） |
-| `ArchiveSweeperError` | Sweeper 操作错误（Storage/Config 变体） |
+| `WorkspaceError` | workspace 操作错误（InvalidAgentId / InvalidUserId / CreationFailed）；校验失败拒绝空字符串、`..`、`/`、`\`、`\0`、`.`、`..`；CreationFailed 由 `std::io::Error` 转化 |
 | `BootstrapLoaderError` | loader 操作错误（InvalidWorkspace / IoError） |
 | `BootstrapMode` | bootstrap 文件集合模式（Minimal / Full）；Minimal 含 AGENTS.md/SOUL.md/IDENTITY.md/USER.md/TOOLS.md（5个），Full 额外包含 BOOTSTRAP.md/MEMORY.md（共7个）；HEARTBEAT.md 不属于任何模式 |
 | `SessionCheckpoint` | 会话持久化状态快照（含 status/last_message_at/message_count/channel/chat_id/agent_id/role 等生命周期字段）；`agent_id` 和 `role` 用于按真实身份过滤；保存时若为 `None` 则由 `CheckpointManager` 自动填充；若 `CheckpointManager` 也未设置则回退到默认值 `"unknown"` / `"main_agent"` |
@@ -203,6 +206,26 @@ SessionRecoveryService::recover()
     ↓
 调用用户回调（restore_fn）
 ```
+
+### 3.5 Workspace 创建流程
+
+```
+新 Session 创建（find_or_create）
+    ↓
+获取 message.to（agent_id）和 message.from（user_id）
+    ↓
+调用 workspace::ensure_workspace_dir(config_dir, agent_id, user_id)
+    ↓
+validate_path_component 校验两个组件（拒绝空字符串、..、/、\、\0、.、..）
+    ↓
+计算路径：{config_dir}/workspaces/{agent_id}/{user_id}/
+    ↓
+create_dir_all 创建目录（幂等安全，已存在不报错）
+    ↓
+返回创建的 workspace 路径
+```
+
+Workspace 目录作为 agent-user 专属写入目标，后续 issue 将基于此实现权限隔离。bootstrap 文件加载仍使用原始 workspace_dir（不拼接 workspaces 子路径），不受影响。
 
 ---
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,6 +22,7 @@ pub mod persistence_tests;
 pub mod recovery;
 pub mod storage;
 pub mod sweeper;
+pub mod workspace;
 
 // Re-export commonly used types
 pub use bootstrap::{BootstrapContext, BootstrapProtection, BootstrapRegion};

--- a/src/session/workspace.rs
+++ b/src/session/workspace.rs
@@ -1,0 +1,181 @@
+//! Workspace directory management for agent-user session isolation.
+//!
+//! Each agent-user combination gets a dedicated workspace directory under
+//! `{config_dir}/workspaces/{agent_id}/{user_id}/`.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Errors that can occur during workspace operations.
+#[derive(Debug, Error)]
+pub enum WorkspaceError {
+    /// Agent ID contains invalid characters (path traversal or separators).
+    #[error("Agent ID '{0}' contains invalid characters")]
+    InvalidAgentId(String),
+
+    /// User ID contains invalid characters (path traversal or separators).
+    #[error("User ID '{0}' contains invalid characters")]
+    InvalidUserId(String),
+
+    /// Failed to create workspace directory.
+    #[error("Failed to create workspace directory: {0}")]
+    CreationFailed(#[from] std::io::Error),
+}
+
+/// Validates that a single path component (agent_id or user_id) is safe.
+///
+/// # Errors
+///
+/// Returns `WorkspaceError` if the component:
+/// - Is empty
+/// - Contains `..` (path traversal)
+/// - Contains `/` or `\` (directory separators)
+/// - Is `.` or `..` (special directory names)
+///
+/// # Examples
+///
+/// ```
+/// # use closeclaw::session::workspace::validate_path_component;
+/// assert!(validate_path_component("user123").is_ok());
+/// assert!(validate_path_component("").is_err());
+/// assert!(validate_path_component("../etc").is_err());
+/// ```
+pub fn validate_path_component(id: &str) -> Result<(), WorkspaceError> {
+    if id.is_empty() {
+        return Err(WorkspaceError::InvalidAgentId(String::new()));
+    }
+
+    if id == "." || id == ".." {
+        return Err(WorkspaceError::InvalidAgentId(id.to_string()));
+    }
+
+    if id.contains("..") {
+        return Err(WorkspaceError::InvalidAgentId(id.to_string()));
+    }
+
+    if id.contains('/') || id.contains('\\') {
+        return Err(WorkspaceError::InvalidAgentId(id.to_string()));
+    }
+
+    if id.contains('\0') {
+        return Err(WorkspaceError::InvalidAgentId(id.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Ensures the workspace directory exists for a given agent-user pair.
+///
+/// The workspace path is computed as:
+/// `{config_dir}/workspaces/{agent_id}/{user_id}/`
+///
+/// # Errors
+///
+/// Returns `WorkspaceError` if:
+/// - `agent_id` or `user_id` fails validation
+/// - Directory creation fails
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::Path;
+/// # use closeclaw::session::workspace::ensure_workspace_dir;
+/// # let temp = tempfile::tempdir().unwrap();
+/// # let config_dir = temp.path();
+/// let workspace = ensure_workspace_dir(config_dir, "agent1", "user1").unwrap();
+/// assert!(workspace.exists());
+/// ```
+pub fn ensure_workspace_dir(
+    config_dir: &Path,
+    agent_id: &str,
+    user_id: &str,
+) -> Result<PathBuf, WorkspaceError> {
+    validate_path_component(agent_id).map_err(|e| match e {
+        WorkspaceError::InvalidAgentId(_) => WorkspaceError::InvalidAgentId(agent_id.to_string()),
+        _ => e,
+    })?;
+
+    validate_path_component(user_id).map_err(|e| match e {
+        WorkspaceError::InvalidAgentId(_) => WorkspaceError::InvalidUserId(user_id.to_string()),
+        _ => e,
+    })?;
+
+    let workspace_path = config_dir.join("workspaces").join(agent_id).join(user_id);
+
+    std::fs::create_dir_all(&workspace_path)?;
+
+    Ok(workspace_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_path_component_ok() {
+        assert!(validate_path_component("user123").is_ok());
+        assert!(validate_path_component("agent_abc").is_ok());
+        assert!(validate_path_component("a").is_ok());
+    }
+
+    #[test]
+    fn test_validate_path_component_empty() {
+        let result = validate_path_component("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_path_component_dot() {
+        assert!(validate_path_component(".").is_err());
+        assert!(validate_path_component("..").is_err());
+    }
+
+    #[test]
+    fn test_validate_path_component_traversal() {
+        assert!(validate_path_component("../etc").is_err());
+        assert!(validate_path_component("foo../bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_path_component_slash() {
+        assert!(validate_path_component("foo/bar").is_err());
+        assert!(validate_path_component("foo/bar/baz").is_err());
+    }
+
+    #[test]
+    fn test_validate_path_component_backslash() {
+        assert!(validate_path_component("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_path_component_null() {
+        assert!(validate_path_component("foo\0bar").is_err());
+    }
+
+    #[test]
+    fn test_ensure_workspace_dir_creates() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path();
+        let workspace = ensure_workspace_dir(config_dir, "agent1", "user1").unwrap();
+        assert!(workspace.exists());
+        assert!(workspace.is_dir());
+    }
+
+    #[test]
+    fn test_ensure_workspace_dir_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path();
+        let workspace1 = ensure_workspace_dir(config_dir, "agent1", "user1").unwrap();
+        let workspace2 = ensure_workspace_dir(config_dir, "agent1", "user1").unwrap();
+        assert_eq!(workspace1, workspace2);
+    }
+
+    #[test]
+    fn test_ensure_workspace_dir_traversal_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path();
+        assert!(ensure_workspace_dir(config_dir, "../etc", "user1").is_err());
+        assert!(ensure_workspace_dir(config_dir, "agent1", "..\\foo").is_err());
+    }
+}


### PR DESCRIPTION
- Add WorkspaceError and validate_path_component for path traversal blocking
- Add ensure_workspace_dir for workspace directory creation
- Integrate workspace creation in SessionManager::find_or_create
- Add comprehensive tests for validation and creation logic

Source: issue #663
Type: feat
