### PR TITLE
docs(design): add mode design doc

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,6 +7,7 @@
 | [agent](agent/README.md) | Agent 配置档案管理、spawn 协调与权限沿链路继承 |
 | [config](config/README.md) | CloseClaw 运行时配置管理：多文件拆分、ConfigManager 统一读写、备份回退、凭据分离、Agent 独立配置、热重载 |
 | [llm](llm/README.md) | 统一多供应商 LLM 调用：五层分离架构、Provider/Protocol/Interpreter 分层、内容块归一化、缓存适配 |
+| [mode](mode/README.md) | Session 运行模式管理：Plan Mode（规划/执行分离、双路径、审批栅栏）和 Auto Mode（连续自主执行），通过工具过滤和权限边界约束 agent 行为 |
 | [permission](permission/README.md) | 系统级身份型访问控制：交集模型、七类权限维度、审批工作流与配置管理 |
 | [processor_chain](processor_chain/README.md) | 消息出站处理与平台渲染：DSL 解析、结构化内容块渲染、流式输出、代码高亮 |
 | [session](session/README.md) | Agent 会话生命周期管理：创建、持久化、压缩、归档与清理 |

--- a/docs/design/mode/README.md
+++ b/docs/design/mode/README.md
@@ -1,0 +1,121 @@
+# 模式系统
+
+## 概述
+
+模式系统管理 session 的运行模式，通过切换模式改变 agent 的工具可用性、系统提示词和权限边界。
+
+## 架构
+
+每个 session 持有一个模式标记，决定 agent 的行为约束。模式切换由用户显式触发（斜杠命令或工具调用），仅 Auto Mode 在所有任务完成后自动退出并恢复默认模式。
+
+### 模式类型
+
+| 模式 | 说明 |
+|------|------|
+| 默认模式 | 无模式标记时的行为状态——agent 按完整配置运行，全工具集可用 |
+| Plan Mode | 规划与执行分离——agent 在只读约束下完成研究→设计→审批。支持标准路径和 Interview 路径。审批通过后进入 Auto Mode |
+| Auto Mode | 连续自主执行模式——agent 不等用户逐步确认，按 plan 自动执行，危险操作需用户审批 |
+
+### 模式生命周期
+
+```
+session 创建（默认模式）
+  ↓ 用户 /plan
+Plan Mode：
+  - 标准路径：Research → Design → Review → Final Plan
+  - Interview 路径：探索 → 增量更新 plan → 提问（循环直到需求收敛）
+  ↓ 审批通过
+Auto Mode：连续自主执行 plan tasks
+  ↓ 全部完成
+默认模式
+```
+
+审批栅栏是模式切换的唯一出口——Plan Mode 只有审批通过才能退出并进入 Auto Mode。
+
+### 模式生效机制
+
+每种模式通过三个层面影响 agent 行为：
+
+- **工具过滤**：按模式规则限制可用工具集。Plan Mode 下工具集与只读白名单取交集，写工具不可见。Auto Mode 下完整工具集可见，但危险操作需运行时审查
+- **系统提示词注入**：根据模式注入特定的行为指令。Plan Mode 注入双路径工作流指引，Auto Mode 注入连续执行指令
+- **权限边界**：模式的写入范围受限。Plan Mode 下仅 plans/ 目录可写，Auto Mode 下危险操作需用户确认
+
+三种约束在 session 创建时计算，运行期间不变。
+
+子功能：[plan-mode.md](plan-mode.md) — Plan Mode 专项：双路径工作流、Agent 类型、审批栅栏、Auto Mode、安全机制、多路径恢复
+
+## 数据流
+
+### 进入 Plan Mode
+
+```
+用户 /plan "任务描述"
+  →
+session 设置模式标记
+  →
+系统判断需求清晰度 → 选择标准路径或 Interview 路径
+  →
+工具过滤：完整工具集取交集模式白名单
+  →
+系统提示词注入对应路径指令
+  →
+权限边界设为 plans/ 目录可写
+  →
+agent 进入对应路径
+```
+
+需求清晰度判断：分析用户输入中是否有明确文件/模块/接口引用、是否有可量化验收条件。清晰 → 标准路径，模糊 → Interview 路径。
+
+### Plan Mode → Auto Mode
+
+```
+agent 调用审批工具
+  →
+框架弹出用户确认
+  ↓ 通过
+session 清除 Plan Mode 标记
+  →
+标记 Auto Mode
+  →
+恢复执行所需工具集，注入 Auto Mode 指令
+  →
+agent 开始执行 plan tasks
+```
+
+### 退出 Auto Mode
+
+```
+全部 tasks 完成
+  →
+session 清除 Auto Mode 标记
+  →
+恢复默认模式
+  →
+plan 标记为 completed
+```
+
+## 模块关系
+
+### 上游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Slash Command | `/plan`、`/execute` 命令入口 |
+| CLI | 命令行传入模式参数 |
+
+### 下游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Session | 存储和持久化模式标记，管理 PlanState，压缩保护，多路径恢复 |
+| System Prompt | 接收模式指令，拼入最终 system prompt |
+| Agent | session 创建时读取模式标记，按模式生成对应类型子 agent |
+| Permission | 工具过滤；Auto Mode 下运行时审查危险操作 |
+
+### 无关
+
+| 模块 | 说明 |
+|------|------|
+| LLM Provider | 不直接调用 |
+| Processor Chain / Renderer | 无关 |
+| IM Adapter | 无关 |

