### PR TITLE
refactor: 删除版本快照相关死代码

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -246,7 +246,6 @@ impl Daemon {
     /// Build permission engine, loading templates from config_dir/templates/ if present.
     fn build_permission_engine(config_dir: &str) -> Arc<PermissionEngine> {
         let rule_set = RuleSet {
-            version: "1.0.0".to_string(),
             rules: Vec::new(),
             defaults: Defaults::default(),
             template_includes: Vec::new(),

--- a/src/daemon/unit_tests.rs
+++ b/src/daemon/unit_tests.rs
@@ -198,7 +198,6 @@ fn test_build_permission_engine_empty_dir() {
     assert!(!Arc::ptr_eq(
         &engine,
         &Arc::new(PermissionEngine::new(crate::permission::RuleSet {
-            version: "1.0.0".to_string(),
             rules: Vec::new(),
             defaults: crate::permission::Defaults::default(),
             template_includes: Vec::new(),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -67,7 +67,6 @@ pub async fn handle_skill(action: SkillAction) -> Result<()> {
     match action {
         SkillAction::List => {
             let rs = RuleSet {
-                version: "1.0.0".into(),
                 rules: vec![],
                 defaults: Defaults::default(),
                 template_includes: vec![],

--- a/src/permission/approval.rs
+++ b/src/permission/approval.rs
@@ -30,7 +30,6 @@
 //!         caller,
 //!         "Test operation".to_string(),
 //!         RiskLevel::Medium,
-//!         "1.0".to_string(),
 //!         "session_resume".to_string(),
 //!         Box::new(|result| {
 //!             println!("Result: {:?}", result);
@@ -82,8 +81,6 @@ pub struct PendingApproval {
     pub operation_desc: String,
     /// Risk level of the operation.
     pub risk_level: RiskLevel,
-    /// Rule set version at time of request.
-    pub rule_version: String,
     /// Session resume handle (opaque token for session continuation).
     pub session_resume: String,
     /// When this entry was created.
@@ -141,7 +138,6 @@ impl ApprovalQueue {
         caller: Caller,
         operation_desc: String,
         risk_level: RiskLevel,
-        rule_version: String,
         session_resume: String,
         callback: Callback,
     ) -> Result<RequestId, RejectReason> {
@@ -163,7 +159,6 @@ impl ApprovalQueue {
             operation_key,
             operation_desc,
             risk_level,
-            rule_version,
             session_resume,
             created_at: Utc::now(),
         };

--- a/src/permission/engine/engine_owner_tests.rs
+++ b/src/permission/engine/engine_owner_tests.rs
@@ -11,7 +11,6 @@ use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
 
 fn owner_evaluate(request_body: PermissionRequestBody) -> PermissionResponse {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Deny)
         .default_command(Effect::Deny)
         .default_network(Effect::Deny)
@@ -158,7 +157,6 @@ fn test_owner_no_matching_rule_default_deny() {
 fn test_non_owner_unaffected_by_owner_shortcut() {
     // Non-owner caller should still evaluate UserAndAgent rules normally
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Allow)
         .default_command(Effect::Allow)
         .default_network(Effect::Allow)
@@ -228,7 +226,6 @@ fn test_owner_shortcut_after_creator_rule() {
     // Creator rule should take priority over owner shortcut.
     // But if caller is both owner AND creator, they get Allowed via creator rule.
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .agent_creator("test-agent", "owner")
         .default_file(Effect::Deny)
         .build()

--- a/src/permission/engine/engine_risk.rs
+++ b/src/permission/engine/engine_risk.rs
@@ -261,7 +261,6 @@ mod tests {
     #[test]
     fn test_git_path_deny_risk_level_high() {
         let ruleset = RuleSetBuilder::new()
-            .version("1.0")
             .default_file(Effect::Deny)
             .default_command(Effect::Deny)
             .default_network(Effect::Deny)
@@ -289,7 +288,6 @@ mod tests {
     #[test]
     fn test_normal_path_deny_risk_level_low() {
         let ruleset = RuleSetBuilder::new()
-            .version("1.0")
             .default_file(Effect::Deny)
             .default_command(Effect::Deny)
             .default_network(Effect::Deny)

--- a/src/permission/engine/engine_tests.rs
+++ b/src/permission/engine/engine_tests.rs
@@ -50,7 +50,6 @@ fn test_glob_double_star() {
 
 fn make_engine() -> PermissionEngine {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Deny)
         .default_command(Effect::Deny)
         .default_network(Effect::Deny)
@@ -97,7 +96,6 @@ fn test_engine_allow_read() {
 #[test]
 fn test_engine_default_deny() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Deny)
         .default_command(Effect::Deny)
         .default_network(Effect::Deny)
@@ -113,7 +111,6 @@ fn test_engine_default_deny() {
 #[test]
 fn test_deny_takes_precedence() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Allow)
         .rule(
             RuleBuilder::new()
@@ -341,7 +338,6 @@ fn test_command_args_allowed() {
 fn test_tool_call_default_independent_from_file() {
     // tool_call defaults to Deny while file defaults to Allow
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Allow)
         .default_tool_call(Effect::Deny)
         .build()
@@ -374,7 +370,6 @@ fn test_tool_call_default_independent_from_file() {
 #[test]
 fn test_tool_call_default_allow() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_tool_call(Effect::Allow)
         .build()
         .unwrap();

--- a/src/permission/engine/engine_two_phase_tests.rs
+++ b/src/permission/engine/engine_two_phase_tests.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 /// Helper to build a minimal RuleSet with given defaults and rules.
 fn make_ruleset(default_file: Effect, rules: Vec<Rule>) -> PermissionEngine {
     let ruleset = RuleSet {
-        version: "1.0".to_string(),
         rules,
         defaults: super::engine_types::Defaults {
             file: default_file,

--- a/src/permission/engine/engine_types.rs
+++ b/src/permission/engine/engine_types.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 /// RuleSet parsed from permissions.json
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RuleSet {
-    pub version: String,
     #[serde(default)]
     pub rules: Vec<Rule>,
     #[serde(default)]

--- a/src/permission/rules/ruleset_builder.rs
+++ b/src/permission/rules/ruleset_builder.rs
@@ -3,7 +3,6 @@ use crate::permission::engine::{Defaults, Effect, Rule, RuleSet};
 /// Builder for constructing [`RuleSet`] instances.
 #[derive(Debug, Default)]
 pub struct RuleSetBuilder {
-    version: Option<String>,
     rules: Vec<Rule>,
     defaults: Defaults,
     template_includes: Vec<String>,
@@ -14,12 +13,6 @@ impl RuleSetBuilder {
     /// Create a new empty builder.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Set the version string.
-    pub fn version(mut self, version: impl Into<String>) -> Self {
-        self.version = Some(version.into());
-        self
     }
 
     /// Add a single rule.
@@ -78,12 +71,7 @@ impl RuleSetBuilder {
 
     /// Finalize and return the constructed [`RuleSet`].
     pub fn build(self) -> Result<RuleSet, RuleSetBuilderError> {
-        let version = self
-            .version
-            .ok_or(RuleSetBuilderError::MissingField("version"))?;
-
         Ok(RuleSet {
-            version,
             rules: self.rules,
             defaults: self.defaults,
             template_includes: self.template_includes,

--- a/src/permission/rules/tests.rs
+++ b/src/permission/rules/tests.rs
@@ -35,7 +35,6 @@ fn test_rule_builder_missing_name() {
 #[test]
 fn test_ruleset_builder() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("test-rule")
@@ -48,7 +47,6 @@ fn test_ruleset_builder() {
         .build()
         .unwrap();
 
-    assert_eq!(ruleset.version, "1.0");
     assert_eq!(ruleset.rules.len(), 1);
     assert_eq!(ruleset.defaults.file, Effect::Deny);
 }
@@ -138,24 +136,8 @@ fn test_validation_no_actions() {
 }
 
 #[test]
-fn test_validation_ruleset_empty_version() {
-    let ruleset = RuleSet {
-        version: String::new(),
-        rules: vec![],
-        defaults: Defaults::default(),
-        template_includes: vec![],
-        agent_creators: std::collections::HashMap::new(),
-    };
-    let errors = validation::validate_ruleset(&ruleset);
-    assert!(errors
-        .iter()
-        .any(|e| matches!(e, validation::RuleSetValidationError::EmptyVersion)));
-}
-
-#[test]
 fn test_validation_has_deny_rules() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("deny-rule")
@@ -178,7 +160,6 @@ fn test_validation_has_deny_rules() {
 #[test]
 fn test_validation_has_allow_rules() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("allow-rule")
@@ -199,29 +180,6 @@ fn test_validation_has_allow_rules() {
 }
 
 #[test]
-fn test_ruleset_builder_missing_version() {
-    let result = RuleSetBuilder::new()
-        .rule(
-            RuleBuilder::new()
-                .name("test-rule")
-                .subject_agent("test")
-                .allow()
-                .action(
-                    ActionBuilder::file("read", vec!["**".to_string()])
-                        .build()
-                        .unwrap(),
-                )
-                .build()
-                .unwrap(),
-        )
-        .build();
-    assert!(matches!(
-        result,
-        Err(RuleSetBuilderError::MissingField("version"))
-    ));
-}
-
-#[test]
 fn test_defaults_tool_call_is_deny() {
     let defaults = Defaults::default();
     assert_eq!(defaults.tool_call, Effect::Deny);
@@ -237,7 +195,6 @@ fn test_defaults_json_missing_tool_call() {
 #[test]
 fn test_ruleset_builder_default_tool_call() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_tool_call(Effect::Allow)
         .build()
         .unwrap();

--- a/src/permission/rules/validation.rs
+++ b/src/permission/rules/validation.rs
@@ -30,10 +30,6 @@ pub fn validate_rule(rule: &Rule) -> Vec<RuleValidationError> {
 pub fn validate_ruleset(ruleset: &RuleSet) -> Vec<RuleSetValidationError> {
     let mut errors = Vec::new();
 
-    if ruleset.version.is_empty() {
-        errors.push(RuleSetValidationError::EmptyVersion);
-    }
-
     for (idx, rule) in ruleset.rules.iter().enumerate() {
         let rule_errors = validate_rule(rule);
         for err in rule_errors {
@@ -73,8 +69,6 @@ pub enum RuleValidationError {
 /// A validation error for a RuleSet.
 #[derive(Debug, thiserror::Error)]
 pub enum RuleSetValidationError {
-    #[error("ruleset version cannot be empty")]
-    EmptyVersion,
     #[error("rule at index {index} is invalid: {error}")]
     InvalidRule {
         index: usize,

--- a/src/permission/sandbox/ipc.rs
+++ b/src/permission/sandbox/ipc.rs
@@ -267,7 +267,6 @@ mod tests {
     #[test]
     fn test_sandbox_request_reload_rules_serialization() {
         let rules = crate::permission::engine::RuleSet {
-            version: "1.0".to_string(),
             rules: vec![],
             defaults: Default::default(),
             template_includes: vec![],

--- a/src/permission/sandbox/tests.rs
+++ b/src/permission/sandbox/tests.rs
@@ -86,7 +86,6 @@ fn dummy_request() -> PermissionRequest {
 
 fn dummy_rules() -> RuleSet {
     RuleSet {
-        version: "1.0".to_string(),
         rules: vec![],
         defaults: Defaults::default(),
         template_includes: vec![],

--- a/src/permission/tests/approval_test.rs
+++ b/src/permission/tests/approval_test.rs
@@ -84,7 +84,6 @@ fn test_enqueue_success() {
         caller.clone(),
         "read file".to_string(),
         RiskLevel::Low,
-        "v1".to_string(),
         "resume-token-1".to_string(),
         Box::new(|_| {}),
     );
@@ -98,7 +97,6 @@ fn test_enqueue_success() {
     assert_eq!(pending.caller.agent, "test-agent");
     assert_eq!(pending.operation_desc, "read file");
     assert_eq!(pending.risk_level, RiskLevel::Low);
-    assert_eq!(pending.rule_version, "v1");
     assert_eq!(pending.session_resume, "resume-token-1");
 }
 
@@ -114,7 +112,6 @@ fn test_enqueue_reject_duplicate() {
             caller.clone(),
             "op1".to_string(),
             RiskLevel::Medium,
-            "v1".to_string(),
             "resume-1".to_string(),
             Box::new(|_| {}),
         )
@@ -126,7 +123,6 @@ fn test_enqueue_reject_duplicate() {
         caller.clone(),
         "op2".to_string(),
         RiskLevel::High,
-        "v2".to_string(),
         "resume-2".to_string(),
         Box::new(|_| {}),
     );
@@ -150,7 +146,6 @@ fn test_approve_triggers_approve_callback() {
             caller,
             "op".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume".to_string(),
             Box::new(|result| {
                 assert_eq!(result, ApproveOrDeny::Approve);
@@ -175,7 +170,6 @@ fn test_deny_triggers_deny_callback() {
             caller,
             "op".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume".to_string(),
             Box::new(|result| {
                 assert_eq!(result, ApproveOrDeny::Deny);
@@ -222,7 +216,6 @@ fn test_clear_triggers_deny_for_all_entries() {
                 caller.clone(),
                 format!("op-{}", i),
                 RiskLevel::Low,
-                format!("v{}", i),
                 format!("resume-{}", i),
                 Box::new(move |result| {
                     assert_eq!(result, ApproveOrDeny::Deny);
@@ -253,7 +246,6 @@ fn test_get_pending_returns_correct_pending_approval() {
             caller.clone(),
             "my operation".to_string(),
             RiskLevel::High,
-            "rule-v3".to_string(),
             "session-resume-abc".to_string(),
             Box::new(|_| {}),
         )
@@ -262,7 +254,6 @@ fn test_get_pending_returns_correct_pending_approval() {
     let pending = queue.get_pending(&id).unwrap();
     assert_eq!(pending.operation_desc, "my operation");
     assert_eq!(pending.risk_level, RiskLevel::High);
-    assert_eq!(pending.rule_version, "rule-v3");
     assert_eq!(pending.session_resume, "session-resume-abc");
     assert_eq!(pending.caller.agent, "test-agent");
 }
@@ -271,28 +262,6 @@ fn test_get_pending_returns_correct_pending_approval() {
 fn test_get_pending_returns_none_for_unknown_id() {
     let queue = ApprovalQueue::new();
     assert!(queue.get_pending("unknown").is_none());
-}
-
-#[test]
-fn test_rule_version_field_correctly_stored() {
-    let mut queue = ApprovalQueue::new();
-    let body = make_file_op("a");
-    let caller = dummy_caller();
-
-    let id = queue
-        .enqueue(
-            body,
-            caller,
-            "op".to_string(),
-            RiskLevel::Medium,
-            "v42".to_string(),
-            "resume".to_string(),
-            Box::new(|_| {}),
-        )
-        .unwrap();
-
-    let pending = queue.get_pending(&id).unwrap();
-    assert_eq!(pending.rule_version, "v42");
 }
 
 #[test]
@@ -311,7 +280,6 @@ fn test_callback_signature_send() {
         dummy_caller(),
         "op".to_string(),
         RiskLevel::Low,
-        "v1".to_string(),
         "resume".to_string(),
         Box::new(|_| {}),
     );
@@ -328,7 +296,6 @@ fn test_enqueue_different_bodies_not_duplicate() {
             caller.clone(),
             "op-a".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume-1".to_string(),
             Box::new(|_| {}),
         )
@@ -341,7 +308,6 @@ fn test_enqueue_different_bodies_not_duplicate() {
             caller.clone(),
             "op-b".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume-2".to_string(),
             Box::new(|_| {}),
         )
@@ -373,7 +339,6 @@ fn test_different_caller_same_body_not_duplicate() {
             caller1,
             "op1".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume-1".to_string(),
             Box::new(|_| {}),
         )
@@ -386,7 +351,6 @@ fn test_different_caller_same_body_not_duplicate() {
             caller2,
             "op2".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume-2".to_string(),
             Box::new(|_| {}),
         )
@@ -408,7 +372,6 @@ fn test_same_caller_same_body_is_duplicate() {
             caller.clone(),
             "op1".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume-1".to_string(),
             Box::new(|_| {}),
         )
@@ -420,7 +383,6 @@ fn test_same_caller_same_body_is_duplicate() {
         caller,
         "op2".to_string(),
         RiskLevel::Low,
-        "v1".to_string(),
         "resume-2".to_string(),
         Box::new(|_| {}),
     );
@@ -441,7 +403,6 @@ fn test_pending_approval_created_at_is_set() {
             dummy_caller(),
             "op".to_string(),
             RiskLevel::Low,
-            "v1".to_string(),
             "resume".to_string(),
             Box::new(|_| {}),
         )

--- a/src/permission/tests/creator_rule_test.rs
+++ b/src/permission/tests/creator_rule_test.rs
@@ -11,7 +11,6 @@ use crate::permission::rules::RuleSetBuilder;
 #[tokio::test]
 async fn test_creator_rule_short_circuit_caller_creator_id() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .agent_creator("dev-agent-01", "ou_john")
         .default_file(Effect::Deny)
         .build()
@@ -38,7 +37,6 @@ async fn test_creator_rule_short_circuit_caller_creator_id() {
 #[tokio::test]
 async fn test_creator_rule_short_circuit_agent_creators_map() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .agent_creator("dev-agent-01", "ou_john")
         .default_file(Effect::Deny)
         .build()
@@ -65,7 +63,6 @@ async fn test_creator_rule_short_circuit_agent_creators_map() {
 #[tokio::test]
 async fn test_creator_rule_not_matching_non_creator() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .agent_creator("dev-agent-01", "ou_john")
         .default_file(Effect::Deny)
         .build()
@@ -92,7 +89,6 @@ async fn test_creator_rule_not_matching_non_creator() {
 #[tokio::test]
 async fn test_creator_rule_priority_over_explicit_deny() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .agent_creator("dev-agent-01", "ou_john")
         .rule(
             crate::permission::rules::RuleBuilder::new()
@@ -128,7 +124,6 @@ async fn test_creator_rule_priority_over_explicit_deny() {
 #[tokio::test]
 async fn test_creator_rule_caller_creator_id_takes_precedence() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .agent_creator("dev-agent-01", "ou_john")
         .default_file(Effect::Deny)
         .build()

--- a/src/permission/tests/rule_evaluation_test.rs
+++ b/src/permission/tests/rule_evaluation_test.rs
@@ -11,7 +11,6 @@ use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
 #[tokio::test]
 async fn test_user_and_agent_rule_matching() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .rule(
             RuleBuilder::new()
                 .name("alice-read")
@@ -54,7 +53,6 @@ async fn test_user_and_agent_rule_matching() {
 #[tokio::test]
 async fn test_user_and_agent_rule_user_mismatch() {
     let ruleset = RuleSetBuilder::new()
-        .version("2.0")
         .rule(
             RuleBuilder::new()
                 .name("alice-read")
@@ -97,7 +95,6 @@ async fn test_user_and_agent_rule_user_mismatch() {
 #[tokio::test]
 async fn test_bare_request_uses_agent_only_matching() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("dev-agent-full")
@@ -128,7 +125,6 @@ async fn test_bare_request_uses_agent_only_matching() {
 #[tokio::test]
 async fn test_with_caller_request_still_matches_agent_only_rules() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("dev-agent-full")
@@ -166,7 +162,6 @@ async fn test_with_caller_request_still_matches_agent_only_rules() {
 #[tokio::test]
 async fn test_rule_priority_higher_evaluated_first() {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .rule(
             RuleBuilder::new()
                 .name("low-priority-allow")

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -231,7 +231,6 @@ mod tests {
         };
         use std::collections::HashMap;
         let rules = RuleSet {
-            version: "1".to_string(),
             rules: vec![Rule {
                 name: "deny-spawn".to_string(),
                 subject: Subject::AgentOnly {
@@ -279,7 +278,6 @@ mod tests {
         };
         use std::collections::HashMap;
         let rules = RuleSet {
-            version: "1".to_string(),
             rules: vec![Rule {
                 name: "parent-deny-spawn".to_string(),
                 subject: Subject::AgentOnly {

--- a/src/skills/builtin/file_ops_tests.rs
+++ b/src/skills/builtin/file_ops_tests.rs
@@ -14,7 +14,6 @@ use tempfile::TempDir;
 /// Build an engine that allows file_read and file_write for "test-agent"
 fn make_allowed_engine() -> Arc<crate::permission::PermissionEngine> {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Deny)
         .rule(
             RuleBuilder::new()
@@ -89,7 +88,6 @@ fn make_allowed_engine() -> Arc<crate::permission::PermissionEngine> {
 /// Build an engine that denies all file actions by default (no matching rules)
 fn make_denied_engine() -> Arc<crate::permission::PermissionEngine> {
     let ruleset = RuleSetBuilder::new()
-        .version("1.0")
         .default_file(Effect::Deny)
         .build()
         .unwrap();

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -111,7 +111,6 @@ mod extra_tests {
     fn make_engine() -> Arc<crate::permission::PermissionEngine> {
         use crate::permission::engine::engine_types::{Defaults, RuleSet};
         let rules = RuleSet {
-            version: "1".to_string(),
             rules: vec![],
             defaults: Defaults::default(),
             template_includes: vec![],

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -118,7 +118,6 @@ mod tests {
     fn make_engine_with_allow_rule() -> Arc<crate::permission::PermissionEngine> {
         use crate::permission::engine::engine_types::MatchType;
         let rules = RuleSet {
-            version: "1".to_string(),
             rules: vec![Rule {
                 name: "test-allow".to_string(),
                 subject: Subject::AgentOnly {

--- a/src/skills/builtin/tests.rs
+++ b/src/skills/builtin/tests.rs
@@ -18,7 +18,6 @@ async fn test_file_ops_read_requires_agent_id_when_engine_set() {
 
     // With engine, agent_id IS required
     let ruleset = crate::permission::RuleSet {
-        version: "1.0".to_string(),
         rules: vec![],
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
@@ -49,7 +48,6 @@ async fn test_file_ops_read_with_permission() {
         priority: 0,
     };
     let ruleset = crate::permission::RuleSet {
-        version: "1.0".to_string(),
         rules: vec![rule],
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
@@ -86,7 +84,6 @@ async fn test_file_ops_read_denied_without_permission() {
         priority: 0,
     };
     let ruleset = crate::permission::RuleSet {
-        version: "1.0".to_string(),
         rules: vec![rule],
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
@@ -116,7 +113,6 @@ async fn test_file_ops_exists_requires_agent_id_when_engine_set() {
     assert!(result.is_ok());
 
     let ruleset = crate::permission::RuleSet {
-        version: "1.0".to_string(),
         rules: vec![],
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
@@ -147,7 +143,6 @@ async fn test_file_ops_exists_with_permission() {
         priority: 0,
     };
     let ruleset = crate::permission::RuleSet {
-        version: "1.0".to_string(),
         rules: vec![rule],
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],

--- a/tests/integration_permission_tests.rs
+++ b/tests/integration_permission_tests.rs
@@ -18,7 +18,6 @@ use closeclaw::permission::rules::{RuleBuilder, RuleSetBuilder};
 /// Creates a ruleset that grants permissions to any agent (using wildcard patterns).
 fn make_test_ruleset() -> RuleSet {
     RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("allow-file-read")
@@ -165,7 +164,6 @@ async fn test_permission_engine_with_registered_agent() {
 async fn test_permission_user_and_agent_dual_key_matching() {
     // Build ruleset with dual-key subject
     let ruleset = RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("admin-full-access")
@@ -255,7 +253,6 @@ async fn test_permission_user_and_agent_dual_key_matching() {
 #[tokio::test]
 async fn test_permission_engine_reload_updates_rules() {
     let initial_rules = RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("initial-allow")
@@ -287,7 +284,6 @@ async fn test_permission_engine_reload_updates_rules() {
 
     // Reload with new rules (no rules, default deny)
     let new_rules = RuleSetBuilder::new()
-        .version("1.0.0")
         .default_file(Effect::Deny)
         .build()
         .unwrap();
@@ -349,7 +345,6 @@ async fn test_permission_engine_template_resolution() {
     );
 
     let ruleset = RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("developer-via-template")

--- a/tests/sandbox_integration_test.rs
+++ b/tests/sandbox_integration_test.rs
@@ -27,7 +27,6 @@ use closeclaw::permission::sandbox::{
 /// Creates a minimal permissive ruleset for testing.
 fn make_permissive_ruleset() -> RuleSet {
     RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("allow-all-file-read")


### PR DESCRIPTION
删除版本快照隔离机制相关死代码。Owner 确认不需要快照隔离，审批响应直接使用当前最新权限规则。

## 改动

- `RuleSet` 删除 `version` 字段
- `PendingApproval` 删除 `rule_version` 字段
- `enqueue()` 删除 `rule_version` 参数
- `RuleSetBuilder` 删除 `.version()` 方法
- `validation.rs` 删除 `EmptyVersion` 校验
- 22 个文件同步更新（测试、daemon、skills）

Source: issue #742
Type: refactor
