### PR TITLE
feat: workspace 路径强制授权

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -251,7 +251,7 @@ impl Daemon {
             template_includes: Vec::new(),
             agent_creators: std::collections::HashMap::new(),
         };
-        let mut engine = PermissionEngine::new(rule_set);
+        let mut engine = PermissionEngine::new(rule_set, PathBuf::from(config_dir));
         let templates_dir = std::path::Path::new(config_dir).join("templates");
         if templates_dir.exists() {
             if let Ok(templates) =

--- a/src/daemon/unit_tests.rs
+++ b/src/daemon/unit_tests.rs
@@ -197,12 +197,14 @@ fn test_build_permission_engine_empty_dir() {
     let engine = Daemon::build_permission_engine(dir.path().to_str().unwrap());
     assert!(!Arc::ptr_eq(
         &engine,
-        &Arc::new(PermissionEngine::new(crate::permission::RuleSet {
-            rules: Vec::new(),
-            defaults: crate::permission::Defaults::default(),
-            template_includes: Vec::new(),
-            agent_creators: std::collections::HashMap::new(),
-        }))
+        &Arc::new(PermissionEngine::new_with_default_data_root(
+            crate::permission::RuleSet {
+                rules: Vec::new(),
+                defaults: crate::permission::Defaults::default(),
+                template_includes: Vec::new(),
+                agent_creators: std::collections::HashMap::new(),
+            }
+        ))
     ));
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -72,7 +72,7 @@ pub async fn handle_skill(action: SkillAction) -> Result<()> {
                 template_includes: vec![],
                 agent_creators: std::collections::HashMap::new(),
             };
-            let eng = Arc::new(PermissionEngine::new(rs));
+            let eng = Arc::new(PermissionEngine::new_with_default_data_root(rs));
             let config = ScanConfig::default();
             let disk_reg = init_disk_skills(&config);
             if disk_reg.is_empty() {

--- a/src/permission/engine/engine_check.rs
+++ b/src/permission/engine/engine_check.rs
@@ -1,0 +1,61 @@
+//! Simplified permission check — convenience method for quick agent action evaluation.
+
+use super::engine_eval::PermissionEngine;
+use super::engine_risk::assess_risk_level;
+use super::engine_types::{PermissionRequest, PermissionRequestBody, PermissionResponse};
+
+impl PermissionEngine {
+    /// Simplified permission check — evaluates if `agent_id` may
+    /// perform `action`.
+    pub fn check(&self, agent_id: &str, action: &str) -> PermissionResponse {
+        let body = match action {
+            "exec" => PermissionRequestBody::CommandExec {
+                agent: agent_id.to_string(),
+                cmd: "*".to_string(),
+                args: Vec::new(),
+            },
+            "file_read" => PermissionRequestBody::FileOp {
+                agent: agent_id.to_string(),
+                path: "*".to_string(),
+                op: "read".to_string(),
+            },
+            "file_write" => PermissionRequestBody::FileOp {
+                agent: agent_id.to_string(),
+                path: "*".to_string(),
+                op: "write".to_string(),
+            },
+            "network" => PermissionRequestBody::NetOp {
+                agent: agent_id.to_string(),
+                host: "*".to_string(),
+                port: 0,
+            },
+            "spawn" => PermissionRequestBody::InterAgentMsg {
+                from: agent_id.to_string(),
+                to: "*".to_string(),
+            },
+            "tool_call" => PermissionRequestBody::ToolCall {
+                agent: agent_id.to_string(),
+                skill: "*".to_string(),
+                method: "*".to_string(),
+            },
+            "config_write" => PermissionRequestBody::ConfigWrite {
+                agent: agent_id.to_string(),
+                config_file: "*".to_string(),
+            },
+            _ => {
+                let body = PermissionRequestBody::ToolCall {
+                    agent: agent_id.to_string(),
+                    skill: action.to_string(),
+                    method: "unknown".to_string(),
+                };
+                return PermissionResponse::Denied {
+                    reason: format!("unknown action: {}", action),
+                    rule: "<check>".to_string(),
+                    risk_level: assess_risk_level(&body),
+                };
+            }
+        };
+
+        self.evaluate(PermissionRequest::Bare(body), None)
+    }
+}

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -4,10 +4,12 @@ use super::engine_helpers::{generate_token, get_agent_deny_subjects, resolve_tem
 use super::engine_matching::action_matches_request;
 use super::engine_risk::assess_risk_level;
 use super::engine_types::{
-    Action, Defaults, Effect, PermissionRequest, PermissionRequestBody, PermissionResponse, Rule,
-    RuleSet, Subject,
+    Defaults, Effect, PermissionRequest, PermissionRequestBody, PermissionResponse, Rule, RuleSet,
+    Subject,
 };
+use super::engine_workspace;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tracing::info;
 
 /// Permission Engine - evaluates access requests against rules
@@ -20,21 +22,29 @@ pub struct PermissionEngine {
     user_agent_rule_index: HashMap<String, Vec<usize>>,
     /// Loaded templates: name -> Template
     templates: HashMap<String, crate::permission::templates::Template>,
+    /// Data root directory for workspace path resolution
+    data_root: PathBuf,
 }
 
 // --- Construction & index management ---
 
 impl PermissionEngine {
     /// Create a new PermissionEngine from a RuleSet
-    pub fn new(rules: RuleSet) -> Self {
+    pub fn new(rules: RuleSet, data_root: PathBuf) -> Self {
         let mut engine = Self {
             rules: rules.clone(),
             agent_rule_index: HashMap::new(),
             user_agent_rule_index: HashMap::new(),
             templates: HashMap::new(),
+            data_root,
         };
         engine.rebuild_indices_with_rules(&rules);
         engine
+    }
+
+    /// Create a new PermissionEngine with a default data root (for tests)
+    pub fn new_with_default_data_root(rules: RuleSet) -> Self {
+        Self::new(rules, PathBuf::from("/tmp/closeclaw_test"))
     }
 
     /// Rebuild the lookup indices from a given ruleset (sync helper).
@@ -74,63 +84,6 @@ impl PermissionEngine {
     }
 }
 
-// --- Simplified check ---
-
-impl PermissionEngine {
-    /// Simplified permission check — evaluates if `agent_id` may perform `action`.
-    pub fn check(&self, agent_id: &str, action: &str) -> PermissionResponse {
-        let body = match action {
-            "exec" => PermissionRequestBody::CommandExec {
-                agent: agent_id.to_string(),
-                cmd: "*".to_string(),
-                args: Vec::new(),
-            },
-            "file_read" => PermissionRequestBody::FileOp {
-                agent: agent_id.to_string(),
-                path: "*".to_string(),
-                op: "read".to_string(),
-            },
-            "file_write" => PermissionRequestBody::FileOp {
-                agent: agent_id.to_string(),
-                path: "*".to_string(),
-                op: "write".to_string(),
-            },
-            "network" => PermissionRequestBody::NetOp {
-                agent: agent_id.to_string(),
-                host: "*".to_string(),
-                port: 0,
-            },
-            "spawn" => PermissionRequestBody::InterAgentMsg {
-                from: agent_id.to_string(),
-                to: "*".to_string(),
-            },
-            "tool_call" => PermissionRequestBody::ToolCall {
-                agent: agent_id.to_string(),
-                skill: "*".to_string(),
-                method: "*".to_string(),
-            },
-            "config_write" => PermissionRequestBody::ConfigWrite {
-                agent: agent_id.to_string(),
-                config_file: "*".to_string(),
-            },
-            _ => {
-                let body = PermissionRequestBody::ToolCall {
-                    agent: agent_id.to_string(),
-                    skill: action.to_string(),
-                    method: "unknown".to_string(),
-                };
-                return PermissionResponse::Denied {
-                    reason: format!("unknown action: {}", action),
-                    rule: "<check>".to_string(),
-                    risk_level: assess_risk_level(&body),
-                };
-            }
-        };
-
-        self.evaluate(PermissionRequest::Bare(body), None)
-    }
-}
-
 // --- Evaluation & helpers ---
 
 impl PermissionEngine {
@@ -142,6 +95,28 @@ impl PermissionEngine {
     ) -> PermissionResponse {
         let caller = request.caller();
         let agent_id = caller.agent.clone();
+
+        // Step 0.5: Workspace forced authorization
+        if let PermissionRequestBody::FileOp { agent, path, op } = request.body() {
+            if (op == "read" || op == "write")
+                && engine_workspace::is_workspace_path(
+                    &self.data_root,
+                    agent,
+                    &caller.user_id,
+                    path,
+                )
+            {
+                info!(
+                    agent = %agent_id,
+                    result = "allowed",
+                    reason = "workspace_forced_auth",
+                    "permission check completed"
+                );
+                return PermissionResponse::Allowed {
+                    token: generate_token(),
+                };
+            }
+        }
 
         info!(
             agent = %agent_id,
@@ -255,7 +230,12 @@ impl PermissionEngine {
 
         if let Some(creator_id) = effective_creator_id {
             if caller.user_id == creator_id {
-                info!(agent = %agent_id, result = "allowed", reason = "creator_rule", "permission check completed");
+                info!(
+                    agent = %agent_id,
+                    result = "allowed",
+                    reason = "creator_rule",
+                    "permission check completed"
+                );
                 return Some(PermissionResponse::Allowed {
                     token: generate_token(),
                 });
@@ -375,7 +355,12 @@ impl PermissionEngine {
         }
 
         if matching_rule_name.is_some() {
-            info!(agent = %caller.agent, result = "allowed", reason = "matched_rule", "permission check completed");
+            info!(
+                agent = %caller.agent,
+                result = "allowed",
+                reason = "matched_rule",
+                "permission check completed"
+            );
             return Some(PermissionResponse::Allowed {
                 token: generate_token(),
             });

--- a/src/permission/engine/engine_owner_tests.rs
+++ b/src/permission/engine/engine_owner_tests.rs
@@ -58,7 +58,7 @@ fn owner_evaluate(request_body: PermissionRequestBody) -> PermissionResponse {
         )
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let request = PermissionRequest::WithCaller {
         caller: Caller {
             user_id: "owner".to_string(),
@@ -178,7 +178,7 @@ fn test_non_owner_unaffected_by_owner_shortcut() {
         )
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     // alice should be denied by UserAndAgent deny rule
     let alice_req = PermissionRequest::WithCaller {
@@ -230,7 +230,7 @@ fn test_owner_shortcut_after_creator_rule() {
         .default_file(Effect::Deny)
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let request = PermissionRequest::WithCaller {
         caller: Caller {
             user_id: "owner".to_string(),

--- a/src/permission/engine/engine_risk.rs
+++ b/src/permission/engine/engine_risk.rs
@@ -16,19 +16,14 @@ use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
 
 /// Risk level for permission requests.
 /// Used to annotate denied responses with severity information.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RiskLevel {
+    #[default]
     Low,
     Medium,
     High,
     Critical,
-}
-
-impl Default for RiskLevel {
-    fn default() -> Self {
-        RiskLevel::Low
-    }
 }
 
 /// A risk pattern with matching logic and associated risk level.
@@ -268,7 +263,7 @@ mod tests {
             .default_config(Effect::Deny)
             .build()
             .unwrap();
-        let engine = PermissionEngine::new(ruleset);
+        let engine = PermissionEngine::new_with_default_data_root(ruleset);
         let resp = engine.evaluate(
             PermissionRequest::Bare(PermissionRequestBody::FileOp {
                 agent: "test-agent".to_string(),
@@ -295,7 +290,7 @@ mod tests {
             .default_config(Effect::Deny)
             .build()
             .unwrap();
-        let engine = PermissionEngine::new(ruleset);
+        let engine = PermissionEngine::new_with_default_data_root(ruleset);
         let resp = engine.evaluate(
             PermissionRequest::Bare(PermissionRequestBody::FileOp {
                 agent: "test-agent".to_string(),

--- a/src/permission/engine/engine_tests.rs
+++ b/src/permission/engine/engine_tests.rs
@@ -83,7 +83,7 @@ fn make_engine() -> PermissionEngine {
         )
         .build()
         .unwrap();
-    PermissionEngine::new(ruleset)
+    PermissionEngine::new_with_default_data_root(ruleset)
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn test_engine_default_deny() {
         .default_config(Effect::Deny)
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let resp = engine.check("unknown-agent", "file_read");
     matches!(resp, PermissionResponse::Denied { .. });
 }
@@ -127,7 +127,7 @@ fn test_deny_takes_precedence() {
         )
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let resp = engine.evaluate(
         PermissionRequest::Bare(PermissionRequestBody::FileOp {
             agent: "test-agent".to_string(),
@@ -342,7 +342,7 @@ fn test_tool_call_default_independent_from_file() {
         .default_tool_call(Effect::Deny)
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     // file op should be allowed (default Allow)
     let file_resp = engine.evaluate(
@@ -373,7 +373,7 @@ fn test_tool_call_default_allow() {
         .default_tool_call(Effect::Allow)
         .build()
         .unwrap();
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let resp = engine.check("unknown-agent", "tool_call");
     matches!(resp, PermissionResponse::Allowed { .. });
 }

--- a/src/permission/engine/engine_two_phase_tests.rs
+++ b/src/permission/engine/engine_two_phase_tests.rs
@@ -24,7 +24,7 @@ fn make_ruleset(default_file: Effect, rules: Vec<Rule>) -> PermissionEngine {
         template_includes: vec![],
         agent_creators: HashMap::new(),
     };
-    PermissionEngine::new(ruleset)
+    PermissionEngine::new_with_default_data_root(ruleset)
 }
 
 /// Helper to make a FileOp request.

--- a/src/permission/engine/engine_workspace.rs
+++ b/src/permission/engine/engine_workspace.rs
@@ -1,0 +1,47 @@
+//! Permission Engine - Workspace path authorization.
+
+use std::path::Path;
+
+/// Check if a path belongs to the agent-user's workspace.
+///
+/// Uses syntax-level normalization (handles `..` and `.`) without
+/// touching the filesystem. Performs boundary-aware prefix matching
+/// to prevent `test-user` from matching `test-user2`.
+pub(super) fn is_workspace_path(
+    data_root: &Path,
+    agent_id: &str,
+    user_id: &str,
+    path: &str,
+) -> bool {
+    let prefix = data_root.join("workspaces").join(agent_id).join(user_id);
+    let norm_prefix = normalize_path(prefix.to_str().unwrap_or(""));
+    let norm_path = normalize_path(path);
+    norm_path == norm_prefix || norm_path.starts_with(&format!("{}/", norm_prefix))
+}
+
+/// Normalize a path by resolving `.` and `..` components syntactically.
+pub(super) fn normalize_path(path: &str) -> String {
+    let mut components: Vec<&str> = Vec::new();
+    for component in Path::new(path).components() {
+        match component {
+            std::path::Component::ParentDir => {
+                components.pop();
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(c) => {
+                components.push(c.to_str().unwrap_or(""));
+            }
+            _ => {}
+        }
+    }
+    let mut normalized = String::new();
+    for comp in &components {
+        normalized.push('/');
+        normalized.push_str(comp);
+    }
+    if normalized.is_empty() {
+        "/".to_string()
+    } else {
+        normalized
+    }
+}

--- a/src/permission/engine/engine_workspace_tests.rs
+++ b/src/permission/engine/engine_workspace_tests.rs
@@ -1,0 +1,202 @@
+use super::engine_eval::PermissionEngine;
+use super::engine_types::{
+    Caller, Effect, PermissionRequest, PermissionRequestBody, PermissionResponse,
+};
+use crate::permission::actions::ActionBuilder;
+use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
+
+fn make_file_request(agent: &str, user_id: &str, path: &str, op: &str) -> PermissionRequest {
+    PermissionRequest::WithCaller {
+        caller: Caller {
+            user_id: user_id.to_string(),
+            agent: agent.to_string(),
+            creator_id: String::new(),
+        },
+        request: PermissionRequestBody::FileOp {
+            agent: agent.to_string(),
+            path: path.to_string(),
+            op: op.to_string(),
+        },
+    }
+}
+
+fn make_exec_request(agent: &str) -> PermissionRequest {
+    PermissionRequest::WithCaller {
+        caller: Caller {
+            user_id: "test-user".to_string(),
+            agent: agent.to_string(),
+            creator_id: String::new(),
+        },
+        request: PermissionRequestBody::CommandExec {
+            agent: agent.to_string(),
+            cmd: "ls".to_string(),
+            args: vec![],
+        },
+    }
+}
+
+fn make_engine() -> PermissionEngine {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Deny)
+        .default_command(Effect::Deny)
+        .default_network(Effect::Deny)
+        .default_inter_agent(Effect::Deny)
+        .default_config(Effect::Deny)
+        .rule(
+            RuleBuilder::new()
+                .name("allow-read")
+                .subject_agent("test-agent")
+                .allow()
+                .action(
+                    ActionBuilder::file("read", vec!["/data/**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("deny-write")
+                .subject_agent("test-agent")
+                .deny()
+                .action(
+                    ActionBuilder::file("write", vec!["/etc/**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    PermissionEngine::new_with_default_data_root(ruleset)
+}
+
+#[test]
+fn test_workspace_read_allowed() {
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/test-agent/test-user/file.txt",
+        "read",
+    );
+    let result = engine.evaluate(request, None);
+    assert!(matches!(result, PermissionResponse::Allowed { .. }));
+}
+
+#[test]
+fn test_workspace_write_allowed() {
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/test-agent/test-user/file.txt",
+        "write",
+    );
+    let result = engine.evaluate(request, None);
+    assert!(matches!(result, PermissionResponse::Allowed { .. }));
+}
+
+#[test]
+fn test_workspace_outside_read_denied() {
+    let engine = make_engine();
+    let request = make_file_request("test-agent", "test-user", "/etc/passwd", "read");
+    let result = engine.evaluate(request, None);
+    // Outside workspace → normal rule evaluation → no matching rule → default Deny
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}
+
+#[test]
+fn test_workspace_outside_write_denied() {
+    let engine = make_engine();
+    let request = make_file_request("test-agent", "test-user", "/etc/passwd", "write");
+    let result = engine.evaluate(request, None);
+    // Outside workspace → normal rule evaluation → deny-write rule → Denied
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}
+
+#[test]
+fn test_workspace_exec_not_auto_authorized() {
+    let engine = make_engine();
+    let request = make_exec_request("test-agent");
+    let result = engine.evaluate(request, None);
+    // exec does not trigger workspace auto-authorization; falls to default Deny
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}
+
+#[test]
+fn test_workspace_path_traversal_blocked() {
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/test-agent/test-user/../../../etc/passwd",
+        "read",
+    );
+    let result = engine.evaluate(request, None);
+    // Normalized to /etc/passwd, outside workspace → falls to default Deny
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}
+
+#[test]
+fn test_workspace_normalize_path_in_workspace() {
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/test-agent/test-user/foo/../bar/file.txt",
+        "read",
+    );
+    let result = engine.evaluate(request, None);
+    assert!(matches!(result, PermissionResponse::Allowed { .. }));
+}
+
+#[test]
+fn test_workspace_normalize_path_outside_workspace() {
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/other-agent/test-user/file.txt",
+        "read",
+    );
+    let result = engine.evaluate(request, None);
+    // agent is "test-agent" but path belongs to "other-agent" → outside workspace
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}
+
+#[test]
+fn test_workspace_owner_allowed() {
+    let engine = make_engine();
+    let request = PermissionRequest::WithCaller {
+        caller: Caller {
+            user_id: "owner".to_string(),
+            agent: "test-agent".to_string(),
+            creator_id: String::new(),
+        },
+        request: PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/tmp/closeclaw_test/workspaces/test-agent/owner/file.txt".to_string(),
+            op: "read".to_string(),
+        },
+    };
+    let result = engine.evaluate(request, None);
+    assert!(matches!(result, PermissionResponse::Allowed { .. }));
+}
+
+#[test]
+fn test_workspace_user_prefix_boundary() {
+    // Security fix: test-user must NOT match test-user2
+    let engine = make_engine();
+    let request = make_file_request(
+        "test-agent",
+        "test-user",
+        "/tmp/closeclaw_test/workspaces/test-agent/test-user2/file.txt",
+        "read",
+    );
+    let result = engine.evaluate(request, None);
+    // test-user2 is NOT the same as test-user → outside workspace
+    assert!(matches!(result, PermissionResponse::Denied { .. }));
+}

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! Runs as a separate OS process, evaluates access rules for agents.
 
+pub mod engine_check;
 pub mod engine_eval;
 pub mod engine_helpers;
 pub mod engine_matching;
 pub mod engine_risk;
 pub mod engine_types;
+pub mod engine_workspace;
 
 pub use engine_eval::PermissionEngine;
 pub use engine_matching::{action_matches_request, glob_match};
@@ -18,6 +20,9 @@ pub use engine_types::{
 
 #[cfg(test)]
 mod engine_tests;
+
+#[cfg(test)]
+mod engine_workspace_tests;
 
 #[cfg(test)]
 mod engine_owner_tests;

--- a/src/permission/sandbox/mod.rs
+++ b/src/permission/sandbox/mod.rs
@@ -281,7 +281,7 @@ impl Drop for Sandbox {
 /// Called when the binary is started with `SANDBOX_ENGINE=1` env var.
 /// Creates a [`PermissionEngine`], binds the IPC socket, and serves requests.
 pub async fn run_engine_subprocess(ipc_path: PathBuf, rules: RuleSet) -> anyhow::Result<()> {
-    let engine = Arc::new(PermissionEngine::new(rules));
+    let engine = Arc::new(PermissionEngine::new_with_default_data_root(rules));
     let channel = IpcChannel::new(ipc_path);
 
     // Apply security policy as early as possible.

--- a/src/permission/tests/creator_rule_test.rs
+++ b/src/permission/tests/creator_rule_test.rs
@@ -16,7 +16,7 @@ async fn test_creator_rule_short_circuit_caller_creator_id() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -42,7 +42,7 @@ async fn test_creator_rule_short_circuit_agent_creators_map() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -68,7 +68,7 @@ async fn test_creator_rule_not_matching_non_creator() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -103,7 +103,7 @@ async fn test_creator_rule_priority_over_explicit_deny() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -129,7 +129,7 @@ async fn test_creator_rule_caller_creator_id_takes_precedence() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {

--- a/src/permission/tests/rule_evaluation_test.rs
+++ b/src/permission/tests/rule_evaluation_test.rs
@@ -32,7 +32,7 @@ async fn test_user_and_agent_rule_matching() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -74,7 +74,7 @@ async fn test_user_and_agent_rule_user_mismatch() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -111,7 +111,7 @@ async fn test_bare_request_uses_agent_only_matching() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::Bare(PermissionRequestBody::FileOp {
         agent: "dev-agent-01".to_string(),
@@ -141,7 +141,7 @@ async fn test_with_caller_request_still_matches_agent_only_rules() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     let request = PermissionRequest::WithCaller {
         caller: Caller {
@@ -192,7 +192,7 @@ async fn test_rule_priority_higher_evaluated_first() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
     let request = PermissionRequest::Bare(PermissionRequestBody::FileOp {
         agent: "test-agent".to_string(),
         path: "/any/path.txt".to_string(),

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -249,7 +249,7 @@ mod tests {
             template_includes: vec![],
             agent_creators: HashMap::new(),
         };
-        Arc::new(crate::permission::PermissionEngine::new(rules))
+        Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(rules))
     }
 
     #[tokio::test]
@@ -296,7 +296,8 @@ mod tests {
             template_includes: vec![],
             agent_creators: HashMap::new(),
         };
-        let engine = Arc::new(crate::permission::PermissionEngine::new(rules));
+        let engine =
+            Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(rules));
         let skill = SkillDiscoverySkill::with_engine(engine);
         // child-agent is spawned by parent-agent, child-agent tries to install a skill
         let result = skill

--- a/src/skills/builtin/file_ops_tests.rs
+++ b/src/skills/builtin/file_ops_tests.rs
@@ -82,7 +82,7 @@ fn make_allowed_engine() -> Arc<crate::permission::PermissionEngine> {
         )
         .build()
         .unwrap();
-    Arc::new(crate::permission::PermissionEngine::new(ruleset))
+    Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset))
 }
 
 /// Build an engine that denies all file actions by default (no matching rules)
@@ -91,7 +91,7 @@ fn make_denied_engine() -> Arc<crate::permission::PermissionEngine> {
         .default_file(Effect::Deny)
         .build()
         .unwrap();
-    Arc::new(crate::permission::PermissionEngine::new(ruleset))
+    Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset))
 }
 
 // -----------------------------------------------------------------

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -116,7 +116,7 @@ mod extra_tests {
             template_includes: vec![],
             agent_creators: std::collections::HashMap::new(),
         };
-        Arc::new(crate::permission::PermissionEngine::new(rules))
+        Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(rules))
     }
 
     #[test]

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -136,7 +136,7 @@ mod tests {
             template_includes: vec![],
             agent_creators: HashMap::new(),
         };
-        Arc::new(crate::permission::PermissionEngine::new(rules))
+        Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(rules))
     }
 
     #[test]

--- a/src/skills/builtin/tests.rs
+++ b/src/skills/builtin/tests.rs
@@ -23,7 +23,7 @@ async fn test_file_ops_read_requires_agent_id_when_engine_set() {
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
     };
-    let engine = Arc::new(crate::permission::PermissionEngine::new(ruleset));
+    let engine = Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset));
     let skill_with = FileOpsSkill::with_engine(engine);
     let result = skill_with
         .execute("read", serde_json::json!({"path": "Cargo.toml"}))
@@ -53,7 +53,7 @@ async fn test_file_ops_read_with_permission() {
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
     };
-    let engine = Arc::new(crate::permission::PermissionEngine::new(ruleset));
+    let engine = Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset));
     let skill = FileOpsSkill::with_engine(engine);
     let result = skill
         .execute(
@@ -89,7 +89,7 @@ async fn test_file_ops_read_denied_without_permission() {
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
     };
-    let engine = Arc::new(crate::permission::PermissionEngine::new(ruleset));
+    let engine = Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset));
     let skill = FileOpsSkill::with_engine(engine);
     let result = skill
         .execute(
@@ -118,7 +118,7 @@ async fn test_file_ops_exists_requires_agent_id_when_engine_set() {
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
     };
-    let engine = Arc::new(crate::permission::PermissionEngine::new(ruleset));
+    let engine = Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset));
     let skill_with = FileOpsSkill::with_engine(engine);
     let result = skill_with
         .execute("exists", serde_json::json!({"path": "Cargo.toml"}))
@@ -148,7 +148,7 @@ async fn test_file_ops_exists_with_permission() {
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
     };
-    let engine = Arc::new(crate::permission::PermissionEngine::new(ruleset));
+    let engine = Arc::new(crate::permission::PermissionEngine::new_with_default_data_root(ruleset));
     let skill = FileOpsSkill::with_engine(engine);
     let result = skill
         .execute(

--- a/tests/integration_permission_tests.rs
+++ b/tests/integration_permission_tests.rs
@@ -106,7 +106,7 @@ fn make_test_ruleset() -> RuleSet {
 async fn test_permission_engine_with_registered_agent() {
     let registry: SharedAgentRegistry = create_registry(30);
     let rules = make_test_ruleset();
-    let engine = PermissionEngine::new(rules);
+    let engine = PermissionEngine::new_with_default_data_root(rules);
 
     // Register an agent (ID will be UUID)
     let agent = registry
@@ -193,7 +193,7 @@ async fn test_permission_user_and_agent_dual_key_matching() {
         .build()
         .unwrap();
 
-    let engine = PermissionEngine::new(ruleset);
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
 
     // Admin user with any agent should get full access (including exec)
     let response = engine.evaluate(
@@ -269,7 +269,7 @@ async fn test_permission_engine_reload_updates_rules() {
         .build()
         .unwrap();
 
-    let mut engine = PermissionEngine::new(initial_rules);
+    let mut engine = PermissionEngine::new_with_default_data_root(initial_rules);
 
     // Initial: should allow
     let response = engine.evaluate(
@@ -362,7 +362,7 @@ async fn test_permission_engine_template_resolution() {
         .build()
         .unwrap();
 
-    let mut engine = PermissionEngine::new(ruleset);
+    let mut engine = PermissionEngine::new_with_default_data_root(ruleset);
     engine.load_templates(templates);
 
     // Test file read via template-resolved rule

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -398,7 +398,7 @@ async fn test_skill_loading_and_execution_chain() {
 #[tokio::test]
 async fn test_skill_with_permission_engine_integration() {
     let rules = make_test_ruleset();
-    let engine = Arc::new(PermissionEngine::new(rules));
+    let engine = Arc::new(PermissionEngine::new_with_default_data_root(rules));
 
     // Create permission skill with engine reference
     let perm_skill = closeclaw::skills::builtin::PermissionSkill::with_engine(engine.clone());


### PR DESCRIPTION
feat: workspace 路径强制授权 — Agent 自动获得自身 workspace 读写权限

## 变更内容

- `PermissionEngine` 新增 `data_root: PathBuf` 字段，`new()` 签名变更
- 新增 `is_workspace_path()` + `normalize_path()` 路径归一化逻辑
- `evaluate()` 开头（Creator 规则之前）新增 workspace 放行检查：FileOp + read/write + 路径匹配 → Allowed
- 路径归一化防止 `../` 穿越，前缀匹配带 `{prefix}/` 分隔符边界
- 提取 `engine_workspace.rs`（路径检查）、`engine_check.rs`（简化检查）降低文件行数
- 9 个新单元测试覆盖所有 workspace 检查分支

## 关联

Closes #754

Source: issue #754
Type: feat
