### PR TITLE
docs(design): add agent module design docs

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,6 +4,7 @@
 
 | 模块 | 简述 |
 |------|------|
+| [agent](agent/README.md) | Agent 配置档案管理、spawn 协调与权限沿链路继承 |
 | [llm](llm/README.md) | 统一多供应商 LLM 调用：五层分离架构、Provider/Protocol/Interpreter 分层、内容块归一化、缓存适配 |
 | [permission](permission/README.md) | 系统级身份型访问控制：交集模型、七类权限维度、审批工作流与配置管理 |
 | [processor_chain](processor_chain/README.md) | 消息出站处理与平台渲染：DSL 解析、结构化内容块渲染、流式输出、代码高亮 |

--- a/docs/design/agent/README.md
+++ b/docs/design/agent/README.md
@@ -1,0 +1,140 @@
+# Agent
+
+## 概述
+
+Agent 模块是 CloseClaw 中"谁在执行任务"的定义层。它负责三件事：Agent 配置档案管理、Agent 孵化（spawn）协调、权限沿 spawn 链路继承。
+
+Agent 本身不管理运行时状态——运行时由 session 模块管理。Agent 不持有对话历史——对话历史在 session 的 transcript 中。Agent 的身份人格由 Bootstrap 文件定义，加载由 system prompt 模块处理。
+
+## 架构
+
+Agent 模块以配置和协调逻辑的形式嵌入系统：session 创建时读 agent 配置，spawn 时介入控制 child session 的创建参数，权限评估时提供 agent 维度的基线规则。
+
+```
+        用户 / 外部事件
+              │
+              ▼
+        Gateway / Daemon ─── 确定目标 agent，触发 session 创建
+              │
+              ▼
+    ┌─────────────────────────────────────────┐
+    │           Agent 模块                     │
+    │                                         │
+    │  Agent 配置档案（JSON）                  │
+    │       ├── model / workspace / agentDir  │
+    │       ├── bootstrapMode / skills        │
+    │       ├── tools / permissions baseline  │
+    │       └── subagents config（spawn 控制） │
+    │                                         │
+    │  Spawn 协调                              │
+    │       ├── sessions_spawn 工具入口       │
+    │       ├── 前置检查（depth/并发/白名单）  │
+    │       ├── child session 参数组装        │
+    │       └── announce 结果回传注册          │
+    │                                         │
+    │  权限沿链路继承                          │
+    └──────────────┬──────────────────────────┘
+                   │
+      ┌────────────┼────────────┐
+      ▼            ▼            ▼
+   Session     Permission    System Prompt
+   模块         模块           模块
+```
+
+核心组件：
+
+- **Agent 配置档案**：每个 agent 对应一份 JSON 配置，定义其能力边界（模型、工具、权限基线、spawn 约束）。存储支持项目级、用户级、系统内置三级优先级，字段级覆盖合并。
+- **Agent 类型**：框架内置仅一个通用 agent（全工具、全 bootstrap），其他 agent 由用户通过 JSON 配置文件自定义。Agent 能力完全由配置字段组合决定。
+- **Spawn 协调**：父 agent 通过 sessions_spawn 工具创建子 session。协调层负责前置检查（深度、并发、白名单）、参数组装、announce 回传注册。参见 `agent-spawn.md`。
+- **Fork 模式**：spawn 的变体，在子 session 中注入父 agent 的对话历史，使子 agent 继承上下文认知。参见 `agent-spawn.md`。
+- **权限继承**：子 agent 的实际权限沿 spawn 链路收窄——只能收窄，不能放宽。参见 `agent-permissions.md`。
+
+子功能文档：
+
+| 文档 | 内容 |
+|------|------|
+| `agent-config.md` | Agent JSON 配置档案：字段定义、存储位置、加载优先级、字段级合并 |
+| `agent-spawn.md` | Spawn 机制、Fork 模式、Steer/Kill、Announce 回传、Depth 追踪 |
+| `agent-permissions.md` | 权限沿 spawn 链路继承、workspace 路径授权 |
+
+## 数据流
+
+### Agent 配置加载
+
+系统启动时加载所有 agent 配置，生成 ResolvedAgentConfig 注册到内存：
+
+```
+内置 agent 定义（仅 general-purpose）
+  +
+扫描用户级配置（~/.closeclaw/agents/*.json）
+  +
+扫描项目级配置（<cwd>/.closeclaw/agents/*.json）
+  ↓
+按优先级合并同 ID 的 agent 配置（字段级覆盖）
+  ↓
+生成 ResolvedAgentConfig（所有字段已补齐默认值）
+  ↓
+注册到内存配置注册表
+```
+
+### Session 创建时读取 Agent 配置
+
+```
+Gateway/Daemon 确定目标 agent ID
+  ↓
+Session 模块读取该 agent 的 ResolvedAgentConfig
+  ↓ 分发各字段到对应模块
+  model        → 设置 session 默认模型
+  bootstrapMode → 决定 bootstrap 文件加载集
+  agentDir     → bootstrap 文件读取路径
+  permissions  → 注入权限模块 Agent 维度规则
+  skills       → 过滤 skill 注册表
+  tools/disallowedTools → 过滤 tool 注册表
+  subagents    → 注入 session 的 spawn 控制上下文
+  ↓
+Session 创建完成
+```
+
+### Spawn 运行时流程
+
+```
+父 agent 调用 sessions_spawn 工具
+  ↓
+Agent 协调层前置检查（depth/并发/白名单/权限）
+  ↓ （全部通过）
+创建 child session（加载目标 agent 配置、注入 task、过滤工具集、workspace fallback）
+  ↓
+子 agent 执行 task
+  ↓
+子 session 完成 → announce 入队到父 session
+  ↓
+父 agent 下一轮 turn 处理 announce
+```
+
+## 模块关系
+
+### 上游（谁调用 Agent 模块）
+
+| 模块 | 调用关系 |
+|------|---------|
+| Session | session 创建时读取 agent 配置档案，决定 bootstrap、模型、工具集、skills 过滤 |
+| Gateway/Daemon | 外部消息到达时确定目标 agent，触发 session 创建 |
+| Tools | sessions_spawn / sessions_steer / sessions_kill 注册在 tools 模块，执行逻辑由 agent 模块提供 |
+
+### 下游（Agent 模块调用谁）
+
+| 模块 | 调用关系 |
+|------|---------|
+| Session | spawn 时创建 child session；steer/kill 时操作子 session |
+| Permission | 提供 Agent 维度权限基线；spawn 时触发权限继承计算 |
+| System Prompt | agent 配置的 bootstrapMode 和 agentDir 决定 bootstrap 文件加载策略 |
+
+### 无关（无调用关系、名称或功能易混淆）
+
+| 模块 | 说明 |
+|------|------|
+| LLM Provider | agent 模块不直接调用 LLM |
+| Processor Chain / Renderer | 消息出站处理与 agent 模块无关 |
+| IM Adapter | 消息路由由 gateway 处理 |
+| Card | 卡片渲染由 renderer 处理 |
+| Audit | 审计日志由各模块自行写入 |

