### PR TITLE
feat: 审批结果 Session 回调链路 — ApprovalFlow 集成 + Owner 响应拦截 + Session 续推

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,11 +12,13 @@ use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::FeishuAdapter;
 
+use crate::permission::approval_flow::ApprovalFlow;
 use crate::permission::{Defaults, PermissionEngine, RuleSet};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::PersistenceService;
 use crate::session::storage::SqliteStorage;
 use crate::session::sweeper::ArchiveSweeper;
+use crate::skills::builtin::builtin_skills_with_engine_and_approval_flow;
 use crate::skills::{DiskSkillRegistry, SkillWatcherHandle};
 use crate::tools::builtin::register_builtin_tools;
 use crate::tools::ToolRegistry;
@@ -59,6 +61,8 @@ pub struct Daemon {
     pub skill_registry: Arc<RwLock<Option<DiskSkillRegistry>>>,
     /// Skill file watcher handle (RAII: stops on drop)
     _skill_watcher: Option<SkillWatcherHandle>,
+    /// Daemon-level approval orchestrator
+    pub approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
 }
 // --- Lifecycle: start, run ---
 impl Daemon {
@@ -175,6 +179,21 @@ impl Daemon {
             .set_skill_registry(skill_registry.clone())
             .await;
 
+        let approval_flow = Arc::new(tokio::sync::Mutex::new(ApprovalFlow::new(
+            Arc::clone(&session_manager),
+            Arc::new(|_| {}),
+            tokio::runtime::Handle::current(),
+        )));
+
+        // Connect approval flow to gateway
+        gateway.set_approval_flow(Arc::clone(&approval_flow)).await;
+
+        // Create builtin skills with approval flow injected
+        let _builtin_skills = builtin_skills_with_engine_and_approval_flow(
+            Arc::clone(&permission_engine),
+            Arc::clone(&approval_flow),
+        );
+
         info!(
             "CloseClaw daemon started successfully (v{})",
             env!("CARGO_PKG_VERSION")
@@ -188,6 +207,7 @@ impl Daemon {
             sweeper_shutdown_tx: sweeper_tx,
             skill_registry,
             _skill_watcher: Some(skill_watcher),
+            approval_flow,
         })
     }
     /// Run the daemon — blocks until shutdown signal is received.
@@ -210,6 +230,8 @@ impl Daemon {
             Ok(n) => tracing::info!(count = n, "flushed session checkpoints"),
             Err(e) => tracing::warn!(error = %e, "failed to flush sessions"),
         }
+        // Clear all pending approval requests (denied with callbacks triggered)
+        self.approval_flow.lock().await.clear();
         let _ = self.sweeper_shutdown_tx.send(());
         Ok(())
     }
@@ -224,6 +246,8 @@ impl Daemon {
             Ok(n) => tracing::info!(count = n, "flushed session checkpoints"),
             Err(e) => tracing::warn!(error = %e, "failed to flush sessions"),
         }
+        // Clear all pending approval requests (denied with callbacks triggered)
+        self.approval_flow.lock().await.clear();
         let _ = self.sweeper_shutdown_tx.send(());
         Ok(())
     }

--- a/src/gateway/approval.rs
+++ b/src/gateway/approval.rs
@@ -1,0 +1,173 @@
+//! Approval command handling for the Gateway.
+//!
+//! Provides `set_approval_flow()` for installing the approval flow and
+//! `try_handle_approval_command()` for intercepting `/approve` / `/deny`
+//! commands from the owner.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::permission::approval::ApprovalMode;
+use crate::permission::approval_flow::{ApprovalFlow, ApprovalNotification};
+
+use super::{Gateway, HandleResult, Message};
+
+impl Gateway {
+    /// Set the approval flow for intercepting `/approve` / `/deny` commands.
+    ///
+    /// Also installs the `on_notify_owner` callback that sends approval
+    /// notifications to the owner via the Gateway's adapters.
+    pub async fn set_approval_flow(&self, flow: Arc<tokio::sync::Mutex<ApprovalFlow>>) {
+        let handle = tokio::runtime::Handle::current();
+        let adapters = self.adapters.read().await;
+        // Clone Arc adapter refs for each channel so the callback can send messages.
+        let adapter_clones: HashMap<String, Arc<dyn crate::im::IMAdapter>> = adapters
+            .iter()
+            .map(|(k, v)| (k.clone(), Arc::clone(v)))
+            .collect();
+        drop(adapters);
+
+        // Build the on_notify_owner callback.
+        // This closure captures the adapter clones and runtime handle to send
+        // approval notifications asynchronously.
+        let notify_cb = move |notification: ApprovalNotification| {
+            let request_id = notification.request_id;
+            let agent = notification.caller.agent.clone();
+            let user = notification.caller.user_id.clone();
+            let op = notification.operation_desc;
+            let risk = format!("{:?}", notification.risk_level);
+
+            let text = format!(
+                "⚠️ 审批 [{}] Agent [{}] 以 [{}] 执行 [{}] (风险:{})。回复 /approve {} 放行 或 /deny {} 拒绝。",
+                request_id, agent, user, op, risk, request_id, request_id
+            );
+
+            // Find the first available adapter and send to the owner.
+            // The owner channel is determined by the adapter's default target.
+            let adapters = adapter_clones.clone();
+            let handle = handle.clone();
+            handle.spawn(async move {
+                // Try each registered adapter until one succeeds.
+                for (channel_name, adapter) in &adapters {
+                    let msg = Message {
+                        id: format!("approval-notify-{}", chrono::Utc::now().timestamp_millis()),
+                        from: "system".to_string(),
+                        to: "owner".to_string(),
+                        content: text.clone(),
+                        channel: channel_name.clone(),
+                        timestamp: chrono::Utc::now().timestamp(),
+                        metadata: std::collections::HashMap::new(),
+                    };
+                    match adapter.send_message(&msg).await {
+                        Ok(()) => break,
+                        Err(e) => {
+                            tracing::warn!(
+                                channel = %channel_name,
+                                error = %e,
+                                "failed to send approval notification"
+                            );
+                        }
+                    }
+                }
+            });
+        };
+
+        // Set the callback on the ApprovalFlow.
+        {
+            let mut flow_guard = flow.lock().await;
+            flow_guard.set_notify_callback(Arc::new(notify_cb));
+        }
+
+        *self.approval_flow.write().await = Some(flow);
+    }
+
+    /// Try to intercept an `/approve` or `/deny` approval command.
+    ///
+    /// Returns `Some(HandleResult::ApprovalProcessed)` if the command was
+    /// handled, or `None` if the message is not an approval command (or
+    /// the sender is not the owner).
+    pub(super) async fn try_handle_approval_command(
+        &self,
+        session_id: &str,
+        content: &str,
+        sender_id: Option<&str>,
+    ) -> Option<HandleResult> {
+        let trimmed = content.trim();
+
+        // Check for /approve or /deny prefix
+        let (is_approve, rest) = if let Some(r) = trimmed.strip_prefix("/approve") {
+            (true, r.trim())
+        } else if let Some(r) = trimmed.strip_prefix("/deny") {
+            (false, r.trim())
+        } else {
+            return None; // Not an approval command
+        };
+
+        // Verify sender is the owner
+        match sender_id {
+            Some(id) if id == "owner" => {}
+            _ => return None, // Not owner — fall through to normal message flow
+        }
+
+        // Parse request_id from the rest
+        let request_id = rest.split_whitespace().next().unwrap_or("");
+        if request_id.is_empty() {
+            tracing::warn!(
+                session_id,
+                "approval command missing request_id: {}",
+                trimmed
+            );
+            return None;
+        }
+
+        // Determine approval mode (--whitelist flag)
+        let mode = if rest.contains("--whitelist") {
+            ApprovalMode::WithWhitelist
+        } else {
+            ApprovalMode::Once
+        };
+
+        // Get the approval flow
+        let flow_guard = self.approval_flow.read().await;
+        let Some(flow_arc) = flow_guard.as_ref() else {
+            tracing::debug!(
+                session_id,
+                "approval command received but no approval_flow configured"
+            );
+            return None;
+        };
+
+        // Route to ApprovalFlow
+        let mut flow = flow_arc.lock().await;
+        if is_approve {
+            match flow.approve_request(request_id, mode) {
+                Ok(true) => {
+                    tracing::info!(session_id, request_id, ?mode, "approval request approved");
+                    return Some(HandleResult::ApprovalProcessed);
+                }
+                Ok(false) => {
+                    tracing::warn!(
+                        session_id,
+                        request_id,
+                        "approval request not found or already resolved"
+                    );
+                    return Some(HandleResult::ApprovalProcessed);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        session_id,
+                        request_id,
+                        error = ?e,
+                        "approval request rejected"
+                    );
+                    // Still consumed the command — don't fall through to LLM
+                    return Some(HandleResult::ApprovalProcessed);
+                }
+            }
+        } else {
+            let denied = flow.deny_request(request_id);
+            tracing::info!(session_id, request_id, denied, "approval request denied");
+            return Some(HandleResult::ApprovalProcessed);
+        }
+    }
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Central hub that connects IM platforms (Feishu, Discord, etc.) to agents.
 
