### PR TITLE
fix: ApprovalQueue 高危操作白名单禁止

### DIFF
--- a/src/permission/approval.rs
+++ b/src/permission/approval.rs
@@ -7,9 +7,12 @@
 //! - Deduplication is based on `OperationKey` (SHA256 of caller + `PermissionRequestBody` JSON).
 //! - Callbacks are triggered on approve/deny/clear operations.
 //!
-//! # Example
+//! # Examples
+//!
+//! ## Single-use approval (`Once` mode)
+//!
 //! ```
-//! use closeclaw::permission::approval::{ApprovalQueue, ApproveOrDeny};
+//! use closeclaw::permission::approval::{ApprovalQueue, ApprovalMode};
 //! use closeclaw::permission::engine::engine_types::{Caller, PermissionRequestBody};
 //! use closeclaw::permission::engine::engine_risk::RiskLevel;
 //!
@@ -36,6 +39,94 @@
 //!         }),
 //!     )
 //!     .expect("enqueue succeeded");
+//!
+//! // Approve with single-use mode
+//! let approved = queue
+//!     .approve(&request_id, ApprovalMode::Once)
+//!     .expect("approval succeeded");
+//! assert!(approved);
+//! ```
+//!
+//! ## Whitelist approval (`WithWhitelist` mode)
+//!
+//! Low and Medium risk operations can be approved with whitelist mode,
+//! which allows future auto-approval of the same operation.
+//! High and critical risk operations are rejected.
+//!
+//! ```
+//! use closeclaw::permission::approval::{ApprovalQueue, ApprovalMode};
+//! use closeclaw::permission::engine::engine_types::{Caller, PermissionRequestBody};
+//! use closeclaw::permission::engine::engine_risk::RiskLevel;
+//!
+//! let mut queue = ApprovalQueue::new();
+//! let request = PermissionRequestBody::ToolCall {
+//!     agent: "test".to_string(),
+//!     skill: "test_skill".to_string(),
+//!     method: "test_method".to_string(),
+//! };
+//! let caller = Caller {
+//!     user_id: "user_123".to_string(),
+//!     agent: "agent_001".to_string(),
+//!     creator_id: "creator_001".to_string(),
+//! };
+//! let request_id = queue
+//!     .enqueue(
+//!         request,
+//!         caller,
+//!         "Test operation".to_string(),
+//!         RiskLevel::Low,
+//!         "session_resume".to_string(),
+//!         Box::new(|result| {
+//!             println!("Result: {:?}", result);
+//!         }),
+//!     )
+//!     .expect("enqueue succeeded");
+//!
+//! // Approve with whitelist mode (succeeds for Low risk)
+//! let approved = queue
+//!     .approve(&request_id, ApprovalMode::WithWhitelist)
+//!     .expect("approval succeeded");
+//! assert!(approved);
+//! ```
+//!
+//! High-risk operations are rejected with [`RejectWhitelistReason::HighRisk`]:
+//!
+//! ```
+//! use closeclaw::permission::approval::{ApprovalQueue, ApprovalMode, RejectWhitelistReason};
+//! use closeclaw::permission::engine::engine_types::{Caller, PermissionRequestBody};
+//! use closeclaw::permission::engine::engine_risk::RiskLevel;
+//!
+//! let mut queue = ApprovalQueue::new();
+//! let request = PermissionRequestBody::ToolCall {
+//!     agent: "test".to_string(),
+//!     skill: "test_skill".to_string(),
+//!     method: "test_method".to_string(),
+//! };
+//! let caller = Caller {
+//!     user_id: "user_456".to_string(),
+//!     agent: "agent_002".to_string(),
+//!     creator_id: "creator_002".to_string(),
+//! };
+//! let request_id = queue
+//!     .enqueue(
+//!         request,
+//!         caller,
+//!         "Dangerous operation".to_string(),
+//!         RiskLevel::High,
+//!         "session_resume".to_string(),
+//!         Box::new(|result| {
+//!             println!("Result: {:?}", result);
+//!         }),
+//!     )
+//!     .expect("enqueue succeeded");
+//!
+//! // Reject: high-risk cannot be whitelisted
+//! let err = queue
+//!     .approve(&request_id, ApprovalMode::WithWhitelist)
+//!     .unwrap_err();
+//! assert_eq!(err, RejectWhitelistReason::HighRisk);
+//! // The request is still pending (not resolved)
+//! assert!(queue.get_pending(&request_id).is_some());
 //! ```
 
 use chrono::{DateTime, Utc};
