### PR TITLE
feat(slash): 新增 /clear 命令 — 手动清除 system prompt 静态层缓存并触发重建

### DIFF
--- a/docs/design/slash/README.md
+++ b/docs/design/slash/README.md
@@ -42,6 +42,7 @@ Dispatcher 不持有 Session 引用——Handler 返回 SlashResult 后，由 Ga
 | WorkdirHandler | cd, pwd, git | Reply / Exec | ❌ |
 | ExecHandler | exec | Exec / Reply | ❌ |
 | HelpHandler | help | Reply | ✅ |
+| ClearHandler | clear | Reply | ✅ |
 
 ### 子功能目录
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -301,6 +301,8 @@ impl From<super::im::AdapterError> for GatewayError {
 }
 
 #[cfg(test)]
+mod session_handler_dynamic_tests;
+#[cfg(test)]
 mod session_handler_tests;
 #[cfg(test)]
 mod tests;

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -114,6 +114,9 @@ impl SessionMessageHandler {
         if content.starts_with("/compact") {
             return self.handle_compact_command(session_id, &content).await;
         }
+        if content.trim() == "/clear" {
+            return self.handle_clear_command(session_id).await;
+        }
         if self.session_manager.is_session_busy(session_id).await {
             self.enqueue_pending(session_id, content).await;
             return HandleResult::MessageQueued;
@@ -202,6 +205,17 @@ impl SessionMessageHandler {
             )
             .await;
         });
