### PR TITLE
fix: 移除 integration_tests 中不存在的 RuleSetBuilder::version 调用

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -28,7 +28,6 @@ use closeclaw::skills::Skill;
 /// having to worry about UUID vs name mismatches.
 fn make_test_ruleset() -> RuleSet {
     RuleSetBuilder::new()
-        .version("1.0.0")
         .rule(
             RuleBuilder::new()
                 .name("allow-file-read")


### PR DESCRIPTION
fix: 移除 integration_tests 中不存在的 RuleSetBuilder::version 调用

PR #755 的 CI 被 master 上的 pre-existing 问题阻塞：commit 0021b76 删除了 RuleSetBuilder::version 方法，但 integration_tests.rs 仍在调用。本 PR 修复该问题以解除 CI 阻塞。

Source: issue #748
Type: fix
