### PR TITLE
fix(processor_chain): ContentBlock[] 出站链传递格式

### DIFF
--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -21,6 +21,7 @@ impl Gateway {
         session_id: &str,
         channel: &str,
         raw_output: &str,
+        content_blocks: Vec<crate::llm::types::ContentBlock>,
     ) -> Result<(), GatewayError> {
         // Step 1: resolve chat_id
         let chat_id = self
@@ -47,6 +48,7 @@ impl Gateway {
                 content: raw_output.to_string(),
                 metadata: serde_json::Map::new(),
                 suppress: false,
+                content_blocks: content_blocks.clone(),
             };
             let result = registry
                 .process_outbound(processed)
@@ -120,6 +122,7 @@ impl Gateway {
                 content: raw_output.to_string(),
                 metadata: serde_json::Map::new(),
                 suppress: false,
+                content_blocks: content_blocks.clone(),
             };
             let result = registry.process_outbound(processed).await;
             match result {

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -12,6 +12,7 @@ use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_sy
 use crate::llm::fallback::FallbackClient;
 use crate::llm::session::ChatSession;
 use crate::llm::types::ContentBlock;
+use crate::llm::types::UnifiedResponse;
 use crate::llm::{ChatRequest, ChatResponse, Message as ChatMessage};
 use crate::session::compaction::{
     execute_compact, CompactConfig, CompactionResult, CompactionService,
@@ -56,18 +57,17 @@ pub enum HandleResult {
 pub struct SessionMessageHandler {
     session_manager: Arc<SessionManager>,
     fallback_client: Arc<FallbackClient>,
-    output_tx: Arc<RwLock<Option<mpsc::Sender<String>>>>,
+    output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     compaction_service: Arc<std::sync::Mutex<CompactionService>>,
 }
 
 // ── Construction ───────────────────────────────────────────────────────────
-
 impl SessionMessageHandler {
     /// Create a new handler with an output channel for streaming responses.
     pub fn new(
         session_manager: Arc<SessionManager>,
         fallback_client: Arc<FallbackClient>,
-        output_tx: mpsc::Sender<String>,
+        output_tx: mpsc::Sender<(String, Vec<ContentBlock>)>,
     ) -> Self {
         Self {
             session_manager,
@@ -257,7 +257,7 @@ impl SessionMessageHandler {
         meta: &MessageMetadata,
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-    ) -> Result<String, crate::llm::LLMError> {
+    ) -> Result<UnifiedResponse, crate::llm::LLMError> {
         // ── Static layer ───────────────────────────────────────────────
         let (static_prompt_opt, turn_count, workdir_path) =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
@@ -297,17 +297,17 @@ impl SessionMessageHandler {
             temperature: 0.7,
             max_tokens: None,
         };
-        let response: ChatResponse = fallback_client.chat(request).await?;
-        Ok(response.content)
+        let response = fallback_client.chat_unified(request).await?;
+        Ok(response)
     }
 
     /// Clear busy flag, send output, and drain pending messages.
     async fn finish_llm(
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-        result: Result<String, crate::llm::LLMError>,
+        result: Result<UnifiedResponse, crate::llm::LLMError>,
         fallback_client: &Arc<FallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<String>>>>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     ) {
         Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
         Self::drain_pending_loop(session_manager, session_id, fallback_client, output_tx).await;
@@ -316,19 +316,27 @@ impl SessionMessageHandler {
     async fn clear_busy_and_send(
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-        result: Result<String, crate::llm::LLMError>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<String>>>>,
+        result: Result<UnifiedResponse, crate::llm::LLMError>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     ) {
         if let Some(cs) = session_manager.get_conversation_session(session_id).await {
             let cs = cs.write().await;
             cs.set_llm_busy(false);
         }
-
         match result {
-            Ok(text) => {
+            Ok(response) => {
+                let text = response
+                    .content_blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text(t) => Some(t.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
                 let guard = output_tx.read().await;
                 if let Some(tx) = guard.as_ref() {
-                    let _ = tx.send(text).await;
+                    let _ = tx.send((text, response.content_blocks)).await;
                 }
             }
             Err(err) => {
@@ -341,7 +349,7 @@ impl SessionMessageHandler {
         session_manager: &Arc<SessionManager>,
         session_id: &str,
         fallback_client: &Arc<FallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<String>>>>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     ) {
         loop {
             // Get next pending message
@@ -368,9 +376,7 @@ impl SessionMessageHandler {
         }
     }
 }
-
 // ── Compaction helpers ─────────────────────────────────────────────────────
-
 fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
     blocks
         .iter()
@@ -419,10 +425,13 @@ async fn apply_compact_result(
     sm.rebuild_system_prompt(session_id).await;
 }
 
-async fn send_output(output_tx: &Arc<RwLock<Option<mpsc::Sender<String>>>>, text: &str) {
+async fn send_output(
+    output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    text: &str,
+) {
     let guard = output_tx.read().await;
     if let Some(tx) = guard.as_ref() {
-        let _ = tx.send(text.to_string()).await;
+        let _ = tx.send((text.to_string(), vec![])).await;
     }
 }
 
@@ -437,13 +446,12 @@ async fn load_compact_inputs(
     let llm_msgs = build_compact_messages(ChatSession::messages(&*cs_read));
     Some((model, llm_msgs))
 }
-
 /// Run manual `/compact` invocation.
 #[allow(clippy::too_many_arguments)]
 async fn run_manual_compact(
     sm: Arc<SessionManager>,
     fc: Arc<FallbackClient>,
-    output_tx: Arc<RwLock<Option<mpsc::Sender<String>>>>,
+    output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     svc: Arc<std::sync::Mutex<CompactionService>>,
     sid: String,
     model: String,
@@ -468,7 +476,6 @@ async fn run_manual_compact(
         }
     }
 }
-
 /// Finalize auto-compact result.
 async fn finalize_auto_compact(
     sm: &Arc<SessionManager>,

--- a/src/gateway/tests_checkpoint.rs
+++ b/src/gateway/tests_checkpoint.rs
@@ -264,7 +264,7 @@ async fn test_gateway_without_checkpoint_manager_has_no_cm() {
     add_session(&mut msg, &sm).await;
     // Without cm, send_outbound just sends without saving checkpoints
     let result = gw
-        .send_outbound("test_channel", &msg.metadata["session_id"], "hello")
+        .send_outbound("test_channel", &msg.metadata["session_id"], "hello", vec![])
         .await;
     assert!(result.is_ok());
 }
@@ -292,7 +292,7 @@ async fn test_send_outbound_with_cm_saves_checkpoint_on_success() {
     let mut msg = make_message();
     add_session(&mut msg, &sm).await;
     let session_id = msg.metadata["session_id"].clone();
-    gw.send_outbound("test_channel", &session_id, "hello")
+    gw.send_outbound("test_channel", &session_id, "hello", vec![])
         .await
         .unwrap();
     // Verify: checkpoint was saved
@@ -344,7 +344,7 @@ async fn test_send_outbound_without_cm_does_not_save_checkpoint() {
     add_session(&mut msg, &sm).await;
     let session_id = msg.metadata["session_id"].clone();
 
-    gw.send_outbound("test_channel", &session_id, "hello")
+    gw.send_outbound("test_channel", &session_id, "hello", vec![])
         .await
         .unwrap();
 
@@ -384,7 +384,7 @@ async fn test_send_failure_does_not_trigger_checkpoint() {
     add_session(&mut msg, &sm).await;
     let session_id = msg.metadata["session_id"].clone();
 
-    let result = gw.send_outbound("test_channel", &session_id, "hello").await;
+    let result = gw.send_outbound("test_channel", &session_id, "hello", vec![]).await;
     assert!(result.is_err(), "send should fail");
 
     // Verify: no checkpoint was saved
@@ -429,7 +429,7 @@ async fn test_send_outbound_interactive_triggers_checkpoint() {
         "content": r#"{"type":"card","elements":[{"tag":"markdown","content":"**hello**"}]}"#
     })
     .to_string();
-    gw.send_outbound("test_channel", &session_id, &interactive_json)
+    gw.send_outbound("test_channel", &session_id, &interactive_json, vec![])
         .await
         .unwrap();
 
@@ -473,7 +473,7 @@ async fn test_send_outbound_pending_message_contains_correct_data() {
     add_session(&mut msg, &sm).await;
     let session_id = msg.metadata["session_id"].clone();
 
-    gw.send_outbound("test_channel", &session_id, "test content")
+    gw.send_outbound("test_channel", &session_id, "test content", vec![])
         .await
         .unwrap();
 

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -53,6 +53,7 @@ impl MessageProcessor for TraceProcessor {
             content: ctx.content.clone(),
             metadata: meta,
             suppress: false,
+            content_blocks: vec![],
         }))
     }
 }
@@ -270,6 +271,7 @@ async fn test_processor_chain_metadata_merge() {
                 content: ctx.content.clone(),
                 metadata: meta,
                 suppress: false,
+                content_blocks: vec![],
             }))
         }
     }

--- a/src/llm/fallback.rs
+++ b/src/llm/fallback.rs
@@ -91,6 +91,14 @@ impl FallbackClient {
         self.try_fallback_chain(request).await
     }
 
+    /// Make a chat request returning structured content blocks.
+    pub async fn chat_unified(
+        &self,
+        request: ChatRequest,
+    ) -> Result<crate::llm::types::UnifiedResponse, LLMError> {
+        self.try_fallback_chain_unified(request).await
+    }
+
     /// Walk the fallback chain until one model succeeds or all are exhausted.
     async fn try_fallback_chain(&self, mut request: ChatRequest) -> Result<ChatResponse, LLMError> {
         let mut model_idx = 0;
@@ -127,6 +135,59 @@ impl FallbackClient {
                     let kind = err.kind();
                     tracing::warn!(
                         provider = %entry.provider, model = %entry.model, error = %err, kind = ?kind, "LLM call failed"
+                    );
+                    self.cooldown
+                        .record_failure(&entry.provider, &entry.model, kind)
+                        .await;
+                    model_idx += 1;
+                }
+            }
+        }
+    }
+}
+
+// --- Unified chat with fallback ---
+
+impl FallbackClient {
+    /// Walk the fallback chain using chat_unified() until one model succeeds.
+    async fn try_fallback_chain_unified(
+        &self,
+        mut request: ChatRequest,
+    ) -> Result<crate::llm::types::UnifiedResponse, LLMError> {
+        let mut model_idx = 0;
+        loop {
+            let entry = self.fallback_chain.get(model_idx).ok_or_else(|| {
+                LLMError::ApiError("all models in fallback chain exhausted".to_string())
+            })?;
+            if self
+                .cooldown
+                .is_in_cooldown(&entry.provider, &entry.model)
+                .await
+            {
+                tracing::debug!(provider = %entry.provider, model = %entry.model, "model in cooldown, skipping");
+                model_idx += 1;
+                continue;
+            }
+            let provider = match self.registry.get(&entry.provider).await {
+                Some(p) => p,
+                None => {
+                    tracing::warn!(provider = %entry.provider, "provider not found, trying next");
+                    model_idx += 1;
+                    continue;
+                }
+            };
+            request.model = entry.model.clone();
+            match provider.chat_unified(request.clone()).await {
+                Ok(response) => {
+                    self.cooldown
+                        .record_success(&entry.provider, &entry.model)
+                        .await;
+                    return Ok(response);
+                }
+                Err(err) => {
+                    let kind = err.kind();
+                    tracing::warn!(
+                        provider = %entry.provider, model = %entry.model, error = %err, kind = ?kind, "LLM unified call failed"
                     );
                     self.cooldown
                         .record_failure(&entry.provider, &entry.model, kind)

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -141,6 +141,25 @@ pub trait LLMProvider: Send + Sync {
     /// List available models
     fn models(&self) -> Vec<&str>;
 
+    /// Send a chat request and return a unified response with structured content blocks.
+    /// Default implementation wraps `chat()` response as a single Text block.
+    async fn chat_unified(
+        &self,
+        request: ChatRequest,
+    ) -> Result<crate::llm::types::UnifiedResponse, LLMError> {
+        let response = self.chat(request).await?;
+        Ok(crate::llm::types::UnifiedResponse {
+            content_blocks: vec![crate::llm::types::ContentBlock::Text(response.content)],
+            usage: crate::llm::types::UnifiedUsage {
+                prompt_tokens: response.usage.prompt_tokens,
+                completion_tokens: response.usage.completion_tokens,
+                total_tokens: Some(response.usage.total_tokens),
+                reasoning_tokens: None,
+            },
+            finish_reason: None,
+        })
+    }
+
     /// Returns true if this is a stub provider that returns fake responses.
     /// When true, callers should treat this as a configuration error.
     fn is_stub(&self) -> bool {

--- a/src/processor_chain/context.rs
+++ b/src/processor_chain/context.rs
@@ -3,6 +3,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::llm::types::ContentBlock;
+
 /// Result type alias for processor chain operations.
 pub type Result<T> = std::result::Result<T, super::error::ProcessError>;
 
@@ -48,6 +50,10 @@ pub struct MessageContext {
     pub metadata: serde_json::Map<String, serde_json::Value>,
     /// Whether the message has been flagged to skip further processing.
     pub skip: bool,
+    /// Structured content blocks (e.g., Text, Thinking, ToolUse, ToolResult).
+    /// Populated on the outbound path by LLM responses; empty on inbound.
+    #[serde(default)]
+    pub content_blocks: Vec<ContentBlock>,
 }
 
 impl MessageContext {
@@ -64,6 +70,7 @@ impl MessageContext {
             raw_message_log: vec![raw_log],
             metadata: serde_json::Map::new(),
             skip: false,
+            content_blocks: vec![],
         }
     }
 
@@ -84,6 +91,9 @@ pub struct ProcessedMessage {
     pub metadata: serde_json::Map<String, serde_json::Value>,
     /// Whether the message should be suppressed entirely.
     pub suppress: bool,
+    /// Structured content blocks carried from the outbound chain.
+    #[serde(default)]
+    pub content_blocks: Vec<ContentBlock>,
 }
 
 impl ProcessedMessage {
@@ -95,6 +105,7 @@ impl ProcessedMessage {
             content: raw.content,
             metadata: serde_json::Map::new(),
             suppress: false,
+            content_blocks: vec![],
         }
     }
 }

--- a/src/processor_chain/context_tests.rs
+++ b/src/processor_chain/context_tests.rs
@@ -1,0 +1,31 @@
+//! Unit tests for context module — content_blocks fields.
+
+use chrono::Utc;
+
+use crate::processor_chain::context::{MessageContext, ProcessedMessage, RawMessage};
+
+#[test]
+fn test_message_context_content_blocks_default_empty() {
+    let raw = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "user_1".to_string(),
+        content: "hello".to_string(),
+        timestamp: Utc::now(),
+        message_id: "msg_1".to_string(),
+    };
+    let ctx = MessageContext::from_raw(raw);
+    assert!(ctx.content_blocks.is_empty());
+}
+
+#[test]
+fn test_processed_message_content_blocks_default_empty() {
+    let raw = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "user_1".to_string(),
+        content: "hello".to_string(),
+        timestamp: Utc::now(),
+        message_id: "msg_1".to_string(),
+    };
+    let processed = ProcessedMessage::from_raw(raw);
+    assert!(processed.content_blocks.is_empty());
+}

--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -110,6 +110,46 @@ impl DslParser {
             .join("\n");
         self.parse(&text)
     }
+
+    /// Parse DSL from `ContentBlock` list, returning both the merged [`DslParseResult`]
+    /// and an updated `Vec<ContentBlock>` where Text blocks have DSL lines stripped
+    /// and non-Text blocks are preserved as-is.
+    ///
+    /// Each Text block is processed independently so original block boundaries are
+    /// retained. Empty Text blocks (after DSL stripping) are dropped.
+    pub fn parse_content_blocks_with_result(
+        &self,
+        blocks: &[ContentBlock],
+    ) -> (DslParseResult, Vec<ContentBlock>) {
+        let mut all_instructions: Vec<DslInstruction> = Vec::new();
+        let mut updated_blocks: Vec<ContentBlock> = Vec::new();
+        let mut clean_parts: Vec<String> = Vec::new();
+
+        for block in blocks {
+            match block {
+                ContentBlock::Text(s) => {
+                    let result = self.parse(s);
+                    all_instructions.extend(result.instructions);
+                    if !result.clean_content.is_empty() {
+                        clean_parts.push(result.clean_content.clone());
+                        updated_blocks.push(ContentBlock::Text(result.clean_content));
+                    }
+                }
+                _ => {
+                    updated_blocks.push(block.clone());
+                }
+            }
+        }
+
+        let clean_content = clean_parts.join("\n");
+        (
+            DslParseResult {
+                clean_content,
+                instructions: all_instructions,
+            },
+            updated_blocks,
+        )
+    }
 }
 
 /// Try to parse a single line as a DSL instruction.
@@ -177,9 +217,19 @@ impl MessageProcessor for DslParser {
         &self,
         ctx: &MessageContext,
     ) -> Result<Option<super::ProcessedMessage>, ProcessError> {
-        let content = &ctx.content;
+        let (result, updated_blocks) = if !ctx.content_blocks.is_empty() {
+            self.parse_content_blocks_with_result(&ctx.content_blocks)
+        } else {
+            let result = self.parse(&ctx.content);
+            // Wrap clean_content as a single Text block when it's non-empty
+            let blocks = if result.clean_content.is_empty() {
+                vec![]
+            } else {
+                vec![ContentBlock::Text(result.clean_content.clone())]
+            };
+            (result, blocks)
+        };
 
-        let result = self.parse(content);
         let json = serde_json::to_string(&result)
             .map_err(|e| ProcessError::processor_failed("DslParser", e))?;
 
@@ -190,6 +240,7 @@ impl MessageProcessor for DslParser {
             content: result.clean_content,
             metadata,
             suppress: false,
+            content_blocks: updated_blocks,
         }))
     }
 }

--- a/src/processor_chain/dsl_parser_tests.rs
+++ b/src/processor_chain/dsl_parser_tests.rs
@@ -1,0 +1,185 @@
+//! Unit tests for DslParser — Step 1.6 (content_blocks support).
+
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::context::MessageContext;
+use crate::processor_chain::dsl_parser::DslParser;
+use crate::processor_chain::processor::MessageProcessor;
+
+fn make_ctx(content: &str, content_blocks: Vec<ContentBlock>) -> MessageContext {
+    MessageContext {
+        content: content.to_string(),
+        content_blocks,
+        metadata: Default::default(),
+        raw_message_log: vec![],
+        skip: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// parse_content_blocks_with_result tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_with_result_mixed_blocks_preserves_non_text() {
+    let parser = DslParser;
+    let blocks = vec![
+        ContentBlock::Text("Hello world".to_string()),
+        ContentBlock::Thinking("thinking...".to_string()),
+        ContentBlock::Text("::button[label:A;action:x;value:1]".to_string()),
+        ContentBlock::ToolUse {
+            id: "call_1".to_string(),
+            name: "search".to_string(),
+            input: "{}".to_string(),
+        },
+        ContentBlock::Text("Done".to_string()),
+        ContentBlock::ToolResult {
+            tool_call_id: "call_1".to_string(),
+            content: "result".to_string(),
+        },
+    ];
+    let (result, updated_blocks) = parser.parse_content_blocks_with_result(&blocks);
+
+    // DSL instruction extracted from Text blocks
+    assert_eq!(result.instructions.len(), 1);
+    assert_eq!(result.clean_content, "Hello world\nDone");
+
+    // Non-Text blocks preserved, empty Text blocks (DSL-only) dropped
+    assert_eq!(updated_blocks.len(), 5);
+    assert!(matches!(&updated_blocks[0], ContentBlock::Text(s) if s == "Hello world"));
+    assert!(matches!(&updated_blocks[1], ContentBlock::Thinking(_)));
+    assert!(matches!(&updated_blocks[2], ContentBlock::ToolUse { .. }));
+    assert!(matches!(&updated_blocks[3], ContentBlock::Text(s) if s == "Done"));
+    assert!(matches!(
+        &updated_blocks[4],
+        ContentBlock::ToolResult { .. }
+    ));
+}
+
+#[test]
+fn test_with_result_preserves_block_boundaries() {
+    let parser = DslParser;
+    let blocks = vec![
+        ContentBlock::Text("Part1".to_string()),
+        ContentBlock::Text("Part2".to_string()),
+        ContentBlock::Text("Part3".to_string()),
+    ];
+    let (_, updated_blocks) = parser.parse_content_blocks_with_result(&blocks);
+
+    assert_eq!(updated_blocks.len(), 3);
+    assert!(matches!(&updated_blocks[0], ContentBlock::Text(s) if s == "Part1"));
+    assert!(matches!(&updated_blocks[1], ContentBlock::Text(s) if s == "Part2"));
+    assert!(matches!(&updated_blocks[2], ContentBlock::Text(s) if s == "Part3"));
+}
+
+#[test]
+fn test_with_result_drops_empty_text_blocks() {
+    let parser = DslParser;
+    let blocks = vec![
+        ContentBlock::Text("::button[label:A;action:x;value:1]".to_string()),
+        ContentBlock::Text("".to_string()),
+        ContentBlock::Text("::button[label:B;action:y;value:2]".to_string()),
+    ];
+    let (result, updated_blocks) = parser.parse_content_blocks_with_result(&blocks);
+
+    assert_eq!(result.instructions.len(), 2);
+    assert!(updated_blocks.is_empty());
+    assert_eq!(result.clean_content, "");
+}
+
+#[test]
+fn test_with_result_empty_input() {
+    let parser = DslParser;
+    let blocks: Vec<ContentBlock> = vec![];
+    let (result, updated_blocks) = parser.parse_content_blocks_with_result(&blocks);
+    assert!(result.instructions.is_empty());
+    assert_eq!(result.clean_content, "");
+    assert!(updated_blocks.is_empty());
+}
+
+#[test]
+fn test_with_result_only_non_text_blocks() {
+    let parser = DslParser;
+    let blocks = vec![
+        ContentBlock::Thinking("hmm".to_string()),
+        ContentBlock::ToolUse {
+            id: "c1".to_string(),
+            name: "fn".to_string(),
+            input: "{}".to_string(),
+        },
+        ContentBlock::ToolResult {
+            tool_call_id: "c1".to_string(),
+            content: "ok".to_string(),
+        },
+    ];
+    let (result, updated_blocks) = parser.parse_content_blocks_with_result(&blocks);
+    assert!(result.instructions.is_empty());
+    assert_eq!(result.clean_content, "");
+    assert_eq!(updated_blocks.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// DslParser::process() branch tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_process_with_content_blocks_non_empty() {
+    let parser = DslParser;
+    let ctx = make_ctx(
+        "fallback content",
+        vec![
+            ContentBlock::Text("Hello\n::button[label:X;action:a;value:1]".to_string()),
+            ContentBlock::Thinking("think".to_string()),
+            ContentBlock::Text("World".to_string()),
+        ],
+    );
+    let result = parser.process(&ctx).await.unwrap().unwrap();
+
+    assert_eq!(result.content, "Hello\nWorld");
+    assert_eq!(result.content_blocks.len(), 3);
+    assert!(matches!(&result.content_blocks[0], ContentBlock::Text(s) if s == "Hello"));
+    assert!(matches!(
+        &result.content_blocks[1],
+        ContentBlock::Thinking(_)
+    ));
+    assert!(matches!(&result.content_blocks[2], ContentBlock::Text(s) if s == "World"));
+}
+
+#[tokio::test]
+async fn test_process_with_empty_content_blocks_falls_back_to_content() {
+    let parser = DslParser;
+    let ctx = make_ctx(
+        "Some text\n::button[label:A;action:x;value:1]\nMore text",
+        vec![],
+    );
+    let result = parser.process(&ctx).await.unwrap().unwrap();
+
+    assert_eq!(result.content, "Some text\nMore text");
+    assert_eq!(result.content_blocks.len(), 1);
+    assert!(
+        matches!(&result.content_blocks[0], ContentBlock::Text(s) if s == "Some text\nMore text")
+    );
+}
+
+#[tokio::test]
+async fn test_process_pure_text_no_dsl_matches_pre_refactor() {
+    let parser = DslParser;
+    let ctx = make_ctx("Just a normal message", vec![]);
+    let result = parser.process(&ctx).await.unwrap().unwrap();
+
+    assert_eq!(result.content, "Just a normal message");
+    assert_eq!(result.content_blocks.len(), 1);
+}
+
+#[tokio::test]
+async fn test_process_content_blocks_takes_priority() {
+    let parser = DslParser;
+    let ctx = make_ctx(
+        "::button[label:IGNORE;action:x;value:1]",
+        vec![ContentBlock::Text("Actual content".to_string())],
+    );
+    let result = parser.process(&ctx).await.unwrap().unwrap();
+
+    assert_eq!(result.content, "Actual content");
+    let dsl_val = result.metadata.get("dsl_result").unwrap();
+    assert!(!dsl_val.to_string().contains("button"));
+}

--- a/src/processor_chain/markdown_normalizer.rs
+++ b/src/processor_chain/markdown_normalizer.rs
@@ -185,6 +185,7 @@ impl MessageProcessor for MarkdownNormalizer {
             content,
             metadata: ctx.metadata.clone(),
             suppress: false,
+            content_blocks: vec![],
         }))
     }
 }

--- a/src/processor_chain/message_cleaner.rs
+++ b/src/processor_chain/message_cleaner.rs
@@ -294,6 +294,7 @@ impl MessageProcessor for MessageCleaner {
             content,
             metadata,
             suppress: false,
+            content_blocks: vec![],
         }))
     }
 }

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -11,7 +11,9 @@
 //! - [`ProcessError`] — error types
 
 pub mod context;
+pub mod context_tests;
 pub mod dsl_parser;
+pub mod dsl_parser_tests;
 pub mod error;
 pub mod loader;
 pub mod markdown_normalizer;

--- a/src/processor_chain/raw_log_processor.rs
+++ b/src/processor_chain/raw_log_processor.rs
@@ -146,6 +146,7 @@ impl MessageProcessor for RawLogProcessor {
             content: ctx.content.clone(),
             metadata: ctx.metadata.clone(),
             suppress: false,
+            content_blocks: vec![],
         }))
     }
 }