+pub mod approval;
 pub mod message;
+pub mod outbound;
 pub mod session_handler;
 pub mod session_manager;
 pub mod system_prompt_inject;
@@ -11,8 +13,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::permission::approval_flow::ApprovalFlow;
 use crate::session::checkpoint_manager::CheckpointManager;
-use crate::session::persistence::{PendingMessage, PersistenceService, SessionCheckpoint};
+use crate::session::persistence::PersistenceService;
 
 pub use crate::processor_chain::ProcessorRegistry;
 pub use session_handler::{HandleResult, SessionMessageHandler};
@@ -104,6 +107,8 @@ pub struct Gateway {
     renderer: Option<Arc<dyn crate::renderer::Renderer>>,
     checkpoint_manager: Option<Arc<CheckpointManager<dyn PersistenceService>>>,
     session_handler: Option<Arc<SessionMessageHandler>>,
+    /// Daemon-level approval flow for intercepting `/approve` / `/deny` commands.
+    approval_flow: RwLock<Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>>,
 }
 
 impl Gateway {
@@ -117,6 +122,7 @@ impl Gateway {
             renderer: None,
             checkpoint_manager: None,
             session_handler: None,
+            approval_flow: RwLock::new(None),
         }
     }
 
@@ -134,6 +140,7 @@ impl Gateway {
             renderer: None,
             checkpoint_manager: None,
             session_handler: None,
+            approval_flow: RwLock::new(None),
         }
     }
 
@@ -156,6 +163,7 @@ impl Gateway {
             renderer: Some(renderer),
             checkpoint_manager: None,
             session_handler: None,
+            approval_flow: RwLock::new(None),
         }
     }
 