+        HandleResult::LlmStarted
+    }
+
+    /// Handle `/clear`: invalidate static-layer cache and rebuild system prompt.
+    async fn handle_clear_command(&self, session_id: &str) -> HandleResult {
+        self.session_manager.rebuild_system_prompt(session_id).await;
+        send_output(
+            &self.output_tx,
+            "System prompt 缓存已清除，下次请求将重新构建。",
+        )
+        .await;
         HandleResult::LlmStarted
     }
 

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -1,0 +1,207 @@
+use super::session_handler::MessageMetadata;
+use super::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use super::*;
+use crate::llm::fallback::FallbackClient;
+use crate::llm::LLMRegistry;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use crate::system_prompt::sections::{
+    clear_append_section, get_append_section, set_append_section, Section,
+};
+
+fn handler_with_sm(sm: Arc<SessionManager>) -> SessionMessageHandler {
+    let registry = Arc::new(LLMRegistry::new());
+    let fallback = Arc::new(FallbackClient::from_strings(registry, vec![]));
+    SessionMessageHandler::new_no_output(sm, fallback)
+}
+
+fn make_msg() -> crate::gateway::Message {
+    use std::collections::HashMap;
+    crate::gateway::Message {
+        id: "msg_1".into(),
+        from: "alice".into(),
+        to: "bob".into(),
+        content: "hello".into(),
+        channel: "ch".into(),
+        timestamp: chrono::Utc::now().timestamp(),
+        metadata: HashMap::new(),
+    }
+}
+
+fn make_meta(sender: &str, channel: &str, ts: i64) -> MessageMetadata {
+    MessageMetadata {
+        sender_id: sender.to_string(),
+        channel: channel.to_string(),
+        timestamp: ts,
+    }
+}
+
+/// build_dynamic_sections always includes ChannelContext with rendered fields.
+#[test]
+fn test_build_dynamic_sections_channel_context() {
+    let meta = make_meta("user_42", "feishu", 1700000000);
+    let sections = build_dynamic_sections(0, &meta);
+
+    // Find ChannelContext section
+    let cc = sections
+        .iter()
+        .find(|s: &&Section| s.name() == "channel_context");
+    assert!(cc.is_some(), "ChannelContext should always be present");
+    let rendered = cc.unwrap().render();
+    assert!(rendered.contains("sender_id: user_42"));
+    assert!(rendered.contains("chat_name: feishu"));
+    // Timestamp should be a valid RFC3339 string
+    assert!(rendered.contains("timestamp:"));
+}
+
+/// build_dynamic_sections always includes SessionState with correct turn_count.
+#[test]
+fn test_build_dynamic_sections_session_state() {
+    let meta = make_meta("u", "ch", 0);
+    let sections = build_dynamic_sections(7, &meta);
+
+    let ss = sections
+        .iter()
+        .find(|s: &&Section| s.name() == "session_state");
+    assert!(ss.is_some(), "SessionState should always be present");
+    let rendered = ss.unwrap().render();
+    assert!(rendered.contains("turn_count: 7"));
+    assert!(rendered.contains("pending_tasks:"));
+}
+
+/// SessionState with zero turn_count.
+#[test]
+fn test_build_dynamic_sections_turn_count_zero() {
+    let meta = make_meta("u", "ch", 0);
+    let sections = build_dynamic_sections(0, &meta);
+    let ss = sections
+        .iter()
+        .find(|s: &&Section| s.name() == "session_state")
+        .unwrap();
+    assert!(ss.render().contains("turn_count: 0"));
+}
+
+/// AppendSection is included when set, cleared after use; absent when unset.
+#[test]
+fn test_build_dynamic_sections_append_section() {
+    // Part 1: set → build → should include and clear
+    clear_append_section();
+    let meta = make_meta("u", "ch", 0);
+    set_append_section("extra instructions here".to_string());
+    let sections = build_dynamic_sections(0, &meta);
+    let has_append = sections.iter().any(|s| s.name() == "append");
+    // Due to global state races with other tests, we only assert the
+    // round-trip: set → get returns Some, then get returns None after build.
+    // (Other tests may clear between set and build in parallel runs.)
+    if has_append {
+        assert!(
+            get_append_section().is_none(),
+            "AppendSection should be cleared after build"
+        );
+    }
+
+    // Part 2: not set → build → should be absent
+    clear_append_section();
+    let sections2 = build_dynamic_sections(0, &meta);
+    assert!(
+        !sections2.iter().any(|s| s.name() == "append"),
+        "AppendSection absent when unset"
+    );
+}
+
+/// build_full_system_prompt composes static + boundary + dynamic sections.
+#[test]
+fn test_build_full_system_prompt_composition() {
+    let meta = make_meta("alice", "telegram", 1700000000);
+    let sections = build_dynamic_sections(3, &meta);
+    let full = build_full_system_prompt(Some("You are helpful."), &sections);
+
+    // Contains static layer
+    assert!(full.contains("You are helpful."));
+    // Contains boundary marker
+    assert!(full.contains("<!-- STATIC_LAYER_END -->"));
+    // Contains dynamic ChannelContext
+    assert!(full.contains("sender_id: alice"));
+    // Contains dynamic SessionState
+    assert!(full.contains("turn_count: 3"));
+}
+
+/// build_full_system_prompt with no static prompt uses only dynamic sections.
+#[test]
+fn test_build_full_system_prompt_no_static() {
+    let meta = make_meta("bob", "ch", 0);
+    let sections = build_dynamic_sections(0, &meta);
+    let full = build_full_system_prompt(None, &sections);
+
+    // No boundary marker when no static prompt
+    assert!(!full.contains("<!-- STATIC_LAYER_END -->"));
+    // Still contains dynamic content
+    assert!(full.contains("sender_id: bob"));
+    assert!(full.contains("turn_count: 0"));
+}
+
+/// build_full_system_prompt with static but empty dynamic sections.
+#[test]
+fn test_build_full_system_prompt_empty_dynamic() {
+    // Clear append section so dynamic sections are only ChannelContext + SessionState
+    clear_append_section();
+    let meta = make_meta("", "", 0);
+    // build_dynamic_sections always returns ChannelContext + SessionState (at minimum)
+    let sections = build_dynamic_sections(0, &meta);
+    // These two sections always render to non-empty strings, so dynamic is never truly empty.
+    // But we verify the composition still works.
+    let full = build_full_system_prompt(Some("static"), &sections);
+    assert!(full.contains("static"));
+    assert!(full.contains("<!-- STATIC_LAYER_END -->"));
+}
+
+/// handle_message backward compat: returns LlmStarted for a normal idle session.
+#[tokio::test]
+async fn test_handle_message_backward_compat() {
+    let config = crate::gateway::GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: crate::gateway::DmScope::default(),
+    };
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let sid = sm.find_or_create("ch", &make_msg(), None).await.unwrap();
+    let handler = handler_with_sm(Arc::clone(&sm));
+
+    // Original handle_message (no meta) should still return LlmStarted
+    let result = handler.handle_message(&sid, "test input".to_string()).await;
+    assert!(matches!(result, HandleResult::LlmStarted));
+    // Session should be busy immediately after
+    assert!(sm.is_session_busy(&sid).await);
+
+    // Wait for the async LLM task to finish (empty chain → failure → busy reset)
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    assert!(!sm.is_session_busy(&sid).await);
+}
+
+/// GitStatus section is included when CURRENT_WORKDIR points to a git repo.
+#[test]
+fn test_build_dynamic_sections_git_status() {
+    use crate::system_prompt::workdir::{clear_workdir, set_workdir};
+
+    // Point workdir at this crate's root (which is a git repo)
+    let ctx = set_workdir(env!("CARGO_MANIFEST_DIR").to_string());
+    let meta = make_meta("u", "ch", 0);
+    let sections = build_dynamic_sections(0, &meta);
+    let has_git = sections.iter().any(|s| s.name() == "git_status");
+    // The crate root may or may not be a git repo depending on
+    // how the repo is laid out, so we just verify the function
+    // does not panic and returns a well-formed Vec.
+    assert!(!sections.is_empty());
+    // If it IS a git repo, git_status should be present
+    if ctx.has_git {
+        assert!(has_git, "GitStatus should be present for a git repo");
+    }
+    clear_workdir();
+}

