### PR TITLE
docs(design): cross-validation fixes for slash module

### DIFF
--- a/docs/design/slash/README.md
+++ b/docs/design/slash/README.md
@@ -39,7 +39,7 @@ Dispatcher 不持有 Session 引用——Handler 返回 SlashResult 后，由 Ga
 | StatusHandler | status | Reply | ✅ |
 | CompactHandler | compact | Compact | ❌ |
 | SystemHandler | system | SystemAppend / Reply | ❌ |
-| WorkdirHandler | cd, pwd, git | Reply | ❌ |
+| WorkdirHandler | cd, pwd, git | Reply / Exec | ❌ |
 | ExecHandler | exec | Exec / Reply | ❌ |
 | HelpHandler | help | Reply | ✅ |
 
@@ -79,7 +79,7 @@ Gateway.handle_inbound()
             │           ├── Stop               → 终止 run + 子 agent + 回复
             │           ├── Compact{...}       → 执行压缩 + 回复
             │           ├── SystemAppend(...)  → 更新追加区 + 回复
-            │           ├── Exec{command}      → 提交 permission 审批
+            │           ├── Exec{command}      → 提交 Gateway 调用 Permission 模块审批
             │           └── Unknown(cmd)       → 回复"未知指令"
             └── 未命中 → SlashResult::Unknown → 回复"未知指令"
 ```
@@ -94,5 +94,7 @@ Gateway.handle_inbound()
 - **上游**：Gateway（入站消息处理）。Gateway 在消息路由前检查 `/` 前缀并分派。
 - **下游**：
   - Session 模块 — 模式切换、会话创建/停止、上下文压缩、system prompt 追加区管理、工作目录设置
-  - Permission 模块 — `/exec` 和 `/git` 写操作的权限审批
+  - Agent 模块 — `/stop` 终止子 agent
+- **间接下游**（通过 Gateway 调用）：
+  - Permission 模块 — `/exec` 和 `/git` 写操作的权限审批（由 Gateway 读取 Exec 结果后调用）
 - **无关**：Processor 链（斜杠指令在 Processor 之前被 Gateway 拦截，不进入 LLM 处理流程）

--- a/docs/design/slash/exec.md
+++ b/docs/design/slash/exec.md
@@ -29,5 +29,6 @@ Gateway 提交 Permission 模块
 ## 模块关系
 
 - **上游**：Gateway → Dispatcher → ExecHandler
-- **下游**：Permission 模块（权限审批）；Shell 执行环境（命令执行）
+- **下游**：Shell 执行环境（命令执行）
+- **间接下游**（通过 Gateway 调用）：Permission 模块（权限审批）
 - **无关**：WorkdirHandler（`/exec` 和 `/cd` 独立，不共享工作目录上下文）

--- a/docs/design/slash/workdir.md
+++ b/docs/design/slash/workdir.md
@@ -39,5 +39,6 @@ WorkdirHandler 返回 Reply(git 输出) 或 Exec
 ## 模块关系
 
 - **上游**：Gateway → Dispatcher → WorkdirHandler
-- **下游**：Session 模块（`set_workdir()` 方法）；Permission 模块（`/git` 写操作审批）
+- **下游**：Session 模块（`set_workdir()` 方法）
+- **间接下游**（通过 Gateway 调用）：Permission 模块（`/git` 写操作审批）
 - **无关**：LLM 对话流程


### PR DESCRIPTION
设计文档：slash/ 模块交叉审查修正

## 新增文件
（无，本次为现有文档修正）

## 修改文件
- `docs/design/slash/README.md` — 交叉审查修正：WorkdirHandler 结果类型补充 Exec、Permission 从"下游"改为"间接下游"、补充 Agent 模块下游声明
- `docs/design/slash/exec.md` — Permission 下游关系对齐为"间接下游（通过 Gateway 调用）"
- `docs/design/slash/workdir.md` — Permission 下游关系对齐为"间接下游（通过 Gateway 调用）"

## 附带修改
（无）

## 代码对照发现
代码与设计文档的差异已全部记录在 workspace/CODE-GAPS.md 的"斜杠指令系统"和"mode 模块"章节：
- P1: 斜杠指令无统一分发入口、SlashCommandResult 缺少 NewSession/Stop/SystemAppend/Exec 变体
- P1: system_prompt/slash_commands.rs 有实现无调用者（/system /cd /pwd /git）
- P2: ReasoningMode 空壳、Immediate 机制缺失、HandlerRegistry 不存在
- P1: mode/ 整模块待删除死代码（含 /code /review /debug /direct /think 旧 ReasoningMode 指令）

以上均为已知技术债，未新增 CODE-GAPS 条目。

Source: user
Type: docs
