### PR TITLE
docs(design): add slash module design docs

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,7 @@
 | [permission](permission/README.md) | 系统级身份型访问控制：交集模型、七类权限维度、审批工作流与配置管理 |
 | [processor_chain](processor_chain/README.md) | 消息出站处理与平台渲染：DSL 解析、结构化内容块渲染、流式输出、代码高亮 |
 | [session](session/README.md) | Agent 会话生命周期管理：创建、持久化、压缩、归档与清理 |
+| [slash](slash/README.md) | 斜杠指令系统：Gateway 层拦截、统一分派、Handler 执行，不进入 LLM 对话流程 |
 | [skills](skills/README.md) | Agent 可复用能力插件体系：磁盘即插即用、五层优先级、frontmatter 配置驱动、双执行模式 |
 | [system-prompt](system-prompt/README.md) | 每次 API 调用的固定前缀：静态/动态层划分、Section 类型、缓存策略、构建与注入入口 |
 | [tools](tools/README.md) | Agent 能力层：两级索引工具体系、内建工具、平台工具、Bash 工具、提示词注入 |

--- a/docs/design/slash/README.md
+++ b/docs/design/slash/README.md
@@ -1,0 +1,98 @@
+# 斜杠指令系统
+
+## 概述
+
+斜杠指令系统提供统一的系统控制指令机制：以 `/` 开头的用户消息在 Gateway 层被拦截，不进入 LLM 对话流程，直接分派给对应的 Handler 执行并回复。
+
+## 架构
+
+斜杠指令系统由三个核心组件组成：
+
+- **Dispatcher**：嵌入 Gateway 的指令分派器。Gateway 收到入站消息后，若内容以 `/` 开头则拦截并交给 Dispatcher，否则正常路由到 Session。
+- **HandlerRegistry**：指令注册表，维护指令名到 Handler 的映射。Gateway 初始化时注册所有 Handler，查询为 O(1)。
+- **Handler**：指令处理器。每个 Handler 负责一组关联指令，接收指令参数和上下文，返回 SlashResult。
+
+Dispatcher 不持有 Session 引用——Handler 返回 SlashResult 后，由 Gateway 根据结果类型调用 Session 对应方法执行副作用。
+
+```
+用户消息到达 Gateway
+  ↓
+是否以 / 开头？
+  ├── 否 → 正常路由到 Session
+  └── 是 → Dispatcher 解析指令名 + 参数
+            ↓
+          HandlerRegistry 查表
+            ↓
+          Handler 处理 → SlashResult
+            ↓
+          Gateway 根据结果类型执行副作用并回复
+```
+
+部分指令支持 Immediate 模式——LLM 正在运行时也能立即响应，不被消息队列阻塞。非 Immediate 指令在 LLM 忙碌时回复等待提示。
+
+### Handler 清单
+
+| Handler | 负责指令 | 结果类型 | Immediate |
+|---------|---------|---------|-----------|
+| ModeSwitchHandler | plan, mode | SetMode / Reply | ❌ |
+| SessionHandler | new, stop | NewSession / Stop | stop ✅ |
+| StatusHandler | status | Reply | ✅ |
+| CompactHandler | compact | Compact | ❌ |
+| SystemHandler | system | SystemAppend / Reply | ❌ |
+| WorkdirHandler | cd, pwd, git | Reply | ❌ |
+| ExecHandler | exec | Exec / Reply | ❌ |
+| HelpHandler | help | Reply | ✅ |
+
+### 子功能目录
+
+- [上下文压缩](compact.md) — `/compact` 触发对话历史压缩
+- [命令执行](exec.md) — `/exec` owner 特权命令执行
+- [帮助](help.md) — `/help` 动态生成帮助文本
+- [模式切换](mode-switching.md) — `/plan` 和 `/mode`，切换 Normal/Plan 模式
+- [会话管理](session-management.md) — `/new` 创建新会话，`/stop` 终止当前运行
+- [状态查询](status.md) — `/status` 查看会话状态
+- [System Prompt 追加](system-append.md) — `/system` 动态管理 system prompt 追加区
+- [工作目录操作](workdir.md) — `/cd`、`/pwd`、`/git` 工作目录操作
+
+## 数据流
+
+```
+入站消息
+  ↓
+Gateway.handle_inbound()
+  ↓
+内容以 / 开头？
+  ├── 否 → route_to_session() → 正常 LLM 对话流程
+  └── 是 → SlashDispatcher.dispatch()
+            ↓
+          parse_slash(): 分离指令名和参数
+            ↓
+          HandlerRegistry.get(指令名)
+            ├── 命中 → handler.handle(args, ctx)
+            │           ↓
+            │         SlashResult 变体
+            │           ↓
+            │         Gateway.handle_slash_result()
+            │           ├── Reply(text)        → 直接回复用户
+            │           ├── SetMode(mode)      → session.set_mode() + 回复
+            │           ├── NewSession         → 创建新 session + 回复
+            │           ├── Stop               → 终止 run + 子 agent + 回复
+            │           ├── Compact{...}       → 执行压缩 + 回复
+            │           ├── SystemAppend(...)  → 更新追加区 + 回复
+            │           ├── Exec{command}      → 提交 permission 审批
+            │           └── Unknown(cmd)       → 回复"未知指令"
+            └── 未命中 → SlashResult::Unknown → 回复"未知指令"
+```
+
+关键判断点：
+- 是否 `/` 开头 → 决定走斜杠指令还是 LLM 对话
+- Immediate 标记 → 决定是否可绕过消息队列立即执行
+- SlashResult 类型 → 决定 Gateway 执行哪种副作用
+
+## 模块关系
+
+- **上游**：Gateway（入站消息处理）。Gateway 在消息路由前检查 `/` 前缀并分派。
+- **下游**：
+  - Session 模块 — 模式切换、会话创建/停止、上下文压缩、system prompt 追加区管理、工作目录设置
+  - Permission 模块 — `/exec` 和 `/git` 写操作的权限审批
+- **无关**：Processor 链（斜杠指令在 Processor 之前被 Gateway 拦截，不进入 LLM 处理流程）

