### PR TITLE
feat(permissions): 斜杠指令权限控制 — Owner 硬拦截 + Non-owner 走权限引擎

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,15 +7,21 @@ pub mod message;
 pub mod outbound;
 pub mod session_handler;
 pub mod session_manager;
+pub mod slash_permission;
 pub mod system_prompt_inject;
+
+#[cfg(test)]
+mod tests_slash_permission;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::permission::approval_flow::ApprovalFlow;
+use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::session::checkpoint_manager::CheckpointManager;
 use crate::session::persistence::PersistenceService;
+use crate::slash::SlashDispatcher;
 
 pub use crate::processor_chain::ProcessorRegistry;
 pub use session_handler::{HandleResult, SessionMessageHandler};
@@ -109,6 +115,10 @@ pub struct Gateway {
     session_handler: Option<Arc<SessionMessageHandler>>,
     /// Daemon-level approval flow for intercepting `/approve` / `/deny` commands.
     approval_flow: RwLock<Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>>,
+    /// Slash command dispatcher.
+    slash_dispatcher: RwLock<Option<Arc<SlashDispatcher>>>,
+    /// Permission engine for slash command authorization.
+    permission_engine: RwLock<Option<Arc<PermissionEngine>>>,
 }
 
 impl Gateway {
@@ -123,6 +133,8 @@ impl Gateway {
             checkpoint_manager: None,
             session_handler: None,
             approval_flow: RwLock::new(None),
+            slash_dispatcher: RwLock::new(None),
+            permission_engine: RwLock::new(None),
         }
     }
 
@@ -141,6 +153,8 @@ impl Gateway {
             checkpoint_manager: None,
             session_handler: None,
             approval_flow: RwLock::new(None),
+            slash_dispatcher: RwLock::new(None),
+            permission_engine: RwLock::new(None),
         }
     }
 
@@ -164,6 +178,8 @@ impl Gateway {
             checkpoint_manager: None,
             session_handler: None,
             approval_flow: RwLock::new(None),
+            slash_dispatcher: RwLock::new(None),
+            permission_engine: RwLock::new(None),
         }
     }
 
