### PR TITLE
fix: generate_listing 添加 user_invocable 过滤

### DIFF
--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -120,7 +120,8 @@ impl DiskSkillRegistry {
     ///
     /// - Sorts by SkillSource priority (Project > Agent > Global > ExtraDirs > Bundled)
     /// - Within the same priority, sorts by name alphabetically
-    /// - Filters: only includes skills where `agent_id` is empty or matches the given agent_id
+    /// - Filters: only includes skills where `agent_id` is empty or matches the given agent_id,
+    ///   and `user_invocable` is true (skills with `user_invocable: false` are excluded)
     /// - Format: `- **{name}**: {description}` + optionally ` — {when_to_use}`
     /// - Returns empty string if no skills match
     pub fn generate_listing(&self, agent_id: Option<&str>) -> String {
@@ -128,8 +129,9 @@ impl DiskSkillRegistry {
             .skills
             .iter()
             .filter(|s| {
-                s.manifest.agent_id.is_empty()
-                    || agent_id.map_or(true, |id| s.manifest.agent_id == id)
+                s.manifest.user_invocable
+                    && (s.manifest.agent_id.is_empty()
+                        || agent_id.map_or(true, |id| s.manifest.agent_id == id))
             })
             .collect();
 
@@ -171,5 +173,5 @@ impl DiskSkillRegistry {
 }
 
 #[cfg(test)]
-#[path = "registry_tests.rs"]
+#[path = "registry_tests/mod.rs"]
 mod tests;

--- a/src/skills/disk/registry_tests/mod.rs
+++ b/src/skills/disk/registry_tests/mod.rs
@@ -3,6 +3,8 @@ use super::DiskSkill;
 use super::DiskSkillRegistry;
 use std::path::{Path, PathBuf};
 
+mod user_invocable;
+
 fn skill(name: &str, source: SkillSource) -> DiskSkill {
     DiskSkill {
         source,
@@ -16,7 +18,7 @@ fn skill(name: &str, source: SkillSource) -> DiskSkill {
             agent_id: String::new(),
             effort: SkillEffort::default(),
             paths: vec![],
-            user_invocable: false,
+            user_invocable: true,
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
@@ -29,7 +31,6 @@ fn test_new_and_len() {
     assert_eq!(r.len(), 1);
     assert!(!r.is_empty());
 }
-
 #[test]
 fn test_empty_registry() {
     let r = DiskSkillRegistry::new(vec![]);
@@ -39,7 +40,6 @@ fn test_empty_registry() {
     assert!(r.list().is_empty());
     assert!(r.filter_by_source(SkillSource::Bundled).is_empty());
 }
-
 #[test]
 fn test_get() {
     let r = DiskSkillRegistry::new(vec![
@@ -49,14 +49,12 @@ fn test_get() {
     assert_eq!(r.get("foo").unwrap().manifest.name, "foo");
     assert!(r.get("baz").is_none());
 }
-
 #[test]
 fn test_contains() {
     let r = DiskSkillRegistry::new(vec![skill("x", SkillSource::Global)]);
     assert!(r.contains("x"));
     assert!(!r.contains("y"));
 }
-
 #[test]
 fn test_list() {
     let r = DiskSkillRegistry::new(vec![
@@ -65,7 +63,6 @@ fn test_list() {
     ]);
     assert_eq!(r.list(), vec!["z", "a"]);
 }
-
 #[test]
 fn test_filter_by_source() {
     let r = DiskSkillRegistry::new(vec![
@@ -91,7 +88,7 @@ fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskS
             agent_id: agent_id.into(),
             effort: SkillEffort::default(),
             paths: vec![],
-            user_invocable: false,
+            user_invocable: true,
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
@@ -111,7 +108,7 @@ fn skill_with_when_to_use(name: &str, source: SkillSource, when_to_use: &str) ->
             agent_id: String::new(),
             effort: SkillEffort::default(),
             paths: vec![],
-            user_invocable: false,
+            user_invocable: true,
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
@@ -124,7 +121,6 @@ fn test_generate_listing_empty() {
     assert_eq!(r.generate_listing(None), "");
     assert_eq!(r.generate_listing(Some("agent1")), "");
 }
-
 #[test]
 fn test_generate_listing_single() {
     let r = DiskSkillRegistry::new(vec![skill("foo", SkillSource::Bundled)]);
@@ -132,7 +128,6 @@ fn test_generate_listing_single() {
     assert!(listing.contains("**foo**"));
     assert!(listing.contains("desc of foo"));
 }
-
 #[test]
 fn test_generate_listing_sorted_by_priority_and_name() {
     let r = DiskSkillRegistry::new(vec![
@@ -152,37 +147,32 @@ fn test_generate_listing_sorted_by_priority_and_name() {
     // Within Agent, alphabetical order
     assert!(listing.find("**a_agent**").unwrap() < listing.find("**z_agent**").unwrap());
 }
-
 #[test]
 fn test_generate_listing_agent_id_filter() {
     let r = DiskSkillRegistry::new(vec![
         skill_with_agent_id("skill_a", SkillSource::Agent, "agent1"),
         skill_with_agent_id("skill_b", SkillSource::Agent, "agent2"),
-        skill_with_agent_id("skill_c", SkillSource::Agent, ""), // no restriction
+        skill_with_agent_id("skill_c", SkillSource::Agent, ""),
     ]);
     // None = no filter, all 3 returned
     assert_eq!(r.generate_listing(None).lines().count(), 3);
-    // agent1 filter = skill_a (matches) + skill_c (no restriction)
     let listing = r.generate_listing(Some("agent1"));
     assert!(listing.contains("**skill_a**"));
     assert!(listing.contains("**skill_c**"));
     assert!(!listing.contains("**skill_b**"));
 }
-
 #[test]
 fn test_generate_listing_when_to_use() {
     let r = DiskSkillRegistry::new(vec![
         skill_with_when_to_use("foo", SkillSource::Bundled, "Use when you need foo"),
-        skill("bar", SkillSource::Bundled), // no when_to_use
+        skill("bar", SkillSource::Bundled),
     ]);
     let listing = r.generate_listing(None);
     assert!(listing.contains(" — Use when you need foo"));
-    // bar should NOT have the dash separator
-    let bar_line = listing.lines().find(|l| l.contains("**bar**")).unwrap();
-    assert!(!bar_line.contains(" — "));
+    assert!(!listing
+        .lines()
+        .any(|l| l.contains("**bar**") && l.contains(" — ")));
 }
-
-// --- helpers for conditional/ paths tests ---
 
 fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> DiskSkill {
     DiskSkill {
@@ -197,14 +187,12 @@ fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> Disk
             agent_id: String::new(),
             effort: SkillEffort::default(),
             paths,
-            user_invocable: false,
+            user_invocable: true,
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
     }
 }
-
-// --- conditional_skills tests ---
 
 #[test]
 fn test_conditional_skills_returns_skills_with_paths() {
@@ -220,7 +208,6 @@ fn test_conditional_skills_returns_skills_with_paths() {
     assert!(names.contains(&"toml-tools"));
     assert!(!names.contains(&"no-cond"));
 }
-
 #[test]
 fn test_conditional_skills_returns_empty_when_no_paths_defined() {
     let r = DiskSkillRegistry::new(vec![
@@ -229,14 +216,11 @@ fn test_conditional_skills_returns_empty_when_no_paths_defined() {
     ]);
     assert!(r.conditional_skills().is_empty());
 }
-
 #[test]
 fn test_conditional_skills_returns_empty_for_empty_registry() {
     let r = DiskSkillRegistry::new(vec![]);
     assert!(r.conditional_skills().is_empty());
 }
-
-// --- matches_paths tests ---
 
 #[test]
 fn test_matches_paths_positive_match() {
@@ -247,7 +231,6 @@ fn test_matches_paths_positive_match() {
     )]);
     assert!(r.matches_paths("rs-skill", &[Path::new("src/main.rs")]));
 }
-
 #[test]
 fn test_matches_paths_negative_match() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -257,7 +240,6 @@ fn test_matches_paths_negative_match() {
     )]);
     assert!(!r.matches_paths("rs-skill", &[Path::new("src/main.ts")]));
 }
-
 #[test]
 fn test_matches_paths_multi_pattern_any_wins() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -269,7 +251,6 @@ fn test_matches_paths_multi_pattern_any_wins() {
     assert!(r.matches_paths("multi", &[Path::new("Cargo.toml")]));
     assert!(!r.matches_paths("multi", &[Path::new("src/main.ts")]));
 }
-
 #[test]
 fn test_matches_paths_empty_paths_arg_returns_false() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -279,7 +260,6 @@ fn test_matches_paths_empty_paths_arg_returns_false() {
     )]);
     assert!(!r.matches_paths("rs-skill", &[]));
 }
-
 #[test]
 fn test_matches_paths_nonexistent_skill_returns_false() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -289,13 +269,11 @@ fn test_matches_paths_nonexistent_skill_returns_false() {
     )]);
     assert!(!r.matches_paths("no-such-skill", &[Path::new("src/main.rs")]));
 }
-
 #[test]
 fn test_matches_paths_skill_without_paths_returns_false() {
     let r = DiskSkillRegistry::new(vec![skill("plain", SkillSource::Bundled)]);
     assert!(!r.matches_paths("plain", &[Path::new("src/main.rs")]));
 }
-
 #[test]
 fn test_matches_paths_multiple_input_paths_any_match() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -303,19 +281,15 @@ fn test_matches_paths_multiple_input_paths_any_match() {
         SkillSource::Bundled,
         vec!["**/*.md".into()],
     )]);
-    // One of the input paths matches
     assert!(r.matches_paths(
         "multi-skill",
-        &[Path::new("src/main.rs"), Path::new("docs/README.md")]
+        &[Path::new("src/main.rs"), Path::new("docs/README.md")],
     ));
-    // None match
     assert!(!r.matches_paths(
         "multi-skill",
-        &[Path::new("src/main.rs"), Path::new("src/lib.rs")]
+        &[Path::new("src/main.rs"), Path::new("src/lib.rs")],
     ));
 }
-
-// --- generate_listing conditional annotation tests ---
 
 #[test]
 fn test_generate_listing_conditional_annotation_shown_for_paths() {
@@ -327,7 +301,6 @@ fn test_generate_listing_conditional_annotation_shown_for_paths() {
     let listing = r.generate_listing(None);
     assert!(listing.contains("⚡ auto-activates on: **/*.rs"));
 }
-
 #[test]
 fn test_generate_listing_conditional_annotation_multi_patterns() {
     let r = DiskSkillRegistry::new(vec![skill_with_paths(
@@ -338,7 +311,6 @@ fn test_generate_listing_conditional_annotation_multi_patterns() {
     let listing = r.generate_listing(None);
     assert!(listing.contains("⚡ auto-activates on: **/*.rs, **/*.toml"));
 }
-
 #[test]
 fn test_generate_listing_conditional_annotation_not_shown_without_paths() {
     let r = DiskSkillRegistry::new(vec![skill("plain", SkillSource::Bundled)]);
@@ -346,7 +318,6 @@ fn test_generate_listing_conditional_annotation_not_shown_without_paths() {
     assert!(!listing.contains("⚡"));
     assert!(!listing.contains("auto-activates"));
 }
-
 #[test]
 fn test_generate_listing_conditional_annotation_mixed() {
     let r = DiskSkillRegistry::new(vec![
@@ -358,18 +329,17 @@ fn test_generate_listing_conditional_annotation_mixed() {
     let listing = r.generate_listing(None);
     let lines: Vec<&str> = listing.lines().collect();
     assert_eq!(lines.len(), 4, "all 4 skills should appear");
-    // cond has annotation, cond2 has annotation
-    let cond_line = lines.iter().find(|l| l.contains("**cond**")).unwrap();
-    assert!(cond_line.contains("⚡ auto-activates on: **/*.rs"));
-    let cond2_line = lines.iter().find(|l| l.contains("**cond2**")).unwrap();
-    assert!(cond2_line.contains("⚡ auto-activates on: **/*.md"));
-    // plain1 and plain2 no annotation
-    let plain1_line = lines.iter().find(|l| l.contains("**plain1**")).unwrap();
-    assert!(!plain1_line.contains("⚡"));
-    let plain2_line = lines.iter().find(|l| l.contains("**plain2**")).unwrap();
-    assert!(!plain2_line.contains("⚡"));
+    let cond = lines.iter().find(|l| l.contains("**cond**")).unwrap();
+    assert!(cond.contains("⚡ auto-activates on: **/*.rs"));
+    let cond2 = lines.iter().find(|l| l.contains("**cond2**")).unwrap();
+    assert!(cond2.contains("⚡ auto-activates on: **/*.md"));
+    assert!(!lines
+        .iter()
+        .any(|l| l.contains("**plain1**") && l.contains("⚡")));
+    assert!(!lines
+        .iter()
+        .any(|l| l.contains("**plain2**") && l.contains("⚡")));
 }
-
 #[test]
 fn test_generate_listing_conditional_with_agent_id_filter() {
     let mut s1 = skill_with_paths("agent1-cond", SkillSource::Agent, vec!["**/*.rs".into()]);
@@ -377,34 +347,25 @@ fn test_generate_listing_conditional_with_agent_id_filter() {
     let s2 = skill_with_paths("any-cond", SkillSource::Agent, vec!["**/*.md".into()]);
     let mut s3 = skill_with_paths("agent2-cond", SkillSource::Agent, vec!["**/*.toml".into()]);
     s3.manifest.agent_id = "agent2".into();
-    let s4 = skill("plain", SkillSource::Agent);
-
-    let r = DiskSkillRegistry::new(vec![s1, s2, s3, s4]);
-
-    // With agent1 filter: agent1-cond (matches agent1) + any-cond (no restriction) + plain (no restriction)
+    let r = DiskSkillRegistry::new(vec![s1, s2, s3, skill("plain", SkillSource::Agent)]);
     let listing = r.generate_listing(Some("agent1"));
     assert!(listing.contains("**agent1-cond**"));
     assert!(listing.contains("**any-cond**"));
     assert!(listing.contains("**plain**"));
     assert!(!listing.contains("**agent2-cond**"));
-    // agent1-cond has annotation
-    let agent1_line = listing
+    let a1 = listing
         .lines()
         .find(|l| l.contains("**agent1-cond**"))
         .unwrap();
-    assert!(agent1_line.contains("⚡ auto-activates on: **/*.rs"));
-    // any-cond has annotation
-    let any_line = listing
+    assert!(a1.contains("⚡ auto-activates on: **/*.rs"));
+    let a2 = listing
         .lines()
         .find(|l| l.contains("**any-cond**"))
         .unwrap();
-    assert!(any_line.contains("⚡ auto-activates on: **/*.md"));
-    // plain has no annotation
-    let plain_line = listing.lines().find(|l| l.contains("**plain**")).unwrap();
-    assert!(!plain_line.contains("⚡"));
+    assert!(a2.contains("⚡ auto-activates on: **/*.md"));
+    let pl = listing.lines().find(|l| l.contains("**plain**")).unwrap();
+    assert!(!pl.contains("⚡"));
 }
-
-// --- find_matching_skills tests ---
 
 #[test]
 fn test_find_matching_skills_basic_and_edge_cases() {
@@ -414,16 +375,15 @@ fn test_find_matching_skills_basic_and_edge_cases() {
         vec!["**/*.rs".into()],
     )];
     let r = DiskSkillRegistry::new(rs);
-    assert!(r.find_matching_skills(&[]).is_empty()); // empty input
-    assert!(r.find_matching_skills(&[Path::new("a.ts")]).is_empty()); // no match
+    assert!(r.find_matching_skills(&[]).is_empty());
+    assert!(r.find_matching_skills(&[Path::new("a.ts")]).is_empty());
     assert!(DiskSkillRegistry::new(vec![])
         .find_matching_skills(&[Path::new("a.rs")])
-        .is_empty()); // empty reg
-    assert!(
-        DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)])
-            .find_matching_skills(&[Path::new("a.rs")])
-            .is_empty()
-    ); // no cond
+        .is_empty());
+    let no_cond = DiskSkillRegistry::new(vec![skill("a", SkillSource::Bundled)]);
+    assert!(no_cond
+        .find_matching_skills(&[Path::new("a.rs")])
+        .is_empty());
     let r2 = DiskSkillRegistry::new(vec![
         skill_with_paths("rs", SkillSource::Bundled, vec!["**/*.rs".into()]),
         skill_with_paths("md", SkillSource::Bundled, vec!["**/*.md".into()]),
@@ -433,7 +393,6 @@ fn test_find_matching_skills_basic_and_edge_cases() {
     assert_eq!(m[0].manifest.name, "rs");
     assert!(r2.find_matching_skills(&[Path::new("a.ts")]).is_empty());
 }
-
 #[test]
 fn test_find_matching_skills_priority_dedup_mixed() {
     let r = DiskSkillRegistry::new(vec![
@@ -442,12 +401,8 @@ fn test_find_matching_skills_priority_dedup_mixed() {
         skill_with_paths("mid", SkillSource::Global, vec!["**/*.rs".into()]),
     ]);
     let m = r.find_matching_skills(&[Path::new("a.rs")]);
-    assert_eq!(
-        m.iter()
-            .map(|s| s.manifest.name.as_str())
-            .collect::<Vec<_>>(),
-        ["low", "mid", "high"]
-    );
+    let names: Vec<&str> = m.iter().map(|s| s.manifest.name.as_str()).collect();
+    assert_eq!(names, ["low", "mid", "high"]);
     // dedup: same name, higher priority wins (Project > Bundled)
     let r2 = DiskSkillRegistry::new(vec![
         skill_with_paths("x", SkillSource::Project, vec!["**/*.rs".into()]),
@@ -456,7 +411,6 @@ fn test_find_matching_skills_priority_dedup_mixed() {
     let m2 = r2.find_matching_skills(&[Path::new("a.rs")]);
     assert_eq!(m2.len(), 1);
     assert_eq!(m2[0].source, SkillSource::Project);
-    // mixed + invalid glob skipped
     let r3 = DiskSkillRegistry::new(vec![
         skill_with_paths("rs", SkillSource::Bundled, vec!["**/*.rs".into()]),
         skill_with_paths("md", SkillSource::Bundled, vec!["**/*.md".into()]),
@@ -464,10 +418,6 @@ fn test_find_matching_skills_priority_dedup_mixed() {
         skill("plain", SkillSource::Bundled),
     ]);
     let m3 = r3.find_matching_skills(&[Path::new("a.rs"), Path::new("a.md")]);
-    assert_eq!(
-        m3.iter()
-            .map(|s| s.manifest.name.as_str())
-            .collect::<Vec<_>>(),
-        ["rs", "md"]
-    );
+    let names3: Vec<&str> = m3.iter().map(|s| s.manifest.name.as_str()).collect();
+    assert_eq!(names3, ["rs", "md"]);
 }

--- a/src/skills/disk/registry_tests/user_invocable.rs
+++ b/src/skills/disk/registry_tests/user_invocable.rs
@@ -1,0 +1,175 @@
+use super::super::super::types::{SkillContext, SkillEffort, SkillManifest, SkillSource};
+use super::super::super::DiskSkill;
+use super::super::super::DiskSkillRegistry;
+use std::path::Path;
+use std::path::PathBuf;
+
+// --- user_invocable filtering tests ---
+
+/// Helper: create a skill with configurable `user_invocable`.
+fn skill_with_invocable(name: &str, source: SkillSource, user_invocable: bool) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+fn skill(name: &str, source: SkillSource) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: true,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: agent_id.into(),
+            effort: SkillEffort::default(),
+            paths: vec![],
+            user_invocable: true,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> DiskSkill {
+    DiskSkill {
+        source,
+        manifest: SkillManifest {
+            name: name.into(),
+            description: format!("desc of {}", name),
+            allowed_tools: vec![],
+            when_to_use: String::new(),
+            context: SkillContext::default(),
+            agent: String::new(),
+            agent_id: String::new(),
+            effort: SkillEffort::default(),
+            paths,
+            user_invocable: true,
+        },
+        readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
+        skill_dir: PathBuf::from(format!("/skills/{}", name)),
+    }
+}
+
+#[test]
+fn test_generate_listing_excludes_user_invocable_false() {
+    let r = DiskSkillRegistry::new(vec![skill_with_invocable(
+        "hidden",
+        SkillSource::Bundled,
+        false,
+    )]);
+    let listing = r.generate_listing(None);
+    assert!(
+        listing.is_empty(),
+        "user_invocable: false skill must not appear in listing"
+    );
+}
+#[test]
+fn test_generate_listing_includes_user_invocable_true() {
+    let r = DiskSkillRegistry::new(vec![skill("visible", SkillSource::Bundled)]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains("**visible**"));
+    assert!(listing.contains("desc of visible"));
+}
+#[test]
+fn test_generate_listing_mixed_user_invocable() {
+    let r = DiskSkillRegistry::new(vec![
+        skill("visible1", SkillSource::Bundled),
+        skill_with_invocable("hidden1", SkillSource::Bundled, false),
+        skill("visible2", SkillSource::Global),
+        skill_with_invocable("hidden2", SkillSource::Agent, false),
+    ]);
+    let listing = r.generate_listing(None);
+    assert!(listing.contains("**visible1**"));
+    assert!(listing.contains("**visible2**"));
+    assert!(!listing.contains("**hidden1**"));
+    assert!(!listing.contains("**hidden2**"));
+    assert_eq!(
+        listing.lines().count(),
+        2,
+        "only user_invocable: true skills should appear"
+    );
+}
+#[test]
+fn test_user_invocable_false_still_gettable() {
+    let r = DiskSkillRegistry::new(vec![skill_with_invocable(
+        "hidden",
+        SkillSource::Bundled,
+        false,
+    )]);
+    let found = r.get("hidden");
+    assert!(
+        found.is_some(),
+        "get() must still find user_invocable: false skills"
+    );
+    assert_eq!(found.unwrap().manifest.name, "hidden");
+    assert!(!found.unwrap().manifest.user_invocable);
+}
+#[test]
+fn test_user_invocable_false_with_agent_id_cross_filter() {
+    let mut hidden = skill_with_agent_id("hidden_agent", SkillSource::Agent, "agent1");
+    hidden.manifest.user_invocable = false;
+    let r = DiskSkillRegistry::new(vec![
+        hidden,
+        skill_with_agent_id("visible_agent", SkillSource::Agent, "agent1"),
+        skill("always_visible", SkillSource::Bundled),
+    ]);
+    let listing = r.generate_listing(Some("agent1"));
+    assert!(listing.contains("**visible_agent**"));
+    assert!(listing.contains("**always_visible**"));
+    assert!(!listing.contains("**hidden_agent**"));
+    let listing_all = r.generate_listing(None);
+    assert!(listing_all.contains("**visible_agent**"));
+    assert!(listing_all.contains("**always_visible**"));
+    assert!(!listing_all.contains("**hidden_agent**"));
+}
+#[test]
+fn test_user_invocable_false_still_findable_by_paths() {
+    let mut hidden = skill_with_paths("hidden_rs", SkillSource::Bundled, vec!["**/*.rs".into()]);
+    hidden.manifest.user_invocable = false;
+    let r = DiskSkillRegistry::new(vec![
+        hidden,
+        skill_with_paths("visible_rs", SkillSource::Global, vec!["**/*.rs".into()]),
+    ]);
+    let matched = r.find_matching_skills(&[Path::new("src/main.rs")]);
+    assert_eq!(matched.len(), 2, "both skills should be matched by paths");
+    let names: Vec<&str> = matched.iter().map(|s| s.manifest.name.as_str()).collect();
+    assert!(names.contains(&"hidden_rs"));
+    assert!(names.contains(&"visible_rs"));
+}

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -21,7 +21,7 @@ fn make_test_skill(name: &str, description: &str, when_to_use: &str, agent_id: &
             agent_id: agent_id.into(),
             effort: SkillEffort::default(),
             paths: vec![],
-            user_invocable: false,
+            user_invocable: true,
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),


### PR DESCRIPTION
fix: generate_listing 缺少 user_invocable 过滤，未声明 user_invocable 的 skill 不应出现在 listing 中

Source: issue #748
Type: fix
