### PR TITLE
feat(security): Bash 安全解析 — tree-sitter AST 分析 + 差异检测 + 信任分级

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "proptest",
  "redis",
  "regex",
+ "regex-lite",
  "reqwest",
  "rusqlite",
  "serde",
@@ -469,6 +470,8 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-bash",
  "uuid",
 ]
 
@@ -1973,6 +1976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +2810,35 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.10",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Regex
 regex = "1.10"
+regex-lite = "0.1"
 
 # Async trait (for IMAdapter)
 async-trait = "0.1"
@@ -81,6 +82,10 @@ dirs = "5"
 # Glob pattern matching (for conditional skill activation)
 glob = "0.3"
 async-stream = "0.3.6"
+
+# Tree-sitter for Bash AST parsing
+tree-sitter = "0.24"
+tree-sitter-bash = "0.23"
 
 
 [dev-dependencies]

--- a/src/tools/builtin/bash.rs
+++ b/src/tools/builtin/bash.rs
@@ -6,6 +6,7 @@ use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_types::PermissionResponse;
 use crate::tasks::BackgroundTaskManager;
 use crate::tools::builtin::bash_classify;
+use crate::tools::security::{BashSecurityAnalyzer, TrustLevel};
 use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
 
 use async_trait::async_trait;
@@ -211,12 +212,30 @@ async fn execute_bash_call(
     let _ = args.get("description");
     let _ = args.get("dangerouslyDisableSandbox");
 
-    // --- 2. Permission check ---
+    // --- 2. Security analysis ---
+    let mut analyzer = BashSecurityAnalyzer::new().map_err(ToolCallError::ExecutionFailed)?;
+    let sec_result = analyzer.analyze(command);
+    match sec_result.trust_level {
+        TrustLevel::Trusted => {}
+        TrustLevel::Uncertain | TrustLevel::Malicious => {
+            return Err(ToolCallError::ExecutionFailed(format!(
+                "Command {} (reason: {})",
+                if sec_result.trust_level == TrustLevel::Malicious {
+                    "blocked"
+                } else {
+                    "requires approval"
+                },
+                sec_result.reason.unwrap_or_default()
+            )));
+        }
+    }
+
+    // --- 3. Permission check ---
     if let PermissionResponse::Denied { reason, .. } = perm.check(&ctx.agent_id, "exec") {
         return Err(ToolCallError::PermissionDenied(reason));
     }
 
-    // --- 3. Execute subprocess ---
+    // --- 4. Execute subprocess ---
     let result = execute_command(command, &cwd, timeout_ms, run_in_background, bg).await;
     match result {
         Ok(r) => Ok(r),
@@ -412,7 +431,7 @@ fn build_result(
 ) -> ToolResult {
     let category = bash_classify::classify_command(command);
     let no_output = bash_classify::no_output_expected(category);
-    let interpretation = bash_classify::interpret_exit_code(command, exit_code);
+    let interpretation = crate::tools::security::interpret_exit_code(command, exit_code);
     let persisted_path = stdout
         .persisted_path
         .as_deref()

--- a/src/tools/builtin/bash_classify.rs
+++ b/src/tools/builtin/bash_classify.rs
@@ -79,30 +79,6 @@ pub(crate) fn no_output_expected(category: CommandCategory) -> bool {
 }
 
 /// Returns a semantic interpretation of the exit code for known
-/// command types. Returns None if no special interpretation is
-/// available.
-pub(crate) fn interpret_exit_code(command: &str, exit_code: i32) -> Option<String> {
-    let word = first_word(command);
-    match word {
-        "grep" => match exit_code {
-            0 => Some("match found".into()),
-            1 => Some("no match found".into()),
-            _ => None,
-        },
-        "diff" => match exit_code {
-            0 => Some("files are identical".into()),
-            1 => Some("files differ".into()),
-            _ => None,
-        },
-        "find" => match exit_code {
-            0 => Some("matches found".into()),
-            1 => Some("no matches found".into()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,26 +121,5 @@ mod tests {
         assert!(!no_output_expected(CommandCategory::List));
         assert!(!no_output_expected(CommandCategory::Neutral));
         assert!(!no_output_expected(CommandCategory::Unknown));
-    }
-
-    #[test]
-    fn test_interpret_exit_code() {
-        assert_eq!(
-            interpret_exit_code("grep pattern file", 0),
-            Some("match found".into())
-        );
-        assert_eq!(
-            interpret_exit_code("grep pattern file", 1),
-            Some("no match found".into())
-        );
-        assert_eq!(
-            interpret_exit_code("diff a b", 0),
-            Some("files are identical".into())
-        );
-        assert_eq!(
-            interpret_exit_code("diff a b", 1),
-            Some("files differ".into())
-        );
-        assert_eq!(interpret_exit_code("echo hi", 0), None);
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod builtin;
 pub mod registry;
+pub mod security;
 
 pub use registry::ToolRegistry;
 

--- a/src/tools/security/bash_analyzer.rs
+++ b/src/tools/security/bash_analyzer.rs
@@ -1,0 +1,411 @@
+//! Bash security analyzer using tree-sitter AST parsing + trust grading.
+
+use tree_sitter::{Node, Parser};
+
+/// Node kinds considered safe standard shell syntax.
+const TRUSTED_NODE_KINDS: &[&str] = &[
+    "program",
+    "command",
+    "pipeline",
+    "list",
+    "redirected_statement",
+    "file_redirect",
+    "heredoc_redirect",
+    "heredoc_body",
+    "variable_assignment",
+    "subshell",
+    "compound_statement",
+    "command_name",
+    "word",
+    "string",
+    "string_content",
+    "raw_string",
+    "ansi_c_string",
+    "simple_expansion",
+    "variable_name",
+    "$",
+    "concatenation",
+    "file_descriptor",
+    "if_statement",
+    "for_statement",
+    "while_statement",
+    "case_statement",
+    "function_definition",
+    "case_item",
+    "do_group",
+    "else_clause",
+    "elif_clause",
+    "test_command",
+    "negated_command",
+    ";",
+    "\n",
+    "|",
+    "&&",
+    "||",
+    "<",
+    ">",
+    ">>",
+    "&>",
+    "&>>",
+    "<&",
+    ">&",
+    "\"",
+];
+
+fn is_trusted_kind(kind: &str) -> bool {
+    TRUSTED_NODE_KINDS.contains(&kind)
+}
+
+// -- Data models --
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustLevel {
+    Trusted,
+    Uncertain,
+    Malicious,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Redirect {
+    pub fd: Option<String>,
+    pub operator: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimpleCommand {
+    pub argv: Vec<String>,
+    pub env_vars: Vec<(String, String)>,
+    pub redirects: Vec<Redirect>,
+    pub source_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseResult {
+    pub commands: Vec<SimpleCommand>,
+    pub trust_level: TrustLevel,
+    pub reason: Option<String>,
+}
+
+// -- Analyzer --
+
+pub struct BashSecurityAnalyzer {
+    parser: Parser,
+}
+
+impl BashSecurityAnalyzer {
+    pub fn new() -> Result<Self, String> {
+        let mut parser = Parser::new();
+        let lang = tree_sitter_bash::LANGUAGE.into();
+        parser
+            .set_language(&lang)
+            .map_err(|e| format!("Failed to set bash language: {e}"))?;
+        Ok(Self { parser })
+    }
+
+    pub fn analyze(&mut self, source: &str) -> ParseResult {
+        let tree = self.parser.parse(source, None);
+        match tree {
+            Some(tree) => {
+                let root = tree.root_node();
+                if root.has_error() {
+                    return uncertain_result(collect_error_text(&root, source));
+                }
+                let commands = extract_commands(&root, source);
+                // Trust grading: malicious → unknown nodes → diff detectors
+                if let Some(r) = detect_malicious(source) {
+                    return ParseResult {
+                        commands,
+                        trust_level: TrustLevel::Malicious,
+                        reason: Some(r),
+                    };
+                }
+                let unknown = collect_unknown_kinds(&root);
+                if !unknown.is_empty() {
+                    return ParseResult {
+                        commands,
+                        trust_level: TrustLevel::Uncertain,
+                        reason: Some(format!("Unknown node types: {}", unknown.join(", "))),
+                    };
+                }
+                if let Some(r) = run_diff_detectors(source) {
+                    return ParseResult {
+                        commands,
+                        trust_level: TrustLevel::Uncertain,
+                        reason: Some(r),
+                    };
+                }
+                ParseResult {
+                    commands,
+                    trust_level: TrustLevel::Trusted,
+                    reason: None,
+                }
+            }
+            None => uncertain_result("Parser returned no tree (possibly timeout)".into()),
+        }
+    }
+}
+
+impl Default for BashSecurityAnalyzer {
+    fn default() -> Self {
+        Self::new().expect("BashSecurityAnalyzer init should not fail")
+    }
+}
+
+// -- Command extraction (module-level functions) --
+
+fn uncertain_result(reason: String) -> ParseResult {
+    ParseResult {
+        commands: vec![],
+        trust_level: TrustLevel::Uncertain,
+        reason: Some(reason),
+    }
+}
+
+fn extract_commands(root: &Node, source: &str) -> Vec<SimpleCommand> {
+    let mut out = Vec::new();
+    walk_for_commands(root, source, &mut out);
+    out
+}
+
+fn walk_for_commands<'a>(node: &Node<'a>, source: &str, out: &mut Vec<SimpleCommand>) {
+    match node.kind() {
+        "command" => {
+            if let Some(cmd) = build_simple_command(node, source) {
+                out.push(cmd);
+            }
+        }
+        "redirected_statement" => handle_redirected(node, source, out),
+        _ => {
+            let mut w = node.walk();
+            for ch in node.children(&mut w) {
+                walk_for_commands(&ch, source, out);
+            }
+        }
+    }
+}
+
+fn handle_redirected<'a>(node: &Node<'a>, source: &str, out: &mut Vec<SimpleCommand>) {
+    let mut cmd_opt: Option<SimpleCommand> = None;
+    let mut redirects = Vec::new();
+    let mut w = node.walk();
+    for ch in node.children(&mut w) {
+        match ch.kind() {
+            "command" => cmd_opt = build_simple_command(&ch, source),
+            "file_redirect" | "heredoc_redirect" => extract_redirect(&ch, source, &mut redirects),
+            _ => {}
+        }
+    }
+    if let Some(mut cmd) = cmd_opt {
+        cmd.redirects = redirects;
+        out.push(cmd);
+    }
+}
+
+fn build_simple_command<'a>(node: &Node<'a>, source: &str) -> Option<SimpleCommand> {
+    let mut argv = Vec::new();
+    let mut env_vars = Vec::new();
+    let mut redirects = Vec::new();
+    let mut w = node.walk();
+    for ch in node.children(&mut w) {
+        match ch.kind() {
+            "command_name" | "word" | "string" | "raw_string" | "simple_expansion"
+            | "concatenation" => {
+                if let Some(t) = node_text(&ch, source) {
+                    argv.push(t);
+                }
+            }
+            "variable_assignment" => extract_var_assign(&ch, source, &mut env_vars),
+            "file_redirect" | "heredoc_redirect" | "redirect" => {
+                extract_redirect(&ch, source, &mut redirects)
+            }
+            _ => {}
+        }
+    }
+    let source_text = node_text(node, source).unwrap_or_default();
+    if argv.is_empty() {
+        None
+    } else {
+        Some(SimpleCommand {
+            argv,
+            env_vars,
+            redirects,
+            source_text,
+        })
+    }
+}
+
+fn extract_var_assign<'a>(node: &Node<'a>, source: &str, env_vars: &mut Vec<(String, String)>) {
+    let t = node_text(node, source).unwrap_or_default();
+    if let Some((k, v)) = t.split_once('=') {
+        env_vars.push((k.into(), v.into()));
+    }
+}
+
+fn extract_redirect<'a>(node: &Node<'a>, source: &str, redirects: &mut Vec<Redirect>) {
+    let (mut fd, mut op, mut tgt) = (None, String::new(), String::new());
+    let mut w = node.walk();
+    for ch in node.children(&mut w) {
+        match ch.kind() {
+            "file_descriptor" => fd = node_text(&ch, source),
+            "<" | ">" | ">>" | "&>" | "&>>" | "<&" | ">&" => op = ch.kind().to_string(),
+            "word" | "string" | "simple_expansion" => {
+                tgt = node_text(&ch, source).unwrap_or_default()
+            }
+            _ => {}
+        }
+    }
+    if !op.is_empty() {
+        redirects.push(Redirect {
+            fd,
+            operator: op,
+            target: tgt,
+        });
+    }
+}
+
+fn node_text(node: &Node, source: &str) -> Option<String> {
+    let (s, e) = (node.start_byte(), node.end_byte());
+    (s <= e && e <= source.len()).then(|| source[s..e].to_string())
+}
+
+fn collect_error_text<'a>(root: &Node<'a>, source: &str) -> String {
+    let mut errs = Vec::new();
+    find_errors(root, source, &mut errs);
+    if errs.is_empty() {
+        "Syntax error in command".into()
+    } else {
+        errs.join("; ")
+    }
+}
+
+fn find_errors<'a>(node: &Node<'a>, source: &str, errors: &mut Vec<String>) {
+    if node.is_error() || node.is_missing() {
+        let t = node_text(node, source).unwrap_or_else(|| node.kind().to_string());
+        let label = if node.is_missing() {
+            "Missing node"
+        } else {
+            "Error node"
+        };
+        errors.push(format!("{label} at row {}: {t}", node.start_position().row));
+    }
+    let mut w = node.walk();
+    for ch in node.children(&mut w) {
+        find_errors(&ch, source, errors);
+    }
+}
+
+// -- Trust whitelist + diff detectors --
+
+fn collect_unknown_kinds(root: &Node) -> Vec<String> {
+    let mut out = Vec::new();
+    walk_unknown(root, &mut out);
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn walk_unknown<'a>(node: &Node<'a>, out: &mut Vec<String>) {
+    let kind = node.kind();
+    if !kind.is_empty()
+        && !node.is_extra()
+        && !is_trusted_kind(kind)
+        && !out.contains(&kind.to_string())
+    {
+        out.push(kind.to_string());
+    }
+    let mut w = node.walk();
+    for ch in node.children(&mut w) {
+        walk_unknown(&ch, out);
+    }
+}
+
+fn detect_malicious(source: &str) -> Option<String> {
+    if detect_ifs_injection(source) {
+        return Some("IFS injection detected".into());
+    }
+    None
+}
+
+fn run_diff_detectors(source: &str) -> Option<String> {
+    if detect_ansi_c_quoting(source) {
+        return Some("ANSI-C quoting detected ($'...')".into());
+    }
+    if detect_brace_expansion(source) {
+        return Some("Brace expansion detected".into());
+    }
+    if detect_unquoted_redirect(source) {
+        return Some("Unquoted redirect target".into());
+    }
+    None
+}
+
+/// Detect `$'...'` (ANSI-C quoting).
+fn detect_ansi_c_quoting(source: &str) -> bool {
+    let b = source.as_bytes();
+    (0..b.len().saturating_sub(1)).any(|i| b[i] == b'$' && b[i + 1] == b'\'')
+}
+
+/// Detect brace expansion like `{a,b}` or `{1..5}`.
+fn detect_brace_expansion(source: &str) -> bool {
+    for i in 0..source.len() {
+        if source.as_bytes()[i] == b'{' {
+            if let Some(end) = source[i..].find('}') {
+                let inner = &source[i + 1..i + end];
+                if inner.contains(',') || inner.contains("..") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Detect unquoted redirect targets (e.g. `> $VAR`).
+fn detect_unquoted_redirect(source: &str) -> bool {
+    regex_lite::Regex::new(r"[<>]{1,2}\s*\$")
+        .map(|r| r.is_match(source))
+        .unwrap_or(false)
+}
+
+/// Detect IFS injection: `IFS=...` with suspicious values or `$IFS`.
+fn detect_ifs_injection(source: &str) -> bool {
+    source.split_ascii_whitespace().any(|w| {
+        w.starts_with("IFS=")
+            && w.len() > 4
+            && !w[4..].starts_with("$'\t\n'")
+            && !w[4..].starts_with("'\t\n'")
+    }) || source.contains("$IFS")
+}
+
+/// Extract the first word of a command string for dispatch.
+fn first_word(segment: &str) -> &str {
+    segment.split_whitespace().next().unwrap_or("")
+}
+
+/// Interpret well-known exit codes for common CLI tools.
+pub fn interpret_exit_code(command: &str, exit_code: i32) -> Option<String> {
+    let word = first_word(command);
+    match word {
+        "grep" => match exit_code {
+            0 => Some("match found".into()),
+            1 => Some("no match found".into()),
+            _ => None,
+        },
+        "diff" => match exit_code {
+            0 => Some("files are identical".into()),
+            1 => Some("files differ".into()),
+            _ => None,
+        },
+        "find" => match exit_code {
+            0 => Some("matches found".into()),
+            1 => Some("no matches found".into()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "bash_analyzer_tests.rs"]
+mod tests;

--- a/src/tools/security/bash_analyzer_tests.rs
+++ b/src/tools/security/bash_analyzer_tests.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+fn analyzer() -> BashSecurityAnalyzer {
+    BashSecurityAnalyzer::new().expect("analyzer creation failed")
+}
+
+#[test]
+fn test_echo_hello() {
+    let r = analyzer().analyze("echo hello");
+    assert_eq!(r.commands.len(), 1);
+    assert_eq!(r.commands[0].argv, vec!["echo", "hello"]);
+    assert_eq!(r.trust_level, TrustLevel::Trusted);
+}
+
+#[test]
+fn test_git_commit() {
+    let r = analyzer().analyze("git commit -m \"fix bug\"");
+    assert_eq!(r.commands.len(), 1);
+    assert!(r.commands[0].argv[0] == "git");
+    assert!(r.commands[0].argv.contains(&"commit".to_string()));
+    assert_eq!(r.trust_level, TrustLevel::Trusted);
+}
+
+#[test]
+fn test_pipe() {
+    let r = analyzer().analyze("ls | wc -l");
+    assert_eq!(r.commands.len(), 2);
+    assert_eq!(r.commands[0].argv[0], "ls");
+    assert_eq!(r.commands[1].argv[0], "wc");
+}
+
+#[test]
+fn test_syntax_error() {
+    let r = analyzer().analyze("if then");
+    assert_eq!(r.trust_level, TrustLevel::Uncertain);
+    assert!(r.reason.is_some());
+}
+
+#[test]
+fn test_redirect() {
+    let r = analyzer().analyze("echo hello > out.txt");
+    assert_eq!(r.commands[0].redirects[0].operator, ">");
+    assert_eq!(r.commands[0].redirects[0].target, "out.txt");
+}
+
+#[test]
+fn test_empty_input() {
+    assert!(analyzer().analyze("").commands.is_empty());
+}
+
+#[test]
+fn test_multiple_commands_semicolon() {
+    assert!(analyzer().analyze("echo a; echo b").commands.len() >= 2);
+}
+
+// Step 1.2 tests
+
+#[test]
+fn test_trusted_simple_command() {
+    assert_eq!(
+        analyzer().analyze("ls -la /tmp").trust_level,
+        TrustLevel::Trusted
+    );
+}
+
+#[test]
+fn test_ansi_c_quoting_uncertain() {
+    let r = analyzer().analyze("echo $'\\x63'");
+    assert_eq!(r.trust_level, TrustLevel::Uncertain);
+    assert!(r.reason.unwrap().contains("ANSI-C"));
+}
+
+#[test]
+fn test_brace_expansion_uncertain() {
+    let r = analyzer().analyze("echo {a,b}");
+    assert_eq!(r.trust_level, TrustLevel::Uncertain);
+    assert!(r.reason.unwrap().contains("Brace"));
+}
+
+#[test]
+fn test_unquoted_redirect_uncertain() {
+    let r = analyzer().analyze("echo hi > $FILE");
+    assert_eq!(r.trust_level, TrustLevel::Uncertain);
+    assert!(r.reason.unwrap().contains("Unquoted redirect"));
+}
+
+#[test]
+fn test_ifs_injection_malicious() {
+    let r = analyzer().analyze("IFS=x read line");
+    assert_eq!(r.trust_level, TrustLevel::Malicious);
+    assert!(r.reason.unwrap().contains("IFS"));
+}
+
+#[test]
+fn test_ifs_dollar_malicious() {
+    assert_eq!(
+        analyzer().analyze("echo $IFS").trust_level,
+        TrustLevel::Malicious
+    );
+}
+
+#[test]
+fn test_variable_as_command_uncertain() {
+    assert_eq!(
+        analyzer().analyze("CMD=ls; $CMD").trust_level,
+        TrustLevel::Uncertain
+    );
+}
+
+#[test]
+fn test_interpret_exit_code() {
+    assert_eq!(
+        interpret_exit_code("grep pattern file", 0),
+        Some("match found".into())
+    );
+    assert_eq!(
+        interpret_exit_code("grep pattern file", 1),
+        Some("no match found".into())
+    );
+    assert_eq!(
+        interpret_exit_code("diff a b", 0),
+        Some("files are identical".into())
+    );
+    assert_eq!(
+        interpret_exit_code("diff a b", 1),
+        Some("files differ".into())
+    );
+    assert_eq!(interpret_exit_code("echo hi", 0), None);
+}

--- a/src/tools/security/mod.rs
+++ b/src/tools/security/mod.rs
@@ -1,0 +1,9 @@
+//! Security analysis module for Bash commands.
+//!
+//! Provides AST-based parsing via tree-sitter and trust-level classification.
+
+pub mod bash_analyzer;
+
+pub use bash_analyzer::{
+    interpret_exit_code, BashSecurityAnalyzer, ParseResult, Redirect, SimpleCommand, TrustLevel,
+};


### PR DESCRIPTION
## 概述

实现 Bash 命令的三层安全解析架构：tree-sitter AST 语法解析 → 差异检测 → 信任分级。

## 变更

- **新增** `src/tools/security/bash_analyzer.rs` — BashSecurityAnalyzer 核心分析器
- **新增** `src/tools/security/bash_analyzer_tests.rs` — 测试文件
- **新增** `src/tools/security/mod.rs` — 模块声明
- **修改** `src/tools/builtin/bash.rs` — 集成安全分析（权限检查前）
- **修改** `src/tools/builtin/bash_classify.rs` — 迁移 interpret_exit_code
- **修改** `src/tools/mod.rs` — 添加 security 模块
- **修改** `Cargo.toml` — 添加 tree-sitter + tree-sitter-bash 依赖

## 测试

- 15 个安全分析单元测试通过
- 4 个 bash_classify 测试通过
- clippy 无新增问题

Closes #760

Source: issue #760
Type: feat