### PR TITLE
fix: 修正 Agent×User 交集语义 — Agent Allow + User 无匹配应为 Denied

### DIFF
--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -176,12 +176,6 @@ impl PermissionEngine {
             ) => PermissionResponse::Allowed {
                 token: generate_token(),
             },
-            (Some(PermissionResponse::Allowed { .. }), None) => PermissionResponse::Allowed {
-                token: generate_token(),
-            },
-            (None, Some(PermissionResponse::Allowed { .. })) => PermissionResponse::Allowed {
-                token: generate_token(),
-            },
             _ => self.default_deny(request.body(), &rules.defaults, "no matching rule"),
         };
         info!(

--- a/src/permission/engine/engine_two_phase_tests.rs
+++ b/src/permission/engine/engine_two_phase_tests.rs
@@ -42,11 +42,9 @@ fn file_request(agent: &str, path: &str, user_id: &str) -> PermissionRequest {
         },
     }
 }
-
 // -------------------------------------------------------------------------
 // Two-phase evaluation tests
 // -------------------------------------------------------------------------
-
 /// Agent Allow + User Allow → Allowed (non-owner)
 #[test]
 fn test_two_phase_agent_allow_user_allow() {
@@ -162,9 +160,9 @@ fn test_two_phase_agent_allow_user_no_match() {
         // No UserAndAgent rule for alice+test-agent
     ];
     let engine = make_ruleset(Effect::Deny, rules);
-    // Agent Allow + User None → Allowed (User has no stance, Agent result takes effect)
+    // Agent Allow + User None → Denied (intersection model: both must Allow)
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+    assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
 /// Two phases both have no match → Denied (default policy)
@@ -273,16 +271,13 @@ fn test_two_phase_non_owner_needs_both_phases() {
     let engine = make_ruleset(Effect::Deny, rules);
     // Alice is not owner, Agent phase has no match, User phase Allow is not enough alone
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    // Agent None + User Allow → Allowed (according to current merge logic in evaluate)
-    // This test documents the actual merge behavior
-    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+    // Agent None + User Allow → Denied (intersection model: both must Allow)
+    assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
-
 // ---------------------------------------------------------------------------
 // Extra deny subjects tests
 // ---------------------------------------------------------------------------
-
-/// extra_deny_subjects = None → normal Allow unchanged
+/// extra_deny_subjects = None → Agent Allow + User no match → Denied (intersection model)
 #[test]
 fn test_extra_deny_subjects_empty() {
     let rules = vec![Rule {
@@ -300,8 +295,9 @@ fn test_extra_deny_subjects_empty() {
         priority: 10,
     }];
     let engine = make_ruleset(Effect::Deny, rules);
+    // Only AgentOnly Allow rule, no UserAndAgent rule → intersection model → Denied
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
+    assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
 /// extra_deny_subjects has a matching subject → overrides result to Denied
@@ -330,7 +326,7 @@ fn test_extra_deny_subjects_match() {
         file_request("test-agent", "/data/file.txt", "alice"),
         Some(extra),
     );
-    let deny_resp = match resp {
+    match resp {
         PermissionResponse::Denied {
             reason,
             rule,
@@ -346,20 +342,38 @@ fn test_extra_deny_subjects_match() {
 /// extra_deny_subjects has a subject but does NOT match caller → normal Allow
 #[test]
 fn test_extra_deny_subjects_no_match() {
-    let rules = vec![Rule {
-        name: "agent-allows-read".to_string(),
-        subject: Subject::AgentOnly {
-            agent: "test-agent".to_string(),
-            match_type: MatchType::Exact,
+    let rules = vec![
+        Rule {
+            name: "agent-allows-read".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "test-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![super::engine_types::Action::File {
+                operation: "read".to_string(),
+                paths: vec!["/data/**".to_string()],
+            }],
+            template: None,
+            priority: 10,
         },
-        effect: Effect::Allow,
-        actions: vec![super::engine_types::Action::File {
-            operation: "read".to_string(),
-            paths: vec!["/data/**".to_string()],
-        }],
-        template: None,
-        priority: 10,
-    }];
+        Rule {
+            name: "user-allows-read".to_string(),
+            subject: Subject::UserAndAgent {
+                user_id: "alice".to_string(),
+                agent: "test-agent".to_string(),
+                user_match: MatchType::Exact,
+                agent_match: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![super::engine_types::Action::File {
+                operation: "read".to_string(),
+                paths: vec!["/data/**".to_string()],
+            }],
+            template: None,
+            priority: 10,
+        },
+    ];
     let engine = make_ruleset(Effect::Deny, rules);
     let extra = vec![Subject::AgentOnly {
         agent: "other-agent".to_string(),
@@ -375,20 +389,38 @@ fn test_extra_deny_subjects_no_match() {
 /// Normal two-phase result is Allow, but extra_deny matches → overrides to Denied
 #[test]
 fn test_extra_deny_overrides_allow() {
-    let rules = vec![Rule {
-        name: "agent-allows-read".to_string(),
-        subject: Subject::AgentOnly {
-            agent: "test-agent".to_string(),
-            match_type: MatchType::Exact,
+    let rules = vec![
+        Rule {
+            name: "agent-allows-read".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "test-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![super::engine_types::Action::File {
+                operation: "read".to_string(),
+                paths: vec!["/data/**".to_string()],
+            }],
+            template: None,
+            priority: 10,
         },
-        effect: Effect::Allow,
-        actions: vec![super::engine_types::Action::File {
-            operation: "read".to_string(),
-            paths: vec!["/data/**".to_string()],
-        }],
-        template: None,
-        priority: 10,
-    }];
+        Rule {
+            name: "user-allows-read".to_string(),
+            subject: Subject::UserAndAgent {
+                user_id: "alice".to_string(),
+                agent: "test-agent".to_string(),
+                user_match: MatchType::Exact,
+                agent_match: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![super::engine_types::Action::File {
+                operation: "read".to_string(),
+                paths: vec!["/data/**".to_string()],
+            }],
+            template: None,
+            priority: 10,
+        },
+    ];
     let engine = make_ruleset(Effect::Deny, rules);
     let extra = vec![Subject::AgentOnly {
         agent: "test-agent".to_string(),
@@ -401,11 +433,9 @@ fn test_extra_deny_overrides_allow() {
     assert!(matches!(resp, PermissionResponse::Denied { reason, .. }
             if reason.contains("parent agent restriction")));
 }
-
 // ---------------------------------------------------------------------------
 // get_agent_deny_subjects tests
 // ---------------------------------------------------------------------------
-
 /// get_agent_deny_subjects extracts parent AgentOnly Deny rules, replacing agent with child_id
 #[test]
 fn test_get_agent_deny_subjects_basic() {

--- a/src/permission/tests/rule_evaluation_test.rs
+++ b/src/permission/tests/rule_evaluation_test.rs
@@ -13,6 +13,18 @@ async fn test_user_and_agent_rule_matching() {
     let ruleset = RuleSetBuilder::new()
         .rule(
             RuleBuilder::new()
+                .name("agent-allows-read")
+                .subject_agent("dev-agent-01")
+                .allow()
+                .action(Action::File {
+                    operation: "read".to_string(),
+                    paths: vec!["**".to_string()],
+                })
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
                 .name("alice-read")
                 .subject_user_and_agent(
                     "ou_alice",
@@ -107,6 +119,18 @@ async fn test_bare_request_uses_agent_only_matching() {
                 .build()
                 .unwrap(),
         )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allows-read")
+                .subject_user_and_agent("", "dev-agent-01", MatchType::Exact, MatchType::Exact)
+                .allow()
+                .action(Action::File {
+                    operation: "read".to_string(),
+                    paths: vec!["**".to_string()],
+                })
+                .build()
+                .unwrap(),
+        )
         .default_file(Effect::Deny)
         .build()
         .unwrap();
@@ -129,6 +153,23 @@ async fn test_with_caller_request_still_matches_agent_only_rules() {
             RuleBuilder::new()
                 .name("dev-agent-full")
                 .subject_agent("dev-agent-01")
+                .allow()
+                .action(Action::File {
+                    operation: "read".to_string(),
+                    paths: vec!["**".to_string()],
+                })
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allows-read")
+                .subject_user_and_agent(
+                    "ou_alice",
+                    "dev-agent-01",
+                    MatchType::Exact,
+                    MatchType::Exact,
+                )
                 .allow()
                 .action(Action::File {
                     operation: "read".to_string(),

--- a/src/skills/builtin/file_ops_tests.rs
+++ b/src/skills/builtin/file_ops_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for file_ops skill — permission engine integration and error paths
 use crate::permission::actions::ActionBuilder;
 use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
-use crate::permission::Effect;
+use crate::permission::{Effect, MatchType};
 use crate::skills::builtin::FileOpsSkill;
 use crate::skills::Skill;
 use std::sync::Arc;
@@ -71,6 +71,72 @@ fn make_allowed_engine() -> Arc<crate::permission::PermissionEngine> {
             RuleBuilder::new()
                 .name("allow-file-list")
                 .subject_agent("test-agent")
+                .allow()
+                .action(
+                    ActionBuilder::file("list", vec!["**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        // UserAndAgent rules (intersection model requires both phases to allow)
+        .rule(
+            RuleBuilder::new()
+                .name("user-allow-file-read")
+                .subject_user_and_agent("*", "test-agent", MatchType::Glob, MatchType::Exact)
+                .allow()
+                .action(
+                    ActionBuilder::file("read", vec!["**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allow-file-write")
+                .subject_user_and_agent("*", "test-agent", MatchType::Glob, MatchType::Exact)
+                .allow()
+                .action(
+                    ActionBuilder::file("write", vec!["**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allow-file-exists")
+                .subject_user_and_agent("*", "test-agent", MatchType::Glob, MatchType::Exact)
+                .allow()
+                .action(
+                    ActionBuilder::file("exists", vec!["**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allow-file-delete")
+                .subject_user_and_agent("*", "test-agent", MatchType::Glob, MatchType::Exact)
+                .allow()
+                .action(
+                    ActionBuilder::file("delete", vec!["**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("user-allow-file-list")
+                .subject_user_and_agent("*", "test-agent", MatchType::Glob, MatchType::Exact)
                 .allow()
                 .action(
                     ActionBuilder::file("list", vec!["**".to_string()])

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -118,20 +118,38 @@ mod tests {
     fn make_engine_with_allow_rule() -> Arc<crate::permission::PermissionEngine> {
         use crate::permission::engine::engine_types::MatchType;
         let rules = RuleSet {
-            rules: vec![Rule {
-                name: "test-allow".to_string(),
-                subject: Subject::AgentOnly {
-                    agent: "agent-1".to_string(),
-                    match_type: MatchType::Exact,
+            rules: vec![
+                Rule {
+                    name: "test-allow".to_string(),
+                    subject: Subject::AgentOnly {
+                        agent: "agent-1".to_string(),
+                        match_type: MatchType::Exact,
+                    },
+                    effect: Effect::Allow,
+                    actions: vec![Action::File {
+                        operation: "read".to_string(),
+                        paths: vec!["*".to_string()],
+                    }],
+                    template: None,
+                    priority: 0,
                 },
-                effect: Effect::Allow,
-                actions: vec![Action::File {
-                    operation: "read".to_string(),
-                    paths: vec!["*".to_string()],
-                }],
-                template: None,
-                priority: 0,
-            }],
+                Rule {
+                    name: "test-user-allow".to_string(),
+                    subject: Subject::UserAndAgent {
+                        user_id: "*".to_string(),
+                        agent: "agent-1".to_string(),
+                        user_match: MatchType::Glob,
+                        agent_match: MatchType::Exact,
+                    },
+                    effect: Effect::Allow,
+                    actions: vec![Action::File {
+                        operation: "read".to_string(),
+                        paths: vec!["*".to_string()],
+                    }],
+                    template: None,
+                    priority: 0,
+                },
+            ],
             defaults: Defaults::default(),
             template_includes: vec![],
             agent_creators: HashMap::new(),

--- a/src/skills/builtin/tests.rs
+++ b/src/skills/builtin/tests.rs
@@ -33,22 +33,40 @@ async fn test_file_ops_read_requires_agent_id_when_engine_set() {
 
 #[tokio::test]
 async fn test_file_ops_read_with_permission() {
-    let rule = Rule {
-        name: "allow-read".to_string(),
-        subject: Subject::AgentOnly {
-            agent: "test-agent".to_string(),
-            match_type: MatchType::Exact,
+    let rules = vec![
+        Rule {
+            name: "allow-read".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "test-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![Action::File {
+                operation: "read".to_string(),
+                paths: vec!["**".to_string()],
+            }],
+            template: None,
+            priority: 0,
         },
-        effect: Effect::Allow,
-        actions: vec![Action::File {
-            operation: "read".to_string(),
-            paths: vec!["**".to_string()],
-        }],
-        template: None,
-        priority: 0,
-    };
+        Rule {
+            name: "user-allow-read".to_string(),
+            subject: Subject::UserAndAgent {
+                user_id: "*".to_string(),
+                agent: "test-agent".to_string(),
+                user_match: MatchType::Glob,
+                agent_match: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![Action::File {
+                operation: "read".to_string(),
+                paths: vec!["**".to_string()],
+            }],
+            template: None,
+            priority: 0,
+        },
+    ];
     let ruleset = crate::permission::RuleSet {
-        rules: vec![rule],
+        rules,
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),
@@ -128,22 +146,40 @@ async fn test_file_ops_exists_requires_agent_id_when_engine_set() {
 
 #[tokio::test]
 async fn test_file_ops_exists_with_permission() {
-    let rule = Rule {
-        name: "allow-exists".to_string(),
-        subject: Subject::AgentOnly {
-            agent: "test-agent".to_string(),
-            match_type: MatchType::Exact,
+    let rules = vec![
+        Rule {
+            name: "allow-exists".to_string(),
+            subject: Subject::AgentOnly {
+                agent: "test-agent".to_string(),
+                match_type: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![Action::File {
+                operation: "read".to_string(),
+                paths: vec!["**".to_string()],
+            }],
+            template: None,
+            priority: 0,
         },
-        effect: Effect::Allow,
-        actions: vec![Action::File {
-            operation: "read".to_string(),
-            paths: vec!["**".to_string()],
-        }],
-        template: None,
-        priority: 0,
-    };
+        Rule {
+            name: "user-allow-exists".to_string(),
+            subject: Subject::UserAndAgent {
+                user_id: "*".to_string(),
+                agent: "test-agent".to_string(),
+                user_match: MatchType::Glob,
+                agent_match: MatchType::Exact,
+            },
+            effect: Effect::Allow,
+            actions: vec![Action::File {
+                operation: "read".to_string(),
+                paths: vec!["**".to_string()],
+            }],
+            template: None,
+            priority: 0,
+        },
+    ];
     let ruleset = crate::permission::RuleSet {
-        rules: vec![rule],
+        rules,
         defaults: crate::permission::Defaults::default(),
         template_includes: vec![],
         agent_creators: std::collections::HashMap::new(),


### PR DESCRIPTION
## 概述

修正 `engine_eval.rs` 中 Step 3 两阶段合并逻辑的两行错误 allow shortcut。当前代码在 Agent Allow + User 无匹配（或反过来）时直接 Allowed，与 `docs/design/permission/README.md` 定义的交集模型不符——交集模型要求 Agent Allow AND User Allow 才放行，任一方无匹配应为 Deny。

## 变更

- **删除** `engine_eval.rs` Step 3 中两行短路 allow 分支：`(Some(Allowed), None) => Allowed` 和 `(None, Some(Allowed)) => Allowed`
- 两分支删除后落入 `_` 默认分支（调用 `default_deny`），返回 Denied
- **更新** 12 个相关测试的期望值和注释，使其与交集语义一致

## 测试

- `cargo test --lib permission` 全部通过
- `cargo test --lib engine_two_phase_tests` 全部通过

Source: issue #682
Type: fix
