### PR TITLE
docs(design): add session-injection design doc

### DIFF
--- a/docs/design/session/session-injection.md
+++ b/docs/design/session/session-injection.md
@@ -1,0 +1,123 @@
+# Session 注入
+
+## 概述
+
+描述新 session 创建时，系统如何将 bootstrap 文件、工具列表、skill 列表和 memory 文件组装成 system prompt 并注入会话。注入链路是 session 生命周期中"创建"阶段的核心环节。
+
+## 架构
+
+### 注入入口
+
+注入流程由 SessionManager 在 find_or_create 中触发，分为三个决策分支：
+
+- **命中 active session**：直接返回，不重新注入。
+- **命中 archived session**：从存储恢复后重新走完整注入流程，确保 system prompt 内容与最新 bootstrap 文件一致。
+- **新 session**：走完整注入链路。
+
+注入链路的核心是 system prompt builder 的 build_from_workspace，它接收已加载的 bootstrap 文件、ToolRegistry 引用和 SkillRegistry 引用，组装生成最终 system prompt。
+
+### 注入的四个 Section
+
+build_from_workspace 组装四种 Section：
+
+- **RoleSection**：bootstrap 文件内容。来自 load_bootstrap_files 的返回值，按 CONTEXT_FILE_ORDER 排序。AGENTS.md 排在首位。Minimal 模式加载 AGENTS/SOUL/IDENTITY/USER/TOOLS，Full 模式额外加载 BOOTSTRAP 和 MEMORY。HEARTBEAT.md 不在注入范围，按需单独读取。
+- **ToolsSection**：工具描述列表。ToolRegistry 根据 agent 类型生成，包含工具名、描述和危险度标记。所有工具 eager load 进 system prompt。
+- **SkillListingSection**：可用 skill 列表。SkillRegistry 按优先级排序（bundled > global > agent > project，同级按名字字母序），输出 name + description 格式，供模型判断何时使用。
+- **MemorySection**：MEMORY.md 内容。走 session 级文件缓存，命中缓存则跳过读取。
+
+四个 Section 拼接后生成完整 system prompt，写入 ConversationSession。
+
+### 静态区与动态区的边界
+
+system prompt 内容分为两层：
+
+- **静态层**：session 创建时注入，内容写入 ConversationSession 的 system_prompt 字段，进入 checkpoint 持久化。包含 RoleSection、ToolsSection、SkillListingSection、MemorySection。
+- **动态层**：每次 API 请求时注入，不持久化。包含 ChannelContext（当前消息来源）和 SessionState（turnCount 等运行时状态）。
+
+静态层和动态层之间通过边界标记分隔，使 API 层可以区分可缓存前缀和必须每次重新计算的后缀。
+
+### 无 Workspace 的 Session
+
+当 session 没有对应 workspace 目录时，不加载 bootstrap 文件，但仍可通过 ToolRegistry 和 SkillRegistry 生成工具列表和 skill 列表。system prompt 仅包含 ToolsSection 和 SkillListingSection。
+
+### Section 失败处理
+
+单个 Section 组装失败时，该 Section 不参与拼接（跳过），其余 Section 继续。不阻断整条注入链路。
+
+### Skill 热更新
+
+skill 文件变更时，SkillRegistry 通知 SessionManager 重新走 build_from_workspace，生成新的 system prompt 替换旧的。不依赖消息 ID 定位（skill listing 直接拼接在 system prompt 中，不是独立消息）。
+
+## 数据流
+
+### 新 Session 创建
+
+```
+用户消息到达
+  →
+  SessionManager.find_or_create
+    ├─ active session 命中 → 直接返回（不重新注入）
+    ├─ archived session 命中 → 恢复 → 重新注入（保证 prompt 最新）
+    └─ 新 session
+        ├─ workspace 存在？
+        │   ├─ 是 → load_bootstrap_files（按 Minimal/Full 模式加载）
+        │   │      → build_from_workspace
+        │   │         ├─ 组装 RoleSection（bootstrap 文件内容）
+        │   │         ├─ 组装 ToolsSection（ToolRegistry 生成工具描述）
+        │   │         ├─ 组装 SkillListingSection（SkillRegistry 生成 skill 列表）
+        │   │         ├─ 组装 MemorySection（MEMORY.md，走缓存）
+        │   │         └─ 拼接生成 system prompt
+        │   │      → ConversationSession.with_system_prompt
+        │   │
+        │   └─ 否 → 组装 ToolsSection + SkillListingSection（跳过 bootstrap）
+        │          → ConversationSession.with_system_prompt
+        │
+        └─ 写入 SessionManager 的运行时映射
+           → 返回 session_id
+```
+
+### 每次 API 请求时的动态区注入
+
+```
+API 请求到达
+  →
+  build_channel_context（当前消息的 channel/sender 信息）
+  build_session_state（turnCount 等运行时状态）
+  →
+  动态 sections 追加到静态 system_prompt 后
+  →
+  发送 LLM 请求
+```
+
+动态 sections 不进 checkpoint，不改变 session 的 system_prompt 字段。
+
+### Session 恢复时的重新注入
+
+从 checkpoint 重建 ConversationSession 后，重新走完整注入流程（而非恢复旧的 system_prompt），确保内容与最新 bootstrap 文件一致。
+
+```
+archived session 被访问
+  →
+  从 checkpoint 重建 ConversationSession
+  →
+  SessionManager 重新走 build_from_workspace（不恢复旧的 system_prompt）
+  →
+  新的 system_prompt 替换旧的
+```
+
+## 模块关系
+
+### 上游
+
+- **SessionManager**：session 生命周期协调者，在 find_or_create 中调用 system prompt builder 完成注入。持有 ToolRegistry 和 SkillRegistry 引用，作为注入的数据来源。
+
+### 下游
+
+- **ToolRegistry**：提供 build_tools_section，生成工具的 name + description + 危险度标记。
+- **SkillRegistry**：提供 generate_listing，生成可用 skill 列表（按优先级 + 字母序排序）。
+- **Bootstrap Loader**：提供 load_bootstrap_files，按 Minimal/Full 模式加载 bootstrap 文件集合。
+
+### 无关
+
+- **LLM Provider**（无调用关系）：注入完成后的 system prompt 通过 ConversationSession 传递给 LLM provider，注入链路本身不调用 provider。
+- **Compaction 模块**（无调用关系）：compaction 时 skill listing 的保护策略在 compaction 模块定义，注入链路不参与压缩逻辑。


### PR DESCRIPTION
## 内容

新增 session 模块子文档：**session-injection.md**，描述新 session 创建时 system prompt 的完整注入链路。

### 文档结构（4 节）

- **概述**：注入链路是 session 生命周期中创建阶段的核心环节
- **架构**：三个决策分支（active/archived/new）、四个 Section 组装（Role/Tools/SkillListing/Memory）、静态动态边界、无 workspace fallback、失败处理、热更新
- **数据流**：新 Session 创建、每次 API 请求动态区注入、Session 恢复重新注入
- **模块关系**：SessionManager（上游）→ ToolRegistry / SkillRegistry / Bootstrap Loader（下游）

### 来源

原始设计文档：`workspace/design/43-new-session-injection-chain.md`

### 代码对照发现（非本文档修改范围）

代码 `session_manager.rs` 当前在新建 session 时绕过了 `build_from_workspace`，直接用内联拼接 bootstrap 文件，导致 ToolsSection 和 SkillListingSection 未注入。详见本文档描述的架构与代码实现之间的差异。

Source: user
Type: docs