### PR TITLE
fix(session): compaction 后重建 system prompt — 修复 Skill 热更新链路断裂

### DIFF
--- a/docs/design/session/session-injection.md
+++ b/docs/design/session/session-injection.md
@@ -119,4 +119,4 @@ archived session 被访问
 ### 无关
 
 - **LLM Provider**（无调用关系）：注入完成后的 system prompt 通过 ConversationSession 传递给 LLM provider，注入链路本身不调用 provider。
-- **Compaction 模块**（无调用关系）：compaction 时 skill listing 的保护策略在 compaction 模块定义，注入链路不参与压缩逻辑。
+- **Compaction 模块**（间接关联）：compaction 后通过 `rebuild_system_prompt` 触发重建，注入链路不直接参与压缩逻辑。

--- a/docs/design/skills/skill-listing-injection.md
+++ b/docs/design/skills/skill-listing-injection.md
@@ -80,7 +80,7 @@ SkillListingSection 渲染格式为 `## Available Skills\n\n{content}\n`。
 
 ### Compaction 保护
 
-System prompt 独立于对话消息流存储（作为 `ConversationSession.system_prompt` 字段），compaction 只压缩对话消息列表。SkillListingSection 作为 system prompt 的一部分，天然不受 compaction 影响，无需额外保护逻辑。
+System prompt 独立于对话消息流存储（作为 `ConversationSession.system_prompt` 字段），compaction 只压缩对话消息列表。compaction 完成后，通过 `rebuild_system_prompt` 触发 system prompt 重建，确保 SkillListingSection 包含最新内容（与 session 创建、archive 恢复走同一重建路径）。
 
 ### 条件激活
 
@@ -148,4 +148,4 @@ Agent 读取 system prompt 中的 skill listing
 - **上游**：Session 启动流程（触发初始注入）、文件监听器 Skill Watcher（触发热重载）
 - **下游**：DiskSkillRegistry（获取 skill 列表数据源）、System Prompt 构建器（接收 listing 字符串作为输入，创建 SkillListingSection 并拼入 system prompt）
 - **相关**：Skills 模块主体（SkillTool 调用后注入正文，与列表注入完全独立、互不干扰）
-- **无关**：Compaction 模块（skill listing 作为 system prompt 的一部分，天然不受压缩影响）
+- **关联**：Compaction 模块（间接关联）：compaction 后通过 `rebuild_system_prompt` 触发 system prompt 重建，SkillListingSection 在重建时从 `DiskSkillRegistry` 获取最新 listing，与 session 创建、archive 恢复走同一路径

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -393,8 +393,14 @@ async fn apply_compact_result(
         content_blocks: vec![ContentBlock::Text(result.boundary_message.clone())],
         timestamp: chrono::Utc::now(),
     };