--- a/docs/design/slash/compact.md
+++ b/docs/design/slash/compact.md
@@ -1,0 +1,34 @@
+# 上下文压缩
+
+## 概述
+
+`/compact` 指令用于手动触发对话历史的上下文压缩，将 LLM 上下文中的历史对话进行摘要压缩以释放 token 空间。
+
+## 架构
+
+CompactHandler 接收可选的自定义保留指令，交由 Gateway 调用会话压缩引擎执行。为非 Immediate 指令，LLM 忙碌时需等待。
+
+```
+/compact [可选保留指令]
+  ↓
+CompactHandler 返回 Compact { instruction }
+  ↓
+Gateway 调用 session.compact(instruction)
+  ↓
+压缩引擎对对话历史进行摘要
+  ↓
+回复压缩前后字符数
+```
+
+无参数时使用默认压缩策略；带参数时（如 `/compact 保留 API 列表`），自定义保留指令传入压缩引擎，用于指导摘要保留的重点内容。
+
+## 数据流
+
+- **`/compact`**（无参数）：Compact { instruction: None } → 默认压缩
+- **`/compact 保留 API 列表`**：Compact { instruction: Some("保留 API 列表") } → 携带保留指令压缩
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → CompactHandler
+- **下游**：Session 模块（`compact()` 方法，执行上下文压缩引擎）
+- **无关**：system prompt 静态区（压缩仅作用于对话历史，静态内容保持不变）