--- a/docs/design/mode/plan-mode.md
+++ b/docs/design/mode/plan-mode.md
@@ -1,0 +1,258 @@
+# Plan Mode
+
+## 概述
+
+Plan Mode 将任务规划与代码执行强制分离。规划阶段 agent 只读（仅 plan 文件可写），经过审批栅栏后方可进入 Auto Mode 执行。可靠性由代码层保证（工具过滤、审批拦截），不依赖 prompt 建议。
+
+支持两条路径：标准路径（需求明确）和 Interview 路径（需求模糊），由系统自动判断入口。
+
+## 架构
+
+### 双路径
+
+```
+需求明确 → 标准 4 阶段 → 审批 → Auto Mode 执行
+需求模糊 → Interview 循环 → 对接标准后段 → 审批 → Auto Mode 执行
+```
+
+**标准路径**：
+
+| Phase | 目标 | 机制 |
+|-------|------|------|
+| Research | 理解需求 + 探索代码库 | 并行 spawn Explore agent（只读） |
+| Design | 生成实现方案 | spawn Plan agent，架构师视角（只读） |
+| Review | 对齐需求 + 澄清问题 | AskUserQuestion（仅限需求澄清） |
+| Final Plan | 写入 plan 文件 | 唯一可写操作 |
+
+**Interview 路径**：无固定阶段。agent 循环"探索代码→增量更新 plan 文件→向用户提问"直到需求收敛，然后对接标准路径的 Review 和 Final Plan 阶段。每轮探索后增量写入 plan 文件。
+
+需求清晰度判断：系统在进入 Plan Mode 时分析用户输入——含明确文件/模块/接口引用且有可量化验收条件 → 标准路径；否则 → Interview 路径。用户可通过命令参数显式指定路径。
+
+阶段切换由 agent 自行判断，无代码层阶段状态机。
+
+### Agent 类型
+
+Plan Mode 各阶段通过 spawn 子 agent + 特定 system prompt 实现不同角色。每种 agent 类型对应 agent 模块的一套固定 prompt 模板和工具白名单：
+
+| 类型 | 阶段 | 能力 | 职责 |
+|------|------|------|------|
+| Explore agent | Research | 只读工具 | 并行探索代码库，理解现有实现和依赖 |
+| Plan agent | Design | 只读工具（禁止写和审批工具） | 架构师视角生成实现方案，输出关键文件列表 |
+| Verification agent | 执行后验证 | 只读工具，仅可写临时测试脚本 | 独立验证实现，尝试打破而非确认能用 |
+| Executor agent | Auto Mode | 完整工具集，危险操作受审查 | 按 plan tasks 逐步实施 |
+
+Plan Mode 不引入 Teammate（持久进程）或 Fork（上下文继承）机制。
+
+### 能力约束
+
+Plan Mode 下的工具限制由 Permission 层硬拦截——写工具不在白名单中则不可见，agent 无法调用：
+
+| 约束 | 机制 |
+|------|------|
+| 只读工具 | 与 plan mode 白名单取交集 |
+| plan 文件写 | plans/ 目录作为独立可写区域 |
+| 子 agent 继承 | spawn 出的子 agent 继承只读约束 |
+
+### Plan 文件
+
+**路径**：`workspace/plans/{identifier}.md`，identifier 支持时间戳格式（如 `2026-05-17-14-30-05-user-auth-flow`）或随机词组格式（如 `calm-wave-oven`），由配置决定。
+
+**文件内容**：
+
+- 任务标题、创建/更新时间
+- 状态标记：draft → confirmed → executing → paused → completed
+- Context 节：背景、约束、已确认决策
+- Tasks 节：有序步骤列表，每步带 checkbox
+- Verification 节：端到端验证方式
+- Notes 节：执行备注
+
+### 审批栅栏
+
+审批工具是 Plan Mode 的唯一出口。代码层保证：
+
+- Permission 层在 Plan Mode 下拦截所有写工具，仅 plans/ 目录放行
+- 审批工具调用时框架弹出用户确认对话框
+- 审批通过 → plan 标记 confirmed → session 退出 plan_mode → 进入 Auto Mode
+- 审批拒绝 → plan 保持 draft → agent 继续修改
+- 禁止用 AskUserQuestion 替代审批——AskUserQuestion 仅用于需求澄清
+
+### 多路径恢复
+
+Plan 内容在以下场景丢失时按优先级恢复（任一可用即可）：
+
+1. **PlanState 持久化**：session 模块维护的 PlanState 字段，压缩时完整保护
+2. **Plan 文件磁盘**：独立于 session 的持久化副本
+3. **审批工具调用记录**：审批时携带的 plan 摘要
+4. **消息历史**：用户消息中的 plan 引用
+
+### 状态持久化
+
+PlanState（plan 文件路径、当前步骤、状态等）由 session 模块持久化，压缩时完整保护，不经过 LLM 总结。步骤推进时框架自动更新。
+
+### Auto Mode（执行阶段）
+
+审批通过后自动进入 Auto Mode——连续自主执行，不等用户逐步确认：
+
+- 低风险工作直接做，不等确认
+- 常规决策自己做，不升级给用户
+- 危险操作（删数据、改生产配置）必须用户确认
+- 不擅自发消息到外部平台，不泄露密钥
+
+**两种执行方式**：
+
+- **Inline**（默认）：主 session 退出 plan_mode，注入 plan 上下文，恢复完整工具集，逐步执行 tasks
+- **Spawn**：spawn executor 子 agent 独立执行，完成后通知父 session
+
+### 安全机制
+
+三层防护：
+
+| 层级 | 机制 | 说明 |
+|------|------|------|
+| 工具过滤 | Permission 层硬拦截 | Plan Mode 下写工具不可见 |
+| 审批栅栏 | 审批工具弹出确认 | 无审批不退出 |
+| 执行审查 | Auto Mode 下危险操作拦截 | 运行时审查每条命令，被拒绝的操作记录拒绝日志（含工具名、操作描述、拒绝原因、时间戳） |
+
+### 状态机
+
+```
+draft ──审批通过──→ confirmed ──进入 Auto Mode──→ executing ──全部完成──→ completed
+  ↑                     |                               ↓
+  └───被拒绝────────────┘                           /pause
+                                                       ↓
+                                                    paused
+```
+
+被拒绝后回到 draft，可重新修改提交。confirmed 后中断走 paused，续活时从当前步骤恢复。
+
+### Plan 归档
+
+completed plan 最后访问超过配置天数后自动归档到 `workspace/plans/archive/`，由 session 模块的后台任务处理。
+
+## 数据流
+
+### 进入 Plan Mode
+
+```
+用户 /plan "任务描述"
+  →
+session 设置 plan_mode 标记
+  →
+系统 prompt 组装：
+  - 分析用户输入清晰度
+  - 清晰 → 注入标准路径 4 阶段指令
+  - 模糊 → 注入 Interview 循环指令
+  →
+工具过滤：只读白名单取交集
+  →
+权限：仅 plans/ 目录可写
+  →
+agent 进入对应路径
+```
+
+### Research 阶段
+
+```
+spawn Explore agent（指定只读 agent 配置 + 探索任务）
+  →
+子 session：轻量上下文，只读工具集，探索行为约束
+  →
+Explore agent 完成探索 → 结果通知父 session
+```
+
+### Design 阶段
+
+```
+spawn Plan agent（指定设计 agent 配置 + 探索结果作输入）
+  →
+子 session：轻量上下文，只读工具集，架构师设计约束
+  →
+Plan agent 输出方案 → 结果通知父 session
+```
+
+### 审批 → Auto Mode（Inline）
+
+```
+审批工具调用 → 用户确认通过
+  →
+plan 状态 = confirmed（写入磁盘）
+  →
+session 退出 plan_mode → 标记 Auto Mode
+  →
+注入 Auto Mode 指令 + plan 文件上下文
+  →
+恢复完整工具集，危险操作受审查
+  →
+逐步执行 tasks，每步完成自动更新 checkbox
+  →
+全部完成 → plan 状态 = completed
+```
+
+### 审批 → Auto Mode（Spawn）
+
+```
+审批通过 → spawn executor 子 agent（传入 plan 文件 + 执行指令）
+  →
+子 session：Auto Mode 标记，完整工具集，危险操作受审查
+  →
+逐步执行 plan tasks → 完成通知父 session
+  →
+plan 状态 = completed
+```
+
+### Interview 路径
+
+```
+需求模糊 → 进入 Interview 循环
+  →
+每轮：spawn Explore agent 探索 → 增量更新 plan 文件 → 向用户提问
+  → 用户回复 → 评估 ambiguities
+  → 仍有模糊点 → 继续循环
+  → ambiguities 消除 → Review + Final Plan → 审批出口（与标准路径相同）
+```
+
+### 验证阶段
+
+```
+执行完成后 → 主 session 判断是否需要验证（非平凡任务触发）
+  →
+spawn Verification agent（传入任务描述 + 改动文件 + 方案）
+  →
+子 session：只读工具集，可写 /tmp 测试脚本，独立审视约束
+  →
+每个检查：检查项 + 命令 + 输出 + PASS/FAIL
+  →
+最终裁决：PASS / FAIL / PARTIAL → 通知父 session
+```
+
+## 模块关系
+
+### 上游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Slash Command | `/plan` `/execute` 入口 |
+| Tools | 审批工具和执行工具注册在此 |
+
+### 下游
+
+| 模块 | 调用关系 |
+|------|---------|
+| Agent | 各阶段 spawn Explore/Plan/Verification/Executor 子 agent |
+| Session | plan_mode 标记、PlanState 持久化、压缩保护、多路径恢复、归档 |
+| System Prompt | 双路径指令、Auto Mode 指令、plan 文件上下文注入 |
+| Permission | 工具过滤、Auto Mode 下运行时审查 |
+
+### 模块内关系
+
+- 依赖模式系统的模式切换机制进入和退出 Plan Mode
+- Agent 类型由 agent 模块的配置系统定义，Plan Mode 消费已有配置
+- Plan 文件读写由 tool 模块代理
+
+### 无关
+
+| 模块 | 说明 |
+|------|------|
+| LLM Provider | 不直接调用 |
+| Processor Chain / Renderer | 无关 |
+| IM Adapter | 无关 |


### PR DESCRIPTION
## 设计文档：mode/README.md（模式系统索引+架构概览）+ plan-mode.md（Plan Mode 专项）

设计基于 workspace/design/25-plan-mode-v2.md，融合 Claude Code 调研设计。

### 新增文件
- `docs/design/mode/README.md` — 模式系统总览：三种模式定义、生命周期、生效机制
- `docs/design/mode/plan-mode.md` — Plan Mode 专项：双路径工作流、Agent 类型、审批栅栏、Auto Mode、安全机制、多路径恢复

### 附带修改
- `docs/design/README.md` — 新增 mode 模块索引条目

### 代码对照发现
src/mode/ 为死代码（整模块无外部调用），仅覆盖模式路由层，缺少工作流、状态机、审批和执行机制。新文档以设计文档为准。

Source: user
Type: docs