@@ -67,6 +158,30 @@ pub enum RejectReason {
 
 /// Callback invoked when an approval decision is made.
 pub type Callback = Box<dyn FnOnce(ApproveOrDeny) + Send>;
+
+/// Approval mode that controls whether the operation may be whitelisted.
+///
+/// - `Once`: approve the operation one time only (existing behavior).
+/// - `WithWhitelist`: approve and add to the whitelist for future auto-approval.
+///   High-risk and critical-risk operations are rejected in this mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalMode {
+    /// Single-use approval — the operation is allowed once.
+    Once,
+    /// Approval with whitelist — the operation is allowed and added to the whitelist.
+    /// Only available for Low and Medium risk operations.
+    WithWhitelist,
+}
+
+/// Reason a whitelist approval was rejected.
+///
+/// This is returned when `ApprovalMode::WithWhitelist` is used for a
+/// high-risk or critical-risk operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectWhitelistReason {
+    /// The operation's risk level is too high for whitelisting.
+    HighRisk,
+}
 
 /// A pending approval entry.
 #[derive(Debug, Clone)]
@@ -171,9 +286,33 @@ impl ApprovalQueue {
     /// Approve a pending request by its ID.
     ///
     /// Triggers the callback with `ApproveOrDeny::Approve` and removes the entry.
-    /// Returns `true` if the request existed and was approved, `false` otherwise.
-    pub fn approve(&mut self, request_id: &str) -> bool {
-        self.do_resolve(request_id, ApproveOrDeny::Approve)
+    ///
+    /// # `mode` parameter
+    ///
+    /// - [`ApprovalMode::Once`]: approve the operation one time only.
+    ///   Returns `Ok(true)` if the request existed and was approved,
+    ///   `Ok(false)` if the request was not found.
+    /// - [`ApprovalMode::WithWhitelist`]: approve **and** add to the whitelist.
+    ///   Returns `Err(RejectWhitelistReason::HighRisk)` when the request's
+    ///   `risk_level` is `High` or `Critical` — such operations may not be
+    ///   whitelisted.  For `Low` / `Medium` risks the behaviour is identical
+    ///   to `Once` mode.
+    pub fn approve(
+        &mut self,
+        request_id: &str,
+        mode: ApprovalMode,
+    ) -> Result<bool, RejectWhitelistReason> {
+        if mode == ApprovalMode::WithWhitelist {
+            if let Some(pending) = self.pending.get(request_id) {
+                match pending.risk_level {
+                    RiskLevel::High | RiskLevel::Critical => {
+                        return Err(RejectWhitelistReason::HighRisk);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(self.do_resolve(request_id, ApproveOrDeny::Approve))
     }
 
     /// Deny a pending request by its ID.

--- a/src/permission/tests/approval_mode_test.rs
+++ b/src/permission/tests/approval_mode_test.rs
@@ -1,0 +1,213 @@
+//!
+//! ApprovalMode + RiskLevel boundary tests
+//!
+
+use crate::permission::approval::{
+    ApprovalMode, ApprovalQueue, ApproveOrDeny, RejectWhitelistReason,
+};
+use crate::permission::engine::engine_risk::RiskLevel;
+use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
+
+fn dummy_caller() -> Caller {
+    Caller {
+        user_id: "test-user".to_string(),
+        agent: "test-agent".to_string(),
+        creator_id: "test-creator".to_string(),
+    }
+}
+
+fn make_file_op(body_variant: &str) -> PermissionRequestBody {
+    match body_variant {
+        "a" => crate::permission::engine::engine_types::PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/a.txt".to_string(),
+            op: "read".to_string(),
+        },
+        "b" => crate::permission::engine::engine_types::PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/b.txt".to_string(),
+            op: "read".to_string(),
+        },
+        "c" => crate::permission::engine::engine_types::PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/repo/c.txt".to_string(),
+            op: "read".to_string(),
+        },
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_approve_whitelist_low_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "low risk op".to_string(),
+            RiskLevel::Low,
+            "resume-1".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Approve);
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::WithWhitelist);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_approve_whitelist_medium_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "medium risk op".to_string(),
+            RiskLevel::Medium,
+            "resume-1".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Approve);
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::WithWhitelist);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_approve_whitelist_high_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "high risk op".to_string(),
+            RiskLevel::High,
+            "resume-1".to_string(),
+            Box::new(|_| {
+                panic!("callback should not be invoked on WithWhitelist reject");
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::WithWhitelist);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), RejectWhitelistReason::HighRisk);
+    // Request should still be pending — not resolved
+    assert_eq!(queue.pending_count(), 1);
+    assert!(queue.get_pending(&id).is_some());
+}
+
+#[test]
+fn test_approve_whitelist_critical_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "critical risk op".to_string(),
+            RiskLevel::Critical,
+            "resume-1".to_string(),
+            Box::new(|_| {
+                panic!("callback should not be invoked on WithWhitelist reject");
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::WithWhitelist);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), RejectWhitelistReason::HighRisk);
+    assert_eq!(queue.pending_count(), 1);
+    assert!(queue.get_pending(&id).is_some());
+}
+
+#[test]
+fn test_approve_once_high_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "high risk op".to_string(),
+            RiskLevel::High,
+            "resume-1".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Approve);
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::Once);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_approve_once_critical_risk() {
+    let mut queue = ApprovalQueue::new();
+    let id = queue
+        .enqueue(
+            make_file_op("a"),
+            dummy_caller(),
+            "critical risk op".to_string(),
+            RiskLevel::Critical,
+            "resume-1".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Approve);
+            }),
+        )
+        .unwrap();
+
+    let result = queue.approve(&id, ApprovalMode::Once);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+}
+
+#[test]
+fn test_approve_nonexistent_request_id() {
+    let mut queue = ApprovalQueue::new();
+    let result = queue.approve("nonexistent-id", ApprovalMode::WithWhitelist);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), false);
+}
+
+#[test]
+fn test_deny_behavior_unchanged() {
+    let mut queue = ApprovalQueue::new();
+    let body = make_file_op("a");
+    let caller = dummy_caller();
+
+    let id = queue
+        .enqueue(
+            body,
+            caller,
+            "op".to_string(),
+            RiskLevel::Low,
+            "resume".to_string(),
+            Box::new(|result| {
+                assert_eq!(result, ApproveOrDeny::Deny);
+            }),
+        )
+        .unwrap();
+
+    // deny does not accept ApprovalMode — behavior unchanged
+    assert!(queue.deny(&id));
+    assert_eq!(queue.pending_count(), 0);
+    assert!(queue.get_pending(&id).is_none());
+
+    // deny on nonexistent id still returns false
+    assert!(!queue.deny("nonexistent-id"));
+}

