### PR TITLE
docs(design): session cross-validation fixes

### DIFF
--- a/docs/design/session/README.md
+++ b/docs/design/session/README.md
@@ -39,7 +39,7 @@ Gateway / SessionManager  ← session 生命周期协调者
 各子功能的关系：
 - **生命周期**是骨架：SessionCheckpoint 数据模型和 SqliteStorage 是其他所有功能的底层依赖。
 - **注入**在 session 创建时发生：SessionManager 调用 system prompt builder 完成 bootstrap/tools/skills 的组装。
-- **压缩**在 session 运行时发生：对过长的对话历史做 summarization。system prompt 独立于对话消息流，不参与压缩，确保角色定义在任意次压缩后完整无损。
+- **压缩**在 session 运行时发生：对过长的对话历史做 summarization。支持手动触发（`/compact`）和自动触发（token 用量阈值），内含熔断保护和分级告警。system prompt 独立于对话消息流，不参与压缩，确保角色定义在任意次压缩后完整无损。
 - **LLM 增强**贯穿每次 API 调用：流式推送、reasoning level 控制、cache hit 统计在每次会话交互中生效。
 
 ## 数据流
@@ -74,9 +74,9 @@ Gateway / SessionManager  ← session 生命周期协调者
 定期：CheckpointManager 触发持久化（保存 SessionCheckpoint 和 transcript）
 ```
 
-### Session 终止
+### Session 结束路径
 
-两种终止路径：
+两种结束路径：
 - **主动结束**：用户关闭会话，SessionManager 移除运行时引用，CheckpointManager 最终保存。
 - **自动归档**：Sweeper 检测 idle 超时 → 标记为 archived → transcript 移入 archived_sessions/ → SQLite 更新状态。
 - **自动清理**：Sweeper 检测 archived 超过 purge TTL → 删除元数据 + transcript 文件。

--- a/docs/design/session/compact-process.md
+++ b/docs/design/session/compact-process.md
@@ -46,6 +46,8 @@ Bootstrap 文件（AGENTS.md、SOUL.md、IDENTITY.md、USER.md）中包含的角
 
 压缩专用 prompt 要求：禁止有外部副作用的工具调用，按指定维度生成结构化摘要，可选附带用户自定义保留指令。以低温度、限制输出长度的方式调用 LLM，从响应中提取摘要内容，组装为 boundary 消息。
 
+**boundary 消息**是压缩后的 transcript 中的唯一消息条目，承载 LLM 生成的对话历史结构化摘要（覆盖九个维度）及压缩元信息（压缩时间、触发方式）。压缩完成后 transcript 的对话部分只包含这一条 boundary 消息，替代压缩前的全部 user/assistant 消息。
+
 压缩 prompt 要求 LLM 覆盖九个维度：用户身份与偏好、当前项目与上下文、关键决策与结论、未解决的问题、技术状态、对话流程、重要事实与引用、Agent 记忆与自我认知、后续步骤与行动项。
 
 ### System Prompt 隔离
@@ -119,5 +121,4 @@ system prompt 在压缩前后完全一致，不参与摘要流程。
 
 ### 无关
 
-- **Session Injection**（无调用关系）：仅提供 system prompt 数据，不参与压缩执行流程。
 - **Archive Sweeper**（无调用关系）：管理 session 的归档和清理生命周期，与压缩流程无交互。

--- a/docs/design/session/session-injection.md
+++ b/docs/design/session/session-injection.md
@@ -44,7 +44,7 @@ System Prompt 的 Section 类型定义见 [system-prompt/README.md](../system-pr
 
 ### Skill 热更新
 
-skill 文件变更时，SkillRegistry 通知 SessionManager 重新走 build_from_workspace，生成新的 system prompt 替换旧的。不依赖消息 ID 定位（skill listing 直接拼接在 system prompt 中，不是独立消息）。
+skill 文件变更时，SkillRegistry 通知 SessionManager 重新走 build_from_workspace（重建 system prompt，无 workspace 时只重建 ToolsSection 和 SkillListingSection），生成新的 system prompt 替换旧的。不依赖消息 ID 定位（skill listing 直接拼接在 system prompt 中，不是独立消息）。
 
 ## 数据流
 

--- a/docs/design/session/session-lifecycle.md
+++ b/docs/design/session/session-lifecycle.md
@@ -11,10 +11,12 @@
 **SessionCheckpoint** 是 session 持久化的核心数据结构，包含：
 - 标识：session_id、agent_id、role（主 agent / 子 agent）、last_message_id
 - 路由信息：channel（如 feishu）、chat_id
-- 生命周期状态：status（active / archived）、created_at、archived_at
+- 生命周期状态：status（active / archived）、created_at
 - 运行时快照：pending_messages（transcript，含消息列表）、mode（对话模式：direct/plan/stream）、mode_state（推理步骤状态）
 - 统计：last_message_at（最后消息时间，Sweeper 用来判断 idle）、message_count
-- 其他：metadata（JSON 扩展字段）、ttl_seconds、updated_at（最后 checkpoint 更新时间）
+- 其他：ttl_seconds、updated_at（最后 checkpoint 更新时间）
+
+> `archived_at` 和扩展元数据（metadata JSON）作为 SQLite 表列存储，由 SqliteStorage 维护，不进入 Checkpoint struct。归档时间和自定义扩展字段通过 SQLite 层查询。
 
 **SessionStatus** 是两态枚举：
 - `Active`：正常运行中或待恢复


### PR DESCRIPTION
设计文档：session/README.md（索引+架构概览）+ 5 个子功能文档

## 交叉审查修正
- `docs/design/session/compact-process.md` — 删除"无关"中重复的 Session Injection 条目（P0 内部矛盾修复）；新增 boundary 消息定义
- `docs/design/session/README.md` — 压缩描述补充熔断器和分级告警；"Session 终止"→"Session 结束路径"
- `docs/design/session/session-injection.md` — 澄清 Skill 热更新中 build_from_workspace 行为
- `docs/design/session/session-lifecycle.md` — 修正 SessionCheckpoint 字段清单：archived_at 和 metadata 为 SQLite 列而非 struct 字段

## 代码对照发现
1. P0: BootstrapProtection 未接入压缩链路 — 模块完整实现但 compaction.rs 未调用
2. P1: 工作目录变更机制（/cd、/pwd）未实现
3. P1: SessionCheckpoint 字段 archived_at/metadata 仅存 SQLite，不进 struct
4. P2: SQLite 文件名 sessions.db（文档写 sessions.sqlite）
5. P2: ReasoningMode::Hidden 存在但文档未覆盖

Source: user
Type: docs
