### PR TITLE
fix: reverse SkillSource enum priority to match design doc

### DIFF
--- a/src/skills/disk/loader.rs
+++ b/src/skills/disk/loader.rs
@@ -1,7 +1,7 @@
 //! Skill directory scanner
 //!
 //! Scans hierarchical skill directories and returns discovered skills
-//! ordered by priority (bundled > extraDirs > global > agent > project).
+//! ordered by priority (project > agent > global > extraDirs > bundled).
 
 use std::collections::BTreeMap;
 
@@ -9,12 +9,12 @@ use super::{DiskSkill, ParsedSkill, ScanConfig, SkillSource};
 
 /// Scan all skill directories and return a list of discovered skills.
 ///
-/// Discovery order (highest to lowest priority):
-/// 1. `bundled_dir` — built-in framework skills
+/// Discovery order (lowest to highest priority, later overwrites earlier):
+/// 1. `bundled_dir` — built-in framework skills (lowest priority)
 /// 2. `extra_dirs` — user-provided additional directories
 /// 3. `global_dir` — global cross-agent skills
 /// 4. Agent-specific directory derived from `agent_id`
-/// 5. `project_root` — project-local skills
+/// 5. `project_root` — project-local skills (highest priority)
 ///
 /// When the same skill name appears at multiple priority levels,
 /// the higher-priority entry wins and a warning is emitted.