-    let mut cs = cs.write().await;
-    cs.replace_messages(vec![boundary]);
+    {
+        let mut cs = cs.write().await;
+        cs.replace_messages(vec![boundary]);
+    }
+    // Rebuild system prompt after compaction so skills stay fresh.
+    // The write guard above is now dropped, so rebuild_system_prompt
+    // can safely acquire its own write lock.
+    sm.rebuild_system_prompt(session_id).await;
 }
 
 async fn send_output(output_tx: &Arc<RwLock<Option<mpsc::Sender<String>>>>, text: &str) {

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -15,6 +15,7 @@ use crate::session::persistence::{
 use crate::session::workspace;
 use crate::skills::DiskSkillRegistry;
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
+use crate::system_prompt::sections::invalidate_all_sections;
 use crate::system_prompt::workdir::set_workdir;
 use crate::tools::{ToolContext, ToolRegistry};
 use std::collections::HashMap;
@@ -408,6 +409,67 @@ impl SessionManager {
         let mut cs = cs.write().await;
         cs.push_pending(msg);
         Ok(())
+    }
+
+    /// Rebuild the system prompt for an existing session.
+    /// Called after compaction to pick up skill/config changes.
+    /// Lock Safety: acquires its own write lock; callers must NOT hold
+    /// any external write guard on the same session.
+    pub async fn rebuild_system_prompt(&self, session_id: &str) {
+        let cs = match self.get_conversation_session(session_id).await {
+            Some(cs) => cs,
+            None => return,
+        };
+        let agent_id = {
+            let sessions = self.sessions.read().await;
+            match sessions.get(session_id) {
+                Some(session) => session.agent_id.clone(),
+                None => return,
+            }
+        };
+        invalidate_all_sections();
+
+        // Build new system prompt (same logic as find_or_create)
+        let bootstrap_files = if let Some(ref workspace) = self.workspace_dir {
+            load_bootstrap_files(workspace, self.bootstrap_mode)
+                .unwrap_or_default()
+                .into_iter()
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let tool_registry_guard = self.tool_registry.read().await;
+        let tool_registry_ref = tool_registry_guard.as_ref().map(|r| r.as_ref());
+        let skill_registry = self.skill_registry.read().await.clone();
+
+        let workdir_ctx = self
+            .workspace_dir
+            .as_ref()
+            .map(|p| set_workdir(p.to_string_lossy().to_string()));
+        let tool_ctx = ToolContext {
+            agent_id: agent_id.clone(),
+            workdir: workdir_ctx,
+        };
+
+        let workspace_root = self.workspace_dir.clone().unwrap_or_default();
+
+        let prompt = build_from_workspace(
+            &workspace_root,
+            WorkspaceBuildConfig {
+                bootstrap_files,
+                tool_registry: tool_registry_ref,
+                tool_ctx: &tool_ctx,
+                skill_registry,
+                agent_id: Some(&agent_id),
+                dynamic_sections: vec![],
+                append_section: None,
+            },
+        )
+        .await;
+
+        let mut cs = cs.write().await;
+        cs.replace_system_prompt(prompt);
     }
 
     /// Pop the oldest pending message for a given session.

--- a/src/gateway/session_manager/flush_tests.rs
+++ b/src/gateway/session_manager/flush_tests.rs
@@ -4,7 +4,13 @@ use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::session::persistence::{AgentRole, PendingMessage, PersistenceError, SessionCheckpoint};
+use crate::system_prompt::{
+    invalidate_all_sections, set_agent_prompt, set_custom_prompt, set_override_prompt,
+};
 use async_trait::async_trait;
+use serial_test::serial;
+use std::io::Write;
+use tempfile::TempDir;
 use tokio::sync::Mutex;
 
 fn test_config() -> GatewayConfig {
@@ -412,4 +418,82 @@ async fn test_with_pending_messages_bulk_set() {
     assert_eq!(cp.pending_messages.len(), 2);
     assert_eq!(cp.pending_messages[0].message_id, "msg_2");
     assert_eq!(cp.pending_messages[1].message_id, "msg_3");
+}
+
+fn clear_global_prompt_state() {
+    set_override_prompt(None);
+    set_agent_prompt(None);
+    set_custom_prompt(None);
+    invalidate_all_sections();
+}
+
+fn make_temp_workspace(files: &[(&str, &str)]) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    for (name, content) in files {
+        let path = tmp.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+    tmp
+}
+
+fn make_test_mgr(workspace: Option<&std::path::Path>) -> SessionManager {
+    SessionManager::new(
+        &test_config(),
+        None,
+        workspace.map(std::path::PathBuf::from),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    )
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Step 1.4 — rebuild_system_prompt unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[serial]
+async fn test_rebuild_system_prompt_normal() {
+    clear_global_prompt_state();
+    let tmp = make_temp_workspace(&[
+        ("AGENTS.md", "original agents"),
+        ("SOUL.md", "original soul"),
+    ]);
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let msg = test_message();
+    let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    {
+        let conv = mgr.get_conversation_session(&session_id).await.unwrap();
+        let conv = conv.read().await;
+        assert!(conv.system_prompt().unwrap().contains("original agents"));
+    }
+    std::fs::write(tmp.path().join("AGENTS.md"), "updated agents").unwrap();
+    mgr.rebuild_system_prompt(&session_id).await;
+    {
+        let conv = mgr.get_conversation_session(&session_id).await.unwrap();
+        let conv = conv.read().await;
+        assert!(conv.system_prompt().unwrap().contains("updated agents"));
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_rebuild_system_prompt_edge_cases() {
+    // nonexistent session — should not panic
+    let mgr = make_test_mgr(None);
+    mgr.rebuild_system_prompt("nonexistent-session-id").await;
+
+    // no workspace — system prompt should only have tools + skills
+    clear_global_prompt_state();
+    let msg = test_message();
+    let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    mgr.rebuild_system_prompt(&session_id).await;
+    {
+        let conv = mgr.get_conversation_session(&session_id).await.unwrap();
+        let conv = conv.read().await;
+        let prompt = conv.system_prompt().unwrap();
+        assert!(!prompt.contains("agents content"));
+        assert!(!prompt.contains("soul content"));
+        assert!(!prompt.contains("memory content"));
+    }
 }

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -11,9 +11,8 @@ use std::io::Write;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
 
-/// Clear all global prompt state and section cache.
-/// Must be called before each test that exercises system prompt generation,
-/// because the global SECTION_CACHE and priority prompts are shared across tests.
+/// Clear global prompt state and section cache. Must be called before tests
+/// that exercise system prompt generation (global SECTION_CACHE is shared).
 fn clear_global_prompt_state() {
     set_override_prompt(None);
     set_agent_prompt(None);
@@ -44,13 +43,7 @@ fn test_message() -> Message {
 
 #[tokio::test]
 async fn test_find_or_create_existing_session() {
-    let mgr = SessionManager::new(
-        &test_config(),
-        None,
-        None,
-        BootstrapMode::Full,
-        ReasoningLevel::default(),
-    );
+    let mgr = make_test_mgr(None);
     let msg = test_message();
     let session_id = mgr.compute_session_key("feishu", &msg, None);
     {
@@ -65,26 +58,16 @@ async fn test_find_or_create_existing_session() {
             },
         );
     }
-
-    // find_or_create should return the existing session (read-lock fast path)
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
     assert_eq!(result, session_id);
 }
 
 #[tokio::test]
 async fn test_find_or_create_new_user_creates_session() {
-    let mgr = SessionManager::new(
-        &test_config(),
-        None,
-        None,
-        BootstrapMode::Full,
-        ReasoningLevel::default(),
-    );
+    let mgr = make_test_mgr(None);
     let msg = test_message();
-
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
     let sessions = mgr.sessions.read().await;
-    assert!(sessions.contains_key(&result));
     let session = sessions.get(&result).unwrap();
     assert_eq!(session.agent_id, "agent-b");
     assert_eq!(session.channel, "feishu");
@@ -92,11 +75,6 @@ async fn test_find_or_create_new_user_creates_session() {
 
 #[tokio::test]
 async fn test_archived_session_restoration() {
-    use crate::session::persistence::ReasoningLevel;
-    use crate::session::persistence::SessionCheckpoint;
-    use std::sync::Arc;
-
-    // Build a mock storage that returns an Archived checkpoint
     let mock_storage = Arc::new(MockPersistService {
         archived_checkpoint: Mutex::new(Some(
             SessionCheckpoint::new("feishu:user-a:agent-b".to_string())
@@ -105,21 +83,16 @@ async fn test_archived_session_restoration() {
         )),
         restore_called: Mutex::new(false),
     });
-
-    let config = test_config();
-    let mut mgr = SessionManager::new(
-        &config,
+    let mgr = SessionManager::new(
+        &test_config(),
         Some(mock_storage.clone()),
         None,
         BootstrapMode::Full,
         ReasoningLevel::default(),
     );
     let msg = test_message();
-
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
     assert_eq!(result, "feishu:user-a:agent-b");
-
-    // Verify restore was called
     let called = *mock_storage.restore_called.lock().await;
     assert!(called, "restore_checkpoint should have been called");
 }
@@ -137,9 +110,17 @@ fn make_temp_workspace(files: &[(&str, &str)]) -> TempDir {
     tmp
 }
 
-/// Test 1: workspace_dir + BootstrapMode::Full → system prompt contains all 7 files.
-/// Uses #[serial] because build_from_workspace shares a global SECTION_CACHE
-/// that caches RoleSection by name — parallel tests would get stale cached content.
+/// Shorthand for `SessionManager::new` with test defaults (Full mode, no storage).
+fn make_test_mgr(workspace: Option<&std::path::Path>) -> SessionManager {
+    SessionManager::new(
+        &test_config(),
+        None,
+        workspace.map(std::path::PathBuf::from),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    )
+}
+
 #[tokio::test]
 #[serial]
 async fn test_bootstrap_full_injects_all_files() {
@@ -185,7 +166,6 @@ async fn test_bootstrap_full_injects_all_files() {
     assert!(prompt.contains("memory content"), "missing memory content");
 }
 
-/// Test 2: workspace_dir + BootstrapMode::Minimal → system prompt contains only 5 minimal files.
 #[tokio::test]
 #[serial]
 async fn test_bootstrap_minimal_injects_five_files() {
@@ -232,20 +212,11 @@ async fn test_bootstrap_minimal_injects_five_files() {
     // even in minimal mode when the workspace contains MEMORY.md.
 }
 
-/// Test 3: No workspace_dir → system prompt exists (contains ToolsSection) but
-/// has no bootstrap file content.
 #[tokio::test]
 #[serial]
 async fn test_no_workspace_dir_no_system_prompt() {
     clear_global_prompt_state();
-
-    let mgr = SessionManager::new(
-        &test_config(),
-        None,
-        None,
-        BootstrapMode::Full,
-        ReasoningLevel::default(),
-    );
+    let mgr = make_test_mgr(None);
     let msg = test_message();
 
     let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
@@ -260,7 +231,6 @@ async fn test_no_workspace_dir_no_system_prompt() {
     );
 }
 
-/// Test 4: Partial bootstrap files → system prompt contains only existing files.
 #[tokio::test]
 #[serial]
 async fn test_partial_bootstrap_files() {
@@ -298,7 +268,6 @@ async fn test_partial_bootstrap_files() {
     );
 }
 
-/// Test 5: ToolRegistry injection → ToolsSection contains actual tool names.
 #[tokio::test]
 #[serial]
 async fn test_find_or_create_with_tool_registry() {
@@ -348,20 +317,10 @@ async fn test_find_or_create_with_tool_registry() {
 
 #[tokio::test]
 async fn test_find_or_create_no_storage() {
-    let mgr = SessionManager::new(
-        &test_config(),
-        None,
-        None,
-        BootstrapMode::Full,
-        ReasoningLevel::default(),
-    );
+    let mgr = make_test_mgr(None);
     let msg = test_message();
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
     assert_eq!(result, "feishu:user-a:agent-b");
-    let sessions = mgr.sessions.read().await;
-    let session = sessions.get(&result).unwrap();
-    assert_eq!(session.agent_id, "agent-b");
-    assert_eq!(session.channel, "feishu");
 }
 
 // Mock persistence service for tests
@@ -439,35 +398,25 @@ async fn test_find_or_create_creates_workspace_directory() {
     );
     let msg = test_message();
     let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
-    let expected_workspace = workspace_dir
+    let expected = workspace_dir
         .unwrap()
         .join("workspaces")
         .join("agent-b")
         .join("user-a");
-    assert!(expected_workspace.exists());
-    assert!(expected_workspace.is_dir());
-
-    // Idempotent: calling again should not fail
+    assert!(expected.exists() && expected.is_dir());
     let session_id2 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
     assert_eq!(session_id, session_id2);
 }
 
 #[tokio::test]
 async fn test_find_or_create_no_workspace_dir_skipped() {
-    let mgr = SessionManager::new(
-        &test_config(),
-        None,
-        None,
-        BootstrapMode::Full,
-        ReasoningLevel::default(),
-    );
+    let mgr = make_test_mgr(None);
     let msg = test_message();
     assert!(mgr.find_or_create("feishu", &msg, None).await.is_ok());
 }
 
 #[tokio::test]
 async fn test_find_or_create_workspace_invalid_ids() {
-    // invalid agent_id
     let tmp = tempfile::TempDir::new().unwrap();
     let mgr = SessionManager::new(
         &test_config(),
@@ -480,7 +429,6 @@ async fn test_find_or_create_workspace_invalid_ids() {
     msg.to = "../etc".to_string();
     assert!(mgr.find_or_create("feishu", &msg, None).await.is_err());
 
-    // invalid user_id
     let tmp = tempfile::TempDir::new().unwrap();
     let mgr = SessionManager::new(
         &test_config(),

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -105,6 +105,12 @@ impl ConversationSession {
         self
     }
 
+    /// Replace the system prompt on an existing session.
+    /// Used by `SessionManager::rebuild_system_prompt` after compaction.
+    pub fn replace_system_prompt(&mut self, prompt: impl Into<String>) {
+        self.system_prompt = Some(prompt.into());
+    }
+
     /// Appends a message to the session.
     fn push_message(&mut self, role: &str, content_blocks: Vec<ContentBlock>) {
         self.messages.push(SessionMessage {


### PR DESCRIPTION
## PR 概述

compaction 后 system prompt 未重建，导致 Skill 热更新链路断裂。修复方案：在 compaction 完成后触发 `rebuild_system_prompt`，确保 session 的 system prompt 与最新文件内容同步。

### 变更内容

- `session_manager.rs`: compaction 后调用 `rebuild_system_prompt`
- `session_handler.rs`: 调整 compaction 触发逻辑
- `session.rs`: 优化 `ConversationSession` 的 prompt 管理
- 测试文件拆分（`flush_tests.rs` 新增 rebuild_system_prompt 测试）

Source: issue #776
Type: fix