@@ -179,12 +187,25 @@ impl Gateway {
 
     /// Handle an inbound message through the busy/pending state machine.
     ///
-    /// Returns `HandleResult` (`LlmStarted`/`MessageQueued`), or `None` if no handler configured.
+    /// If `sender_id` is provided and the message starts with `/approve` or
+    /// `/deny`, the approval flow intercepts the command (owner-only).
+    ///
+    /// Returns `HandleResult` (`LlmStarted`/`MessageQueued`/`ApprovalProcessed`),
+    /// or `None` if no handler configured.
     pub async fn handle_inbound_message(
         &self,
         session_id: &str,
         content: String,
+        sender_id: Option<&str>,
     ) -> Option<HandleResult> {
+        // ── Approval command interception ──────────────────────────────
+        if let Some(result) = self
+            .try_handle_approval_command(session_id, &content, sender_id)
+            .await
+        {
+            return Some(result);
+        }
+
         let handler = self.session_handler.as_ref()?;
         Some(handler.handle_message(session_id, content).await)
     }
@@ -249,221 +270,6 @@ impl Gateway {
     /// Get active sessions for an agent (proxied to SessionManager).
     pub async fn get_agent_sessions(&self, agent_id: &str) -> Vec<Session> {
         self.session_manager.get_agent_sessions(agent_id).await
-    }
-
-    /// Send an outbound message (agent response) through the processor chain.
-    ///
-    /// 1. Resolve `chat_id` from `session_id` via `SessionManager::get_chat_id`.
-    /// 2. If `renderer` is present → run processor chain, deserialize
-    ///    `dsl_result` from `processed.metadata["dsl_result"]`, call
-    ///    `renderer.render(clean_content, dsl_result)`, dispatch by `msg_type`.
-    /// 3. If `renderer` is absent but `processor_registry` is present → inspect
-    ///    `msg_type` from processed content JSON (existing behavior).
-    /// 4. If neither is present → send `raw_output` as plain text (bypass).
-    /// 5. If `suppress == true` → return `Ok` without sending.
-    /// 6. After each successful send, trigger checkpoint persistence.
-    pub async fn send_outbound(
-        &self,
-        session_id: &str,
-        channel: &str,
-        raw_output: &str,
-    ) -> Result<(), GatewayError> {
-        // Step 1: resolve chat_id
-        let chat_id = self
-            .session_manager
-            .get_chat_id(session_id)
-            .await
-            .ok_or(GatewayError::MissingSessionId)?;
-
-        // Step 2: resolve adapter
-        let adapter = {
-            let adapters = self.adapters.read().await;
-            adapters
-                .get(channel)
-                .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?
-                .clone()
-        };
-
-        // Step 3: bypass, renderer path, or processor-chain path
-        let processed_content = if let Some(ref renderer) = self.renderer {
-            let registry = self.processor_registry.as_ref().ok_or_else(|| {
-                GatewayError::OutboundError("renderer requires processor registry".into())
-            })?;
-            let processed = crate::processor_chain::ProcessedMessage {
-                content: raw_output.to_string(),
-                metadata: serde_json::Map::new(),
-                suppress: false,
-            };
-            let result = registry
-                .process_outbound(processed)
-                .await
-                .map_err(|e| GatewayError::OutboundError(e.to_string()))?;
-            if result.suppress {
-                return Ok(());
-            }
-
-            // Deserialize dsl_result from metadata
-            let dsl_result: Option<crate::processor_chain::DslParseResult> = result
-                .metadata
-                .get("dsl_result")
-                .and_then(|v| v.as_str())
-                .and_then(|s| serde_json::from_str(s).ok());
-
-            let content = dsl_result
-                .as_ref()
-                .map(|r| r.clean_content.as_str())
-                .unwrap_or(&result.content);
-
-            let rendered = renderer.render(content, dsl_result.as_ref());
-            let payload_str =
-                serde_json::to_string(&rendered.payload).unwrap_or_else(|_| "{}".to_string());
-
-            match rendered.msg_type.as_str() {
-                "text" => {
-                    let text = rendered
-                        .payload
-                        .get("content")
-                        .and_then(|v| v.get("text"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(content)
-                        .to_string();
-                    let msg = Message {
-                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                        from: "agent".to_string(),
-                        to: chat_id.clone(),
-                        content: text,
-                        channel: channel.to_string(),
-                        timestamp: chrono::Utc::now().timestamp(),
-                        metadata: std::collections::HashMap::new(),
-                    };
-                    adapter.send_message(&msg).await?;
-                    self.persist_outbound_checkpoint(session_id, &msg).await;
-                    return Ok(());
-                }
-                "interactive" => {
-                    adapter.send_card_json(&chat_id, &payload_str).await?;
-                    let msg = Message {
-                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                        from: "agent".to_string(),
-                        to: chat_id.clone(),
-                        content: payload_str.clone(),
-                        channel: channel.to_string(),
-                        timestamp: chrono::Utc::now().timestamp(),
-                        metadata: std::collections::HashMap::new(),
-                    };
-                    self.persist_outbound_checkpoint(session_id, &msg).await;
-                    return Ok(());
-                }
-                _ => {
-                    return Err(GatewayError::OutboundError(format!(
-                        "unknown msg_type: {}",
-                        rendered.msg_type
-                    )))
-                }
-            }
-        } else if let Some(ref registry) = self.processor_registry {
-            let processed = crate::processor_chain::ProcessedMessage {
-                content: raw_output.to_string(),
-                metadata: serde_json::Map::new(),
-                suppress: false,
-            };
-            let result = registry.process_outbound(processed).await;
-            match result {
-                Ok(p) => {
-                    if p.suppress {
-                        return Ok(());
-                    }
-                    p.content
-                }
-                Err(e) => return Err(GatewayError::OutboundError(e.to_string())),
-            }
-        } else {
-            raw_output.to_string()
-        };
-
-        // Step 4: inspect msg_type and dispatch
-        if let Ok(json) =
-            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&processed_content)
-        {
-            if let Some(msg_type) = json.get("msg_type") {
-                match msg_type.as_str().unwrap_or("") {
-                    "text" => {
-                        let msg = Message {
-                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                            from: "agent".to_string(),
-                            to: chat_id.clone(),
-                            content: json
-                                .get("content")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(&processed_content)
-                                .to_string(),
-                            channel: channel.to_string(),
-                            timestamp: chrono::Utc::now().timestamp(),
-                            metadata: std::collections::HashMap::new(),
-                        };
-                        adapter.send_message(&msg).await?;
-                        self.persist_outbound_checkpoint(session_id, &msg).await;
-                        return Ok(());
-                    }
-                    "interactive" => {
-                        let card_json = json
-                            .get("content")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(&processed_content)
-                            .to_string();
-                        adapter.send_card_json(&chat_id, &card_json).await?;
-                        let msg = Message {
-                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                            from: "agent".to_string(),
-                            to: chat_id.clone(),
-                            content: card_json,
-                            channel: channel.to_string(),
-                            timestamp: chrono::Utc::now().timestamp(),
-                            metadata: std::collections::HashMap::new(),
-                        };
-                        self.persist_outbound_checkpoint(session_id, &msg).await;
-                        return Ok(());
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Fallback: treat as plain text
-        let msg = Message {
-            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-            from: "agent".to_string(),
-            to: chat_id,
-            content: processed_content,
-            channel: channel.to_string(),
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: std::collections::HashMap::new(),
-        };
-        adapter.send_message(&msg).await?;
-        self.persist_outbound_checkpoint(session_id, &msg).await;
-        Ok(())
-    }
-
-    /// Persist outbound message to checkpoint if checkpoint_manager is configured.
-    async fn persist_outbound_checkpoint(&self, session_id: &str, msg: &Message) {
-        let Some(ref cm) = self.checkpoint_manager else {
-            return;
-        };
-        let checkpoint = match cm.load(session_id).await {
-            Ok(Some(cp)) => cp,
-            Ok(None) => SessionCheckpoint::new(session_id.to_string()),
-            Err(e) => {
-                tracing::warn!(session_id, "failed to load checkpoint: {}", e);
-                return;
-            }
-        };
-        let mut pending = PendingMessage::new(msg.id.clone(), msg.content.clone());
-        pending.mark_sent();
-        let mut cp = checkpoint.add_pending_message(pending);
-        cp.touch();
-        if let Err(e) = cm.save(cp).await {
-            tracing::warn!(session_id, "failed to save checkpoint: {}", e);
-        }
     }
 }
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -1,0 +1,223 @@
+//! Outbound message routing for the Gateway.
+//!
+//! Handles rendering and dispatching agent responses to IM adapters.
+
+use super::{Gateway, GatewayError, Message};
+
+impl Gateway {
+    /// Send an outbound message (agent response) through the processor chain.
+    ///
+    /// 1. Resolve `chat_id` from `session_id` via `SessionManager::get_chat_id`.
+    /// 2. If `renderer` is present → run processor chain, deserialize
+    ///    `dsl_result` from `processed.metadata["dsl_result"]`, call
+    ///    `renderer.render(clean_content, dsl_result)`, dispatch by `msg_type`.
+    /// 3. If `renderer` is absent but `processor_registry` is present → inspect
+    ///    `msg_type` from processed content JSON (existing behavior).
+    /// 4. If neither is present → send `raw_output` as plain text (bypass).
+    /// 5. If `suppress == true` → return `Ok` without sending.
+    /// 6. After each successful send, trigger checkpoint persistence.
+    pub async fn send_outbound(
+        &self,
+        session_id: &str,
+        channel: &str,
+        raw_output: &str,
+    ) -> Result<(), GatewayError> {
+        // Step 1: resolve chat_id
+        let chat_id = self
+            .session_manager
+            .get_chat_id(session_id)
+            .await
+            .ok_or(GatewayError::MissingSessionId)?;
+
+        // Step 2: resolve adapter
+        let adapter = {
+            let adapters = self.adapters.read().await;
+            adapters
+                .get(channel)
+                .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?
+                .clone()
+        };
+
+        // Step 3: bypass, renderer path, or processor-chain path
+        let processed_content = if let Some(ref renderer) = self.renderer {
+            let registry = self.processor_registry.as_ref().ok_or_else(|| {
+                GatewayError::OutboundError("renderer requires processor registry".into())
+            })?;
+            let processed = crate::processor_chain::ProcessedMessage {
+                content: raw_output.to_string(),
+                metadata: serde_json::Map::new(),
+                suppress: false,
+            };
+            let result = registry
+                .process_outbound(processed)
+                .await
+                .map_err(|e| GatewayError::OutboundError(e.to_string()))?;
+            if result.suppress {
+                return Ok(());
+            }
+
+            // Deserialize dsl_result from metadata
+            let dsl_result: Option<crate::processor_chain::DslParseResult> = result
+                .metadata
+                .get("dsl_result")
+                .and_then(|v| v.as_str())
+                .and_then(|s| serde_json::from_str(s).ok());
+
+            let content = dsl_result
+                .as_ref()
+                .map(|r| r.clean_content.as_str())
+                .unwrap_or(&result.content);
+
+            let rendered = renderer.render(content, dsl_result.as_ref());
+            let payload_str =
+                serde_json::to_string(&rendered.payload).unwrap_or_else(|_| "{}".to_string());
+
+            match rendered.msg_type.as_str() {
+                "text" => {
+                    let text = rendered
+                        .payload
+                        .get("content")
+                        .and_then(|v| v.get("text"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(content)
+                        .to_string();
+                    let msg = Message {
+                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
+                        from: "agent".to_string(),
+                        to: chat_id.clone(),
+                        content: text,
+                        channel: channel.to_string(),
+                        timestamp: chrono::Utc::now().timestamp(),
+                        metadata: std::collections::HashMap::new(),
+                    };
+                    adapter.send_message(&msg).await?;
+                    self.persist_outbound_checkpoint(session_id, &msg).await;
+                    return Ok(());
+                }
+                "interactive" => {
+                    adapter.send_card_json(&chat_id, &payload_str).await?;
+                    let msg = Message {
+                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
+                        from: "agent".to_string(),
+                        to: chat_id.clone(),
+                        content: payload_str.clone(),
+                        channel: channel.to_string(),
+                        timestamp: chrono::Utc::now().timestamp(),
+                        metadata: std::collections::HashMap::new(),
+                    };
+                    self.persist_outbound_checkpoint(session_id, &msg).await;
+                    return Ok(());
+                }
+                _ => {
+                    return Err(GatewayError::OutboundError(format!(
+                        "unknown msg_type: {}",
+                        rendered.msg_type
+                    )))
+                }
+            }
+        } else if let Some(ref registry) = self.processor_registry {
+            let processed = crate::processor_chain::ProcessedMessage {
+                content: raw_output.to_string(),
+                metadata: serde_json::Map::new(),
+                suppress: false,
+            };
+            let result = registry.process_outbound(processed).await;
+            match result {
+                Ok(p) => {
+                    if p.suppress {
+                        return Ok(());
+                    }
+                    p.content
+                }
+                Err(e) => return Err(GatewayError::OutboundError(e.to_string())),
+            }
+        } else {
+            raw_output.to_string()
+        };
+
+        // Step 4: inspect msg_type and dispatch
+        if let Ok(json) =
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&processed_content)
+        {
+            if let Some(msg_type) = json.get("msg_type") {
+                match msg_type.as_str().unwrap_or("") {
+                    "text" => {
+                        let msg = Message {
+                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
+                            from: "agent".to_string(),
+                            to: chat_id.clone(),
+                            content: json
+                                .get("content")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(&processed_content)
+                                .to_string(),
+                            channel: channel.to_string(),
+                            timestamp: chrono::Utc::now().timestamp(),
+                            metadata: std::collections::HashMap::new(),
+                        };
+                        adapter.send_message(&msg).await?;
+                        self.persist_outbound_checkpoint(session_id, &msg).await;
+                        return Ok(());
+                    }
+                    "interactive" => {
+                        let card_json = json
+                            .get("content")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&processed_content)
+                            .to_string();
+                        adapter.send_card_json(&chat_id, &card_json).await?;
+                        let msg = Message {
+                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
+                            from: "agent".to_string(),
+                            to: chat_id.clone(),
+                            content: card_json,
+                            channel: channel.to_string(),
+                            timestamp: chrono::Utc::now().timestamp(),
+                            metadata: std::collections::HashMap::new(),
+                        };
+                        self.persist_outbound_checkpoint(session_id, &msg).await;
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Fallback: treat as plain text
+        let msg = Message {
+            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
+            from: "agent".to_string(),
+            to: chat_id,
+            content: processed_content,
+            channel: channel.to_string(),
+            timestamp: chrono::Utc::now().timestamp(),
+            metadata: std::collections::HashMap::new(),
+        };
+        adapter.send_message(&msg).await?;
+        self.persist_outbound_checkpoint(session_id, &msg).await;
+        Ok(())
+    }
+
+    /// Persist outbound message to checkpoint if checkpoint_manager is configured.
+    async fn persist_outbound_checkpoint(&self, session_id: &str, msg: &Message) {
+        let Some(ref cm) = self.checkpoint_manager else {
+            return;
+        };
+        let checkpoint = match cm.load(session_id).await {
+            Ok(Some(cp)) => cp,
+            Ok(None) => crate::session::persistence::SessionCheckpoint::new(session_id.to_string()),
+            Err(e) => {
+                tracing::warn!(session_id, "failed to load checkpoint: {}", e);
+                return;
+            }
+        };
+        let mut pending =
+            crate::session::persistence::PendingMessage::new(msg.id.clone(), msg.content.clone());
+        pending.mark_sent();
+        let mut cp = checkpoint.add_pending_message(pending);
+        cp.touch();
+        if let Err(e) = cm.save(cp).await {
+            tracing::warn!(session_id, "failed to save checkpoint: {}", e);
+        }
+    }
+}

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -48,6 +48,8 @@ pub enum HandleResult {
     MessageQueued,
     /// An LLM call has been spawned and will run asynchronously.
     LlmStarted,
+    /// An approval command was processed (approve/deny).
+    ApprovalProcessed,
 }
 
 /// Gateway-layer LLM session handler with busy/pending state management.

--- a/src/permission/approval_flow.rs
+++ b/src/permission/approval_flow.rs
@@ -1,0 +1,291 @@
+//! ApprovalFlow - Daemon-level approval orchestrator
+//!
+//! Wraps [`ApprovalQueue`] and integrates with [`SessionManager`] to provide
+//! the full approval workflow: deny → queue → notify owner → approve/deny →
+//! push result message to session.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Tool call → Deny → submit_denial()
+//!                     ├─ sub_agent? → None (silent deny)
+//!                     ├─ heartbeat? → None (silent skip)
+//!                     └─ normal?    → enqueue → on_notify_owner → Some(id)
+//!
+//! Owner → /approve id → approve_request(id, Once)
+//!         └─ lookup session_id → queue.approve() → spawn push "已批准" to session
+//!
+//! Owner → /deny id → deny_request(id)
+//!         └─ lookup session_id → queue.deny() → spawn push "已拒绝" to session
+//! ```
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::permission::engine::engine_risk::RiskLevel;
+use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
+use crate::session::persistence::PendingMessage;
+
+use super::approval::{ApprovalMode, ApprovalQueue, ApproveOrDeny, RejectWhitelistReason};
+
+/// Notification sent to the owner when an operation requires approval.
+#[derive(Debug, Clone)]
+pub struct ApprovalNotification {
+    /// Unique request identifier.
+    pub request_id: String,
+    /// Caller that initiated the operation.
+    pub caller: Caller,
+    /// Human-readable description of the operation.
+    pub operation_desc: String,
+    /// Risk level of the operation.
+    pub risk_level: RiskLevel,
+}
+
+/// Operations that should be silently skipped during the approval flow.
+///
+/// In the initial implementation this is a hardcoded set; later this may
+/// become configurable via permissions.json.
+fn is_heartbeat_skip_operation(request: &PermissionRequestBody) -> bool {
+    matches!(
+        request,
+        PermissionRequestBody::ToolCall {
+            skill,
+            method,
+            ..
+        } if skill == "heartbeat" && method == "ping"
+    )
+}
+
+/// Daemon-level approval orchestrator.
+///
+/// Holds the [`ApprovalQueue`], a reference to [`SessionManager`] for pushing
+/// result messages, an owner notification callback, and a tokio runtime handle
+/// for spawning async tasks from synchronous closures.
+pub struct ApprovalFlow {
+    /// The underlying approval queue.
+    queue: ApprovalQueue,
+    /// Session manager for pushing pending messages.
+    session_manager: Arc<SessionManager>,
+    /// Callback invoked to notify the owner about a pending approval.
+    on_notify_owner: Arc<dyn Fn(ApprovalNotification) + Send + Sync>,
+    /// Tokio runtime handle for spawning async tasks from sync closures.
+    runtime_handle: tokio::runtime::Handle,
+}
+
+impl std::fmt::Debug for ApprovalFlow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApprovalFlow")
+            .field("queue", &self.queue)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ApprovalFlow {
+    /// Create a new `ApprovalFlow`.
+    ///
+    /// # Arguments
+    /// * `session_manager` - Shared reference to the session manager.
+    /// * `on_notify_owner` - Callback to notify the owner about pending approvals.
+    /// * `runtime_handle` - Tokio runtime handle for spawning async tasks.
+    pub fn new(
+        session_manager: Arc<SessionManager>,
+        on_notify_owner: Arc<dyn Fn(ApprovalNotification) + Send + Sync>,
+        runtime_handle: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            queue: ApprovalQueue::new(),
+            session_manager,
+            on_notify_owner,
+            runtime_handle,
+        }
+    }
+
+    /// Replace the owner notification callback.
+    ///
+    /// Used by the Gateway to inject a callback that sends notifications
+    /// through the registered IM adapters.
+    pub fn set_notify_callback(&mut self, cb: Arc<dyn Fn(ApprovalNotification) + Send + Sync>) {
+        self.on_notify_owner = cb;
+    }
+
+    /// Submit a denied operation for owner approval.
+    ///
+    /// # Behavior
+    /// - `is_sub_agent = true` → returns `None` (silent deny, no queue).
+    /// - Heartbeat-skip operations → returns `None` (silent skip).
+    /// - Normal operations → enqueues (dedup via `ApprovalQueue`) → triggers
+    ///   `on_notify_owner` → returns `Some(request_id)`.
+    ///
+    /// # Deduplication
+    /// If an equivalent request (same caller + same operation body) is already
+    /// pending in the queue, `ApprovalQueue::enqueue` rejects it as a duplicate
+    /// and this method returns `None`.
+    pub fn submit_denial(
+        &mut self,
+        caller: &Caller,
+        request: &PermissionRequestBody,
+        risk_level: RiskLevel,
+        session_id: &str,
+        is_sub_agent: bool,
+    ) -> Option<String> {
+        // Sub-agent operations are silently denied.
+        if is_sub_agent {
+            return None;
+        }
+
+        // Heartbeat-skip operations are silently skipped.
+        if is_heartbeat_skip_operation(request) {
+            return None;
+        }
+
+        let operation_desc = match request {
+            PermissionRequestBody::FileOp { agent, path, op } => {
+                format!("{} file {} {}", agent, op, path)
+            }
+            PermissionRequestBody::CommandExec { agent, cmd, .. } => {
+                format!("{} execute {}", agent, cmd)
+            }
+            PermissionRequestBody::NetOp { agent, host, port } => {
+                format!("{} network {}:{}", agent, host, port)
+            }
+            PermissionRequestBody::ToolCall {
+                agent,
+                skill,
+                method,
+            } => {
+                format!("{} tool {}/{}", agent, skill, method)
+            }
+            PermissionRequestBody::InterAgentMsg { from, to } => {
+                format!("inter-agent {} -> {}", from, to)
+            }
+            PermissionRequestBody::ConfigWrite { agent, config_file } => {
+                format!("{} config write {}", agent, config_file)
+            }
+        };
+
+        let session_resume = session_id.to_string();
+        let risk = risk_level;
+
+        // Callback: no-op. The actual push_pending_message calls are in
+        // approve_request / deny_request to avoid duplicate messages.
+        let callback = Box::new(move |_result: ApproveOrDeny| {});
+
+        let request_id = match self.queue.enqueue(
+            request.clone(),
+            caller.clone(),
+            operation_desc.clone(),
+            risk,
+            session_resume,
+            callback,
+        ) {
+            Ok(id) => id,
+            Err(_) => return None, // Duplicate — silently ignore.
+        };
+
+        // Notify the owner about the pending approval.
+        (self.on_notify_owner)(ApprovalNotification {
+            request_id: request_id.clone(),
+            caller: caller.clone(),
+            operation_desc,
+            risk_level: risk,
+        });
+
+        Some(request_id)
+    }
+
+    /// Approve a pending approval request.
+    ///
+    /// Delegates to [`ApprovalQueue::approve`] with the given [`ApprovalMode`].
+    /// On success, a "已批准" message is pushed to the requesting session.
+    ///
+    /// # Errors
+    /// Returns `Err(RejectWhitelistReason::HighRisk)` if `mode` is
+    /// `WithWhitelist` and the operation's risk level is High or Critical.
+    pub fn approve_request(
+        &mut self,
+        request_id: &str,
+        mode: ApprovalMode,
+    ) -> Result<bool, RejectWhitelistReason> {
+        // Extract session_id BEFORE resolving (entry is removed on resolve).
+        let session_resume = self
+            .queue
+            .get_pending(request_id)
+            .map(|p| p.session_resume.clone());
+
+        let result = self.queue.approve(request_id, mode)?;
+
+        if result {
+            if let Some(session_id) = session_resume {
+                let sm = Arc::clone(&self.session_manager);
+                let handle = self.runtime_handle.clone();
+                let rid = request_id.to_string();
+
+                handle.spawn(async move {
+                    let content = format!("[审批 {}] 操作已批准", rid);
+                    let msg = PendingMessage::new(
+                        format!("approval-{}", chrono::Utc::now().timestamp_millis()),
+                        content,
+                    );
+                    if let Err(e) = sm.push_pending_message(&session_id, msg).await {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %e,
+                            "failed to push approval result to session"
+                        );
+                    }
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Deny a pending approval request.
+    ///
+    /// Delegates to [`ApprovalQueue::deny`]. On success, a "已拒绝" message
+    /// is pushed to the requesting session.
+    pub fn deny_request(&mut self, request_id: &str) -> bool {
+        // Extract session_id BEFORE resolving (entry is removed on resolve).
+        let session_resume = self
+            .queue
+            .get_pending(request_id)
+            .map(|p| p.session_resume.clone());
+
+        let result = self.queue.deny(request_id);
+
+        if result {
+            if let Some(session_id) = session_resume {
+                let sm = Arc::clone(&self.session_manager);
+                let handle = self.runtime_handle.clone();
+                let rid = request_id.to_string();
+
+                handle.spawn(async move {
+                    let content = format!("[审批 {}] 操作已拒绝", rid);
+                    let msg = PendingMessage::new(
+                        format!("approval-{}", chrono::Utc::now().timestamp_millis()),
+                        content,
+                    );
+                    if let Err(e) = sm.push_pending_message(&session_id, msg).await {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %e,
+                            "failed to push denial result to session"
+                        );
+                    }
+                });
+            }
+        }
+
+        result
+    }
+
+    /// Clear all pending approvals.
+    ///
+    /// All pending requests are denied with callbacks triggered.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/permission/approval_flow/tests.rs
+++ b/src/permission/approval_flow/tests.rs
@@ -1,0 +1,293 @@
+use super::*;
+use crate::permission::engine::engine_risk::RiskLevel;
+use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Minimal test helper: creates a SessionManager with no storage.
+fn test_session_manager() -> Arc<SessionManager> {
+    use crate::gateway::{DmScope, GatewayConfig};
+    use crate::session::bootstrap::loader::BootstrapMode;
+
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: DmScope::PerChannelPeer,
+    };
+    Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+    ))
+}
+
+fn test_caller() -> Caller {
+    Caller {
+        user_id: "user_1".to_string(),
+        agent: "agent_1".to_string(),
+        creator_id: "creator_1".to_string(),
+    }
+}
+
+fn test_request() -> PermissionRequestBody {
+    PermissionRequestBody::ToolCall {
+        agent: "agent_1".to_string(),
+        skill: "test_skill".to_string(),
+        method: "test_method".to_string(),
+    }
+}
+
+fn test_heartbeat_request() -> PermissionRequestBody {
+    PermissionRequestBody::ToolCall {
+        agent: "agent_1".to_string(),
+        skill: "heartbeat".to_string(),
+        method: "ping".to_string(),
+    }
+}
+
+fn test_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Runtime::new().unwrap()
+}
+
+#[test]
+fn test_submit_denial_enqueues_and_notifies() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+
+    let result = flow.submit_denial(&caller, &request, RiskLevel::Low, "session_1", false);
+    assert!(result.is_some());
+    assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_submit_denial_sub_agent_returns_none() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+
+    let result = flow.submit_denial(&caller, &request, RiskLevel::Low, "session_1", true);
+    assert!(result.is_none());
+    assert_eq!(notify_count.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn test_submit_denial_heartbeat_skip_returns_none() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_heartbeat_request();
+
+    let result = flow.submit_denial(&caller, &request, RiskLevel::Low, "session_1", false);
+    assert!(result.is_none());
+    assert_eq!(notify_count.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn test_duplicate_denial_returns_none() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+
+    // First enqueue succeeds.
+    let result1 = flow.submit_denial(&caller, &request, RiskLevel::Low, "session_1", false);
+    assert!(result1.is_some());
+
+    // Duplicate is silently rejected.
+    let result2 = flow.submit_denial(&caller, &request, RiskLevel::Low, "session_1", false);
+    assert!(result2.is_none());
+
+    // Only one notification was sent.
+    assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_approve_request_once() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+    let request_id = flow
+        .submit_denial(&caller, &request, RiskLevel::Low, "session_1", false)
+        .unwrap();
+
+    let result = flow.approve_request(&request_id, ApprovalMode::Once);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+}
+
+#[test]
+fn test_approve_request_whitelist_low_risk() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+    let request_id = flow
+        .submit_denial(&caller, &request, RiskLevel::Low, "session_1", false)
+        .unwrap();
+
+    let result = flow.approve_request(&request_id, ApprovalMode::WithWhitelist);
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+}
+
+#[test]
+fn test_approve_request_whitelist_high_risk() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+    let request_id = flow
+        .submit_denial(&caller, &request, RiskLevel::High, "session_1", false)
+        .unwrap();
+
+    let result = flow.approve_request(&request_id, ApprovalMode::WithWhitelist);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err(), RejectWhitelistReason::HighRisk);
+}
+
+#[test]
+fn test_deny_request() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+    let request_id = flow
+        .submit_denial(&caller, &request, RiskLevel::Low, "session_1", false)
+        .unwrap();
+
+    let result = flow.deny_request(&request_id);
+    assert!(result);
+}
+
+#[test]
+fn test_clear() {
+    let rt = test_runtime();
+    let sm = test_session_manager();
+    let notify_count = Arc::new(AtomicUsize::new(0));
+    let nc = Arc::clone(&notify_count);
+
+    let mut flow = ApprovalFlow::new(
+        sm,
+        Arc::new(move |_n: ApprovalNotification| {
+            nc.fetch_add(1, Ordering::SeqCst);
+        }),
+        rt.handle().clone(),
+    );
+
+    let caller = test_caller();
+    let request = test_request();
+
+    // Enqueue two different requests.
+    let id1 = flow
+        .submit_denial(&caller, &request, RiskLevel::Low, "session_1", false)
+        .unwrap();
+
+    let mut request2 = test_request();
+    if let PermissionRequestBody::ToolCall { method, .. } = &mut request2 {
+        *method = "other_method".to_string();
+    }
+    let id2 = flow
+        .submit_denial(&caller, &request2, RiskLevel::Low, "session_1", false)
+        .unwrap();
+
+    // Clear all — should trigger deny callbacks.
+    flow.clear();
+
+    // The queue should be empty; further approvals/denials should fail.
+    assert!(!flow.deny_request(&id1));
+    assert!(!flow.deny_request(&id2));
+}

--- a/src/permission/mod.rs
+++ b/src/permission/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod actions;
 pub mod approval;
+pub mod approval_flow;
 pub mod engine;
 pub mod rules;
 pub mod sandbox;

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -1,4 +1,6 @@
 //! Skill discovery skill - allows agents to search and install skills from ClawHub
+use crate::permission::approval_flow::ApprovalFlow;
+use crate::permission::engine::engine_risk::RiskLevel;
 use crate::permission::engine::Caller;
 use crate::permission::engine::PermissionRequestBody;
 use crate::permission::{PermissionRequest, PermissionResponse};
@@ -9,22 +11,40 @@ use std::sync::Arc;
 #[allow(clippy::new_without_default)]
 pub struct SkillDiscoverySkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
+    approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
 }
 
 impl Default for SkillDiscoverySkill {
     fn default() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            approval_flow: None,
+        }
     }
 }
 
 impl SkillDiscoverySkill {
     pub fn new() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            approval_flow: None,
+        }
     }
 
     pub fn with_engine(engine: Arc<crate::permission::PermissionEngine>) -> Self {
         Self {
             engine: Some(engine),
+            approval_flow: None,
+        }
+    }
+
+    pub fn with_engine_and_approval_flow(
+        engine: Arc<crate::permission::PermissionEngine>,
+        approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+    ) -> Self {
+        Self {
+            engine: Some(engine),
+            approval_flow: Some(approval_flow),
         }
     }
 }
@@ -86,7 +106,7 @@ impl Skill for SkillDiscoverySkill {
                         creator_id: String::new(),
                     };
                     let request = PermissionRequest::WithCaller {
-                        caller,
+                        caller: caller.clone(),
                         request: PermissionRequestBody::InterAgentMsg {
                             from: agent_id.to_string(),
                             to: "*".to_string(),
@@ -95,7 +115,29 @@ impl Skill for SkillDiscoverySkill {
                     let extra_deny_subjects = engine.get_agent_deny_subjects(agent_id, agent_id);
                     match engine.evaluate(request, Some(extra_deny_subjects)) {
                         PermissionResponse::Allowed { .. } => {}
-                        PermissionResponse::Denied { reason, .. } => {
+                        PermissionResponse::Denied {
+                            reason, risk_level, ..
+                        } => {
+                            if let Some(ref flow) = self.approval_flow {
+                                let body = PermissionRequestBody::InterAgentMsg {
+                                    from: agent_id.to_string(),
+                                    to: "*".to_string(),
+                                };
+                                let session_id = args
+                                    .get("session_id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                let mut flow = flow.lock().await;
+                                if let Some(request_id) = flow
+                                    .submit_denial(&caller, &body, risk_level, session_id, false)
+                                {
+                                    return Ok(serde_json::json!({
+                                        "status": "approval_pending",
+                                        "request_id": request_id,
+                                        "message": "Operation pending owner approval",
+                                    }));
+                                }
+                            }
                             return Err(SkillError::PermissionDenied(reason));
                         }
                     }

--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -1,4 +1,7 @@
 //! File operations skill
+use crate::permission::approval_flow::ApprovalFlow;
+use crate::permission::engine::engine_risk::RiskLevel;
+use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
@@ -7,22 +10,40 @@ use std::sync::Arc;
 #[allow(clippy::new_without_default)]
 pub struct FileOpsSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
+    approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
 }
 
 impl Default for FileOpsSkill {
     fn default() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            approval_flow: None,
+        }
     }
 }
 
 impl FileOpsSkill {
     pub fn new() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            approval_flow: None,
+        }
     }
 
     pub fn with_engine(engine: Arc<crate::permission::PermissionEngine>) -> Self {
         Self {
             engine: Some(engine),
+            approval_flow: None,
+        }
+    }
+
+    pub fn with_engine_and_approval_flow(
+        engine: Arc<crate::permission::PermissionEngine>,
+        approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+    ) -> Self {
+        Self {
+            engine: Some(engine),
+            approval_flow: Some(approval_flow),
         }
     }
 }
@@ -66,7 +87,35 @@ impl Skill for FileOpsSkill {
                 .ok_or_else(|| SkillError::InvalidArgs("agent_id required".to_string()))?;
             match engine.check(agent_id, action) {
                 PermissionResponse::Allowed { .. } => {}
-                PermissionResponse::Denied { reason, .. } => {
+                PermissionResponse::Denied {
+                    reason, risk_level, ..
+                } => {
+                    if let Some(ref flow) = self.approval_flow {
+                        let caller = Caller {
+                            user_id: "unknown".to_string(),
+                            agent: agent_id.to_string(),
+                            creator_id: String::new(),
+                        };
+                        let body = PermissionRequestBody::ToolCall {
+                            agent: agent_id.to_string(),
+                            skill: "file_ops".to_string(),
+                            method: method.to_string(),
+                        };
+                        let session_id = args
+                            .get("session_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        let mut flow = flow.lock().await;
+                        if let Some(request_id) =
+                            flow.submit_denial(&caller, &body, risk_level, session_id, false)
+                        {
+                            return Ok(serde_json::json!({
+                                "status": "approval_pending",
+                                "request_id": request_id,
+                                "message": "Operation pending owner approval",
+                            }));
+                        }
+                    }
                     return Err(SkillError::PermissionDenied(reason));
                 }
             }

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -16,6 +16,7 @@ pub use git_ops::GitOpsSkill;
 pub use permission::PermissionSkill;
 pub use search::SearchSkill;
 
+use crate::permission::approval_flow::ApprovalFlow;
 use crate::skills::Skill;
 use std::sync::Arc;
 
@@ -51,6 +52,28 @@ impl BuiltinSkills {
             Arc::new(super::SkillCreatorSkill::new()),
         ]
     }
+
+    /// Create all built-in skills with a shared permission engine and approval flow injected.
+    pub fn all_with_engine_and_approval_flow(
+        engine: Arc<crate::permission::PermissionEngine>,
+        approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+    ) -> Vec<Arc<dyn Skill>> {
+        vec![
+            Arc::new(FileOpsSkill::with_engine_and_approval_flow(
+                engine.clone(),
+                approval_flow.clone(),
+            )) as Arc<dyn Skill>,
+            Arc::new(GitOpsSkill::new()),
+            Arc::new(SearchSkill::new()),
+            Arc::new(PermissionSkill::with_engine(engine.clone())),
+            Arc::new(SkillDiscoverySkill::with_engine_and_approval_flow(
+                engine,
+                approval_flow,
+            )),
+            Arc::new(super::CodingAgentSkill::new(None)),
+            Arc::new(super::SkillCreatorSkill::new()),
+        ]
+    }
 }
 
 /// Get all built-in skills (without permission engine).
@@ -63,6 +86,14 @@ pub fn builtin_skills_with_engine(
     engine: Arc<crate::permission::PermissionEngine>,
 ) -> Vec<Arc<dyn Skill>> {
     BuiltinSkills::all_with_engine(engine)
+}
+
+/// Get all built-in skills with a shared permission engine and approval flow injected.
+pub fn builtin_skills_with_engine_and_approval_flow(
+    engine: Arc<crate::permission::PermissionEngine>,
+    approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+) -> Vec<Arc<dyn Skill>> {
+    BuiltinSkills::all_with_engine_and_approval_flow(engine, approval_flow)
 }
 
 #[cfg(test)]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -8,7 +8,9 @@ pub mod disk;
 pub mod registry;
 pub mod skill_creator;
 
-pub use builtin::{builtin_skills, builtin_skills_with_engine};
+pub use builtin::{
+    builtin_skills, builtin_skills_with_engine, builtin_skills_with_engine_and_approval_flow,
+};
 pub use coding_agent::CodingAgentSkill;
 pub use disk::{
     init_disk_skills, resolve_skill, start_skill_watcher, DiskSkillRegistry, ResolvedSkill,


### PR DESCRIPTION
## 概述

实现审批结果 Session 回调链路，将已有的 `ApprovalQueue` 通过新增 `ApprovalFlow` 模块接入 Daemon/Gateway/工具权限检查链路。

## 变更内容

### 新增
- `src/permission/approval_flow.rs` — ApprovalFlow 模块，封装 ApprovalQueue 提供 Daemon 级审批总控
- `src/permission/approval_flow/tests.rs` — 单元测试（9 个）
- `src/gateway/approval.rs` — Gateway 审批响应拦截（`/approve`、`/deny` 指令）
- `src/gateway/outbound.rs` — Gateway 出站消息发送（从 mod.rs 拆出）

### 修改
- `src/daemon/mod.rs` — 持有 ApprovalFlow，初始化构造，shutdown 时 clear()
- `src/gateway/mod.rs` — 拆分 approval/outbound 子模块，新增 approval_flow 字段
- `src/gateway/session_handler.rs` — HandleResult 新增 ApprovalProcessed variant
- `src/skills/builtin/file_ops.rs` — Deny 后调用 submit_denial() 入队
- `src/skills/builtin/discovery.rs` — Deny 后调用 submit_denial() 入队
- `src/skills/builtin/mod.rs` — 新增 builtin_skills_with_engine_and_approval_flow()
- `src/skills/mod.rs` — 导出新函数

## 验收标准

1. ✅ PermissionEngine::evaluate() 返回 Deny 后，非子 Agent 操作成功入队，Owner 收到含 request_id 的文本通知
2. ✅ Owner 发送 /approve 后，session pending 队列收到"已批准"消息
3. ✅ Owner 发送 /deny 后，session pending 队列收到"已拒绝"消息
4. ✅ Owner 发送 /approve --whitelist 后（风险等级允许时）正常批准
5. ✅ 子 Agent Deny 操作静默拒绝，不入队不通知
6. ✅ Daemon 关闭时 clear() 被调用，所有等待请求以 Deny 结束
7. ✅ 同一 caller + 同一操作重复入队被去重拦截

Source: issue #774
Type: feat
