### PR TITLE
feat: add NormalizedMessage type for IM adapter

### DIFF
--- a/src/im/mod.rs
+++ b/src/im/mod.rs
@@ -3,7 +3,11 @@
 //! Each adapter implements the IMAdapter trait for a specific IM platform.
 
 pub mod feishu;
+pub mod normalized;
+#[cfg(test)]
+pub mod normalized_tests;
 pub mod processor;
+pub use normalized::NormalizedMessage;
 
 use crate::gateway::Message;
 use async_trait::async_trait;

--- a/src/im/normalized.rs
+++ b/src/im/normalized.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+/// Normalized inbound message produced by IM platform adapters.
+///
+/// This is the unified intermediate structure across all messaging platforms,
+/// shielding platform-specific differences from the Processor Chain and Gateway.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedMessage {
+    /// Platform identifier, e.g. `"feishu"`, `"discord"`.
+    pub platform: String,
+
+    /// Sender's platform-specific user ID.
+    pub sender_id: String,
+
+    /// Peer ID — a `chat_id` for group chats, or the other party's user ID for
+    /// private chats.
+    pub peer_id: String,
+
+    /// Message text content.
+    pub content: String,
+
+    /// Message send time as a Unix timestamp (seconds since epoch).
+    pub timestamp: i64,
+
+    /// Optional thread/topic ID. Used for定向 replies on platforms that support
+    /// threads; does **not** participate in session key calculation.
+    pub thread_id: Option<String>,
+
+    /// Optional tenant/account identifier for multi-tenant session isolation.
+    pub account_id: Option<String>,
+}

--- a/src/im/normalized_tests.rs
+++ b/src/im/normalized_tests.rs
@@ -1,0 +1,79 @@
+#[cfg(test)]
+mod tests {
+    use crate::im::NormalizedMessage;
+
+    #[test]
+    fn test_roundtrip_with_all_fields() {
+        let msg = NormalizedMessage {
+            platform: "feishu".to_string(),
+            sender_id: "ou_abc123".to_string(),
+            peer_id: "oc_group456".to_string(),
+            content: "Hello, world!".to_string(),
+            timestamp: 1700000000,
+            thread_id: Some("omt_thread789".to_string()),
+            account_id: Some("tenant_001".to_string()),
+        };
+
+        let json = serde_json::to_string(&msg).expect("serialization failed");
+        let deserialized: NormalizedMessage =
+            serde_json::from_str(&json).expect("deserialization failed");
+
+        assert_eq!(deserialized.platform, "feishu");
+        assert_eq!(deserialized.sender_id, "ou_abc123");
+        assert_eq!(deserialized.peer_id, "oc_group456");
+        assert_eq!(deserialized.content, "Hello, world!");
+        assert_eq!(deserialized.timestamp, 1700000000);
+        assert_eq!(deserialized.thread_id.as_deref(), Some("omt_thread789"));
+        assert_eq!(deserialized.account_id.as_deref(), Some("tenant_001"));
+    }
+
+    #[test]
+    fn test_roundtrip_with_none_optional_fields() {
+        let msg = NormalizedMessage {
+            platform: "discord".to_string(),
+            sender_id: "user123".to_string(),
+            peer_id: "dm456".to_string(),
+            content: "Direct message".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+
+        let json = serde_json::to_string(&msg).expect("serialization failed");
+        let deserialized: NormalizedMessage =
+            serde_json::from_str(&json).expect("deserialization failed");
+
+        assert_eq!(deserialized.platform, "discord");
+        assert_eq!(deserialized.sender_id, "user123");
+        assert_eq!(deserialized.peer_id, "dm456");
+        assert_eq!(deserialized.content, "Direct message");
+        assert_eq!(deserialized.timestamp, 1700000000);
+        assert!(deserialized.thread_id.is_none());
+        assert!(deserialized.account_id.is_none());
+    }
+
+    #[test]
+    fn test_json_field_names_are_correct() {
+        let msg = NormalizedMessage {
+            platform: "test".to_string(),
+            sender_id: "s".to_string(),
+            peer_id: "p".to_string(),
+            content: "c".to_string(),
+            timestamp: 42,
+            thread_id: None,
+            account_id: None,
+        };
+
+        let json = serde_json::to_value(&msg).expect("serialization to value failed");
+        let obj = json.as_object().expect("expected JSON object");
+
+        assert!(obj.contains_key("platform"));
+        assert!(obj.contains_key("sender_id"));
+        assert!(obj.contains_key("peer_id"));
+        assert!(obj.contains_key("content"));
+        assert!(obj.contains_key("timestamp"));
+        assert!(obj.contains_key("thread_id"));
+        assert!(obj.contains_key("account_id"));
+        assert_eq!(obj.len(), 7);
+    }
+}


### PR DESCRIPTION
Add `NormalizedMessage` type as the unified inbound message format for IM adapters. This resolves the overlap between `gateway::Message` and `RawMessage` by providing a single normalized type with 7 fields: platform, sender_id, peer_id, content, timestamp, thread_id, account_id. Only the type definition and tests are added; no callers are migrated yet.

Source: issue #731
Type: feat
