### PR TITLE
docs(design): processor_chain cross-review fixes

### DIFF
--- a/docs/design/processor_chain/README.md
+++ b/docs/design/processor_chain/README.md
@@ -55,7 +55,7 @@ LLM Provider 输出 UnifiedResponse（含 ContentBlock[]）
 
 ## 模块关系
 
-- **上游**：Session（提供 ContentBlock[] 消息数据）、LLM Provider（生成 UnifiedResponse）
+- **上游**：Session（提供 ContentBlock[] 消息数据）；LLM Provider 为数据来源（生成 UnifiedResponse 和 ContentBlock 类型，但不直接调用 processor_chain）
 - **下游**：IM Adapter（接收渲染后的平台消息并发送）
 - **子文档**（按出站链执行顺序排列，新增文档依此规则）：
   - [出站链路](outbound-chain.md) — 完整出站流程与 Processor 链调度

--- a/docs/design/processor_chain/code-render.md
+++ b/docs/design/processor_chain/code-render.md
@@ -53,6 +53,6 @@ ContentBlock[] 中的 Text 块
 
 ## 模块关系
 
-- **上游**：渲染 Processor 框架（提供 ContentBlock[] 输入）
-- **下游**：IM Adapter（接收渲染后的消息）
+- **上游**：渲染 Processor（提供 ContentBlock[] 输入）
+- **下游**：Gateway（提取平台 payload 传递给 IM Adapter 发送）
 - **所属**：各平台渲染 Processor 的内部子功能，不独立为 Processor

--- a/docs/design/processor_chain/outbound-chain.md
+++ b/docs/design/processor_chain/outbound-chain.md
@@ -41,8 +41,9 @@ Session 消息（含 ContentBlock[]）
   ↓ Gateway 构造 ProcessedMessage
 DslParser.process(ctx)
   → 输入：含 ContentBlock 数组的消息上下文
-  → 处理：遍历 Text 块，匹配 DSL 语法 → 解析为结构化指令 → 剥离 DSL 行
-  → 输出：clean Text 块 + metadata["dsl_result"]（DslParseResult 序列化 JSON）
+  → 处理：遍历 Text 块，匹配 DSL 语法 → 解析为结构化指令 → 剥离 DSL 行；
+    Thinking/ToolUse/ToolResult 块不参与 DSL 解析，直接透传
+  → 输出：clean Text 块（含透传的非 Text 块）+ metadata["dsl_result"]（DslParseResult）
   ↓
 <Platform>Renderer.process(ctx)
   → 输入：清理后的 ContentBlock[] + metadata 中的 DSL 结果
@@ -64,7 +65,7 @@ Gateway 提取 payload → IM Adapter
 
 ## 模块关系
 
-- **上游**：Session（提供 ContentBlock[]）、LLM Provider（生成 UnifiedResponse）
+- **上游**：Session（提供 ContentBlock[]）；LLM Provider 为数据来源（生成 UnifiedResponse 和 ContentBlock 类型，但不直接调用 processor_chain）
 - **下游**：IM Adapter（接收渲染后的平台消息并发送）
 - **链内**：
   - DslParser — DSL 指令解析，为渲染 Processor 提供交互数据

--- a/docs/design/processor_chain/streaming-render.md
+++ b/docs/design/processor_chain/streaming-render.md
@@ -64,6 +64,6 @@ Gateway 将事件转发给渲染 Processor
 
 ## 模块关系
 
-- **上游**：LLM Provider（产生 StreamEvent 序列）
+- **上游**：Gateway（接收 LLM StreamEvent 并转发给渲染 Processor）
 - **下游**：IM Adapter（接收增量渲染输出并发送）
-- **所属**：各平台渲染 Processor 的内部子功能
+- **所属**：各平台渲染 Processor 的内部子功能，不独立为 Processor


### PR DESCRIPTION
处理器链交叉审查修正，4 处措辞对齐 + 1 处关系澄清。

## 修改文件
- `docs/design/processor_chain/README.md` — LLM Provider 从"上游"修正为"数据来源"
- `docs/design/processor_chain/outbound-chain.md` — 补充 DslParser 非 Text 块透传；LLM Provider 关系澄清
- `docs/design/processor_chain/code-render.md` — 上下游措辞对齐
- `docs/design/processor_chain/streaming-render.md` — 上游修正为 Gateway；补"不独立为 Processor"

## 交叉审查发现摘要
- **P0**：出站链模型不支持流式（DslParser 需全文 vs 流式增量），记入 CODE-GAPS 待架构重新设计
- **P1**：processor_chain 对 LLM Provider 关系声明与 llm 模块"无关"冲突 → 已修正为数据来源
- **P2**：4 处措辞对齐 → 已修

## 代码对照发现
- Renderer 非 Processor（独立 Renderer trait）→ 记入 CODE-GAPS P0
- 链输入 String 非 ContentBlock[] → 记入 CODE-GAPS P0
- 入站链无设计文档 → 记入 CODE-GAPS P1
- 设计文档 v1 vs 代码 v2 架构体系性差异 → 记入 CODE-GAPS P2（owner 决策保留文档）

Source: user
Type: docs
