### PR TITLE
feat: Thinking 内容清理防线 — 孤立 Thinking 过滤 + 末尾 Thinking 移除

### DIFF
--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -173,6 +173,48 @@ impl ConversationSession {
         self.pending_messages.iter().cloned().collect()
     }
 
+    /// Cleans thinking-only artifacts from a message list.
+    ///
+    /// Two passes:
+    /// 1. Remove assistant messages whose content blocks are *all* Thinking
+    ///    (orphaned thinking).
+    /// 2. Trim trailing Thinking blocks from the last assistant message;
+    ///    if the result is empty, insert an empty Text placeholder.
+    fn clean_thinking_content(messages: &[SessionMessage]) -> Vec<SessionMessage> {
+        // Pass 1: filter out orphaned thinking messages.
+        let mut cleaned: Vec<SessionMessage> = messages
+            .iter()
+            .cloned()
+            .filter(|msg| {
+                if msg.role == "assistant" {
+                    !msg.content_blocks
+                        .iter()
+                        .all(|b| matches!(b, ContentBlock::Thinking(_)))
+                } else {
+                    true
+                }
+            })
+            .collect();
+
+        // Pass 2: trim trailing Thinking blocks from the last assistant message.
+        if let Some(last_assistant) = cleaned.iter_mut().rev().find(|m| m.role == "assistant") {
+            while last_assistant
+                .content_blocks
+                .last()
+                .map_or(false, |b| matches!(b, ContentBlock::Thinking(_)))
+            {
+                last_assistant.content_blocks.pop();
+            }
+            if last_assistant.content_blocks.is_empty() {
+                last_assistant
+                    .content_blocks
+                    .push(ContentBlock::Text(String::new()));
+            }
+        }
+
+        cleaned
+    }
+
     /// Restores pending messages from checkpoint data.
     /// Only pushes messages where `sent == false` back into the queue.
     pub fn restore_pending_messages(
@@ -230,7 +272,8 @@ impl ChatSession for ConversationSession {
                 content: prompt.clone(),
             });
         }