--- a/src/permission/tests/approval_test.rs
+++ b/src/permission/tests/approval_test.rs
@@ -2,7 +2,9 @@
 //! ApprovalQueue unit tests
 //!
 
-use crate::permission::approval::{ApprovalQueue, ApproveOrDeny, RejectReason};
+use crate::permission::approval::{
+    ApprovalMode, ApprovalQueue, ApproveOrDeny, RejectReason, RejectWhitelistReason,
+};
 use crate::permission::engine::engine_risk::RiskLevel;
 use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
 
@@ -153,7 +155,7 @@ fn test_approve_triggers_approve_callback() {
         )
         .unwrap();
 
-    assert!(queue.approve(&id));
+    assert!(queue.approve(&id, ApprovalMode::Once).unwrap());
     assert_eq!(queue.pending_count(), 0);
     assert!(queue.get_pending(&id).is_none());
 }
@@ -185,7 +187,7 @@ fn test_deny_triggers_deny_callback() {
 #[test]
 fn test_approve_nonexistent_returns_false() {
     let mut queue = ApprovalQueue::new();
-    assert!(!queue.approve("nonexistent-id"));
+    assert!(!queue.approve("nonexistent-id", ApprovalMode::Once).unwrap());
 }
 
 #[test]
@@ -275,7 +277,7 @@ fn test_callback_signature_send() {
     }
     let mut queue = ApprovalQueue::new();
     let body = make_file_op("a");
-    queue.enqueue(
+    let _ = queue.enqueue(
         body,
         dummy_caller(),
         "op".to_string(),

--- a/src/permission/tests/mod.rs
+++ b/src/permission/tests/mod.rs
@@ -1,4 +1,5 @@
 //! Permission module tests
+mod approval_mode_test;
 mod approval_test;
 mod creator_rule_test;
 mod request_test;


### PR DESCRIPTION
新增 ApprovalMode 枚举区分单次放行(Once)和白名单放行(WithWhitelist)两种审批模式。
WithWhitelist 模式下，High/Critical 风险操作返回 Err(RejectWhitelistReason::HighRisk)，不允许加入白名单。

变更内容：
- 新增 ApprovalMode 枚举（Once / WithWhitelist）
- 新增 RejectWhitelistReason 枚举（HighRisk）
- 修改 approve() 签名，接受 ApprovalMode 参数，返回 Result<bool, RejectWhitelistReason>
- 新增 8 个单元测试覆盖所有风险等级×审批模式组合
- 更新 3 个 doc test 覆盖 Once/WithWhitelist/HighRisk 路径

Source: issue #768
Type: fix