--- a/docs/design/slash/exec.md
+++ b/docs/design/slash/exec.md
@@ -1,0 +1,33 @@
+# 命令执行
+
+## 概述
+
+`/exec` 指令用于以 owner 身份执行 Shell 命令，经 Permission 模块审批后执行。非 owner 用户调用直接拒绝。
+
+## 架构
+
+ExecHandler 本身不做权限判断——仅构造 SlashResult::Exec，权限验证由 Permission 模块负责。
+
+```
+/exec <command>
+  ↓
+ExecHandler 返回 Exec { command }
+  ↓
+Gateway 提交 Permission 模块
+  ├── 非 owner → Permission 返回拒绝 → Reply("权限不足")
+  └── owner → Permission 返回通过 → 执行命令 → 回复输出
+```
+
+权限判断完全由 Permission 模块处理，ExecHandler 不感知权限逻辑。
+
+## 数据流
+
+- **输入**：Shell 命令字符串
+- **处理**：ExecHandler 构造 Exec 结果 → Gateway 调用 Permission 模块 → 审批通过后执行
+- **输出**：命令执行结果或权限拒绝提示
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → ExecHandler
+- **下游**：Permission 模块（权限审批）；Shell 执行环境（命令执行）
+- **无关**：WorkdirHandler（`/exec` 和 `/cd` 独立，不共享工作目录上下文）

--- a/docs/design/slash/help.md
+++ b/docs/design/slash/help.md
@@ -1,0 +1,33 @@
+# 帮助
+
+## 概述
+
+`/help` 指令用于动态生成所有已注册指令的帮助文本。标记为 Immediate 指令，LLM 运行时也能响应。
+
+## 架构
+
+HelpHandler 遍历 HandlerRegistry 中的所有注册条目，提取每个 Handler 的指令名和描述，动态生成帮助文本。新增指令自动出现在帮助中，无需手动维护。
+
+```
+/help
+  ↓
+HelpHandler 遍历 HandlerRegistry
+  ↓
+提取每个 Entry 的 commands + description
+  ↓
+格式化为帮助文本
+  ↓
+返回 Reply(帮助文本)
+```
+
+## 数据流
+
+- **输入**：无参数
+- **处理**：遍历 HandlerRegistry，收集所有已注册指令的名称和描述
+- **输出**：Reply 包含指令列表及说明
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → HelpHandler
+- **下游**：HandlerRegistry（读取已注册指令信息）
+- **无关**：LLM 对话流程

--- a/docs/design/slash/mode-switching.md
+++ b/docs/design/slash/mode-switching.md
@@ -1,0 +1,42 @@
+# 模式切换
+
+## 概述
+
+`/plan` 和 `/mode` 指令用于在 Normal（普通）和 Plan（规划）两种会话模式之间切换。模式切换不立即变更 system prompt，仅标记会话状态；下一条用户消息进入 LLM 前由 system prompt builder 根据当前模式重新组装 prompt。
+
+## 架构
+
+模式切换的核心机制是延迟生效：`set_mode()` 仅写入会话状态，system prompt 的实际变更推迟到下一条消息的 prompt 构建阶段。
+
+```
+/plan 或 /mode plan
+  ↓
+ModeSwitchHandler 返回 SetMode(Plan)
+  ↓
+Gateway 调用 session.set_mode(Plan)
+  ↓
+回复"已切换到 Plan 模式"
+  ↓
+下一条用户消息进入 LLM 前
+  ↓
+system prompt builder 检测 mode=Plan
+  ↓
+注入 Plan 工作流指令（Research → Design → Review → Confirm）
+限制工具集为只读 + plan 文件写
+```
+
+`/plan` 后的额外文本（如 `/plan 设计缓存`）被丢弃，不传递到 Session。
+
+## 数据流
+
+- **`/plan`**：无参数 → SetMode(Plan)
+- **`/mode`**（无参数）：从 SlashContext 读取当前模式 → Reply("当前模式：Plan")
+- **`/mode plan`**：等价于 `/plan` → SetMode(Plan)
+- **`/mode normal`**：SetMode(Normal) → 下一条消息恢复标准 system prompt
+- **`/mode` 非法参数**：Reply("无效模式。可用：normal, plan")，模式不变
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → ModeSwitchHandler
+- **下游**：Session 模块（`set_mode()` 方法）；system prompt builder（读取 mode 决定 prompt 内容）
+- **无关**：LLM 对话流程（切换本身不触发 LLM 调用）