--- a/docs/design/agent/agent-config.md
+++ b/docs/design/agent/agent-config.md
@@ -1,0 +1,169 @@
+# Agent 配置档案
+
+## 概述
+
+Agent 配置档案定义每个 agent 的静态属性和能力边界。每个 agent 对应一份 JSON 配置文件，在 session 创建时被读取并分发到各相关模块。
+
+Agent 配置（JSON）和 Bootstrap 文件（Markdown）是两层独立的事：配置定义"能力边界"（模型、工具、权限、spawn 控制），Bootstrap 定义"身份人格"（AGENTS.md、SOUL.md 等）。配置不混入 Markdown 正文。
+
+## 架构
+
+### 配置字段
+
+| 字段 | 含义 | 必填 | 默认值 |
+|------|------|------|--------|
+| `id` | agent 唯一标识 | 是 | - |
+| `name` | 显示名称 | 否 | 同 id |
+| `model` | 默认 LLM 模型及 fallback 列表 | 否 | 系统默认模型 |
+| `workspace` | 工作目录路径 | 否 | 系统默认 workspace |
+| `agentDir` | bootstrap 文件所在目录 | 否 | 系统默认 agent 目录 |
+| `bootstrapMode` | bootstrap 加载模式 | 否 | `"full"` |
+| `skills` | 可用 skill 名称列表，`"*"` 表示全部可用 | 否 | `["*"]` |
+| `tools` | 可用工具名称白名单 | 否 | `["*"]` |
+| `disallowedTools` | 禁用工具黑名单 | 否 | `[]` |
+| `permissions` | Agent 维度权限基线规则 | 否 | 默认仅消息 |
+| `subagents` | spawn 控制参数 | 否 | 见子字段 |
+
+`bootstrapMode` 取值：
+- `"full"`：加载完整 bootstrap 文件集（AGENTS.md、SOUL.md、IDENTITY.md、USER.md、TOOLS.md、MEMORY.md 等）
+- `"minimal"`：仅加载核心文件，减少上下文占用
+
+`subagents` 子字段：
+
+| 字段 | 含义 | 默认值 |
+|------|------|--------|
+| `allowAgents` | 允许 spawn 的目标 agent ID 白名单 | `["*"]` |
+| `requireAgentId` | spawn 时是否必须显式指定 agentId | `false` |
+| `maxSpawnDepth` | 最大 spawn 嵌套深度 | `1` |
+| `maxChildren` | 最大并发活跃子 session 数 | `5` |
+| `defaultChildAgent` | 默认子 agent ID（spawn 不指定时使用） | 无 |
+| `model` | 子 agent 的默认模型覆盖 | 无（用子 agent 自身配置） |
+
+`allowAgents` 为 `["*"]` 时不限制；为空数组 `[]` 时禁止 spawn 任何子 agent。
+
+### 配置存储位置和优先级
+
+采用字段级覆盖合并：高优先级配置中未指定的字段回退到低优先级配置的值。
+
+```
+项目级：<repo>/.closeclaw/agents/<id>.json   ← 最高优先级
+用户级：~/.closeclaw/agents/<id>.json        ← 次优先级
+系统内置：框架预定义的 agent 定义             ← 最低优先级
+```
+
+### Agent 能力模型
+
+Agent 能力完全由配置字段组合决定，不依赖预定义的类型枚举：
+
+| 能力维度 | 配置字段 | 效果 |
+|---------|---------|------|
+| 行为限制 | `tools` / `disallowedTools` | 控制可见工具集 |
+| 上下文大小 | `bootstrapMode` | `"minimal"` 减少 context 占用 |
+| 权限边界 | `permissions` | 控制文件/网络/命令等权限 |
+| 繁衍能力 | `subagents.allowAgents` / `maxSpawnDepth` | 控制能否 spawn 子 agent |
+
+### 配置示例
+
+```json
+{
+  "id": "code-reviewer",
+  "name": "代码审查助手",
+  "model": "deepseek/deepseek-chat",
+  "workspace": null,
+  "agentDir": null,
+  "bootstrapMode": "minimal",
+  "skills": ["code-review"],
+  "tools": ["read", "grep", "glob", "web_search", "web_fetch"],
+  "disallowedTools": [],
+  "permissions": {
+    "file_read": { "allowed": true },
+    "file_write": { "allowed": false },
+    "exec": { "allowed": false },
+    "network": { "allowed": false }
+  },
+  "subagents": {
+    "allowAgents": [],
+    "maxSpawnDepth": 0,
+    "maxChildren": 0
+  }
+}
+```
+
+### Prompt 模板
+
+框架提供嵌入式 prompt 模板，用于 spawn 子 agent 时自动注入任务要求：
+
+| 模板 | 用途 | 效果 |
+|------|------|------|
+| `explore` | 只读研究 | 注入"只做研究不修改文件"的行为约束 |
+| `validation` | 校验审计 | 注入"逐条校验并报告差异"的结构化输出要求 |
+
+模板不影响 agent 配置，仅在 sessions_spawn 调用时作为 prompt 前缀注入。
+
+## 数据流
+
+### 配置加载流程
+
+```
+系统启动
+  ↓
+加载内置 agent 定义（仅 general-purpose）
+  ↓
+扫描用户级 agent 配置（~/.closeclaw/agents/*.json）
+  ↓
+扫描项目级 agent 配置（<cwd>/.closeclaw/agents/*.json）
+  ↓
+按优先级合并同 ID 的 agent 配置（字段级覆盖）
+  ↓
+生成 ResolvedAgentConfig（所有字段已补齐默认值）
+  ↓
+注册到内存配置注册表
+```
+
+### 模型解析优先级
+
+spawn 子 agent 时，模型的最终选择按以下顺序确定：
+
+```
+显式 model 参数 > 父 agent.subagents.model > 目标 agent.model > 系统默认
+```
+
+### 配置生效路径
+
+```
+ResolvedAgentConfig 各字段分发到对应模块
+  ↓
+  model        → Session：设置默认 LLM 模型
+  bootstrapMode → System Prompt：决定 bootstrap 文件加载集
+  agentDir     → System Prompt：bootstrap 文件读取路径
+  permissions  → Permission：Agent 维度权限基线
+  skills       → Skill Registry：过滤可见 skill 列表
+  tools        → Tool Registry：过滤可见工具白名单
+  disallowedTools → Tool Registry：排除禁用工具
+  subagents    → Agent：注入 session 的 spawn 控制上下文
+```
+
+## 模块关系
+
+### 上游（谁调用 Agent 配置）
+
+| 模块 | 调用关系 |
+|------|---------|
+| 初始化阶段 | 由 Agent 模块在启动时加载配置文件，生成 ResolvedAgentConfig |
+| Session | 创建 session 时读取 agent 配置，分发各字段 |
+| Gateway/Daemon | 外部消息到达时确定目标 agent ID |
+
+### 下游（Agent 配置被谁消费）
+
+| 模块 | 消费方式 |
+|------|---------|
+| Session | 读取 model、workspace |
+| System Prompt | 读取 bootstrapMode、agentDir |
+| Permission | 读取 permissions 基线规则 |
+| Skill Registry | 读取 skills 白名单 |
+| Tool Registry | 读取 tools 白名单、disallowedTools 黑名单 |
+| Agent Spawn | 读取 subagents 控制参数 |
+
+### 无关
+
+Agent 配置档案是纯数据定义层，不调用任何模块。配置加载后由各消费模块自行读取。

