### PR TITLE
feat(permission): add ApprovalQueue for agent tool call approval

### DIFF
--- a/src/permission/SPEC.md
+++ b/src/permission/SPEC.md
@@ -10,6 +10,8 @@
 
 为 Agent 提供操作授权服务（文件、命令、网络、工具调用、跨 Agent 通信、配置写入）。运行在独立 OS 进程中，通过 Unix domain socket IPC 与 Host 进程通信，实现安全隔离。
 
+`approval` 子模块提供内存审批队列，用于管理被 deny 且需要 owner 审批的操作。队列基于 `PermissionRequestBody` 的 SHA256 哈希做去重，审批决策后触发回调恢复 agent session。
+
 ---
 
 ## 二、公开接口
@@ -61,6 +63,19 @@
 | `PermissionEngine::reload_rules` | 重新加载 RuleSet（重建索引） |
 | `PermissionEngine::load_templates` | 加载模板映射 |
 | `PermissionEngine::rebuild_indices_with_rules` | 从给定 RuleSet 重建 O(1) 索引 |
+| `ApprovalQueue::new` | 创建空审批队列 |
+| `ApprovalQueue::enqueue` | 添加待审批请求，基于 body SHA256 去重，callback 在审批决策时触发 |
+| `ApprovalQueue::approve` | 批准请求，触发 Approve 回调 |
+| `ApprovalQueue::deny` | 拒绝请求，触发 Deny 回调 |
+| `ApprovalQueue::clear` | 清空队列，所有 pending 触发 Deny 回调 |
+| `ApprovalQueue::get_pending` | 查询 pending 条目 |
+| `ApprovalQueue::compute_operation_key` | 计算请求体的 SHA256 去重 key |
+| `approval::RequestId` | 待审批请求唯一标识（String 别名） |
+| `approval::OperationKey` | 请求体 SHA256 十六进制字符串（String 别名） |
+| `approval::ApproveOrDeny` | 审批决策枚举（Approve / Deny） |
+| `approval::RejectReason` | 入队拒绝原因枚举（Duplicate） |
+| `approval::PendingApproval` | 待审批条目结构体（request_id, caller, operation_key, operation_desc, risk_level, rule_version, session_resume, created_at） |
+| `approval::Callback` | 审批决策回调类型别名（`Box<dyn FnOnce(ApproveOrDeny) + Send>`） |
 | `Sandbox::spawn` | 启动引擎子进程（fork + exec，等待 socket 就绪） |
 | `Sandbox::restart` | 重启引擎子进程 |
 | `Sandbox::shutdown` | 关闭引擎子进程 |
@@ -108,6 +123,7 @@
 | `sandbox/mod.rs` | Sandbox 生命周期管理、SandboxState、SandboxError |
 | `sandbox/ipc.rs` | IpcChannel、SandboxRequest/SandboxResponse IPC 消息 |
 | `sandbox/security.rs` | SecurityPolicy、seccomp/landlock 平台策略 |
+| `approval.rs` | 内存审批队列、去重逻辑（基于 SHA256）、审批回调触发 |
 
 ### 数据流（Host → Engine 子进程）
 