--- a/src/processor_chain/registry.rs
+++ b/src/processor_chain/registry.rs
@@ -72,6 +72,7 @@ impl ProcessorRegistry {
             match processor.process(&ctx).await? {
                 Some(out) => {
                     ctx.content = out.content;
+                    ctx.content_blocks = out.content_blocks;
                     for (k, v) in out.metadata {
                         ctx.metadata.insert(k, v);
                     }
@@ -91,6 +92,7 @@ impl ProcessorRegistry {
             content: ctx.content,
             metadata: ctx.metadata,
             suppress: ctx.skip,
+            content_blocks: ctx.content_blocks,
         })
     }
 
@@ -117,6 +119,7 @@ impl ProcessorRegistry {
         };
         let mut ctx = MessageContext::from_raw(synthetic_raw);
         ctx.metadata = llm_output.metadata.clone();
+        ctx.content_blocks = llm_output.content_blocks.clone();
         if llm_output.suppress {
             ctx.skip = true;
         }
@@ -131,6 +134,7 @@ impl ProcessorRegistry {
             match processor.process(&ctx).await? {
                 Some(out) => {
                     ctx.content = out.content;
+                    ctx.content_blocks = out.content_blocks;
                     for (k, v) in out.metadata {
                         ctx.metadata.insert(k, v);
                     }
@@ -150,6 +154,7 @@ impl ProcessorRegistry {
             content: ctx.content,
             metadata: ctx.metadata,
             suppress: ctx.skip,
+            content_blocks: ctx.content_blocks,
         })
     }
 }

--- a/src/processor_chain/registry_tests.rs
+++ b/src/processor_chain/registry_tests.rs
@@ -107,6 +107,7 @@ impl MessageProcessor for TestProc {
             content: self.name.clone(),
             metadata,
             suppress: self.suppress,
+            content_blocks: vec![],
         }))
     }
 }
