### PR TITLE
docs(design): add skills design doc

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,4 +8,5 @@
 | [permission](permission/README.md) | 系统级身份型访问控制：交集模型、七类权限维度、审批工作流与配置管理 |
 | [processor_chain](processor_chain/README.md) | 消息出站处理与平台渲染：DSL 解析、Renderer 跨平台渲染框架 |
 | [session](session/README.md) | Agent 会话生命周期管理：创建、持久化、压缩、归档与清理 |
+| [skills](skills/README.md) | Agent 可复用能力插件体系：磁盘即插即用、五层优先级、frontmatter 配置驱动、双执行模式 |
 | [tools](tools/README.md) | Agent 能力层：两级索引工具体系、内建工具、平台工具、Bash 工具、提示词注入 |

--- a/docs/design/skills/README.md
+++ b/docs/design/skills/README.md
@@ -1,0 +1,163 @@
+# Skills 模块
+
+## 概述
+
+Skills 模块是 CloseClaw 的 agent 可复用能力插件体系。用户创建 SKILL.md 文件放入指定目录即可自动被发现和加载，无需修改代码即可扩展 agent 能力。
+
+核心设计：
+- 磁盘即插即用，放 SKILL.md 到对应目录即生效
+- 五层优先级目录结构，同名冲突按优先级取高
+- frontmatter 配置驱动行为（描述、权限、执行模式、触发条件等）
+- skills 和 tools 统一注册中心，共享调用协议
+- 双执行模式：inline（当前 agent 上下文）和 fork（隔离子 agent）
+- 多 agent 独立，各自有独立的 skill 空间
+
+### 子功能索引
+
+| 文档 | 内容 |
+|------|------|
+| [skill-listing-injection.md](skill-listing-injection.md) | Skill 列表注入：session 启动时的列表注入、热重载替换、compaction 保护、条件激活 |
+
+## 架构
+
+Skills 模块由五个核心组件构成：Skill 定义层、磁盘加载层、注册中心层、执行层、注入层。
+
+```
+磁盘文件系统
+  │
+  ├─ ~/.closeclaw/skills/           ← 全局 skill
+  ├─ ~/.closeclaw/agents/<id>/skills/ ← agent 专属 skill
+  ├─ <project>/.closeclaw/skills/   ← 项目级 skill
+  ├─ extraDirs 配置路径              ← 外部复用 skill
+  └─ bundled/                        ← 编译期内置 skill
+        │
+        ▼
+磁盘加载层（Disk Loader）
+  → 扫描五层目录 → 解析 SKILL.md frontmatter → 同名冲突去重
+        │
+        ▼
+注册中心层（Skill Registry）
+  → 统一管理 disk skill 与 bundled skill → 提供查询路由
+        │
+        ▼
+注入层（Injection）
+  → session 启动时注入 skill listing → 让 agent 获知可用 skill
+        │
+        ▼
+执行层（Execution）
+  → agent 决策调用 SkillTool → inline 或 fork 执行 → 结果返回
+```
+
+### Skill 定义
+
+每个 skill 由三部分组成：配置清单（frontmatter）、正文（SKILL.md 中 frontmatter 之后的指令文本）、执行入口。
+
+下文中"正文"均指 SKILL.md 的指令文本部分，区别于 frontmatter 配置。
+
+**配置清单**（frontmatter）包含以下字段：
+
+| 字段 | 必填 | 作用 |
+|------|------|------|
+| description | 是 | 供 agent 决策是否调用 |
+| name | 否 | 默认取目录名 |
+| allowed-tools | 否 | 限制 skill 可用的工具，不填则无限制 |
+| when-to-use | 否 | 决策提示，帮助 agent 判断调用时机 |
+| context | 否 | 执行模式：inline（默认）或 fork |
+| agent | 否 | fork 模式下使用的 agent 类型 |
+| agent-id | 否 | 限定只有特定 agent 可用 |
+| effort | 否 | 成本估算，供 agent 调度参考 |
+| paths | 否 | 条件激活的文件 glob 匹配模式 |
+| user-invocable | 否 | 是否可通过 slash command 调用 |
+
+**执行模式**两种：
+- **inline**：在当前 agent 上下文中执行，skill 内容展开到 agent prompt，权限修改留在当前 session
+- **fork**：在独立 sub-agent 中执行，上下文隔离，allowed-tools 不泄露到父 agent
+
+### 目录层级与优先级
+
+五个技能来源按优先级从高到低排列：
+
+| 层级 | 路径 | 作用域 | 优先级 |
+|------|------|--------|--------|
+| Project | `<project-root>/.closeclaw/skills/` | 仅该项目 | 最高 |
+| Agent | `~/.closeclaw/agents/<agent-id>/skills/` | 仅该 agent | 高 |
+| Global | `~/.closeclaw/skills/` | 所有 agent | 中 |
+| ExtraDirs | 配置路径（如复用外部工具链的 skill 目录） | 由配置决定 | 低 |
+| Bundled | 编译期内置 | 全局内建 | 最低 |
+
+同名冲突处理：高优先级生效，低优先级被跳过并记录警告。
+
+### 磁盘加载
+
+Session 启动时按优先级从低到高扫描全部五个来源目录，每层覆盖上一层的同名 skill。加载完成后注册中心冻结，skill 集合在 session 内不可变（热重载除外）。
+
+优化方案：可采用两阶段加载——启动时只注册 skill listing（名称、描述、来源、条件路径），调用时再按需加载正文。
+
+### 注册中心
+
+采用双注册表架构过渡：
+
+- **SkillRegistry**（已有）：管理 bundled skill，异步操作
+- **DiskSkillRegistry**（新增）：管理磁盘加载的 skill，同步查询
+
+查询路由：先查 DiskSkillRegistry，未命中再查 SkillRegistry。
+
+### 权限控制
+
+权限检查不在 skills 模块内实现，而是由上游 agent 运行时调用权限引擎校验。Skill 的 frontmatter 声明 allowed-tools 字段，权限引擎据此限制 skill 可用工具集。
+
+### 错误处理
+
+磁盘加载阶段的错误不影响 session 正常运行：
+
+- extraDirs 路径不存在：记录警告，跳过该来源
+- 单个 SKILL.md 格式错误：记录错误，跳过该 skill，其他 skill 正常加载
+- 同名冲突：跳过低优先级版本，记录警告
+- 必填字段缺失（description）：视为严重错误，启动时报告但不阻止 session 继续
+
+## 数据流
+
+### 加载与注入
+
+```
+Session 启动
+  → 扫描五层目录（bundled → extraDirs → global → agent → project）
+    → 每层解析 SKILL.md frontmatter
+      → 同名冲突去重（高优先级覆盖）
+        → 写入注册中心
+          → 生成 skill listing 字符串（名称 + 描述 + 触发条件）
+            → 作为 system-reminder 消息注入 session 最开头
+              → agent 在对话初始化时看到全部可用 skill
+```
+
+### 技能调用
+
+```
+Agent 决策调用某个 skill
+  → 通过 SkillTool 发起调用
+    → 从注册中心查找 skill 实例
+      → 权限校验（allowed-tools）
+        → 按需加载 skill 正文（如采用两阶段加载）
+          → 判断执行模式
+            ├─ inline：正文内容展开到 agent 上下文，权限修改留在当前 session
+            └─ fork：创建隔离子 agent，注入 allowed-tools 权限，在子 agent 中执行
+              → 执行结果返回
+                → 注入到对话上下文供 agent 继续处理
+```
+
+### 热重载
+
+```
+文件系统变更（SKILL.md 新增/修改/删除）
+  → 文件监听器检测到变更（300ms debounce）
+    → 使 skill listing 缓存失效
+      → 重新生成 skill listing
+        → 替换 session 开头的旧 listing 消息
+          → agent 在下一轮对话中看到更新后的 skill 列表
+```
+
+## 模块关系
+
+- **上游**：agent 运行时（调度 skill 调用）、system prompt 构建器（注入 skill listing）、session 管理器（启动时加载、关闭时释放）
+- **下游**：文件系统（扫描目录、读取 SKILL.md）、sub-agent 管理（fork 模式下创建隔离子 agent）、权限引擎（执行前校验 allowed-tools）
+- **无关**：processor_chain（skill 不参与消息出站处理）、renderer（skill 不参与平台渲染）