--- a/src/gateway/session_handler_tests.rs
+++ b/src/gateway/session_handler_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::llm::fallback::FallbackClient;
+use crate::llm::session::ChatSession;
 use crate::llm::LLMRegistry;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
@@ -278,146 +279,9 @@ async fn test_compact_command_with_instruction() {
     assert!(matches!(result, HandleResult::LlmStarted));
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Step 1.4 — Dynamic layer injection tests
-// ═══════════════════════════════════════════════════════════════════════════
-
-use super::session_handler::MessageMetadata;
-use super::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
-use crate::system_prompt::sections::{
-    clear_append_section, get_append_section, set_append_section, Section,
-};
-
-fn make_meta(sender: &str, channel: &str, ts: i64) -> MessageMetadata {
-    MessageMetadata {
-        sender_id: sender.to_string(),
-        channel: channel.to_string(),
-        timestamp: ts,
-    }
-}
-
-/// build_dynamic_sections always includes ChannelContext with rendered fields.
-#[test]
-fn test_build_dynamic_sections_channel_context() {
-    let meta = make_meta("user_42", "feishu", 1700000000);
-    let sections = build_dynamic_sections(0, &meta);
-
-    // Find ChannelContext section
-    let cc = sections
-        .iter()
-        .find(|s: &&Section| s.name() == "channel_context");
-    assert!(cc.is_some(), "ChannelContext should always be present");
-    let rendered = cc.unwrap().render();
-    assert!(rendered.contains("sender_id: user_42"));
-    assert!(rendered.contains("chat_name: feishu"));
-    // Timestamp should be a valid RFC3339 string
-    assert!(rendered.contains("timestamp:"));
-}
-
-/// build_dynamic_sections always includes SessionState with correct turn_count.
-#[test]
-fn test_build_dynamic_sections_session_state() {
-    let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(7, &meta);
-
-    let ss = sections
-        .iter()
-        .find(|s: &&Section| s.name() == "session_state");
-    assert!(ss.is_some(), "SessionState should always be present");
-    let rendered = ss.unwrap().render();
-    assert!(rendered.contains("turn_count: 7"));
-    assert!(rendered.contains("pending_tasks:"));
-}
-
-/// SessionState with zero turn_count.
-#[test]
-fn test_build_dynamic_sections_turn_count_zero() {
-    let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta);
-    let ss = sections
-        .iter()
-        .find(|s: &&Section| s.name() == "session_state")
-        .unwrap();
-    assert!(ss.render().contains("turn_count: 0"));
-}
-
-/// AppendSection is included when set, cleared after use; absent when unset.
-#[test]
-fn test_build_dynamic_sections_append_section() {
-    // Part 1: set → build → should include and clear
-    clear_append_section();
-    let meta = make_meta("u", "ch", 0);
-    set_append_section("extra instructions here".to_string());
-    let sections = build_dynamic_sections(0, &meta);
-    let has_append = sections.iter().any(|s| s.name() == "append");
-    // Due to global state races with other tests, we only assert the
-    // round-trip: set → get returns Some, then get returns None after build.
-    // (Other tests may clear between set and build in parallel runs.)
-    if has_append {
-        assert!(
-            get_append_section().is_none(),
-            "AppendSection should be cleared after build"
-        );
-    }
-
-    // Part 2: not set → build → should be absent
-    clear_append_section();
-    let sections2 = build_dynamic_sections(0, &meta);
-    assert!(
-        !sections2.iter().any(|s| s.name() == "append"),
-        "AppendSection absent when unset"
-    );
-}
-
-/// build_full_system_prompt composes static + boundary + dynamic sections.
-#[test]
-fn test_build_full_system_prompt_composition() {
-    let meta = make_meta("alice", "telegram", 1700000000);
-    let sections = build_dynamic_sections(3, &meta);
-    let full = build_full_system_prompt(Some("You are helpful."), &sections);
-
-    // Contains static layer
-    assert!(full.contains("You are helpful."));
-    // Contains boundary marker
-    assert!(full.contains("<!-- STATIC_LAYER_END -->"));
-    // Contains dynamic ChannelContext
-    assert!(full.contains("sender_id: alice"));
-    // Contains dynamic SessionState
-    assert!(full.contains("turn_count: 3"));
-}
-
-/// build_full_system_prompt with no static prompt uses only dynamic sections.
-#[test]
-fn test_build_full_system_prompt_no_static() {
-    let meta = make_meta("bob", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta);
-    let full = build_full_system_prompt(None, &sections);
-
-    // No boundary marker when no static prompt
-    assert!(!full.contains("<!-- STATIC_LAYER_END -->"));
-    // Still contains dynamic content
-    assert!(full.contains("sender_id: bob"));
-    assert!(full.contains("turn_count: 0"));
-}
-
-/// build_full_system_prompt with static but empty dynamic sections.
-#[test]
-fn test_build_full_system_prompt_empty_dynamic() {
-    // Clear append section so dynamic sections are only ChannelContext + SessionState
-    clear_append_section();
-    let meta = make_meta("", "", 0);
-    // build_dynamic_sections always returns ChannelContext + SessionState (at minimum)
-    let sections = build_dynamic_sections(0, &meta);
-    // These two sections always render to non-empty strings, so dynamic is never truly empty.
-    // But we verify the composition still works.
-    let full = build_full_system_prompt(Some("static"), &sections);
-    assert!(full.contains("static"));
-    assert!(full.contains("<!-- STATIC_LAYER_END -->"));
-}
-
-/// handle_message backward compat: returns LlmStarted for a normal idle session.
+/// `/clear` command returns LlmStarted
 #[tokio::test]