-        for msg in &self.messages {
+        let cleaned = Self::clean_thinking_content(&self.messages);
+        for msg in &cleaned {
             let content = msg
                 .content_blocks
                 .iter()

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -423,6 +423,7 @@ fn test_replace_messages_empty_vec_clears() {
 
 // ── reasoning_level tests ─────────────────────────────────────────────────
 
+use crate::llm::types::ContentBlock;
 use crate::session::persistence::ReasoningLevel;
 
 #[test]
@@ -462,6 +463,8 @@ fn test_build_api_request_default_reasoning_level() {
     let req = session.build_api_request();
     assert_eq!(req.reasoning_level, ReasoningLevel::High);
 }
+
+mod thinking_clean_tests;
 
 #[test]
 fn test_build_api_request_reasoning_level_medium() {

--- a/src/llm/session/tests/thinking_clean_tests.rs
+++ b/src/llm/session/tests/thinking_clean_tests.rs
@@ -1,0 +1,145 @@
+use super::*;
+use crate::llm::types::UnifiedUsage;
+use std::path::PathBuf;
+
+#[test]
+fn test_clean_thinking_mixed_text_and_thinking_unchanged() {
+    // Mixed messages: trailing Thinking on last assistant is removed
+    let messages = vec![
+        SessionMessage {
+            role: "user".into(),
+            content_blocks: vec![ContentBlock::Text("hello".into())],
+            timestamp: Utc::now(),
+        },
+        SessionMessage {
+            role: "assistant".into(),
+            content_blocks: vec![
+                ContentBlock::Text("reply".into()),
+                ContentBlock::Thinking("thought".into()),
+            ],
+            timestamp: Utc::now(),
+        },
+    ];
+    let cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(cleaned.len(), 2);
+    assert_eq!(cleaned[1].content_blocks.len(), 1);
+    assert!(matches!(&cleaned[1].content_blocks[0], ContentBlock::Text(t) if t == "reply"));
+}
+
+#[test]
+fn test_clean_thinking_pure_thinking_removed() {
+    // Pure-Thinking assistant messages are removed entirely
+    let messages = vec![
+        SessionMessage {
+            role: "user".into(),
+            content_blocks: vec![ContentBlock::Text("hi".into())],
+            timestamp: Utc::now(),
+        },
+        SessionMessage {
+            role: "assistant".into(),
+            content_blocks: vec![ContentBlock::Thinking("only thinking".into())],
+            timestamp: Utc::now(),
+        },
+    ];
+    let cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(cleaned.len(), 1);
+    assert_eq!(cleaned[0].role, "user");
+}
+
+#[test]
+fn test_clean_thinking_trailing_removed_middle_kept() {
+    // Trailing Thinking removed, middle Thinking preserved
+    let messages = vec![SessionMessage {
+        role: "assistant".into(),
+        content_blocks: vec![
+            ContentBlock::Text("start".into()),
+            ContentBlock::Thinking("middle thought".into()),
+            ContentBlock::Text("end".into()),
+            ContentBlock::Thinking("trailing thought".into()),
+        ],
+        timestamp: Utc::now(),
+    }];
+    let cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(cleaned.len(), 1);
+    assert_eq!(cleaned[0].content_blocks.len(), 3);
+    assert!(matches!(&cleaned[0].content_blocks[0], ContentBlock::Text(t) if t == "start"));
+    assert!(matches!(
+        &cleaned[0].content_blocks[1],
+        ContentBlock::Thinking(_)
+    ));
+    assert!(matches!(&cleaned[0].content_blocks[2], ContentBlock::Text(t) if t == "end"));
+}
+
+#[test]
+fn test_clean_thinking_all_thinking_replaced_with_empty_text() {
+    // Trailing Thinking stripped; remaining Text content is kept
+    let messages = vec![SessionMessage {
+        role: "assistant".into(),
+        content_blocks: vec![
+            ContentBlock::Text("real content".into()),
+            ContentBlock::Thinking("trailing".into()),
+        ],
+        timestamp: Utc::now(),
+    }];
+    let cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(cleaned.len(), 1);
+    assert_eq!(cleaned[0].content_blocks.len(), 1);
+    assert!(matches!(&cleaned[0].content_blocks[0], ContentBlock::Text(t) if t == "real content"));
+}
+
+#[test]
+fn test_clean_thinking_last_assistant_only_thinking_becomes_empty_text() {
+    // Empty Text + all trailing Thinking → after trim only empty Text remains
+    let messages = vec![SessionMessage {
+        role: "assistant".into(),
+        content_blocks: vec![
+            ContentBlock::Text(String::new()),
+            ContentBlock::Thinking("t1".into()),
+            ContentBlock::Thinking("t2".into()),
+        ],
+        timestamp: Utc::now(),
+    }];
+    let cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(cleaned.len(), 1);
+    assert_eq!(cleaned[0].content_blocks.len(), 1);
+    assert!(matches!(&cleaned[0].content_blocks[0], ContentBlock::Text(t) if t.is_empty()));
+}
+
+#[test]
+fn test_clean_thinking_isolation_original_unchanged() {
+    // clean_thinking_content does not modify original messages
+    let messages = vec![SessionMessage {
+        role: "assistant".into(),
+        content_blocks: vec![ContentBlock::Thinking("secret".into())],
+        timestamp: Utc::now(),
+    }];
+    let original_len = messages[0].content_blocks.len();
+    let _cleaned = ConversationSession::clean_thinking_content(&messages);
+    assert_eq!(messages[0].content_blocks.len(), original_len);
+    assert!(matches!(&messages[0].content_blocks[0], ContentBlock::Thinking(t) if t == "secret"));
+}
+
+#[test]
+fn test_build_api_request_does_not_modify_self_messages() {
+    // build_api_request isolation: self.messages unchanged after call
+    let mut session =
+        ConversationSession::new("s_iso".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    session.append_response(UnifiedResponse {
+        content_blocks: vec![
+            ContentBlock::Text("hi".into()),
+            ContentBlock::Thinking("think".into()),
+        ],
+        usage: UnifiedUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: Some(2),
+            reasoning_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    });
+    let original_count = session.messages().len();
+    let original_blocks = session.messages()[0].content_blocks.len();
+    let _req = session.build_api_request();
+    assert_eq!(session.messages().len(), original_count);
+    assert_eq!(session.messages()[0].content_blocks.len(), original_blocks);
+}


### PR DESCRIPTION
在 ConversationSession::build_api_request() 中新增两道 Thinking 清理防线：
1. 孤立 Thinking 清理：移除仅含 Thinking 块的 assistant 消息
2. 末尾 Thinking 清理：从最后一条 assistant 消息末尾移除 Thinking 块

两道防线在 API 请求构建前执行，不修改 session 内部消息历史。

Source: issue #793
Type: feat
