### PR TITLE
fix: clear section cache in clear_all_prompts to fix flaky test

### DIFF
--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -253,6 +253,7 @@ mod tests {
         set_override_prompt(None);
         set_agent_prompt(None);
         set_custom_prompt(None);
+        invalidate_all_sections();
     }
 
     #[test]


### PR DESCRIPTION
## 问题
CI run 26641151484 在 master 上失败：`test_build_append_section_appended` 断言 `result.contains("base")` 失败。

## 根因
`clear_all_prompts()` 清除了全局 prompt 变量，但未清除 section 缓存。`render_section` 对 cacheable section（如 RoleSection）优先返回缓存内容，导致测试拿到的是之前测试缓存的旧数据。

## 修复
在 `clear_all_prompts()` 中添加 `invalidate_all_sections()` 调用。

Fixes CI failure on master.