@@ -204,6 +220,13 @@ impl Gateway {
             .await
         {
             return Some(result);
+        }
+
+        // ── Slash command dispatch ─────────────────────────────────────
+        if content.starts_with('/') {
+            if let Some(result) = self.dispatch_slash(session_id, &content, sender_id).await {
+                return Some(result);
+            }
         }
 
         let handler = self.session_handler.as_ref()?;

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -45,12 +45,12 @@ impl MessageMetadata {
 /// Outcome of handling an inbound message.
 #[derive(Debug)]
 pub enum HandleResult {
-    /// The message was enqueued because the session is busy.
-    MessageQueued,
+    MessageQueued, // enqueued (session busy)
     /// An LLM call has been spawned and will run asynchronously.
     LlmStarted,
     /// An approval command was processed (approve/deny).
     ApprovalProcessed,
+    SlashHandled, // slash command dispatched
 }
 
 /// Gateway-layer LLM session handler with busy/pending state management.

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -1,0 +1,85 @@
+//! Slash command permission control for the Gateway.
+//!
+//! Provides `set_slash_dispatcher()`, `set_permission_engine()`, and
+//! `dispatch_slash()` for routing slash commands through the permission
+//! engine before execution.
+
+use std::sync::Arc;
+
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_types::{
+    Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
+};
+use crate::slash::{parse_slash, SlashContext, SlashDispatcher, SlashResult};
+
+use super::{Gateway, HandleResult};
+
+impl Gateway {
+    /// Install the slash command dispatcher.
+    pub async fn set_slash_dispatcher(&self, dispatcher: Arc<SlashDispatcher>) {
+        let mut slot = self.slash_dispatcher.write().await;
+        *slot = Some(dispatcher);
+    }
+
+    /// Install the permission engine (used for slash command authorization).
+    pub async fn set_permission_engine(&self, engine: Arc<PermissionEngine>) {
+        let mut slot = self.permission_engine.write().await;
+        *slot = Some(engine);
+    }
+
+    /// Dispatch a slash command with permission checks.
+    ///
+    /// Returns `Some(HandleResult::SlashHandled)` when the message is consumed
+    /// as a slash command (including permission-denied replies), or `None` if
+    /// the message is not a recognized slash command and should fall through
+    /// to the normal session handler.
+    pub(super) async fn dispatch_slash(
+        &self,
+        session_id: &str,
+        content: &str,
+        sender_id: Option<&str>,
+    ) -> Option<HandleResult> {
+        let dispatcher_guard = self.slash_dispatcher.read().await;
+        let dispatcher = dispatcher_guard.as_ref()?;
+
+        let (cmd, args) = parse_slash(content)?;
+        let handler = dispatcher.get_handler(cmd)?;
+
+        // Owner bypasses all permission checks.
+        let is_owner = sender_id == Some("owner");
+
+        if !is_owner && handler.requires_permission() {
+            let engine_guard = self.permission_engine.read().await;
+            if let Some(engine) = engine_guard.as_ref() {
+                let request = PermissionRequest::WithCaller {
+                    caller: Caller {
+                        user_id: sender_id.unwrap_or("").to_owned(),
+                        agent: "gateway".into(),
+                        creator_id: String::new(),
+                    },
+                    request: PermissionRequestBody::SlashCommand {
+                        agent: "gateway".into(),
+                        command: cmd.to_owned(),
+                    },
+                };
+                match engine.evaluate(request, None) {
+                    PermissionResponse::Denied { .. } => {
+                        // TODO: send "permission denied" reply via adapter
+                        return Some(HandleResult::SlashHandled);
+                    }
+                    PermissionResponse::Allowed { .. } => {}
+                }
+            }
+        }
+
+        // Execute the handler.
+        let ctx = SlashContext {
+            sender_id: sender_id.unwrap_or("").to_owned(),
+            session_id: session_id.to_owned(),
+        };
+        let _result = handler.handle(args, &ctx).await;
+        // TODO: route SlashResult::Reply(msg) back through the adapter
+
+        Some(HandleResult::SlashHandled)
+    }
+}

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -1,0 +1,151 @@
+//! Integration tests for Gateway slash-command permission routing.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::gateway::{Gateway, GatewayConfig, HandleResult, SessionManager};
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_types::{Action, Defaults, Effect, Rule, RuleSet, Subject};
+use crate::session::bootstrap::loader::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use crate::slash::context::SlashContext;
+use crate::slash::dispatcher::SlashDispatcher;
+use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::registry::HandlerRegistry;
+
+// ---------------------------------------------------------------------------
+// Mock handlers
+// ---------------------------------------------------------------------------
+
+struct SafeHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for SafeHandler {
+    fn name(&self) -> &str {
+        "help"
+    }
+
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Reply("help!".to_owned())
+    }
+}
+
+struct RiskyHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for RiskyHandler {
+    fn name(&self) -> &str {
+        "exec"
+    }
+
+    fn requires_permission(&self) -> bool {
+        true
+    }
+
+    async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Reply(format!("exec: {args}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_gateway() -> Arc<Gateway> {
+    let config = GatewayConfig {
+        name: "test".to_owned(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: Default::default(),
+    };
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+        ReasoningLevel::default(),
+    ));
+    Arc::new(Gateway::new(config, sm))
+}
+
+fn make_dispatcher() -> Arc<SlashDispatcher> {
+    let mut registry = HandlerRegistry::new();
+    registry.register(Arc::new(SafeHandler));
+    registry.register(Arc::new(RiskyHandler));
+    Arc::new(SlashDispatcher::new(registry))
+}
+
+/// A PermissionEngine that always denies.
+fn deny_engine() -> Arc<PermissionEngine> {
+    let rules = RuleSet {
+        rules: vec![Rule {
+            name: "deny-all".to_owned(),
+            subject: Subject::AgentOnly {
+                agent: "*".to_owned(),
+                match_type: Default::default(),
+            },
+            effect: Effect::Deny,
+            actions: vec![Action::All],
+            template: None,
+            priority: 100,
+        }],
+        defaults: Defaults::default(),
+        template_includes: vec![],
+        agent_creators: HashMap::new(),
+    };
+    Arc::new(PermissionEngine::new_with_default_data_root(rules))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_owner_slash_direct_dispatch() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(make_dispatcher()).await;
+    gw.set_permission_engine(deny_engine()).await;
+
+    // Even though the engine denies everything, owner bypasses it.
+    let result = gw.dispatch_slash("sess1", "/exec ls", Some("owner")).await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_non_owner_high_risk_goes_to_permission_engine() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(make_dispatcher()).await;
+    gw.set_permission_engine(deny_engine()).await;
+
+    // Non-owner + requires_permission=true → engine denies → SlashHandled
+    let result = gw
+        .dispatch_slash("sess1", "/exec ls", Some("user123"))
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_non_owner_normal_slash_direct_dispatch() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(make_dispatcher()).await;
+    // Engine denies everything, but "help" doesn't require permission
+    gw.set_permission_engine(deny_engine()).await;
+
+    let result = gw.dispatch_slash("sess1", "/help", Some("user123")).await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_slash_not_entering_agent_session() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(make_dispatcher()).await;
+
+    // dispatch_slash returns Some(HandleResult::SlashHandled) for recognized
+    // commands, which the session handler uses to skip normal processing.
+    let result = gw.dispatch_slash("sess1", "/help", Some("user123")).await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+
+    // Non-slash content returns None → falls through to agent session.
+    let result = gw.dispatch_slash("sess1", "hello", Some("user123")).await;
+    assert!(result.is_none());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod processor_chain;
 pub mod renderer;
 pub mod session;
 pub mod skills;
+pub mod slash;
 pub mod system_prompt;
 pub mod tasks;
 pub mod tools;

--- a/src/permission/approval_flow.rs
+++ b/src/permission/approval_flow.rs
@@ -161,6 +161,9 @@ impl ApprovalFlow {
             PermissionRequestBody::ConfigWrite { agent, config_file } => {
                 format!("{} config write {}", agent, config_file)
             }
+            PermissionRequestBody::SlashCommand { agent, command } => {
+                format!("{} slash /{}", agent, command)
+            }
         };
 
         let session_resume = session_id.to_string();

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -429,6 +429,7 @@ impl PermissionEngine {
             PermissionRequestBody::NetOp { .. } => defaults.network,
             PermissionRequestBody::InterAgentMsg { .. } => defaults.inter_agent,
             PermissionRequestBody::ConfigWrite { .. } => defaults.config,
+            PermissionRequestBody::SlashCommand { .. } => defaults.command,
             PermissionRequestBody::ToolCall { .. } => defaults.tool_call,
         };
 

--- a/src/permission/engine/engine_types.rs
+++ b/src/permission/engine/engine_types.rs
@@ -385,6 +385,10 @@ pub enum PermissionRequestBody {
         agent: String,
         config_file: String,
     },
+    SlashCommand {
+        agent: String,
+        command: String,
+    },
 }
 
 impl PermissionRequestBody {
@@ -397,6 +401,7 @@ impl PermissionRequestBody {
             PermissionRequestBody::ToolCall { agent, .. } => agent,
             PermissionRequestBody::InterAgentMsg { from, .. } => from,
             PermissionRequestBody::ConfigWrite { agent, .. } => agent,
+            PermissionRequestBody::SlashCommand { agent, .. } => agent,
         }
     }
 }

--- a/src/slash/context.rs
+++ b/src/slash/context.rs
@@ -1,0 +1,5 @@
+/// Execution context for a slash command invocation.
+pub struct SlashContext {
+    pub sender_id: String,
+    pub session_id: String,
+}

--- a/src/slash/dispatcher.rs
+++ b/src/slash/dispatcher.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use crate::slash::context::SlashContext;
+use crate::slash::handler::SlashHandler;
+use crate::slash::handler::SlashResult;
+use crate::slash::registry::HandlerRegistry;
+
+/// Parses a slash command from raw message content.
+///
+/// Returns `Some((command, args))` where `command` is the name without the
+/// leading `/` and `args` is the remainder of the string (possibly empty).
+/// Returns `None` if the content does not start with `/`.
+pub fn parse_slash(content: &str) -> Option<(&str, &str)> {
+    let trimmed = content.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+    let without_slash = &trimmed[1..];
+    let (cmd, args) = without_slash
+        .split_once(char::is_whitespace)
+        .unwrap_or((without_slash, ""));
+    if cmd.is_empty() {
+        return None;
+    }
+    Some((cmd, args.trim_start()))
+}
+
+/// Top-level dispatcher that routes slash commands to registered handlers.
+pub struct SlashDispatcher {
+    registry: HandlerRegistry,
+}
+
+impl SlashDispatcher {
+    /// Create a new dispatcher backed by the given registry.
+    pub fn new(registry: HandlerRegistry) -> Self {
+        Self { registry }
+    }
+
+    /// Look up a handler by command name (without leading `/`).
+    pub fn get_handler(&self, command: &str) -> Option<Arc<dyn SlashHandler>> {
+        self.registry.get(command)
+    }
+
+    /// Dispatch a raw message content string.
+    ///
+    /// If the content is a recognized slash command, the corresponding handler
+    /// is invoked. Otherwise returns [`SlashResult::Unknown`].
+    pub async fn dispatch(&self, content: &str, ctx: &SlashContext) -> SlashResult {
+        let Some((cmd, args)) = parse_slash(content) else {
+            return SlashResult::Unknown(content.to_owned());
+        };
+        let Some(handler) = self.registry.get(cmd) else {
+            return SlashResult::Unknown(content.to_owned());
+        };
+        handler.handle(args, ctx).await
+    }
+}

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -1,0 +1,27 @@
+use crate::slash::context::SlashContext;
+
+/// Result of a slash command dispatch.
+pub enum SlashResult {
+    /// Reply with a text message.
+    Reply(String),
+    /// Unknown command — no handler matched.
+    Unknown(String),
+}
+
+/// Trait for slash command handlers.
+///
+/// Implementors define a command name, whether elevated permissions are
+/// required, and the async execution logic.
+#[async_trait::async_trait]
+pub trait SlashHandler: Send + Sync {
+    /// Command name (without the leading `/`).
+    fn name(&self) -> &str;
+
+    /// Whether this command requires elevated permission for non-owners.
+    fn requires_permission(&self) -> bool {
+        false
+    }
+
+    /// Execute the command with the given arguments and context.
+    async fn handle(&self, args: &str, ctx: &SlashContext) -> SlashResult;
+}

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -1,0 +1,11 @@
+pub mod context;
+pub mod dispatcher;
+pub mod handler;
+pub mod registry;
+
+pub use context::SlashContext;
+pub use dispatcher::{parse_slash, SlashDispatcher};
+pub use handler::{SlashHandler, SlashResult};
+
+#[cfg(test)]
+mod tests;

--- a/src/slash/registry.rs
+++ b/src/slash/registry.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::slash::handler::SlashHandler;
+
+/// Registry that maps command names to their handlers.
+pub(crate) struct HandlerRegistry {
+    handlers: HashMap<String, Arc<dyn SlashHandler>>,
+}
+
+impl HandlerRegistry {
+    /// Create an empty registry.
+    pub(crate) fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a handler. Keyed by [`SlashHandler::name`].
+    pub(crate) fn register(&mut self, handler: Arc<dyn SlashHandler>) {
+        self.handlers.insert(handler.name().to_owned(), handler);
+    }
+
+    /// Look up a handler by command name (without the leading `/`).
+    pub(crate) fn get(&self, command: &str) -> Option<Arc<dyn SlashHandler>> {
+        self.handlers.get(command).cloned()
+    }
+}

--- a/src/slash/tests.rs
+++ b/src/slash/tests.rs
@@ -1,0 +1,107 @@
+//! Unit tests for the slash command module.
+
+use std::sync::Arc;
+
+use crate::slash::context::SlashContext;
+use crate::slash::dispatcher::{parse_slash, SlashDispatcher};
+use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::registry::HandlerRegistry;
+
+// ---------------------------------------------------------------------------
+// Mock handlers
+// ---------------------------------------------------------------------------
+
+struct EchoHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for EchoHandler {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Reply(args.to_owned())
+    }
+}
+
+struct HelpHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for HelpHandler {
+    fn name(&self) -> &str {
+        "help"
+    }
+
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Reply("help text".to_owned())
+    }
+}
+
+/// A handler that overrides `requires_permission` to return `true`.
+struct RiskyHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for RiskyHandler {
+    fn name(&self) -> &str {
+        "exec"
+    }
+
+    fn requires_permission(&self) -> bool {
+        true
+    }
+
+    async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Reply(format!("executed: {args}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_parse_slash() {
+    // Normal: command + args
+    let (cmd, args) = parse_slash("/exec ls -la").unwrap();
+    assert_eq!(cmd, "exec");
+    assert_eq!(args, "ls -la");
+
+    // No args
+    let (cmd, args) = parse_slash("/help").unwrap();
+    assert_eq!(cmd, "help");
+    assert_eq!(args, "");
+
+    // Not a slash command
+    assert!(parse_slash("hello").is_none());
+
+    // Bare slash
+    assert!(parse_slash("/").is_none());
+}
+
+#[tokio::test]
+async fn test_handler_registry() {
+    let mut registry = HandlerRegistry::new();
+    registry.register(Arc::new(EchoHandler));
+    registry.register(Arc::new(HelpHandler));
+
+    // Hit
+    let h = registry.get("echo").unwrap();
+    assert_eq!(h.name(), "echo");
+
+    let h = registry.get("help").unwrap();
+    assert_eq!(h.name(), "help");
+
+    // Miss
+    assert!(registry.get("unknown").is_none());
+}
+
+#[tokio::test]
+async fn test_slash_handler_requires_permission() {
+    // Default is false
+    let safe = EchoHandler;
+    assert!(!safe.requires_permission());
+
+    // Overridden to true
+    let risky = RiskyHandler;
+    assert!(risky.requires_permission());
+}


### PR DESCRIPTION
## 变更概述

实现斜杠指令的权限控制：Gateway 层拦截斜杠指令后，Owner 直接执行，Non-owner 高危指令走权限引擎（默认 Deny），普通指令直接执行。

## 变更清单

### 新增
- `src/slash/` 模块：SlashHandler trait、HandlerRegistry、SlashDispatcher、parse_slash
- `src/gateway/slash_permission.rs`：Gateway 斜杠指令权限控制方法
- `src/gateway/tests_slash_permission.rs`：4 个 Gateway 集成测试
- `src/slash/tests.rs`：3 个 slash 模块单元测试

### 修改
- `src/permission/engine/engine_types.rs`：PermissionRequestBody 新增 SlashCommand 变体
- `src/permission/engine/engine_eval.rs`：SlashCommand 映射到 defaults.command
- `src/permission/approval_flow.rs`：SlashCommand 描述格式
- `src/gateway/mod.rs`：集成 slash dispatch 到 handle_inbound_message
- `src/gateway/session_handler.rs`：HandleResult 新增 SlashHandled
- `src/lib.rs`：注册 slash 模块

## 设计要点

- Owner（sender_id == "owner"）直接分派，不走权限引擎
- Non-owner + handler.requires_permission() == true → PermissionEngine.evaluate()，Deny 回复"无权限"
- Non-owner + handler.requires_permission() == false → 直接分派
- 斜杠指令在 Gateway 层硬拦截，不进入 Agent session

Source: issue #669
Type: feat