### PR TITLE
docs(design): add system-prompt design doc

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,4 +9,5 @@
 | [processor_chain](processor_chain/README.md) | 消息出站处理与平台渲染：DSL 解析、Renderer 跨平台渲染框架 |
 | [session](session/README.md) | Agent 会话生命周期管理：创建、持久化、压缩、归档与清理 |
 | [skills](skills/README.md) | Agent 可复用能力插件体系：磁盘即插即用、五层优先级、frontmatter 配置驱动、双执行模式 |
+| [system-prompt](system-prompt/README.md) | 每次 API 调用的固定前缀：静态/动态层划分、Section 类型、缓存策略、构建与注入入口 |
 | [tools](tools/README.md) | Agent 能力层：两级索引工具体系、内建工具、平台工具、Bash 工具、提示词注入 |

--- a/docs/design/session/session-injection.md
+++ b/docs/design/session/session-injection.md
@@ -18,23 +18,21 @@
 
 ### 注入的四个 Section
 
-build_from_workspace 组装四种 Section：
+System Prompt 的 Section 类型定义见 [system-prompt/README.md](../system-prompt/README.md)。注入链路中 build_from_workspace 对四个 Section 的组装行为：
 
-- **RoleSection**：bootstrap 文件内容。来自 load_bootstrap_files 的返回值，按 CONTEXT_FILE_ORDER 排序。AGENTS.md 排在首位。Minimal 模式加载 AGENTS/SOUL/IDENTITY/USER/TOOLS，Full 模式额外加载 BOOTSTRAP 和 MEMORY。HEARTBEAT.md 不在注入范围，按需单独读取。
-- **ToolsSection**：工具描述列表。ToolRegistry 根据 agent 类型生成，包含工具名、描述和危险度标记。所有工具 eager load 进 system prompt。
-- **SkillListingSection**：可用 skill 列表。SkillRegistry 按优先级排序（bundled > global > agent > project，同级按名字字母序），输出 name + description 格式，供模型判断何时使用。
-- **MemorySection**：MEMORY.md 内容。走 session 级文件缓存，命中缓存则跳过读取。
+- **RoleSection**：调用 load_bootstrap_files 加载 bootstrap 文件，按固定顺序排列（AGENTS.md 排在首位）。Minimal 模式加载 AGENTS/SOUL/IDENTITY/USER/TOOLS，Full 模式额外加载 BOOTSTRAP 和 MEMORY。HEARTBEAT.md 不在注入范围。
+- **ToolsSection**：通过 ToolRegistry 生成工具分组索引（常用工具含行为描述，延迟工具仅含名称和危险度标记）。
+- **SkillListingSection**：通过 SkillRegistry 生成 skill 摘要清单，按优先级排序（来源优先级 → 名字字母序）。
+- **MemorySection**：读取 MEMORY.md，走 session 级文件缓存，命中缓存则跳过读取。
 
-四个 Section 拼接后生成完整 system prompt，写入 ConversationSession。
+四个 Section 拼接后写入 ConversationSession 的 system_prompt 字段。
 
-### 静态区与动态区的边界
+### 静态层与动态层的注入行为
 
-system prompt 内容分为两层：
+静态层和动态层的边界定义见 [system-prompt/README.md](../system-prompt/README.md)。注入链路的行为：
 
-- **静态层**：session 创建时注入，内容写入 ConversationSession 的 system_prompt 字段，进入 checkpoint 持久化。包含 RoleSection、ToolsSection、SkillListingSection、MemorySection。
-- **动态层**：每次 API 请求时注入，不持久化。包含 ChannelContext（当前消息来源）和 SessionState（turnCount 等运行时状态）。
-
-静态层和动态层之间通过边界标记分隔，使 API 层可以区分可缓存前缀和必须每次重新计算的后缀。
+- **静态层**（RoleSection + ToolsSection + SkillListingSection + MemorySection）：session 创建时注入，写入 ConversationSession 的 system_prompt 字段，进入 checkpoint 持久化。
+- **动态层**（ChannelContext + SessionState）：每次 API 请求时注入，不持久化，不改变 session 的 system_prompt 字段。
 
 ### 无 Workspace 的 Session
 
