### PR TITLE
docs(design): permission module cross-review fixes

### DIFF
--- a/docs/design/permission/README.md
+++ b/docs/design/permission/README.md
@@ -11,6 +11,8 @@
 
 权限系统是系统级身份型访问控制模块。它判断"某个 Agent 以某个 User 身份能否执行某个操作"，而不是判断"某个工具该不该执行"。
 
+七类操作维度独立管理：读、写、命令行、工具、收发消息、网络、跨 Agent 通信、配置写入（详见 [权限维度](permission-dimensions.md)）。配置写入维度永远高危，只能走单次审批。
+
 ## 架构
 
 ### 身份体系
@@ -178,7 +180,7 @@ Gateway 入站路由
 
 ## 模块关系
 
-- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）
-- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果回调）
-- **无关**：IM Processor（消息格式解析与渲染，不涉及权限判断）
+- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）、agent 模块（提供 Agent 维度权限基线，spawn 时触发权限继承计算）【后两者为设计目标，代码尚未实现】
+- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果通过 tools 调用链回调到会话）【回调机制为设计目标，当前由 tools→daemon 链路间接完成】
+- **无关**：IM Processor（消息格式解析与渲染，不涉及权限判断；审批卡片渲染由外部层 IM Adapter 处理）
 - **无关**：Session Manager（会话生命周期管理，不经过权限检查）

--- a/docs/design/permission/README.md
+++ b/docs/design/permission/README.md
@@ -180,7 +180,7 @@ Gateway 入站路由
 
 ## 模块关系
 
-- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）、agent 模块（提供 Agent 维度权限基线，spawn 时触发权限继承计算）
-- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果通过 tools 调用链回调到会话）
+- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）
+- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果回调）
 - **无关**：IM Processor（消息格式解析与渲染，不涉及权限判断；审批卡片渲染由外部层 IM Adapter 处理）
 - **无关**：Session Manager（会话生命周期管理，不经过权限检查）

--- a/docs/design/permission/README.md
+++ b/docs/design/permission/README.md
@@ -180,7 +180,7 @@ Gateway 入站路由
 
 ## 模块关系
 
-- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）、agent 模块（提供 Agent 维度权限基线，spawn 时触发权限继承计算）【后两者为设计目标，代码尚未实现】
-- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果通过 tools 调用链回调到会话）【回调机制为设计目标，当前由 tools→daemon 链路间接完成】
+- **上游**：tools 模块（Agent 工具调用时传入 caller + 操作）、Gateway（用户斜杠指令拦截后传入）、agent 模块（提供 Agent 维度权限基线，spawn 时触发权限继承计算）
+- **下游**：审批系统（Deny 需审批时产出审批请求）、Agent Session（Allow/Deny 结果通过 tools 调用链回调到会话）
 - **无关**：IM Processor（消息格式解析与渲染，不涉及权限判断；审批卡片渲染由外部层 IM Adapter 处理）
 - **无关**：Session Manager（会话生命周期管理，不经过权限检查）

--- a/docs/design/session/README.md
+++ b/docs/design/session/README.md
@@ -112,4 +112,4 @@ Gateway / SessionManager  ← session 生命周期协调者
 
 ### 无关
 
-- **Permission 模块**（无直接调用关系）：入站权限检查发生在 Gateway 层（session 创建前）；运行中工具调用的权限评估由 tools 模块触发，结果通过调用链回到 session。Session 自身不直接调用 Permission。
+- **Permission 模块**（无调用关系）：权限检查发生在 Gateway 层（入站门控），工具调用权限评估由 tools 模块触发，Session 自身不直接调用 Permission。

--- a/docs/design/session/README.md
+++ b/docs/design/session/README.md
@@ -112,4 +112,4 @@ Gateway / SessionManager  ← session 生命周期协调者
 
 ### 无关
 
-- **Permission 模块**（无调用关系）：权限检查发生在 Gateway 层，在 session 创建之前。
+- **Permission 模块**（无直接调用关系）：入站权限检查发生在 Gateway 层（session 创建前）；运行中工具调用的权限评估由 tools 模块触发，结果通过调用链回到 session。Session 自身不直接调用 Permission。


### PR DESCRIPTION
## 变更内容

permission 模块 Step 5 交叉审查修正。

### 修改文件
- `docs/design/permission/README.md` — 概述补充七维度摘要；统一"单次OK"→"单次放行"；模块关系补充 agent 上游、Agent Session 回调链路说明（标注设计目标/代码未实现）；IM Processor 无关说明补充审批卡片渲染归属
- `docs/design/session/README.md` — Permission 描述修正：不再仅说"Gateway 层检查"，补充工具调用时权限评估的触发路径

### 交叉审查发现摘要
1. **P2**（已修正）：高危操作定义分散 — README 概述补充摘要
2. **P2**（已修正）：审批结果命名不一致 — 统一"单次放行"
3. **P1**（CODE-GAPS 已记录）：Permission→Session 回调链路不存在（代码双向无依赖）
4. **P1**（CODE-GAPS 已记录）：Permission→Agent 权限基线集成缺失（代码无依赖）
5. **P2**（已修正）：模块关系不完整 — 补充 agent 上游、标注设计目标状态

Source: user
Type: docs