--- a/docs/design/slash/session-management.md
+++ b/docs/design/slash/session-management.md
@@ -1,0 +1,45 @@
+# 会话管理
+
+## 概述
+
+`/new` 和 `/stop` 指令用于会话生命周期管理：创建新会话和强行终止当前运行。
+
+## 架构
+
+两个指令由同一个 SessionHandler 处理，但行为独立：
+
+- **`/new`**：创建新会话，分配新会话标识，绑定当前 channel。旧会话保留（后续由会话生命周期策略处理 archive）。后续消息自动路由到新会话。
+- **`/stop`**：标记为 Immediate 指令，可在 LLM 运行时立即响应。终止当前 LLM 调用和所有子 agent，清除运行队列。
+
+```
+/new
+  ↓
+SessionHandler 返回 NewSession
+  ↓
+Gateway 创建新 session（新 ID，绑定 channel）
+  ↓
+回复"已创建新 session：{id}"
+
+/stop
+  ↓
+SessionHandler 返回 Stop
+  ↓
+Gateway 终止当前 LLM run + 所有子 agent
+  ↓
+清除运行队列
+  ↓
+回复"已停止当前任务"
+```
+
+## 数据流
+
+- **`/new`**：无参数 → SlashResult::NewSession → Gateway 创建新会话
+- **`/stop`**：无参数 → SlashResult::Stop → Gateway 终止运行并清理
+
+`/new` 为非 Immediate 指令，LLM 忙碌时需等待；`/stop` 为 Immediate 指令，LLM 运行时也能立即执行。
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → SessionHandler
+- **下游**：Session 模块（`new_session()`、`stop()` 方法）；Agent 模块（子 agent 终止）
+- **无关**：Processor 链（指令在 Gateway 层处理完毕，不进入 LLM）

--- a/docs/design/slash/status.md
+++ b/docs/design/slash/status.md
@@ -1,0 +1,36 @@
+# 状态查询
+
+## 概述
+
+`/status` 指令用于查看当前会话的运行状态，包括模式、模型、上下文用量、活跃子 agent 数、工作目录和 system prompt 追加内容。
+
+## 架构
+
+StatusHandler 从 SlashContext 读取会话状态并格式化输出。标记为 Immediate 指令，LLM 运行时也能响应。
+
+```
+/status
+  ↓
+StatusHandler 从 SlashContext 读取：
+  - current_mode, current_model
+  - context_usage, subagent_count
+  - workdir, system_append
+  ↓
+格式化为状态文本
+  ↓
+返回 Reply(状态文本)
+  ↓
+Gateway 直接回复用户
+```
+
+## 数据流
+
+- **输入**：无参数
+- **处理**：读取 SlashContext 中的会话状态字段
+- **输出**：Reply 包含当前模式、模型名称、上下文用量、活跃子 agent 数量、工作目录、system prompt 追加指令列表
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → StatusHandler
+- **下游**：无（仅读取 SlashContext，不触发副作用）
+- **无关**：LLM 对话流程

--- a/docs/design/slash/system-append.md
+++ b/docs/design/slash/system-append.md
@@ -1,0 +1,49 @@
+# System Prompt 追加
+
+## 概述
+
+`/system` 指令用于动态管理 system prompt 中的追加区（append section）。追加区位于 system prompt 静态部分的末尾，与 AGENTS.md 等静态内容互不干扰，是独立分区。owner 可通过此指令在运行时增删 system prompt 指令，无需修改配置文件。
+
+## 架构
+
+追加区是 system prompt 中的一个独立分区，位于静态内容末尾、对话历史之前。以标题行开头，内容为 `[N] 内容` 格式的编号列表。由 `/system` 子指令增删，由 system prompt builder 在每次构建 prompt 时读取并拼入。
+
+关键属性：
+- 多次 `/system add` 叠加（accumulate），不覆盖
+- 持久化在会话状态中，会话恢复时保留
+- 不受上下文压缩影响（压缩仅作用于对话历史，静态区不变）
+- 与 AGENTS.md 无优先级冲突——二者是独立分区
+
+## 数据流
+
+```
+/system add <内容>
+  ↓
+SystemHandler 返回 SystemAppend::Add(内容)
+  ↓
+Gateway 调用 session.add_system_append(内容)
+  ↓
+回复"已追加指令 #N"
+
+/system list 或 /system
+  ↓
+SystemHandler 从 SlashContext 读取 system_append
+  ↓
+返回 Reply(编号列表) 或 "无追加指令"
+
+/system clear
+  ↓
+SystemHandler 返回 SystemAppend::Clear
+  ↓
+Gateway 调用 session.clear_system_append()
+  ↓
+回复"已清除 N 条追加指令"
+```
+
+`/system add` 无内容时，回复用法提示。
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → SystemHandler
+- **下游**：Session 模块（`add_system_append()`、`clear_system_append()` 方法）；system prompt builder（构建时读取追加列表并拼入静态区末尾）
+- **无关**：AGENTS.md 加载（追加区与 AGENTS.md 是独立分区，无优先级冲突）