@@ -76,7 +74,7 @@ skill 文件变更时，SkillRegistry 通知 SessionManager 重新走 build_from
            → 返回 session_id
 ```
 
-### 每次 API 请求时的动态区注入
+### 每次 API 请求时的动态层注入
 
 ```
 API 请求到达
@@ -84,12 +82,12 @@ API 请求到达
   build_channel_context（当前消息的 channel/sender 信息）
   build_session_state（turnCount 等运行时状态）
   →
-  动态 sections 追加到静态 system_prompt 后
+  动态层追加到静态 system_prompt 后
   →
   发送 LLM 请求
 ```
 
-动态 sections 不进 checkpoint，不改变 session 的 system_prompt 字段。
+动态层不进 checkpoint，不改变 session 的 system_prompt 字段。
 
 ### Session 恢复时的重新注入
 

--- a/docs/design/system-prompt/README.md
+++ b/docs/design/system-prompt/README.md
@@ -1,0 +1,133 @@
+# System Prompt 模块
+
+## 概述
+
+System Prompt 是每次 API 调用时发送给 LLM 的固定前缀，承载 agent 的身份定义、能力边界和运行上下文。
+
+## 架构
+
+System Prompt 由六个 Section 组成，分为静态层和动态层，两层之间通过边界标记分隔。
+
+### 静态层
+
+Session 创建时组装，写入会话持久化存储，在 session 生命周期内保持不变（除非触发重建）。
+
+| Section | 内容 | 来源 |
+|---------|------|------|
+| RoleSection | Agent 操作规程、角色定义、身份标识、Owner 信息、工具使用规范 | Bootstrap 文件（AGENTS.md、SOUL.md、IDENTITY.md、USER.md、TOOLS.md） |
+| ToolsSection | 所有可用工具的分组索引（名称 + 危险度标记 + 常用工具的行为描述） | ToolRegistry |
+| SkillListingSection | 可用 skill 的摘要清单（名称 + 描述 + 触发条件） | SkillRegistry |
+| MemorySection | 跨 session 的长期记忆 | MEMORY.md |
+
+Bootstrap 文件按固定顺序注入 RoleSection：AGENTS.md（操作规程）→ SOUL.md（角色）→ IDENTITY.md（身份）→ USER.md（Owner）→ TOOLS.md（工具规范）。按 Minimal/Full 两种模式加载，文件集合如下：
+
+| 文件 | Minimal | Full |
+|------|---------|------|
+| AGENTS.md | ✅ | ✅ |
+| SOUL.md | ✅ | ✅ |
+| IDENTITY.md | ✅ | ✅ |
+| USER.md | ✅ | ✅ |
+| TOOLS.md | ✅ | ✅ |
+| BOOTSTRAP.md | ❌ | ✅ |
+| MEMORY.md | ❌ | ✅ |
+| HEARTBEAT.md | ❌ | ❌ |
+
+HEARTBEAT.md 不在此体系内，由 agent 按需单独读取。
+
+ToolsSection 按分组聚合输出，常用工具注入完整行为描述，延迟工具仅注入名称和危险度标记。一级索引有总长度上限，超出时截断。
+
+SkillListingSection 按来源优先级排列，标注条件激活标记。
+
+单个 Section 组装失败时跳过该 Section，其余继续。
+
+### 动态层
+
+每次 API 请求时注入，不进持久化存储，不改变 session 的 system prompt。
+
+| Section | 内容 | 来源 |
+|---------|------|------|
+| ChannelContext | 当前消息来源（channel 类型、chat_id、发送者） | 入站消息元数据 |
+| SessionState | 运行时状态（turnCount、pendingTasks） | ConversationSession |
+| AppendSection | Owner 通过 `/system` 命令追加的临时指令，当次生效后自动清除，最大 500 字 | `/system` 命令 |
+| GitStatus | 当前工作目录的 git 分支和变更状态 | 工作目录 |
+
+### 边界标记
+
+静态层和动态层之间通过标记分隔，使 API 层可以区分可缓存前缀和必须每次重新计算的后续内容。
+
+### 缓存策略
+
+静态层内容走 session 级缓存。注意：此缓存节省的是本地文件读取和字符串拼接开销，而非 API 侧的 KV Cache。API KV Cache 命中要求请求的完整 token 序列完全相同——对话历史每次增长，完整 payload 每次都不同，KV Cache 无法命中。静态层精简的意义在于直接减少每次发送的 token 数量，降低 API 费用。
+
+缓存失效触发：
+- 文件变更（bootstrap 或 MEMORY.md）→ 对应 Section 缓存失效，下次请求重建
+- `/clear` 命令 → 所有静态层缓存失效
+- Skill 文件变更 → SkillRegistry 通知重建 SkillListingSection
+- 工具定义变更 → 重建 ToolsSection
+- Session 恢复 → 强制重建全部静态层，确保内容与最新文件一致
+
+Bootstrap 文件不存在时跳过，不报错，其余 Section 正常组装。
+
+### 无 Workspace 的 Session
+
+当 session 没有对应 workspace 目录时，不加载 bootstrap 文件，静态层仅包含 ToolsSection 和 SkillListingSection。
+
+## 数据流
+
+### 构建（Session 创建时）
+
+```
+SessionManager 创建新 session
+  →
+  Bootstrap Loader 按模式加载文件
+  ToolRegistry 生成工具分组索引
+  SkillRegistry 生成 skill 摘要清单
+  读取 MEMORY.md（命中缓存则跳过）
+  →
+  组装静态层：RoleSection + ToolsSection + SkillListingSection + MemorySection
+  →
+  写入 ConversationSession
+```
+
+### 请求（每次 API 调用时）
+
+```
+API 请求到达
+  →
+  从 ConversationSession 取出静态层
+  构建动态层：ChannelContext + SessionState
+  →
+  拼接：静态层 + 边界标记 + 动态层
+  →
+  发送 LLM 请求
+```
+
+### 恢复
+
+```
+Archived session 被访问
+  →
+  从存储重建 ConversationSession
+  →
+  强制重新走构建流程（不恢复旧的 system prompt）
+  →
+  新 system prompt 替换旧的
+```
+
+## 模块关系
+
+### 上游
+
+- **SessionManager**：在 session 创建和恢复时触发 system prompt 构建。
+
+### 下游
+
+- **Bootstrap Loader**：提供 bootstrap 文件内容，按 Minimal/Full 模式加载。
+- **ToolRegistry**：提供 ToolSection 的分组索引。
+- **SkillRegistry**：提供 SkillListingSection 的 skill 摘要清单。
+
+### 无关
+
+- **LLM Provider**（无调用关系）：system prompt 构建完成后通过 ConversationSession 传递给 LLM provider，构建流程本身不调用 provider。
+- **Compaction 模块**（无调用关系）：compaction 时 system prompt 独立于对话消息流，不参与压缩。保护策略在 compaction 模块定义。
+- **Permission 模块**（无调用关系）：权限检查在 Gateway 层，发生在 system prompt 构建之前。


### PR DESCRIPTION
设计文档：system-prompt/README.md（模块级索引 + 架构概览）

## 新增文件
- `docs/design/system-prompt/README.md` — System Prompt 产品定义：静态/动态层划分、6 个 Section 类型（含新增 AppendSection/GitStatus）、缓存策略、构建与注入全链路

## 附带修改
- `docs/design/README.md` — 新增 system-prompt 模块索引条目
- `docs/design/session/session-injection.md` — 精简注入 Section 描述（引用 system-prompt 做权威定义），修正术语混用（动态区→动态层）

## 代码对照发现
1. 代码比文档多 4 个 Section 变体（WorkspaceSection/HeartbeatSection/GitStatus/AppendSection）：AppendSection 和 GitStatus 已补入文档，WorkspaceSection 为死代码，HeartbeatSection 已通过文字说明覆盖
2. 代码有 Override Prompt 优先级系统（OVERRIDE/AGENT/CUSTOM_PROMPT）文档未提：已在 CODE-GAPS 记录，建议另立 issue 做专项设计
3. P0/P1 缺陷已在 CODE-GAPS 中记录：find_or_create 绕过 build_from_workspace、边界标记缺失、/clear 未实现

Source: user
Type: docs