@@ -22,8 +22,16 @@ pub fn scan_all_skills(config: &ScanConfig) -> Vec<DiskSkill> {
     let mut skills_by_name: BTreeMap<String, DiskSkill> = BTreeMap::new();
 
     // Scan from lowest to highest priority so higher priority always overwrites
-    if let Some(ref project_root) = config.project_root {
-        scan_layer(project_root, SkillSource::Project, &mut skills_by_name);
+    if let Some(ref dir) = config.bundled_dir {
+        scan_layer(dir, SkillSource::Bundled, &mut skills_by_name);
+    }
+
+    for dir in &config.extra_dirs {
+        scan_layer(dir, SkillSource::ExtraDirs, &mut skills_by_name);
+    }
+
+    if let Some(ref dir) = config.global_dir {
+        scan_layer(dir, SkillSource::Global, &mut skills_by_name);
     }
 
     if let Some(ref agent_id) = config.agent_id {
@@ -33,16 +41,8 @@ pub fn scan_all_skills(config: &ScanConfig) -> Vec<DiskSkill> {
         }
     }
 
-    if let Some(ref dir) = config.global_dir {
-        scan_layer(dir, SkillSource::Global, &mut skills_by_name);
-    }
-
-    for dir in &config.extra_dirs {
-        scan_layer(dir, SkillSource::ExtraDirs, &mut skills_by_name);
-    }
-
-    if let Some(ref dir) = config.bundled_dir {
-        scan_layer(dir, SkillSource::Bundled, &mut skills_by_name);
+    if let Some(ref project_root) = config.project_root {
+        scan_layer(project_root, SkillSource::Project, &mut skills_by_name);
     }
 
     skills_by_name.into_values().collect()
@@ -200,21 +200,21 @@ mod tests {
     #[test]
     fn test_priority_override() {
         let temp = tempfile::tempdir().unwrap();
-        let lower_dir = temp.path().join("lower");
-        let higher_dir = temp.path().join("higher");
+        let bundled_dir = temp.path().join("bundled");
+        let project_dir = temp.path().join("project");
 
         create_file(
-            &lower_dir.join("shared-skill").join("SKILL.md"),
+            &bundled_dir.join("shared-skill").join("SKILL.md"),
             "---\ndescription: Lower\n---\n# Lower\n",
         );
         create_file(
-            &higher_dir.join("shared-skill").join("SKILL.md"),
+            &project_dir.join("shared-skill").join("SKILL.md"),
             "---\ndescription: Higher\n---\n# Higher\n",
         );
 
         let config = ScanConfig {
-            bundled_dir: Some(higher_dir),
-            project_root: Some(lower_dir),
+            bundled_dir: Some(bundled_dir),
+            project_root: Some(project_dir),
             ..Default::default()
         };
 

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -83,7 +83,7 @@ impl DiskSkillRegistry {
 
     /// Returns all conditional skills (those with non-empty `paths`) that
     /// match any of the given file paths, sorted by [`SkillSource`] priority
-    /// (Bundled > ExtraDirs > Global > Agent > Project) with deduplication
+    /// (Project > Agent > Global > ExtraDirs > Bundled) with deduplication
     /// by name (higher-priority skill wins).
     ///
     /// Returns an empty vec when `paths` is empty or no conditional skills match.
@@ -118,7 +118,7 @@ impl DiskSkillRegistry {
 
     /// Generates a formatted skill listing string for the given agent_id.
     ///
-    /// - Sorts by SkillSource priority (Bundled > ExtraDirs > Global > Agent > Project)
+    /// - Sorts by SkillSource priority (Project > Agent > Global > ExtraDirs > Bundled)
     /// - Within the same priority, sorts by name alphabetically
     /// - Filters: only includes skills where `agent_id` is empty or matches the given agent_id
     /// - Format: `- **{name}**: {description}` + optionally ` — {when_to_use}`

--- a/src/skills/disk/registry_tests.rs
+++ b/src/skills/disk/registry_tests.rs
@@ -146,11 +146,11 @@ fn test_generate_listing_sorted_by_priority_and_name() {
     let listing = r.generate_listing(None);
     let lines: Vec<&str> = listing.lines().collect();
     assert_eq!(lines.len(), 6);
-    // Bundled before Global before Agent
-    assert!(listing.find("**a_bundled**").unwrap() < listing.find("**a_global**").unwrap());
-    assert!(listing.find("**a_global**").unwrap() < listing.find("**a_agent**").unwrap());
-    // Within Bundled, alphabetical order
-    assert!(listing.find("**a_bundled**").unwrap() < listing.find("**z_bundled**").unwrap());
+    // Agent before Global before Bundled (Project > Agent > Global > ExtraDirs > Bundled)
+    assert!(listing.find("**a_agent**").unwrap() < listing.find("**a_global**").unwrap());
+    assert!(listing.find("**a_global**").unwrap() < listing.find("**a_bundled**").unwrap());
+    // Within Agent, alphabetical order
+    assert!(listing.find("**a_agent**").unwrap() < listing.find("**z_agent**").unwrap());
 }
 
 #[test]
@@ -446,16 +446,16 @@ fn test_find_matching_skills_priority_dedup_mixed() {
         m.iter()
             .map(|s| s.manifest.name.as_str())
             .collect::<Vec<_>>(),
-        ["high", "mid", "low"]
+        ["low", "mid", "high"]
     );
-    // dedup: same name, higher priority wins
+    // dedup: same name, higher priority wins (Project > Bundled)
     let r2 = DiskSkillRegistry::new(vec![
         skill_with_paths("x", SkillSource::Project, vec!["**/*.rs".into()]),
         skill_with_paths("x", SkillSource::Bundled, vec!["**/*.rs".into()]),
     ]);
     let m2 = r2.find_matching_skills(&[Path::new("a.rs")]);
     assert_eq!(m2.len(), 1);
-    assert_eq!(m2[0].source, SkillSource::Bundled);
+    assert_eq!(m2[0].source, SkillSource::Project);
     // mixed + invalid glob skipped
     let r3 = DiskSkillRegistry::new(vec![
         skill_with_paths("rs", SkillSource::Bundled, vec!["**/*.rs".into()]),

--- a/src/skills/disk/types.rs
+++ b/src/skills/disk/types.rs
@@ -5,19 +5,19 @@ use std::fmt;
 
 /// Source of a skill in the discovery hierarchy.
 ///
-/// Lower variant index = higher priority (bundled overrides everything).
+/// Lower variant index = higher priority (project overrides everything).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SkillSource {
-    /// Built-in skills bundled with the framework.
-    Bundled = 0,
-    /// Skills from user-provided extra directories.
-    ExtraDirs = 1,
+    /// Project-local skills (highest priority).
+    Project = 0,
+    /// Agent-specific skills.
+    Agent = 1,
     /// Global skills shared across all agents.
     Global = 2,
-    /// Agent-specific skills.
-    Agent = 3,
-    /// Project-local skills.
-    Project = 4,
+    /// Skills from user-provided extra directories.
+    ExtraDirs = 3,
+    /// Built-in skills bundled with the framework (lowest priority).
+    Bundled = 4,
 }
 
 impl fmt::Display for SkillSource {
@@ -163,10 +163,10 @@ mod tests {
 
     #[test]
     fn test_skill_source_priority() {
-        assert!(SkillSource::Bundled < SkillSource::ExtraDirs);
-        assert!(SkillSource::ExtraDirs < SkillSource::Global);
-        assert!(SkillSource::Global < SkillSource::Agent);
-        assert!(SkillSource::Agent < SkillSource::Project);
+        assert!(SkillSource::Project < SkillSource::Agent);
+        assert!(SkillSource::Agent < SkillSource::Global);
+        assert!(SkillSource::Global < SkillSource::ExtraDirs);
+        assert!(SkillSource::ExtraDirs < SkillSource::Bundled);
     }
 
     #[test]


### PR DESCRIPTION
Fix SkillSource enum priority direction to align with design doc `docs/design/skills/README.md`.

The enum values were reversed: Bundled was 0 (highest) and Project was 4 (lowest), causing bundled skills to always override user-defined project skills. Now Project=0 (highest) and Bundled=4 (lowest), matching the design doc's intent.

Changes:
- Reverse SkillSource enum values in `src/skills/disk/types.rs`
- Adjust scan order in `loader.rs` to load from lowest to highest priority
- Fix doc comments in `registry.rs`
- Update test assertions in `registry_tests.rs`

Source: issue #739
Type: fix