@@ -133,6 +134,7 @@ async fn test_outbound_bypass() {
         content: "llm said hello".to_string(),
         metadata: serde_json::Map::new(),
         suppress: false,
+        content_blocks: vec![],
     };
     let result = registry.process_outbound(llm_out.clone()).await.unwrap();
 
@@ -196,6 +198,7 @@ async fn test_outbound_chained_override() {
             content: "llm".to_string(),
             metadata: serde_json::Map::new(),
             suppress: false,
+            content_blocks: vec![],
         })
         .await
         .unwrap();
@@ -275,6 +278,7 @@ async fn test_outbound_error_propagates() {
             content: "llm".to_string(),
             metadata: serde_json::Map::new(),
             suppress: false,
+            content_blocks: vec![],
         })
         .await
         .unwrap_err();

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -38,6 +38,7 @@ impl MessageProcessor for MockOutboundProcessor {
             content: self.output_content.clone(),
             metadata: serde_json::Map::new(),
             suppress: self.output_suppress,
+            content_blocks: vec![],
         }))
     }
 }
@@ -121,7 +122,7 @@ async fn test_send_outbound_no_registry_bypass() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 }
@@ -152,7 +153,7 @@ async fn test_send_outbound_text_path() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 }
@@ -184,7 +185,7 @@ async fn test_send_outbound_interactive_path() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -225,7 +226,7 @@ async fn test_send_outbound_suppress() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -240,7 +241,7 @@ async fn test_send_outbound_unknown_session() {
         .await;
 
     let result = gw
-        .send_outbound("nonexistent-session", "tracking", "raw")
+        .send_outbound("nonexistent-session", "tracking", "raw", vec![])
         .await;
     assert!(matches!(result, Err(GatewayError::MissingSessionId)));
 }