--- a/docs/design/skills/skill-listing-injection.md
+++ b/docs/design/skills/skill-listing-injection.md
@@ -1,0 +1,177 @@
+# Skill 列表注入
+
+## 概述
+
+Skill 列表注入机制负责在 session 启动时将可用 skill 的摘要清单注入到 agent 上下文中，让 agent 在对话初始化时就知道有哪些 skill 可用、何时使用。同时支持热重载替换和 compaction 保护。
+
+核心设计：
+- 纯函数生成：固定排序规则，相同输入产生相同输出
+- 注入位置固定：session 最开头的 system-reminder 消息
+- 热重载直接替换：不缓存、不做增量优化
+- compaction 原样保留：压缩只针对多轮对话部分
+
+## 架构
+
+列表注入由三个子组件协作完成：列表生成器、注入器、文件监听器。
+
+```
+DiskSkillRegistry ─────────── 数据源
+        │
+        ▼
+┌─ 列表生成器（Listing Generator）─┐
+│  过滤：agent-id 匹配             │
+│        user-invocable = true    │
+│  排序：source 优先级 → name 序   │
+│  格式化：## Available Skills     │
+│         - **{name}**: {desc}    │
+│           ⚡ auto-activates on   │
+└────────────────┬────────────────┘
+                 │
+                 ▼
+┌─ 注入器（Injector）───────────┐
+│  创建 system-reminder 消息       │
+│  标记 is_meta=true（用户不可见） │
+│  附加 SkillListingAttachment    │
+│  插入 session transcript 最开头  │
+└────────────────┬────────────────┘
+                 │
+                 ▼
+┌─ 文件监听器（Skill Watcher）──┐
+│  监听技能目录文件变更            │
+│  300ms debounce 聚合事件        │
+│  变更后触发 → 重新生成 → 替换   │
+└────────────────────────────────┘
+```
+
+### 列表生成
+
+列表生成是纯函数，输入 DiskSkillRegistry 和 agent_id，输出格式化字符串。格式为：
+
+```
+## Available Skills
+- **{name}**: {description} — {whenToUse}
+  ⚡ auto-activates on: {glob pattern}
+```
+
+whenToUse 可选（无则不显示 `—` 后缀），⚡ 标注仅在 skill 声明 paths 时出现。
+
+排序规则两层：
+1. 按 skill 来源优先级排序（高优先级在前）
+2. 同来源内按 name 字母序升序
+
+过滤条件：
+- 仅注入 agent-id 匹配的 skill（agent-id 为空或匹配当前 agent）
+- 仅注入 user-invocable 为 true 的 skill（用户可通过 slash command 显式调用）
+
+### 列表注入
+
+Session 启动时，生成的 skill listing 作为 system-reminder 类型的消息插入 session transcript 最开头。该消息标记为元信息（用户不可见），agent 在对话初始化时读取（"正文"指 SKILL.md 中 frontmatter 之后的指令文本，与 skill listing 的摘要条目是不同概念）。
+
+消息附带附件（skill listing attachment），记录以下元数据供后续热重载和 compaction 定位使用：
+- 格式化文本内容
+- 当前 skill 总数
+- 是否初始批次标记
+
+### 热重载替换
+
+文件监听器通过底层文件系统事件机制检测 SKILL.md 的创建、修改、删除。热重载链路跨模块协作：
+
+1. **skills 模块负责**：文件变更事件触发 → 300ms debounce → 使注册中心 listing 缓存失效 → 重新扫描变更目录 → 重新生成 listing
+2. **system prompt 构建器负责**：检测到缓存已失效 → 获取新列表 → 查找 session 转录中旧的 listing 消息 → 替换消息内容（保留消息位置）→ 更新附件元数据标记为非初始批次
+
+### Compaction 保护
+
+Session 压缩时将 session 消息分为三个区域处理：
+
+- **保护区域**：bootstrap 文件（AGENTS.md、SOUL.md 等）和 skill listing 消息，原样保留
+- **压缩区域**：多轮对话部分（tool calls + responses），通过摘要器压缩为摘要消息
+- **拼接方式**：bootstrap + skill listing + 压缩后的对话摘要
+
+### 条件激活
+
+带 `paths` 字段的 skill 在 listing 中有特殊标注（⚡ 标记），表示该 skill 在操作匹配文件时自动激活。
+
+当 agent 操作的文件路径匹配某 skill 的 paths glob 时，该 skill 移入动态激活列表，在下一轮 listing 中体现。
+
+## 数据流
+
+### 启动注入
+
+```
+Session 启动
+  │
+  ├─ 加载 bootstrap 文件
+  │
+  ├─ 从 DiskSkillRegistry 获取全部 skill
+  │     │
+  │     ├─ agent_id 匹配？（不匹配 → 跳过）
+  │     └─ user_invocable 匹配？（false → 跳过）
+  │
+  ├─ 排序：source 优先级高→低
+  │         └─ 同 source 内 name 字母序
+  │
+  ├─ 格式化：## Available Skills
+  │         - **{name}**: {description} — {whenToUse}
+  │           ⚡ auto-activates on: {paths}
+  │
+  └─ 创建 system-reminder 消息（is_meta=true）
+        └─ 插入 session transcript 最开头
+            └─ agent 在对话初始化时读取全部可用 skill
+```
+
+### 热重载
+
+```
+SKILL.md 文件变更
+  → 文件监听器捕获事件
+    → 300ms debounce 等待写入完成
+      → 使注册中心缓存失效
+        → 重新扫描变更目录
+          → 重新生成 skill listing
+            → 查找 session 开头旧 listing 消息
+              → 替换消息内容
+                → 更新附件元数据
+                  → agent 在下一轮对话看到更新后的 skill 列表
+```
+
+### 技能调用衔接
+
+```
+Agent 读取 skill listing（摘要）
+  │
+  ├─ 判断：whenToUse 条件满足？
+  │     ├─ 不满足 → 不调用（纯 awareness）
+  │     └─ 满足 → 决策调用
+  │
+  ├─ 通过 SkillTool 发起调用
+  │     └─ 从注册中心查找 skill 实例
+  │
+  ├─ 按需加载 skill 正文（SKILL.md 指令文本）
+  │
+  └─ 正文注入对话上下文 → agent 继续执行
+
+此流程与列表注入完全独立：列表注入发生在 session 启动，
+正文注入发生在每次调用时。
+```
+
+### Compaction 处理
+
+```
+触发 compaction
+  │
+  ├─ 识别 session transcript 消息结构
+  │     ├─ [0..N]   bootstrap 区域（AGENTS.md 等）→ 保护
+  │     ├─ [N+1]    skill listing 消息           → 保护
+  │     └─ [N+2..]  多轮对话区域                  → 压缩
+  │
+  ├─ 压缩对话区域 → 摘要器生成摘要消息
+  │
+  └─ 拼接结果写入 session transcript：
+        [bootstrap] + [skill listing] + [对话摘要]
+```
+
+## 模块关系
+
+- **上游**：session 启动流程（触发初始注入）、文件监听器（触发热重载）、compaction 流程（触发保护逻辑）
+- **下游**：DiskSkillRegistry（获取 skill 列表数据源）、session transcript（读取和修改消息列表）
+- **相关**：Skills 模块主体（SkillTool 调用后注入正文，与 listing 注入完全独立、互不干扰）


### PR DESCRIPTION
设计文档：skills/README.md（索引+架构概览）+ 1 个子功能文档

## 新增文件
- `docs/design/skills/README.md` — Skills 模块架构概览：五层优先级、frontmatter 配置驱动、双执行模式、磁盘加载流程
- `docs/design/skills/skill-listing-injection.md` — Skill 列表注入机制：纯函数生成、启动注入、热重载替换、compaction 保护、条件激活

## 附带修改
- `docs/design/README.md` — 新增 skills 模块索引条目

## 代码对照发现
1. Skill listing 注入 session transcript 未实现：生成逻辑有，但实际注入依赖上游 system_prompt 补充（P1）
2. 热重载替换 listing 消息未实现：只做缓存失效，消息替换逻辑缺（P1）
3. Compaction 保护 skill listing 未实现（P2）
4. 两阶段加载未实现：当前全量加载（P2）
5. Skill 执行层（inline/fork）未实现：只有类型定义（P2）

总体评价：两方可接受。代码实现了设计文档的核心框架，文档描述的上游集成层职责（注入、替换、保护）尚待实现。

Source: user
Type: docs