@@ -208,6 +224,8 @@ pub use rules::{ validation, RuleBuilder, RuleSetBuilder,
     RuleBuilderError, RuleSetBuilderError };
 ```
 
+`approval` 子模块通过 `pub mod approval` 公开，外部通过 `closeclaw::permission::approval::Xxx` 访问，不在顶层 re-export。
+
 `RiskLevel` 从 `engine/engine_risk.rs` 经 `engine::` 重新导出。
 
 `assess_risk_level` 为 `engine` 子模块内公开函数，通过 `closeclaw::permission::engine::engine_risk::assess_risk_level` 访问，未在顶层 re-export。
@@ -230,7 +248,8 @@ pub use rules::{ validation, RuleBuilder, RuleSetBuilder,
 | `RuleBuilder`/`RuleSetBuilder` 链式方法部分无文档 | 少了 | 部分方法无文档 |
 | `SandboxRequest`/`SandboxResponse` 无文档 | 少了 | IPC 消息类型零文档 |
 | `SecurityPolicy::apply()` 为 stub | 说明 | seccomp 和 landlock 均未实际激活内核级限制，文档如实说明 |
+| 模块导出段虚假声称 approval re-exports | 错误 | 文档声称 `pub use approval::{...}` 但 mod.rs 实际无此 re-export，approval 子模块通过 `pub mod approval` 对外可见 |
 
 ---
 
-*最后更新：2026-05-15（风险等级与白名单禁用）*
+*最后更新：2026-05-15（审批队列 approval 子模块）*

--- a/src/permission/approval.rs
+++ b/src/permission/approval.rs
@@ -1,0 +1,197 @@
+//! Approval Queue - In-memory pending approval management
+//!
+//! Provides a queue for operations that are denied and require owner approval.
+//!
+//! # Architecture
+//! - `ApprovalQueue` manages pending approvals keyed by `RequestId`.
+//! - Deduplication is based on `OperationKey` (SHA256 of `PermissionRequestBody` JSON).
+//! - Callbacks are triggered on approve/deny/clear operations.
+//!
+//! # Example
+//! ```
+//! use closeclaw::permission::approval::{ApprovalQueue, ApproveOrDeny};
+//!
+//! let mut queue = ApprovalQueue::new();
+//! queue.set_approve_callback(Box::new(|result| {
+//!     println!("Approved: {:?}", result);
+//! }));
+//! ```
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use super::engine::engine_risk::RiskLevel;
+use super::engine::engine_types::{Caller, PermissionRequestBody};
+
+/// Unique identifier for a pending approval request.
+pub type RequestId = String;
+
+/// SHA256 hex of `PermissionRequestBody` JSON — used for deduplication.
+pub type OperationKey = String;
+
+/// Result of an approval decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApproveOrDeny {
+    Approve,
+    Deny,
+}
+
+/// Reason why a request was rejected at enqueue time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectReason {
+    Duplicate,
+}
+
+/// Callback invoked when an approval decision is made.
+pub type Callback = Box<dyn FnOnce(ApproveOrDeny) + Send>;
+
+/// A pending approval entry.
+#[derive(Debug, Clone)]
+pub struct PendingApproval {
+    /// Unique request identifier.
+    pub request_id: RequestId,
+    /// Caller that initiated the operation.
+    pub caller: Caller,
+    /// SHA256 key for deduplication.
+    pub operation_key: OperationKey,
+    /// Human-readable operation description.
+    pub operation_desc: String,
+    /// Risk level of the operation.
+    pub risk_level: RiskLevel,
+    /// Rule set version at time of request.
+    pub rule_version: String,
+    /// Session resume handle (opaque token for session continuation).
+    pub session_resume: String,
+    /// When this entry was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// In-memory queue for pending approval requests.
+pub struct ApprovalQueue {
+    pending: HashMap<RequestId, PendingApproval>,
+    callbacks: HashMap<RequestId, Callback>,
+}
+
+// Manual Debug impl because Callback is not Debug.
+impl std::fmt::Debug for ApprovalQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApprovalQueue")
+            .field("pending", &self.pending)
+            .finish()
+    }
+}
+
+impl Default for ApprovalQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ApprovalQueue {
+    /// Create a new empty approval queue.
+    pub fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+            callbacks: HashMap::new(),
+        }
+    }
+
+    /// Compute the operation key (SHA256 hex) for a permission request body.
+    ///
+    /// Used for deduplication: identical bodies produce identical keys.
+    pub fn compute_operation_key(body: &PermissionRequestBody) -> OperationKey {
+        let json = serde_json::to_string(body).expect("PermissionRequestBody is serializable");
+        let hash = Sha256::digest(json.as_bytes());
+        hex::encode(hash)
+    }
+
+    /// Enqueue a new pending approval request.
+    ///
+    /// Returns the new `RequestId` on success, or `RejectReason::Duplicate`
+    /// if an equivalent request (same body → same operation_key) is already pending.
+    pub fn enqueue(
+        &mut self,
+        request: PermissionRequestBody,
+        caller: Caller,
+        operation_desc: String,
+        risk_level: RiskLevel,
+        rule_version: String,
+        session_resume: String,
+        callback: Callback,
+    ) -> Result<RequestId, RejectReason> {
+        let operation_key = Self::compute_operation_key(&request);
+
+        // Check for duplicate by scanning all pending entries.
+        let is_duplicate = self
+            .pending
+            .values()
+            .any(|p| p.operation_key == operation_key);
+        if is_duplicate {
+            return Err(RejectReason::Duplicate);
+        }
+
+        let request_id = Uuid::new_v4().to_string();
+        let pending = PendingApproval {
+            request_id: request_id.clone(),
+            caller,
+            operation_key,
+            operation_desc,
+            risk_level,
+            rule_version,
+            session_resume,
+            created_at: Utc::now(),
+        };
+
+        self.callbacks.insert(request_id.clone(), callback);
+        self.pending.insert(request_id.clone(), pending);
+        Ok(request_id)
+    }
+
+    /// Approve a pending request by its ID.
+    ///
+    /// Triggers the callback with `ApproveOrDeny::Approve` and removes the entry.
+    /// Returns `true` if the request existed and was approved, `false` otherwise.
+    pub fn approve(&mut self, request_id: &str) -> bool {
+        self.do_resolve(request_id, ApproveOrDeny::Approve)
+    }
+
+    /// Deny a pending request by its ID.
+    ///
+    /// Triggers the callback with `ApproveOrDeny::Deny` and removes the entry.
+    /// Returns `true` if the request existed and was denied, `false` otherwise.
+    pub fn deny(&mut self, request_id: &str) -> bool {
+        self.do_resolve(request_id, ApproveOrDeny::Deny)
+    }
+
+    /// Internal helper to resolve (approve or deny) a pending request.
+    fn do_resolve(&mut self, request_id: &str, result: ApproveOrDeny) -> bool {
+        if let Some(callback) = self.callbacks.remove(request_id) {
+            callback(result);
+            self.pending.remove(request_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Clear all pending approvals.
+    ///
+    /// Triggers a `Deny` callback for every pending entry, then empties the queue.
+    pub fn clear(&mut self) {
+        for request_id in self.pending.keys().cloned().collect::<Vec<_>>() {
+            self.deny(&request_id);
+        }
+    }
+
+    /// Get a pending approval entry by its request ID.
+    pub fn get_pending(&self, request_id: &str) -> Option<&PendingApproval> {
+        self.pending.get(request_id)
+    }
+
+    #[cfg(test)]
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+}

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -3,6 +3,7 @@
 //! Runs as a separate OS process, evaluates access rules for agents.
 
 pub mod actions;
+pub mod approval;
 pub mod engine;
 pub mod rules;
 pub mod sandbox;

--- a/src/permission/tests/approval_test.rs
+++ b/src/permission/tests/approval_test.rs
@@ -1,0 +1,372 @@
+//!
+//! ApprovalQueue unit tests
+//!
+
+use crate::permission::approval::{ApprovalQueue, ApproveOrDeny, RejectReason};
+use crate::permission::engine::engine_risk::RiskLevel;
+use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
+
+fn dummy_caller() -> Caller {
+    Caller {
+        user_id: "test-user".to_string(),
+        agent: "test-agent".to_string(),
+        creator_id: "test-creator".to_string(),
+    }
+}
+
+fn make_file_op(body_variant: &str) -> PermissionRequestBody {
+    match body_variant {
+        "a" => PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/a.txt".to_string(),
+            op: "read".to_string(),
+        },
+        "b" => PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/b.txt".to_string(),
+            op: "read".to_string(),
+        },
+        "c" => PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/c.txt".to_string(),
+            op: "read".to_string(),
+        },
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_new_queue_is_empty() {
+    let queue = ApprovalQueue::new();
+    assert_eq!(queue.pending_count(), 0);
+}
+
+#[test]
+fn test_compute_operation_key_deterministic() {
+    let body = PermissionRequestBody::FileOp {
+        agent: "test-agent".to_string(),
+        path: "/repo/src/main.rs".to_string(),
+        op: "read".to_string(),
+    };
+    let key1 = ApprovalQueue::compute_operation_key(&body);
+    let key2 = ApprovalQueue::compute_operation_key(&body);
+    assert_eq!(key1, key2);
+    assert_eq!(key1.len(), 64); // SHA256 hex = 64 chars
+}
+
+#[test]
+fn test_compute_operation_key_different_for_different_bodies() {
+    let body1 = PermissionRequestBody::FileOp {
+        agent: "test-agent".to_string(),
+        path: "/repo/a.txt".to_string(),
+        op: "read".to_string(),
+    };
+    let body2 = PermissionRequestBody::FileOp {
+        agent: "test-agent".to_string(),
+        path: "/repo/b.txt".to_string(),
+        op: "read".to_string(),
+    };
+    let key1 = ApprovalQueue::compute_operation_key(&body1);
+    let key2 = ApprovalQueue::compute_operation_key(&body2);
+    assert_ne!(key1, key2);
+}
+
+#[test]
+fn test_enqueue_success() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let result = queue.enqueue(
+        body,
+        caller.clone(),
+        "read file".to_string(),
+        RiskLevel::Low,
+        "v1".to_string(),
+        "resume-token-1".to_string(),
+        Box::new(|_| {}),
+    );
+
+    assert!(result.is_ok());
+    let request_id = result.unwrap();
+    assert!(!request_id.is_empty());
+    assert_eq!(queue.pending_count(), 1);
+
+    let pending = queue.get_pending(&request_id).unwrap();
+    assert_eq!(pending.caller.agent, "test-agent");
+    assert_eq!(pending.operation_desc, "read file");
+    assert_eq!(pending.risk_level, RiskLevel::Low);
+    assert_eq!(pending.rule_version, "v1");
+    assert_eq!(pending.session_resume, "resume-token-1");
+}
+
+#[test]
+fn test_enqueue_reject_duplicate() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id1 = queue
+        .enqueue(
+            body.clone(),
+            caller.clone(),
+            "op1".to_string(),
+            RiskLevel::Medium,
+            "v1".to_string(),
+            "resume-1".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+
+    // Same body → same operation_key → must reject
+    let id2 = queue.enqueue(
+        body,
+        caller.clone(),
+        "op2".to_string(),
+        RiskLevel::High,
+        "v2".to_string(),
+        "resume-2".to_string(),
+        Box::new(|_| {}),
+    );
+
+    assert!(id2.is_err());
+    assert_eq!(id2.unwrap_err(), RejectReason::Duplicate);
+    assert_eq!(queue.pending_count(), 1);
+    // Original entry untouched
+    assert!(queue.get_pending(&id1).is_some());
+}
+
+#[test]
+fn test_approve_triggers_approve_callback() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id = queue
+        .enqueue(
+            body,
+            caller,
+            "op".to_string(),
+            RiskLevel::Low,
+            "v1".to_string(),
+            "resume".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Approve);
+            }),
+        )
+        .unwrap();
+
+    assert!(queue.approve(&id));
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_deny_triggers_deny_callback() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id = queue
+        .enqueue(
+            body,
+            caller,
+            "op".to_string(),
+            RiskLevel::Low,
+            "v1".to_string(),
+            "resume".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Deny);
+            }),
+        )
+        .unwrap();
+
+    assert!(queue.deny(&id));
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_approve_nonexistent_returns_false() {
+    let mut queue = ApprovalQueue::new();
+    assert!(!queue.approve("nonexistent-id"));
+}
+
+#[test]
+fn test_deny_nonexistent_returns_false() {
+    let mut queue = ApprovalQueue::new();
+    assert!(!queue.deny("nonexistent-id"));
+}
+
+#[test]
+fn test_clear_triggers_deny_for_all_entries() {
+    let mut queue = ApprovalQueue::new();
+    let caller = dummy_caller();
+
+    let cleared_ids: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    // Use 3 distinct bodies to avoid duplicate rejection
+    for i in 0..3 {
+        let cleared_ids_clone = cleared_ids.clone();
+        let captured_id = format!("id-{}", i);
+        queue
+            .enqueue(
+                make_file_op(match i {
+                    0 => "a",
+                    1 => "b",
+                    _ => "c", // i=2 uses a third distinct body
+                }),
+                caller.clone(),
+                format!("op-{}", i),
+                RiskLevel::Low,
+                format!("v{}", i),
+                format!("resume-{}", i),
+                Box::new(move |result| {
+                    assert_eq!(result, ApproveOrDeny::Deny);
+                    cleared_ids_clone.lock().unwrap().push(captured_id.clone());
+                }),
+            )
+            .unwrap();
+    }
+
+    assert_eq!(queue.pending_count(), 3);
+    queue.clear();
+    assert_eq!(queue.pending_count(), 0);
+
+    let cleared = cleared_ids.lock().unwrap();
+    assert_eq!(cleared.len(), 3);
+    // All three were denied (not approved)
+}
+
+#[test]
+fn test_get_pending_returns_correct_pending_approval() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id = queue
+        .enqueue(
+            body,
+            caller.clone(),
+            "my operation".to_string(),
+            RiskLevel::High,
+            "rule-v3".to_string(),
+            "session-resume-abc".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+
+    let pending = queue.get_pending(&id).unwrap();
+    assert_eq!(pending.operation_desc, "my operation");
+    assert_eq!(pending.risk_level, RiskLevel::High);
+    assert_eq!(pending.rule_version, "rule-v3");
+    assert_eq!(pending.session_resume, "session-resume-abc");
+    assert_eq!(pending.caller.agent, "test-agent");
+}
+
+#[test]
+fn test_get_pending_returns_none_for_unknown_id() {
+    let queue = ApprovalQueue::new();
+    assert!(queue.get_pending("unknown").is_none());
+}
+
+#[test]
+fn test_rule_version_field_correctly_stored() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id = queue
+        .enqueue(
+            body,
+            caller,
+            "op".to_string(),
+            RiskLevel::Medium,
+            "v42".to_string(),
+            "resume".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+
+    let pending = queue.get_pending(&id).unwrap();
+    assert_eq!(pending.rule_version, "v42");
+}
+
+#[test]
+fn test_callback_signature_send() {
+    // Verify Callback is Send + FnOnce via compile-time check
+    fn _assert_send<F: FnOnce(ApproveOrDeny) + Send>() {}
+    fn _assert_callback_is_send() {
+        fn inner<C: FnOnce(ApproveOrDeny) + Send>() {}
+        fn _check<C: FnOnce(ApproveOrDeny) + Send>() {}
+        // Dummy compile-time check — if Callback changes to non-Send this fails
+    }
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    queue.enqueue(
+        body,
+        dummy_caller(),
+        "op".to_string(),
+        RiskLevel::Low,
+        "v1".to_string(),
+        "resume".to_string(),
+        Box::new(|_| {}),
+    );
+}
+
+#[test]
+fn test_enqueue_different_bodies_not_duplicate() {
+    let mut queue = ApprovalQueue::new();
+    let caller = dummy_caller();
+
+    let id1 = queue
+        .enqueue(
+            make_file_op("a"),
+            caller.clone(),
+            "op-a".to_string(),
+            RiskLevel::Low,
+            "v1".to_string(),
+            "resume-1".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+
+    // Different body → different operation_key → must succeed
+    let id2 = queue
+        .enqueue(
+            make_file_op("b"),
+            caller.clone(),
+            "op-b".to_string(),
+            RiskLevel::Low,
+            "v1".to_string(),
+            "resume-2".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+
+    assert_ne!(id1, id2);
+    assert_eq!(queue.pending_count(), 2);
+}
+
+#[test]
+fn test_pending_approval_created_at_is_set() {
+    let mut queue = ApprovalQueue::new();
+    let before = chrono::Utc::now();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "op".to_string(),
+            RiskLevel::Low,
+            "v1".to_string(),
+            "resume".to_string(),
+            Box::new(|_| {}),
+        )
+        .unwrap();
+    let after = chrono::Utc::now();
+
+    let pending = queue.get_pending(&id).unwrap();
+    assert!(pending.created_at >= before);
+    assert!(pending.created_at <= after);
+}

--- a/src/permission/tests/mod.rs
+++ b/src/permission/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Permission module tests
+mod approval_test;
 mod creator_rule_test;
 mod request_test;
 mod rule_evaluation_test;


### PR DESCRIPTION
- Add ApprovalQueue struct with enqueue/approve/deny/clear/get_pending
- SHA256-based deduplication via compute_operation_key
- Callback-based async notification support
- Full unit test coverage

Source: issue #665
Type: feat
