### PR TITLE
feat(permission): add sub-agent permission inheritance via parent agent deny propagation

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -391,7 +391,7 @@ impl Daemon {
     ) -> crate::permission::PermissionResponse {
         let caller = request.caller().clone();
         let agent_id = caller.agent.clone();
-        let response = self.permission_engine.evaluate(request.clone());
+        let response = self.permission_engine.evaluate(request.clone(), None);
         let result = match &response {
             crate::permission::PermissionResponse::Allowed { .. } => AuditResult::Allow,
             crate::permission::PermissionResponse::Denied { .. } => AuditResult::Deny,

--- a/src/permission/SPEC.md
+++ b/src/permission/SPEC.md
@@ -58,8 +58,9 @@
 
 | 接口 | 功能 |
 |------|------|
-| `PermissionEngine::check` | 简化权限检查（接受字符串 action 名） |
-| `PermissionEngine::evaluate` | 完整权限评估流程 |
+| `PermissionEngine::check` | 简化权限检查（接受字符串 action 名，内部调用 `evaluate` 并传入 `None` 作为 `extra_deny_subjects`） |
+| `PermissionEngine::evaluate` | 完整权限评估流程，支持 `extra_deny_subjects` 参数在标准评估后对额外 subject 做 deny 覆盖扫描 |
+| `PermissionEngine::get_agent_deny_subjects` | 提取父 agent 的 AgentOnly + Deny 规则 subject（将 agent 字段替换为 child_id），用于子 agent 权限递减链 |
 | `PermissionEngine::reload_rules` | 重新加载 RuleSet（重建索引） |
 | `PermissionEngine::load_templates` | 加载模板映射 |
 | `PermissionEngine::rebuild_indices_with_rules` | 从给定 RuleSet 重建 O(1) 索引 |
@@ -142,7 +143,7 @@ Host 进程                              Engine 子进程
    │  Result<PermissionResponse>          │
 ```
 
-### 评估算法（8 步）
+### 评估算法（9 步）
 
 1. **Creator 规则短路**：若 caller.user_id == agent_creators[agent_id]，直接 Allow
 2. **Agent 阶段**：调用 `collect_agent_candidates()` 收集 AgentOnly 候选规则 → `match_rules()` 求值 → 得到 agent_result
@@ -158,6 +159,7 @@ Host 进程                              Engine 子进程
 6. **风险评估**：在 `match_rules()` 和 `default_deny()` 返回 Denied 前，调用 `assess_risk_level(request)` 遍历 `HIGH_RISK_PATTERNS`，命中则返回对应等级，否则 Low。风险等级写入 `PermissionResponse::Denied.risk_level`
 7. **模板展开**：在 `match_rules()` 内部调用 `expand_templates_sync()` 展开 template 引用为实际 actions
 8. **默认策略**：任一阶段返回 None → Denied
+9. **Extra Deny 覆盖**：在步骤 1~8 完成后，若 `extra_deny_subjects` 不为空，逐一对每个 subject 调用 `subject.matches(&caller)`，任一匹配则将最终结果覆盖为 `PermissionResponse::Denied`（reason = "action denied by parent agent restriction"，rule = "<extra_deny>"）
 
 ### O(1) 索引
 

--- a/src/permission/engine/engine_owner_tests.rs
+++ b/src/permission/engine/engine_owner_tests.rs
@@ -68,7 +68,7 @@ fn owner_evaluate(request_body: PermissionRequestBody) -> PermissionResponse {
         },
         request: request_body,
     };
-    engine.evaluate(request)
+    engine.evaluate(request, None)
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn test_non_owner_unaffected_by_owner_shortcut() {
             op: "read".to_string(),
         },
     };
-    let alice_resp = engine.evaluate(alice_req);
+    let alice_resp = engine.evaluate(alice_req, None);
     assert!(
         matches!(alice_resp, PermissionResponse::Denied { .. }),
         "non-owner should be denied by UserAndAgent deny rule: {:?}",
@@ -215,7 +215,7 @@ fn test_non_owner_unaffected_by_owner_shortcut() {
             op: "read".to_string(),
         },
     };
-    let bob_resp = engine.evaluate(bob_req);
+    let bob_resp = engine.evaluate(bob_req, None);
     assert!(
         matches!(bob_resp, PermissionResponse::Allowed { .. }),
         "bob (different user) should get default allow, not blocked by alice's rule: {:?}",
@@ -246,7 +246,7 @@ fn test_owner_shortcut_after_creator_rule() {
             args: vec![],
         },
     };
-    let resp = engine.evaluate(request);
+    let resp = engine.evaluate(request, None);
     assert!(
         matches!(resp, PermissionResponse::Allowed { .. }),
         "owner who is also creator gets Allowed via creator rule (higher priority): {:?}",

--- a/src/permission/engine/engine_risk.rs
+++ b/src/permission/engine/engine_risk.rs
@@ -270,11 +270,14 @@ mod tests {
             .build()
             .unwrap();
         let engine = PermissionEngine::new(ruleset);
-        let resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
-            agent: "test-agent".to_string(),
-            path: "/repo/.git/config".to_string(),
-            op: "read".to_string(),
-        }));
+        let resp = engine.evaluate(
+            PermissionRequest::Bare(PermissionRequestBody::FileOp {
+                agent: "test-agent".to_string(),
+                path: "/repo/.git/config".to_string(),
+                op: "read".to_string(),
+            }),
+            None,
+        );
         match resp {
             PermissionResponse::Denied { risk_level, .. } => {
                 assert_eq!(risk_level, RiskLevel::High);
@@ -295,11 +298,14 @@ mod tests {
             .build()
             .unwrap();
         let engine = PermissionEngine::new(ruleset);
-        let resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
-            agent: "test-agent".to_string(),
-            path: "/repo/src/main.rs".to_string(),
-            op: "read".to_string(),
-        }));
+        let resp = engine.evaluate(
+            PermissionRequest::Bare(PermissionRequestBody::FileOp {
+                agent: "test-agent".to_string(),
+                path: "/repo/src/main.rs".to_string(),
+                op: "read".to_string(),
+            }),
+            None,
+        );
         match resp {
             PermissionResponse::Denied { risk_level, .. } => {
                 assert_eq!(risk_level, RiskLevel::Low);

--- a/src/permission/engine/engine_tests.rs
+++ b/src/permission/engine/engine_tests.rs
@@ -131,11 +131,14 @@ fn test_deny_takes_precedence() {
         .build()
         .unwrap();
     let engine = PermissionEngine::new(ruleset);
-    let resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
-        agent: "test-agent".to_string(),
-        path: "/etc/shadow".to_string(),
-        op: "write".to_string(),
-    }));
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/etc/shadow".to_string(),
+            op: "write".to_string(),
+        }),
+        None,
+    );
     matches!(resp, PermissionResponse::Denied { .. });
 }
 
@@ -346,19 +349,25 @@ fn test_tool_call_default_independent_from_file() {
     let engine = PermissionEngine::new(ruleset);
 
     // file op should be allowed (default Allow)
-    let file_resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::FileOp {
-        agent: "unknown-agent".to_string(),
-        path: "/tmp/test".to_string(),
-        op: "read".to_string(),
-    }));
+    let file_resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::FileOp {
+            agent: "unknown-agent".to_string(),
+            path: "/tmp/test".to_string(),
+            op: "read".to_string(),
+        }),
+        None,
+    );
     matches!(file_resp, PermissionResponse::Allowed { .. });
 
     // tool call should be denied (default Deny)
-    let tool_resp = engine.evaluate(PermissionRequest::Bare(PermissionRequestBody::ToolCall {
-        agent: "unknown-agent".to_string(),
-        skill: "some_tool".to_string(),
-        method: "run".to_string(),
-    }));
+    let tool_resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "unknown-agent".to_string(),
+            skill: "some_tool".to_string(),
+            method: "run".to_string(),
+        }),
+        None,
+    );
     matches!(tool_resp, PermissionResponse::Denied { .. });
 }
 

--- a/src/permission/engine/engine_two_phase_tests.rs
+++ b/src/permission/engine/engine_two_phase_tests.rs
@@ -84,7 +84,7 @@ fn test_two_phase_agent_allow_user_allow() {
         },
     ];
     let engine = make_ruleset(Effect::Deny, rules);
-    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"));
+    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
     assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 
@@ -124,18 +124,21 @@ fn test_two_phase_agent_deny_user_allow() {
         },
     ];
     let engine = make_ruleset(Effect::Deny, rules);
-    let resp = engine.evaluate(PermissionRequest::WithCaller {
-        caller: Caller {
-            user_id: "alice".to_string(),
-            agent: "test-agent".to_string(),
-            creator_id: String::new(),
+    let resp = engine.evaluate(
+        PermissionRequest::WithCaller {
+            caller: Caller {
+                user_id: "alice".to_string(),
+                agent: "test-agent".to_string(),
+                creator_id: String::new(),
+            },
+            request: PermissionRequestBody::FileOp {
+                agent: "test-agent".to_string(),
+                path: "/etc/passwd".to_string(),
+                op: "write".to_string(),
+            },
         },
-        request: PermissionRequestBody::FileOp {
-            agent: "test-agent".to_string(),
-            path: "/etc/passwd".to_string(),
-            op: "write".to_string(),
-        },
-    });
+        None,
+    );
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
@@ -161,7 +164,7 @@ fn test_two_phase_agent_allow_user_no_match() {
     ];
     let engine = make_ruleset(Effect::Deny, rules);
     // Agent Allow + User None → Allowed (User has no stance, Agent result takes effect)
-    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"));
+    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
     assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 
@@ -170,7 +173,7 @@ fn test_two_phase_agent_allow_user_no_match() {
 fn test_two_phase_no_match_default_deny() {
     // No rules at all
     let engine = make_ruleset(Effect::Deny, vec![]);
-    let resp = engine.evaluate(file_request("unknown-agent", "/data/file.txt", "bob"));
+    let resp = engine.evaluate(file_request("unknown-agent", "/data/file.txt", "bob"), None);
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
@@ -195,7 +198,7 @@ fn test_two_phase_owner_agent_allow() {
         // No UserAndAgent rules (owner skips user phase)
     ];
     let engine = make_ruleset(Effect::Deny, rules);
-    let resp = engine.evaluate(file_request("test-agent", "/etc/passwd", "owner"));
+    let resp = engine.evaluate(file_request("test-agent", "/etc/passwd", "owner"), None);
     assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 
@@ -217,18 +220,21 @@ fn test_two_phase_owner_agent_deny() {
         priority: 10,
     }];
     let engine = make_ruleset(Effect::Deny, rules);
-    let resp = engine.evaluate(PermissionRequest::WithCaller {
-        caller: Caller {
-            user_id: "owner".to_string(),
-            agent: "test-agent".to_string(),
-            creator_id: String::new(),
+    let resp = engine.evaluate(
+        PermissionRequest::WithCaller {
+            caller: Caller {
+                user_id: "owner".to_string(),
+                agent: "test-agent".to_string(),
+                creator_id: String::new(),
+            },
+            request: PermissionRequestBody::FileOp {
+                agent: "test-agent".to_string(),
+                path: "/etc/passwd".to_string(),
+                op: "write".to_string(),
+            },
         },
-        request: PermissionRequestBody::FileOp {
-            agent: "test-agent".to_string(),
-            path: "/etc/passwd".to_string(),
-            op: "write".to_string(),
-        },
-    });
+        None,
+    );
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
@@ -238,7 +244,10 @@ fn test_two_phase_owner_agent_no_match() {
     // No rules at all
     let engine = make_ruleset(Effect::Deny, vec![]);
     // Owner still gets default deny when no rules match
-    let resp = engine.evaluate(file_request("unknown-agent", "/data/file.txt", "owner"));
+    let resp = engine.evaluate(
+        file_request("unknown-agent", "/data/file.txt", "owner"),
+        None,
+    );
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
@@ -264,8 +273,198 @@ fn test_two_phase_non_owner_needs_both_phases() {
     }];
     let engine = make_ruleset(Effect::Deny, rules);
     // Alice is not owner, Agent phase has no match, User phase Allow is not enough alone
-    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"));
+    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
     // Agent None + User Allow → Allowed (according to current merge logic in evaluate)
     // This test documents the actual merge behavior
     assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// Extra deny subjects tests
+// ---------------------------------------------------------------------------
+
+/// extra_deny_subjects = None → normal Allow unchanged
+#[test]
+fn test_extra_deny_subjects_empty() {
+    let rules = vec![Rule {
+        name: "agent-allows-read".to_string(),
+        subject: Subject::AgentOnly {
+            agent: "test-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        effect: Effect::Allow,
+        actions: vec![super::engine_types::Action::File {
+            operation: "read".to_string(),
+            paths: vec!["/data/**".to_string()],
+        }],
+        template: None,
+        priority: 10,
+    }];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
+    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+}
+
+/// extra_deny_subjects has a matching subject → overrides result to Denied
+#[test]
+fn test_extra_deny_subjects_match() {
+    let rules = vec![Rule {
+        name: "agent-allows-read".to_string(),
+        subject: Subject::AgentOnly {
+            agent: "test-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        effect: Effect::Allow,
+        actions: vec![super::engine_types::Action::File {
+            operation: "read".to_string(),
+            paths: vec!["/data/**".to_string()],
+        }],
+        template: None,
+        priority: 10,
+    }];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let extra = vec![Subject::AgentOnly {
+        agent: "test-agent".to_string(),
+        match_type: MatchType::Exact,
+    }];
+    let resp = engine.evaluate(
+        file_request("test-agent", "/data/file.txt", "alice"),
+        Some(extra),
+    );
+    let deny_resp = match resp {
+        PermissionResponse::Denied {
+            reason,
+            rule,
+            risk_level: _,
+        } => {
+            assert!(reason.contains("parent agent restriction"));
+            assert_eq!(rule, "<extra_deny>");
+        }
+        _ => panic!("expected Denied, got {:?}", resp),
+    };
+}
+
+/// extra_deny_subjects has a subject but does NOT match caller → normal Allow
+#[test]
+fn test_extra_deny_subjects_no_match() {
+    let rules = vec![Rule {
+        name: "agent-allows-read".to_string(),
+        subject: Subject::AgentOnly {
+            agent: "test-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        effect: Effect::Allow,
+        actions: vec![super::engine_types::Action::File {
+            operation: "read".to_string(),
+            paths: vec!["/data/**".to_string()],
+        }],
+        template: None,
+        priority: 10,
+    }];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let extra = vec![Subject::AgentOnly {
+        agent: "other-agent".to_string(),
+        match_type: MatchType::Exact,
+    }];
+    let resp = engine.evaluate(
+        file_request("test-agent", "/data/file.txt", "alice"),
+        Some(extra),
+    );
+    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+}
+
+/// Normal two-phase result is Allow, but extra_deny matches → overrides to Denied
+#[test]
+fn test_extra_deny_overrides_allow() {
+    let rules = vec![Rule {
+        name: "agent-allows-read".to_string(),
+        subject: Subject::AgentOnly {
+            agent: "test-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        effect: Effect::Allow,
+        actions: vec![super::engine_types::Action::File {
+            operation: "read".to_string(),
+            paths: vec!["/data/**".to_string()],
+        }],
+        template: None,
+        priority: 10,
+    }];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let extra = vec![Subject::AgentOnly {
+        agent: "test-agent".to_string(),
+        match_type: MatchType::Exact,
+    }];
+    let resp = engine.evaluate(
+        file_request("test-agent", "/data/file.txt", "alice"),
+        Some(extra),
+    );
+    assert!(matches!(resp, PermissionResponse::Denied { reason, .. }
+            if reason.contains("parent agent restriction")));
+}
+
+// ---------------------------------------------------------------------------
+// get_agent_deny_subjects tests
+// ---------------------------------------------------------------------------
+
+/// get_agent_deny_subjects extracts parent AgentOnly Deny rules, replacing agent with child_id
+#[test]
+fn test_get_agent_deny_subjects_basic() {
+    let rules = vec![
+        Rule {
+            name: "parent-deny-spawn".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "parent-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Deny,
+            actions: vec![super::engine_types::Action::ToolCall {
+                skill: "*".to_string(),
+                methods: vec![],
+            }],
+            template: None,
+            priority: 10,
+        },
+        Rule {
+            name: "parent-allow-read".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "parent-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![super::engine_types::Action::File {
+                operation: "read".to_string(),
+                paths: vec!["/**".to_string()],
+            }],
+            template: None,
+            priority: 5,
+        },
+    ];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let subjects = engine.get_agent_deny_subjects("parent-agent", "child-agent");
+    assert_eq!(subjects.len(), 1);
+    let replaced = &subjects[0];
+    assert!(matches!(replaced, Subject::AgentOnly { agent, .. } if agent == "child-agent"));
+}
+
+/// Parent agent has no deny rules → returns empty
+#[test]
+fn test_get_agent_deny_subjects_empty() {
+    let rules = vec![Rule {
+        name: "parent-allow-read".to_string(),
+        subject: Subject::AgentOnly {
+            agent: "parent-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        effect: Effect::Allow,
+        actions: vec![super::engine_types::Action::File {
+            operation: "read".to_string(),
+            paths: vec!["/**".to_string()],
+        }],
+        template: None,
+        priority: 5,
+    }];
+    let engine = make_ruleset(Effect::Deny, rules);
+    let subjects = engine.get_agent_deny_subjects("parent-agent", "child-agent");
+    assert!(subjects.is_empty());
 }

--- a/src/permission/sandbox/ipc.rs
+++ b/src/permission/sandbox/ipc.rs
@@ -178,7 +178,7 @@ async fn handle_connection(
         // Process request
         let response = match &request {
             SandboxRequest::Evaluate { request } => {
-                SandboxResponse::PermissionResponse(engine.evaluate(request.clone()))
+                SandboxResponse::PermissionResponse(engine.evaluate(request.clone(), None))
             }
             SandboxRequest::ReloadRules { rules: _ } => {
                 // The engine is recreated externally; we just acknowledge.

--- a/src/permission/tests/creator_rule_test.rs
+++ b/src/permission/tests/creator_rule_test.rs
@@ -31,7 +31,7 @@ async fn test_creator_rule_short_circuit_caller_creator_id() {
             args: vec!["-rf".to_string(), "/".to_string()],
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -58,7 +58,7 @@ async fn test_creator_rule_short_circuit_agent_creators_map() {
             args: vec!["-rf".to_string(), "/".to_string()],
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -85,7 +85,7 @@ async fn test_creator_rule_not_matching_non_creator() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Denied { .. }));
 }
 
@@ -121,7 +121,7 @@ async fn test_creator_rule_priority_over_explicit_deny() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -148,6 +148,6 @@ async fn test_creator_rule_caller_creator_id_takes_precedence() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }

--- a/src/permission/tests/rule_evaluation_test.rs
+++ b/src/permission/tests/rule_evaluation_test.rs
@@ -47,7 +47,7 @@ async fn test_user_and_agent_rule_matching() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -90,7 +90,7 @@ async fn test_user_and_agent_rule_user_mismatch() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Denied { .. }));
 }
 
@@ -121,7 +121,7 @@ async fn test_bare_request_uses_agent_only_matching() {
         path: "/any/path.txt".to_string(),
         op: "read".to_string(),
     });
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -159,7 +159,7 @@ async fn test_with_caller_request_still_matches_agent_only_rules() {
             op: "read".to_string(),
         },
     };
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Allowed { .. }));
 }
 
@@ -203,6 +203,6 @@ async fn test_rule_priority_higher_evaluated_first() {
         path: "/any/path.txt".to_string(),
         op: "read".to_string(),
     });
-    let response = engine.evaluate(request);
+    let response = engine.evaluate(request, None);
     assert!(matches!(response, PermissionResponse::Denied { .. }));
 }

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -1,5 +1,7 @@
 //! Skill discovery skill - allows agents to search and install skills from ClawHub
-use crate::permission::PermissionResponse;
+use crate::permission::engine::Caller;
+use crate::permission::engine::PermissionRequestBody;
+use crate::permission::{PermissionRequest, PermissionResponse};
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -78,7 +80,20 @@ impl Skill for SkillDiscoverySkill {
                 let version = args.get("version").and_then(|v| v.as_str());
 
                 if let Some(ref engine) = self.engine {
-                    match engine.check(agent_id, "spawn") {
+                    let caller = Caller {
+                        user_id: String::new(),
+                        agent: agent_id.to_string(),
+                        creator_id: String::new(),
+                    };
+                    let request = PermissionRequest::WithCaller {
+                        caller,
+                        request: PermissionRequestBody::InterAgentMsg {
+                            from: agent_id.to_string(),
+                            to: "*".to_string(),
+                        },
+                    };
+                    let extra_deny_subjects = engine.get_agent_deny_subjects(agent_id, agent_id);
+                    match engine.evaluate(request, Some(extra_deny_subjects)) {
                         PermissionResponse::Allowed { .. } => {}
                         PermissionResponse::Denied { reason, .. } => {
                             return Err(SkillError::PermissionDenied(reason));
@@ -254,5 +269,54 @@ mod tests {
         // May be denied or may succeed if engine check doesn't match action "spawn"
         // The important thing is it doesn't panic
         let _ = result;
+    }
+
+    /// Parent agent has deny rule → child agent install is denied
+    #[tokio::test]
+    async fn test_install_permission_with_extra_deny() {
+        use crate::permission::engine::engine_types::{
+            Action, Defaults, Effect, MatchType, Rule, RuleSet, Subject,
+        };
+        use std::collections::HashMap;
+        let rules = RuleSet {
+            version: "1".to_string(),
+            rules: vec![Rule {
+                name: "parent-deny-spawn".to_string(),
+                subject: Subject::AgentOnly {
+                    agent: "parent-agent".to_string(),
+                    match_type: MatchType::Exact,
+                },
+                effect: Effect::Deny,
+                actions: vec![Action::ToolCall {
+                    skill: "*".to_string(),
+                    methods: vec![],
+                }],
+                template: None,
+                priority: 10,
+            }],
+            defaults: Defaults::default(),
+            template_includes: vec![],
+            agent_creators: HashMap::new(),
+        };
+        let engine = Arc::new(crate::permission::PermissionEngine::new(rules));
+        let skill = SkillDiscoverySkill::with_engine(engine);
+        // child-agent is spawned by parent-agent, child-agent tries to install a skill
+        let result = skill
+            .execute(
+                "install",
+                serde_json::json!({
+                    "agent_id": "child-agent",
+                    "skill": "test-skill"
+                }),
+            )
+            .await;
+        // Should be denied because parent-agent has a deny rule for tool_call,
+        // and get_agent_deny_subjects propagates it to child-agent
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::skills::SkillError::PermissionDenied(_)
+        ));
     }
 }


### PR DESCRIPTION
- Add extra_deny_subjects parameter to evaluate() for independent deny scan
- Add get_agent_deny_subjects() to extract parent agent deny rules for child agents
- Upgrade discovery.rs spawn permission check to use evaluate() with extra deny

Source: issue #666
Type: feat