@@ -251,7 +252,7 @@ async fn test_send_outbound_unknown_channel() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    let result = gw.send_outbound(&sid, "unknown", "raw").await;
+    let result = gw.send_outbound(&sid, "unknown", "raw", vec![]).await;
     assert!(matches!(result, Err(GatewayError::UnknownChannel(_))));
 }
 

--- a/tests/gateway_send_outbound_renderer.rs
+++ b/tests/gateway_send_outbound_renderer.rs
@@ -50,6 +50,7 @@ impl MessageProcessor for MockOutboundProcessor {
             content: self.output_content.clone(),
             metadata,
             suppress: self.output_suppress,
+            content_blocks: vec![],
         }))
     }
 }
@@ -161,7 +162,7 @@ async fn test_send_outbound_with_renderer_text() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -206,7 +207,7 @@ async fn test_send_outbound_with_renderer_interactive() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -250,7 +251,7 @@ async fn test_send_outbound_with_renderer_dsl_result_passed() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -290,7 +291,7 @@ async fn test_send_outbound_no_renderer_fallback_text() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -309,7 +310,7 @@ async fn test_send_outbound_no_renderer_no_registry_bypass() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "bypass raw")
+    gw.send_outbound(&sid, "tracking", "bypass raw", vec![])
         .await
         .unwrap();
 