--- a/docs/design/agent/agent-permissions.md
+++ b/docs/design/agent/agent-permissions.md
@@ -1,0 +1,92 @@
+# Agent 权限继承
+
+## 概述
+
+Agent 权限沿 spawn 链路继承，子 agent 的实际权限是目标 agent 自身权限、所有父 agent 当前权限、以及当前用户权限的交集。权限只能收窄，不能放宽。
+
+## 架构
+
+### 权限计算规则
+
+子 agent 权限由三方取交集：
+
+```
+子 agent 权限 = 子 AgentConfig.permissions
+               ∩ 父 agent 当前权限
+               ∩ 当前 User 权限
+```
+
+沿 spawn 链路，该规则递归应用：父 agent 的"当前权限"本身也是由其自身配置与更上层父 agent 权限的交集决定。最终形成从根到叶的权限收敛链。
+
+### 约束规则
+
+- 权限只能收窄，不能放宽
+- 子 agent 的权限被 Deny 时静默返回，不进入审批流程（子 agent 不是面向用户的入口）
+
+### Workspace 路径授权
+
+子 agent 的 workspace 路径授权规则：
+
+- 子 agent 使用目标 agent 配置中的 workspace
+- 如果目标 agent 未指定 workspace，使用父 agent workspace 下的子目录
+- workspace 路径的自动授权按子 agent 的 agent_id 和 user_id 重新计算
+
+## 数据流
+
+### 权限评估流程
+
+```
+操作请求（Agent A 以 User U 身份执行 Operation O）
+  ↓
+权限模块评估：
+  1. 提取 Agent A 的 permissions 基线规则
+  2. 沿 spawn 链路，收集所有父 agent 的当前权限
+  3. 计算交集：Agent 链路权限 = 基线 ∩ 父₁ ∩ 父₂ ∩ ... ∩ 根 agent
+  4. 同时评估 User U 的权限规则
+  5. 最终结果 = Agent 链路权限 ∩ User 权限
+      - 双方都 Allow → Allow
+      - 任一方 Deny → Deny
+      - Owner（User ID = "owner"）→ 跳过 User 维度，仅评估 Agent 维度
+  6. 子 agent 被 Deny → 静默返回 PermissionDenied 错误
+```
+
+### 继承链路示例
+
+```
+根 agent（depth=0）
+  ├── permissions: { exec: allow, file_write: allow, network: deny }
+  │
+  └── spawn → 子 agent A（depth=1）
+        ├── AgentConfig.permissions: { exec: allow, file_write: deny }
+        ├── 父 agent 当前权限:         { exec: allow, file_write: allow, network: deny }
+        └── 实际权限:                  { exec: allow, file_write: deny, network: deny }
+              （file_write 被 AgentConfig 收窄为 deny）
+              │
+              └── spawn → 子 agent B（depth=2）
+                    ├── AgentConfig.permissions: { exec: allow }
+                    ├── 父 agent（A）当前权限:    { exec: allow, file_write: deny, network: deny }
+                    └── 实际权限:                 { exec: allow, file_write: deny, network: deny }
+```
+
+## 模块关系
+
+### 上游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Session | 操作请求触发时，调用权限模块评估（含 agent 维度） |
+| Agent Spawn | spawn 时向权限模块传递 spawn 链路信息，触发继承计算 |
+
+### 下游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Permission | 权限模块接收 agent 维度的基线规则和 spawn 链路信息，执行最终的权限评估 |
+
+### 无关
+
+| 模块 | 说明 |
+|------|------|
+| Agent Config | Agent Config 定义 permissions 基线但不参与继承计算 |
+| System Prompt | 权限规则不在 bootstrap 中定义 |
+| Tools | 工具可见性由 tools/disallowedTools 白名单控制，不做运行时权限判断 |