--- a/docs/design/slash/workdir.md
+++ b/docs/design/slash/workdir.md
@@ -1,0 +1,43 @@
+# 工作目录操作
+
+## 概述
+
+`/cd`、`/pwd` 和 `/git` 指令用于管理会话的工作目录和执行 Git 操作。
+
+## 架构
+
+三个指令由同一个 WorkdirHandler 处理：
+
+- **`/cd <路径>`**：变更工作目录。先校验路径存在性，不存在则回复错误；存在则切换并回复目录信息和当前 Git 分支。
+- **`/pwd`**：输出当前工作目录路径。
+- **`/git <args>`**：经 Permission 模块审批后执行 Git 命令。仅允许只读子命令（status、log、diff、branch、show），写操作需额外审批。
+
+```
+/cd <路径>
+  ↓
+WorkdirHandler 校验路径存在性
+  ├── 不存在 → Reply("目录不存在")
+  └── 存在 → Gateway 调用 session.set_workdir(路径)
+              ↓
+            Reply(目录路径 + git 分支信息)
+
+/git <args>
+  ↓
+WorkdirHandler 返回 Reply(git 输出) 或 Exec
+  ↓
+只读命令 → 直接执行并回复
+写命令 → 提交 Permission 模块审批 → 通过后执行
+```
+
+## 数据流
+
+- **`/cd <路径>`**：校验路径 → 切换工作目录 → 回复目录状态（含 Git 分支）
+- **`/pwd`**：读取当前工作目录 → 回复路径
+- **`/git status`**：Permission 审批 → 执行 → 回复输出
+- **`/git commit`**：Permission 审批拦截写操作，不执行
+
+## 模块关系
+
+- **上游**：Gateway → Dispatcher → WorkdirHandler
+- **下游**：Session 模块（`set_workdir()` 方法）；Permission 模块（`/git` 写操作审批）
+- **无关**：LLM 对话流程


### PR DESCRIPTION
设计文档：slash/README.md（索引+架构概览）+ 8 个子功能文档

## 新增文件
- `docs/design/slash/README.md` — 模块架构概览、Handler 清单、子功能目录索引
- `docs/design/slash/mode-switching.md` — /plan /mode 模式切换（延迟生效机制）
- `docs/design/slash/session-management.md` — /new /stop 会话管理
- `docs/design/slash/status.md` — /status 会话状态查询（Immediate）
- `docs/design/slash/compact.md` — /compact 上下文压缩
- `docs/design/slash/system-append.md` — /system system prompt 追加区管理
- `docs/design/slash/workdir.md` — /cd /pwd /git 工作目录操作
- `docs/design/slash/exec.md` — /exec owner 特权命令执行
- `docs/design/slash/help.md` — /help 动态帮助

## 附带修改
- `docs/design/README.md` — 新增 slash 模块索引条目

## 代码对照发现
代码库中无 `src/slash/` 目录，现有斜杠指令实现分散在 `mode/slash_command.rs`、`system_prompt/slash_commands.rs`、`chat/session.rs` 三处。设计文档是全新方案，所有 8 项差异均为设计文档更好（统一拦截点、Dispatcher/Registry 机制、SlashResult 完整变体集、Immediate 机制等）。源码 `docs/design/45-slash-command-system.md`。

Source: user
Type: docs