@@ -349,7 +350,7 @@ async fn test_send_outbound_renderer_with_suppress() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output")
+    gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
 
@@ -379,6 +380,6 @@ async fn test_send_outbound_renderer_requires_registry() {
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    let result = gw.send_outbound(&sid, "tracking", "raw").await;
+    let result = gw.send_outbound(&sid, "tracking", "raw", vec![]).await;
     assert!(matches!(result, Err(GatewayError::OutboundError(_))));
 }


### PR DESCRIPTION
## Summary

解决 processor_chain 出站链中 ContentBlock[] 的传递格式问题，使结构化内容块能完整贯穿整条处理链。

## Changes

- **MessageContext / ProcessedMessage** 新增 `content_blocks: Vec<ContentBlock>` 字段
- **DslParser::process()** 改用 `parse_content_blocks_with_result()` 解析内容块
- **process_outbound()** 支持 `ContentBlock[]` 透传
- **send_outbound()** 新增 `content_blocks` 参数
- **FallbackClient** 新增 `chat_unified()` 方法
- **session_handler** `output_tx` 改为传递 `(String, Vec<ContentBlock>)`
- 新增 `context_tests.rs`、`dsl_parser_tests.rs` 单元测试

## Test Plan

- [x] `cargo test` 全部通过
- [x] 新增单元测试覆盖 ContentBlock 解析与传递

Source: issue #794
Type: fix
