### PR TITLE
fix(docs): correct doc tests to match actual API behavior

### DIFF
--- a/src/permission/approval.rs
+++ b/src/permission/approval.rs
@@ -10,11 +10,33 @@
 //! # Example
 //! ```
 //! use closeclaw::permission::approval::{ApprovalQueue, ApproveOrDeny};
+//! use closeclaw::permission::engine::engine_types::{Caller, PermissionRequestBody};
+//! use closeclaw::permission::engine::engine_risk::RiskLevel;
 //!
 //! let mut queue = ApprovalQueue::new();
-//! queue.set_approve_callback(Box::new(|result| {
-//!     println!("Approved: {:?}", result);
-//! }));
+//! let request = PermissionRequestBody::ToolCall {
+//!     agent: "test".to_string(),
+//!     skill: "test_skill".to_string(),
+//!     method: "test_method".to_string(),
+//! };
+//! let caller = Caller {
+//!     user_id: "user_123".to_string(),
+//!     agent: "agent_001".to_string(),
+//!     creator_id: "creator_001".to_string(),
+//! };
+//! let request_id = queue
+//!     .enqueue(
+//!         request,
+//!         caller,
+//!         "Test operation".to_string(),
+//!         RiskLevel::Medium,
+//!         "1.0".to_string(),
+//!         "session_resume".to_string(),
+//!         Box::new(|result| {
+//!             println!("Result: {:?}", result);
+//!         }),
+//!     )
+//!     .expect("enqueue succeeded");
 //! ```
 
 use chrono::{DateTime, Utc};

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -11,8 +11,15 @@
 //! use closeclaw::renderer::feishu::FeishuRenderer;
 //!
 //! let renderer = FeishuRenderer::new();
+//! // "Hello **world**" contains inline formatting (**), so renderer returns
+//! // `"interactive"` card instead of `"text"`. With dsl_result=None there are
+//! // no DSL buttons in the payload.
 //! let output = renderer.render("Hello **world**", None);
-//! assert_eq!(output.msg_type, "text");
+//! assert_eq!(output.msg_type, "interactive");
+//! // No DSL → no action/button elements in the card
+//! let elements = output.payload.get("card").and_then(|c| c.get("elements")).and_then(|e| e.as_array());
+//! assert!(elements.is_some());
+//! assert!(elements.unwrap().iter().all(|e| e.get("tag").and_then(|t| t.as_str()) != Some("action")));
 //! ```
 
 pub mod feishu;


### PR DESCRIPTION
## Summary

Fix 2 doc test failures on master (CI run #25880082623):

1. **`src/permission/approval.rs`** — removed call to non-existent `set_approve_callback`, replaced with correct `enqueue()` API that accepts callback as a parameter.

2. **`src/renderer/mod.rs`** — fixed assertion: text with inline markdown (`**bold**`) triggers interactive card rendering, so `msg_type` is `"interactive"`, not `"text"`.

## Validation

- `cargo test --doc`: 7 passed, 0 failed, 3 ignored

Source: CI