--- a/docs/design/agent/agent-spawn.md
+++ b/docs/design/agent/agent-spawn.md
@@ -1,0 +1,179 @@
+# Agent Spawn
+
+## 概述
+
+Spawn 是父 agent 创建子 agent 执行子任务的机制。一次 spawn = 创建一个 child session，子 session 使用目标 agent 的配置档案运行。Spawn 由 tools 模块暴露给 LLM 调用，由 agent 模块负责协调控制。
+
+## 架构
+
+### 入口：sessions_spawn 工具
+
+`sessions_spawn` 注册在 tools 模块中，LLM 调用时携带以下参数：
+
+| 参数 | 含义 | 默认 |
+|------|------|------|
+| `agentId` | 目标 agent 的 ID | 父 agent 配置中的 `defaultChildAgent` |
+| `task` | 任务描述，注入子 session 首条消息 | 必填 |
+| `mode` | `"run"`（一次性）/ `"session"`（持久线程） | `"run"` |
+| `fork` | 是否 fork 父 agent 上下文 | `false` |
+| `model` | 覆盖目标 agent 的默认模型 | 目标 agent 配置 |
+| `workspace` | 独立工作目录 | 目标 agent 配置 |
+| `label` | 子 session 简短标签 | 自动生成 |
+| `lightContext` | 是否使用 minimal bootstrap | `false` |
+| `promptTemplate` | 注入的 prompt 模板（`explore` / `validation`） | 无 |
+
+`lightContext` 复用 session 模块已有的 `bootstrapMode: "minimal"` 机制。spawn 时指定 `lightContext: true`，子 session 以 minimal bootstrap 启动。
+
+### Spawn 控制流程
+
+```
+LLM 调用 sessions_spawn(agentId, task, ...)
+  ↓
+Agent 协调层前置检查：
+  ① depth 检查：当前深度 >= 父 agent.subagents.maxSpawnDepth → 拒绝
+  ② 并发检查：活跃子 session 数 >= 父 agent.subagents.maxChildren → 拒绝
+  ③ 白名单检查：agentId 不在父 agent.subagents.allowAgents 中 → 拒绝
+  ④ requireAgentId 检查：配置要求显式指定但未提供 → 拒绝
+  ↓
+全部检查通过 → 创建 child session：
+  - 加载目标 agent 的 JSON 配置档案
+  - bootstrap 模式：lightContext=true → minimal；否则 → 目标 agent.bootstrapMode
+  - 注入 task 作为首条用户消息
+  - 按 agent 配置过滤 tools/skills
+  - 注入 spawn 角色标记（parent_session_id, depth, spawn_mode, fork）
+  ↓
+子 session 注册到父 session 的子 session 跟踪表
+  ↓
+子 session 启动执行
+  ↓
+mode="run"：子 session 完成后触发 announce
+mode="session"：子 session 保持存活，等待父 agent 后续 steer
+```
+
+### Depth 追踪
+
+Spawn 深度沿父链递归计算。根 session（用户直接对话）depth = 0。默认 `maxSpawnDepth = 1`，即只允许一层 spawn。
+
+```
+用户会话（depth=0）
+  └── spawn(code-reviewer, depth=1)
+        └── 拒绝 spawn 任何子 agent（maxSpawnDepth=1）
+```
+
+### Fork 模式
+
+Fork 是 spawn 的变体：在子 session 的 system prompt 和 task prompt 之间插入父 agent 的对话历史，使子 agent 继承父 agent 的上下文认知。
+
+```
+Spawn:   [system prompt] [task prompt]
+Fork:    [system prompt] [父 agent messages] [task prompt]
+```
+
+Fork 与 Spawn 共用同一 session 创建流程，区别仅在 session 组装阶段：fork 模式在注入 task 之前先注入父 agent 的 transcript messages。
+
+| | Spawn | Fork |
+|---|-------|------|
+| 子 agent 上下文 | 仅 task 描述 | 父 agent 完整对话历史 + task 描述 |
+| 适用场景 | 独立子任务，需完整 briefing | 父 agent 需要子 agent 理解已发生的事 |
+| 父 agent 的说明成本 | 子 agent 不知前情，需解释背景 | 子 agent 已知前情，只需写指令 |
+
+### Announce 机制
+
+子 session 完成后，结果通过 announce 注入父 session（push-based，父 agent 不 poll）：
+
+- 子 session 的最后一条 assistant 消息作为 announce 内容
+- announce 作为内部事件推送到父 session 的消息队列
+- 父 agent 在下一轮 turn 开始时处理该事件
+- announce 不混入用户消息流，是一条独立的内部事件记录
+
+### Steer 和 Kill
+
+父 agent 对存活中的子 session（mode="session"）有两种控制操作，通过 `sessions_steer` / `sessions_kill` 工具暴露给 LLM：
+
+- **Steer**：向子 session 发送新 task，子 session 重新执行
+- **Kill**：终止子 session，释放资源，session 对话历史保留
+
+两个操作通过子 session 跟踪表完成。
+
+## 数据流
+
+### Spawn Run 模式完整流程
+
+```
+父 session 调用 sessions_spawn(mode="run", agentId, task, ...)
+  ↓
+前置检查：depth / 并发 / 白名单 / 权限
+  ↓ （全部通过）
+创建 child session：
+  agent_id = 目标 agent
+  parent_session_id = 父 session
+  depth = 父 depth + 1
+  bootstrap = 按 lightContext 决定
+  tools = 目标 agent 配置白名单
+  permissions = 继承计算结果（见 agent-permissions.md）
+  first_message = task 内容
+  ↓
+子 session 注册到父 session 的子 session 跟踪表
+  ↓
+子 agent 执行 task（可能多轮 turn）
+  ↓
+子 session 完成：
+  - 最后一条 assistant 消息提取为 announce 内容
+  - announce 入队到父 session 的消息队列
+  - 跟踪表中标记完成
+  ↓
+父 agent 下一轮 turn 开始时处理 announce
+```
+
+### Fork 模式流程
+
+```
+父 session 调用 sessions_spawn(fork=true, task, ...)
+  ↓
+与 Spawn 流程完全相同，唯一区别在 session 组装时：
+  首条注入的不是 task
+  → 先注入父 session 的 transcript messages
+  → 再注入 task 消息
+  ↓
+子 agent 看到完整上下文 + 新任务
+```
+
+### Session 模式流程
+
+```
+父 session 调用 sessions_spawn(mode="session", agentId, task, ...)
+  ↓
+创建 child session（与 run 模式一致）
+  ↓
+子 session 启动执行 → 完成后保持存活
+  ↓
+父 agent 可通过 sessions_steer 发送新 task
+父 agent 可通过 sessions_kill 终止子 session
+  ↓
+子 session 最终被 kill 或超时自动清理
+```
+
+## 模块关系
+
+### 上游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Tools | 注册 sessions_spawn / sessions_steer / sessions_kill 工具，LLM 调用后委托 agent 模块执行 |
+| Agent Config | 读取父 agent 的 subagents 配置（allowAgents、maxSpawnDepth 等），读取目标 agent 的完整配置 |
+
+### 下游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Session | 创建 child session、注入 task 消息、管理子 session 跟踪表和 announce 队列 |
+| Permission | spawn 时触发权限继承计算（见 agent-permissions.md） |
+| System Prompt | 按 lightContext/agent.bootstrapMode 决定子 session 的 bootstrap 文件集 |
+
+### 无关
+
+| 模块 | 说明 |
+|------|------|
+| LLM Provider | spawn 不直接调用 LLM，子 session 的 LLM 调用由 session 模块管理 |
+| Processor Chain / Renderer | announce 内容的渲染由 session 的消息处理管线负责 |
+| IM Adapter | spawn 不涉及外部消息路由 |