-async fn test_handle_message_backward_compat() {
+async fn test_clear_command_returns_llm_started() {
     let config = crate::gateway::GatewayConfig {
         name: "test".to_string(),
         rate_limit_per_minute: 100,
@@ -434,34 +298,88 @@ async fn test_handle_message_backward_compat() {
     let sid = sm.find_or_create("ch", &make_msg(), None).await.unwrap();
     let handler = handler_with_sm(Arc::clone(&sm));
 
-    // Original handle_message (no meta) should still return LlmStarted
-    let result = handler.handle_message(&sid, "test input".to_string()).await;
+    let result = handler.handle_message(&sid, "/clear".to_string()).await;
     assert!(matches!(result, HandleResult::LlmStarted));
-    // Session should be busy immediately after
-    assert!(sm.is_session_busy(&sid).await);
-
-    // Wait for the async LLM task to finish (empty chain → failure → busy reset)
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    assert!(!sm.is_session_busy(&sid).await);
 }
 
-/// GitStatus section is included when CURRENT_WORKDIR points to a git repo.
-#[test]
-fn test_build_dynamic_sections_git_status() {
-    use crate::system_prompt::workdir::{clear_workdir, set_workdir};
+/// `/clear` bypasses busy check (does not return MessageQueued when session is busy)
+#[tokio::test]
+async fn test_clear_command_bypasses_busy() {
+    let config = crate::gateway::GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: crate::gateway::DmScope::default(),
+    };
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let sid = sm.find_or_create("ch", &make_msg(), None).await.unwrap();
 
-    // Point workdir at this crate's root (which is a git repo)
-    let ctx = set_workdir(env!("CARGO_MANIFEST_DIR").to_string());
-    let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta);
-    let has_git = sections.iter().any(|s| s.name() == "git_status");
-    // The crate root may or may not be a git repo depending on
-    // how the repo is laid out, so we just verify the function
-    // does not panic and returns a well-formed Vec.
-    assert!(!sections.is_empty());
-    // If it IS a git repo, git_status should be present
-    if ctx.has_git {
-        assert!(has_git, "GitStatus should be present for a git repo");
+    // Manually set busy
+    if let Some(cs) = sm.get_conversation_session(&sid).await {
+        cs.write().await.set_llm_busy(true);
     }
-    clear_workdir();
+
+    let handler = handler_with_sm(Arc::clone(&sm));
+    let result = handler.handle_message(&sid, "/clear".to_string()).await;
+    // `/clear` should bypass busy check and NOT return MessageQueued
+    assert!(!matches!(result, HandleResult::MessageQueued));
+    assert!(matches!(result, HandleResult::LlmStarted));
+}
+
+/// `/clear` triggers system prompt rebuild via SessionManager
+#[tokio::test]
+async fn test_clear_command_rebuilds_system_prompt() {
+    let config = crate::gateway::GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: crate::gateway::DmScope::default(),
+    };
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let sid = sm.find_or_create("ch", &make_msg(), None).await.unwrap();
+
+    // Record the system prompt before /clear
+    let prompt_before = {
+        let cs = sm.get_conversation_session(&sid).await.unwrap();
+        let cs = cs.read().await;
+        cs.system_prompt().map(|s| s.to_string())
+    };
+
+    let handler = handler_with_sm(Arc::clone(&sm));
+    let result = handler.handle_message(&sid, "/clear".to_string()).await;
+    assert!(matches!(result, HandleResult::LlmStarted));
+
+    // After /clear, system prompt should have been rebuilt
+    let prompt_after = {
+        let cs = sm.get_conversation_session(&sid).await.unwrap();
+        let cs = cs.read().await;
+        cs.system_prompt().map(|s| s.to_string())
+    };
+
+    // The rebuild replaces the system prompt via replace_system_prompt.
+    // Even if content is the same (no workspace), the call itself confirms
+    // the rebuild path was taken. We verify the prompt is Some (not None).
+    assert!(
+        prompt_after.is_some(),
+        "system prompt should be Some after rebuild"
+    );
+    // If original prompt was also Some, verify rebuild ran (both Some is valid).
+    // The key invariant is that rebuild_system_prompt was called and didn't skip.
+    // We also verify the session is not busy (rebuild does not set busy).
+    assert!(
+        !sm.is_session_busy(&sid).await,
+        "/clear should not leave the session busy"
+    );
 }


### PR DESCRIPTION
新增 /clear 斜杠指令，允许用户手动清除 system prompt 静态层缓存并触发重建。

改动：
- SessionMessageHandler 新增 handle_clear_command 方法
- /clear 为 Immediate 指令，绕过 busy 检查
- 复用 SessionManager::rebuild_system_prompt 重建
- design doc Handler 清单新增 ClearHandler
- 拆分 session_handler_tests.rs（500 行限制）
- 新增 3 个单元测试

Source: issue #787
Type: feat
