### PR TITLE
feat(permission): add risk level assessment for high-risk operations

### DIFF
--- a/src/permission/SPEC.md
+++ b/src/permission/SPEC.md
@@ -68,6 +68,7 @@
 | `Sandbox::reload_rules` | 通过 IPC 重新加载规则 |
 | `load_templates_from_dir` | 从目录加载所有 `.json` 模板文件并展开继承链 |
 | `Template` / `TemplateSubject` / `load_templates_from_dir` | 模板数据结构和加载接口（见 templates.rs） |
+| `closeclaw::permission::engine::engine_risk::assess_risk_level` | 评估请求的风险等级（遍历高危模式列表，engine 子模块内公开） |
 
 ### 查询
 
@@ -96,6 +97,7 @@
 | 子模块 | 职责 |
 |--------|------|
 | `engine/` | 核心评估逻辑：类型定义、O(1) 索引、评估算法 |
+| `engine/engine_risk.rs` | 风险等级枚举（RiskLevel）、高危模式列表、风险评估函数（assess_risk_level） |
 | `actions/` | Action 类型及其 Builder |
 | `rules/` | Rule/RuleSet Builder 及验证逻辑 |
 | `rules/builder.rs` | RuleBuilder + RuleBuilderError |
@@ -124,7 +126,7 @@ Host 进程                              Engine 子进程
    │  Result<PermissionResponse>          │
 ```
 
-### 评估算法（7 步）
+### 评估算法（8 步）
 
 1. **Creator 规则短路**：若 caller.user_id == agent_creators[agent_id]，直接 Allow
 2. **Agent 阶段**：调用 `collect_agent_candidates()` 收集 AgentOnly 候选规则 → `match_rules()` 求值 → 得到 agent_result
@@ -137,8 +139,9 @@ Host 进程                              Engine 子进程
    - Agent Allow + User None → Allowed（向后兼容：仅 Agent 维度有规则，User 维度无立场）
    - Agent None + User Allow → Allowed（向后兼容：仅 User 维度有规则，Agent 维度无立场）
    - Agent None + User None → 默认 Deny
-6. **模板展开**：在 `match_rules()` 内部调用 `expand_templates_sync()` 展开 template 引用为实际 actions
-7. **默认策略**：任一阶段返回 None → Denied
+6. **风险评估**：在 `match_rules()` 和 `default_deny()` 返回 Denied 前，调用 `assess_risk_level(request)` 遍历 `HIGH_RISK_PATTERNS`，命中则返回对应等级，否则 Low。风险等级写入 `PermissionResponse::Denied.risk_level`
+7. **模板展开**：在 `match_rules()` 内部调用 `expand_templates_sync()` 展开 template 引用为实际 actions
+8. **默认策略**：任一阶段返回 None → Denied
 
 ### O(1) 索引
 
@@ -158,6 +161,8 @@ PermissionRequest
 ├── WithCaller { caller: Caller, request: PermissionRequestBody }
 └── Bare(PermissionRequestBody)
 
+RiskLevel（枚举：Low / Medium / High / Critical，Default = Low）
+
 PermissionRequestBody
 ├── FileOp { path: String, operation: String }
 ├── CommandExec { command: String, args: Vec<String> }
@@ -165,6 +170,10 @@ PermissionRequestBody
 ├── ToolCall { skill: String, method: String }
 ├── InterAgentMsg { agent: String }
 └── ConfigWrite { path: String }
+
+PermissionResponse
+├── Allowed { token: String }
+└── Denied { reason: String, rule: String, risk_level: RiskLevel }
 
 Action
 ├── File { operation: String, paths: Vec<String> }
@@ -193,10 +202,15 @@ Subject
 ```rust
 pub use engine::{ glob_match, Action, Caller, CommandArgs,
     Defaults, Effect, MatchType, PermissionEngine, PermissionRequest,
-    PermissionRequestBody, PermissionResponse, Rule, RuleSet, Subject, TemplateRef };
+    PermissionRequestBody, PermissionResponse, Rule, RuleSet, Subject, TemplateRef,
+    RiskLevel };
 pub use rules::{ validation, RuleBuilder, RuleSetBuilder,
     RuleBuilderError, RuleSetBuilderError };
 ```
+
+`RiskLevel` 从 `engine/engine_risk.rs` 经 `engine::` 重新导出。
+
+`assess_risk_level` 为 `engine` 子模块内公开函数，通过 `closeclaw::permission::engine::engine_risk::assess_risk_level` 访问，未在顶层 re-export。
 
 `glob_match` 在 `engine` 子模块内可直接访问，通过根模块也可访问。`action_matches_request` 仅在 `engine` 子模块内导出，**未**在根模块 re-export。
 
@@ -219,4 +233,4 @@ pub use rules::{ validation, RuleBuilder, RuleSetBuilder,
 
 ---
 
-*最后更新：2026-05-14（Owner 短路新增）*
+*最后更新：2026-05-15（风险等级与白名单禁用）*

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -1,6 +1,7 @@
 //! Permission Engine - Evaluation logic.
 
 use super::engine_matching::action_matches_request;
+use super::engine_risk::assess_risk_level;
 use super::engine_types::{
     Action, Defaults, Effect, PermissionRequest, PermissionRequestBody, PermissionResponse, Rule,
     RuleSet, Subject,
@@ -112,9 +113,15 @@ impl PermissionEngine {
                 config_file: "*".to_string(),
             },
             _ => {
+                let body = PermissionRequestBody::ToolCall {
+                    agent: agent_id.to_string(),
+                    skill: action.to_string(),
+                    method: "unknown".to_string(),
+                };
                 return PermissionResponse::Denied {
                     reason: format!("unknown action: {}", action),
                     rule: "<check>".to_string(),
+                    risk_level: assess_risk_level(&body),
                 };
             }
         };
@@ -182,10 +189,12 @@ impl PermissionEngine {
             (Some(PermissionResponse::Denied { .. }), _) => PermissionResponse::Denied {
                 reason: "action denied by agent rule".to_string(),
                 rule: "<agent_phase>".to_string(),
+                risk_level: assess_risk_level(request.body()),
             },
             (_, Some(PermissionResponse::Denied { .. })) => PermissionResponse::Denied {
                 reason: "action denied by user rule".to_string(),
                 rule: "<user_phase>".to_string(),
+                risk_level: assess_risk_level(request.body()),
             },
             (
                 Some(PermissionResponse::Allowed { .. }),
@@ -346,6 +355,7 @@ impl PermissionEngine {
                 return Some(PermissionResponse::Denied {
                     reason,
                     rule: rule.name.clone(),
+                    risk_level: assess_risk_level(request_body),
                 });
             }
         }
@@ -436,6 +446,7 @@ impl PermissionEngine {
             Effect::Deny => PermissionResponse::Denied {
                 reason: reason.to_string(),
                 rule: "default".to_string(),
+                risk_level: assess_risk_level(request),
             },
         }
     }

--- a/src/permission/engine/engine_risk.rs
+++ b/src/permission/engine/engine_risk.rs
@@ -1,0 +1,310 @@
+//! Permission Engine - Risk assessment
+//!
+//! Provides risk level classification for permission requests.
+
+use crate::permission::engine::engine_types::PermissionRequestBody;
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+use crate::permission::engine::engine_eval::PermissionEngine;
+#[cfg(test)]
+use crate::permission::engine::engine_types::{
+    Effect, PermissionRequest, PermissionRequestBody as _, PermissionResponse, Rule, RuleSet,
+};
+#[cfg(test)]
+use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
+
+/// Risk level for permission requests.
+/// Used to annotate denied responses with severity information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl Default for RiskLevel {
+    fn default() -> Self {
+        RiskLevel::Low
+    }
+}
+
+/// A risk pattern with matching logic and associated risk level.
+struct RiskPattern {
+    /// Returns Some(RiskLevel) if the request matches, None otherwise.
+    matches: fn(&PermissionRequestBody) -> Option<RiskLevel>,
+}
+
+/// Check if a path contains or ends with `.git`.
+fn path_has_git(path: &str) -> bool {
+    path.contains("/.git/") || path.ends_with("/.git") || path == ".git"
+}
+
+/// Check if this is a bare `rm -rf` (no specific path in args).
+/// Bare means: cmd="rm" and args contain only force/recursive flags without actual paths.
+fn is_bare_rm_rf(cmd: &str, args: &[String]) -> bool {
+    if cmd != "rm" {
+        return false;
+    }
+    // Collect non-flag args (paths)
+    let has_path = args.iter().any(|arg| !arg.starts_with('-'));
+    if has_path {
+        return false;
+    }
+    // Must have at least one of -f, -r, -rf, -fr
+    let has_force_or_recursive = args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-f" | "-r" | "-rf" | "-fr" | "--force" | "--recursive"
+        )
+    });
+    has_force_or_recursive
+}
+
+const HIGH_RISK_PATTERNS: &[RiskPattern] = &[
+    // .git path read/write → High
+    RiskPattern {
+        matches: |request| match request {
+            PermissionRequestBody::FileOp { path, op, .. }
+                if (op == "read" || op == "write") && path_has_git(path) =>
+            {
+                Some(RiskLevel::High)
+            }
+            _ => None,
+        },
+    },
+    // permissions.json → Critical
+    RiskPattern {
+        matches: |request| match request {
+            PermissionRequestBody::FileOp { path, op, .. }
+                if (op == "read" || op == "write")
+                    && (path.ends_with("permissions.json")
+                        || path.contains("/permissions.json")) =>
+            {
+                Some(RiskLevel::Critical)
+            }
+            _ => None,
+        },
+    },
+    // Template files in permission module → Critical
+    RiskPattern {
+        matches: |request| match request {
+            PermissionRequestBody::FileOp { path, op, .. }
+                if (op == "read" || op == "write")
+                    && path.contains("/templates/")
+                    && path.contains("permission") =>
+            {
+                Some(RiskLevel::Critical)
+            }
+            _ => None,
+        },
+    },
+    // daemon/gateway config write → Critical
+    RiskPattern {
+        matches: |request| match request {
+            PermissionRequestBody::ConfigWrite { config_file, .. }
+                if config_file.contains("daemon") || config_file.contains("gateway") =>
+            {
+                Some(RiskLevel::Critical)
+            }
+            _ => None,
+        },
+    },
+    // Bare rm -rf → High
+    RiskPattern {
+        matches: |request| match request {
+            PermissionRequestBody::CommandExec { cmd, args, .. } if is_bare_rm_rf(cmd, args) => {
+                Some(RiskLevel::High)
+            }
+            _ => None,
+        },
+    },
+];
+
+/// Assess the risk level of a permission request.
+///
+/// Returns the highest matching risk level, or `RiskLevel::Low` if no patterns match.
+pub fn assess_risk_level(request: &PermissionRequestBody) -> RiskLevel {
+    for pattern in HIGH_RISK_PATTERNS {
+        if let Some(level) = (pattern.matches)(request) {
+            return level;
+        }
+    }
+    RiskLevel::Low
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_git_path_file_read_returns_high() {
+        let request = PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/.git/config".to_string(),
+            op: "read".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::High);
+    }
+
+    #[test]
+    fn test_git_path_file_write_returns_high() {
+        let request = PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "src/.git/HEAD".to_string(),
+            op: "write".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::High);
+    }
+
+    #[test]
+    fn test_permissions_json_returns_critical() {
+        let request = PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/etc/permissions.json".to_string(),
+            op: "read".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Critical);
+    }
+
+    #[test]
+    fn test_template_path_in_permission_module_returns_critical() {
+        // Templates within permission module: path contains /templates/ AND has permission context
+        let request = PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/permissions/templates/admin_template.json".to_string(),
+            op: "write".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Critical);
+    }
+
+    #[test]
+    fn test_daemon_config_write_returns_critical() {
+        let request = PermissionRequestBody::ConfigWrite {
+            agent: "test-agent".to_string(),
+            config_file: "daemon.json".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Critical);
+    }
+
+    #[test]
+    fn test_bare_rm_rf_returns_high() {
+        let request = PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "rm".to_string(),
+            args: vec!["-rf".to_string()],
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::High);
+    }
+
+    #[test]
+    fn test_bare_rm_f_r_returns_high() {
+        let request = PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "rm".to_string(),
+            args: vec!["-f".to_string(), "-r".to_string()],
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::High);
+    }
+
+    #[test]
+    fn test_rm_with_path_returns_low() {
+        let request = PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "rm".to_string(),
+            args: vec!["-rf".to_string(), "/tmp/foo".to_string()],
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_normal_file_returns_low() {
+        let request = PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/src/main.rs".to_string(),
+            op: "read".to_string(),
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_normal_command_returns_low() {
+        let request = PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "ls".to_string(),
+            args: vec!["-la".to_string()],
+        };
+        assert_eq!(assess_risk_level(&request), RiskLevel::Low);
+    }
+
+    #[test]
+    fn test_risk_level_serde() {
+        let level = RiskLevel::Critical;
+        let json = serde_json::to_string(&level).unwrap();
+        assert_eq!(json, "\"critical\"");
+        let parsed: RiskLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, RiskLevel::Critical);
+    }
+
+    #[test]
+    fn test_risk_level_default() {
+        let level = RiskLevel::default();
+        assert_eq!(level, RiskLevel::Low);
+    }
+
+    // -------------------------------------------------------------------------
+    // End-to-end risk level tests via PermissionEngine
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_git_path_deny_risk_level_high() {
+        let ruleset = RuleSetBuilder::new()
+            .version("1.0")
+            .default_file(Effect::Deny)
+            .default_command(Effect::Deny)
+            .default_network(Effect::Deny)
+            .default_inter_agent(Effect::Deny)
+            .default_config(Effect::Deny)
+            .build()
+            .unwrap();
+        let engine = PermissionEngine::new(ruleset);
+        let resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/.git/config".to_string(),
+            op: "read".to_string(),
+        }));
+        match resp {
+            PermissionResponse::Denied { risk_level, .. } => {
+                assert_eq!(risk_level, RiskLevel::High);
+            }
+            other => panic!("expected Denied, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normal_path_deny_risk_level_low() {
+        let ruleset = RuleSetBuilder::new()
+            .version("1.0")
+            .default_file(Effect::Deny)
+            .default_command(Effect::Deny)
+            .default_network(Effect::Deny)
+            .default_inter_agent(Effect::Deny)
+            .default_config(Effect::Deny)
+            .build()
+            .unwrap();
+        let engine = PermissionEngine::new(ruleset);
+        let resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/src/main.rs".to_string(),
+            op: "read".to_string(),
+        }));
+        match resp {
+            PermissionResponse::Denied { risk_level, .. } => {
+                assert_eq!(risk_level, RiskLevel::Low);
+            }
+            other => panic!("expected Denied, got {:?}", other),
+        }
+    }
+}

--- a/src/permission/engine/engine_types.rs
+++ b/src/permission/engine/engine_types.rs
@@ -3,6 +3,7 @@
 //! Types, data structures, and Subject/Rule validation logic.
 
 use super::engine_matching::glob_match;
+use super::engine_risk::RiskLevel;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -467,6 +468,12 @@ impl PermissionRequest {
 /// Permission response from the engine
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum PermissionResponse {
-    Allowed { token: String },
-    Denied { reason: String, rule: String },
+    Allowed {
+        token: String,
+    },
+    Denied {
+        reason: String,
+        rule: String,
+        risk_level: RiskLevel,
+    },
 }

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -4,10 +4,12 @@
 
 pub mod engine_eval;
 pub mod engine_matching;
+pub mod engine_risk;
 pub mod engine_types;
 
 pub use engine_eval::PermissionEngine;
 pub use engine_matching::{action_matches_request, glob_match};
+pub use engine_risk::RiskLevel;
 pub use engine_types::{
     Action, Caller, CommandArgs, Defaults, Effect, MatchType, PermissionRequest,
     PermissionRequestBody, PermissionResponse, Rule, RuleSet, Subject, TemplateRef,

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -67,11 +67,16 @@ impl Skill for PermissionSkill {
                             "agent_id": agent_id,
                             "action": action,
                         })),
-                        PermissionResponse::Denied { reason, rule: _ } => Ok(serde_json::json!({
+                        PermissionResponse::Denied {
+                            reason,
+                            rule: _,
+                            risk_level,
+                        } => Ok(serde_json::json!({
                             "allowed": false,
                             "agent_id": agent_id,
                             "action": action,
                             "reason": reason,
+                            "risk_level": risk_level,
                         })),
                     }
                 } else {

--- a/tests/sandbox_integration_test.rs
+++ b/tests/sandbox_integration_test.rs
@@ -373,7 +373,11 @@ async fn test_sandbox_evaluate_permission_request() {
             PermissionResponse::Allowed { token: _ } => {
                 // Permissive rules allow this request
             }
-            PermissionResponse::Denied { reason, rule: _ } => {
+            PermissionResponse::Denied {
+                reason,
+                rule: _,
+                risk_level: _,
+            } => {
                 panic!(
                     "expected Allowed with permissive rules, got Denied: {}",
                     reason


### PR DESCRIPTION
- Add RiskLevel enum (Low/Medium/High/Critical) in engine_risk.rs
- Add HIGH_RISK_PATTERNS for .git paths, permission config, daemon config, bare rm -rf
- Add assess_risk_level() function for risk evaluation
- Add risk_level field to PermissionResponse::Denied
- Update SPEC.md with risk level documentation

Source: issue #664