### PR DESCRIPTION
设计文档：agent/README.md（索引+架构概览）+ 3 个子功能文档

## 新增文件
- `docs/design/agent/README.md` — Agent 模块概览：架构总图、数据流、上下游关系、子文档索引
- `docs/design/agent/agent-config.md` — Agent JSON 配置档案：字段定义、存储优先级、字段级合并、Prompt 模板
- `docs/design/agent/agent-spawn.md` — Spawn 机制：sessions_spawn 工具、Spawn/Fork/Session 模式、Steer/Kill、Announce、Depth 追踪
- `docs/design/agent/agent-permissions.md` — 权限沿 spawn 链路继承：三方交集计算、约束规则、Workspace 路径授权

## 附带修改
- `docs/design/README.md` — 更新 agent 模块索引简述（旧描述已与新设计不符）

## 代码对照发现
- P0：Agent 模块管理运行时状态 vs 设计要求 Agent 不管状态 → 文档更好
- P0：Spawn = OS 进程 fork + stdin/stdout 通信 vs 设计中的 Session 模型 → 文档更好
- P0：配置字段大量缺失（缺 model/workspace/tools/subagents 等 8+ 字段） → 文档更好
- P0：配置加载：单文件 vs 三级优先级 + 字段级合并 → 文档更好
- P0：InboxManager poll 模式 vs 设计中 push announce → 不等价
- P1：权限模型仅通信白名单 vs Allow/Deny 操作级 + 三方交集 → 文档更好
- P1：Steer/Kill 不存在、Fork 模式未实现、权限继承无交集计算 → 文档更好
- P2：Checkpoint 机制代码有但设计无 → 代码更好（可考虑补充到设计）
- 结论：设计文档全面优于代码，代码是多进程模型需重写为多 session 模型

Source: user
Type: docs
