### PR TITLE
feat(llm): 新增缓存适配器 — Anthropic cache_control + Kimi prompt_cache_key

### DIFF
--- a/src/llm/adapter/legacy_provider.rs
+++ b/src/llm/adapter/legacy_provider.rs
@@ -74,6 +74,8 @@ impl<P: LLMProvider> LegacyProviderAdapter<P> {
                 prompt_tokens: response.usage.prompt_tokens,
                 completion_tokens: response.usage.completion_tokens,
                 total_tokens: Some(response.usage.total_tokens),
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: None,
         }

--- a/src/llm/adapter/legacy_provider_tests.rs
+++ b/src/llm/adapter/legacy_provider_tests.rs
@@ -31,6 +31,10 @@ fn make_internal_request(content: &str) -> InternalRequest {
         max_tokens: Some(256),
         stream: false,
         extra_body: Default::default(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
         reasoning_level: ReasoningLevel::default(),
     }
 }

--- a/src/llm/adapter/legacy_session.rs
+++ b/src/llm/adapter/legacy_session.rs
@@ -140,6 +140,10 @@ impl ChatSession for LegacySessionAdapter {
             max_tokens: None,
             stream: false,
             extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: self.reasoning_level,
         }
     }
@@ -205,6 +209,8 @@ mod tests {
                 completion_tokens: 2,
                 total_tokens: Some(3),
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: Some("stop".into()),
         });
@@ -226,6 +232,8 @@ mod tests {
                 completion_tokens: 0,
                 total_tokens: Some(0),
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: None,
         });
@@ -247,6 +255,8 @@ mod tests {
                 completion_tokens: 1,
                 total_tokens: Some(2),
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: Some("stop".into()),
         });

--- a/src/llm/cache_adapter/mod.rs
+++ b/src/llm/cache_adapter/mod.rs
@@ -1,0 +1,214 @@
+//! Cache adapter layer for LLM provider-specific prompt caching strategies.
+//!
+//! Different LLM providers expose different caching mechanisms. This module
+//! provides a [`CacheAdapter`] trait and implementations for each provider's
+//! caching strategy. The adapter runs *before* the Plugin Pipeline, acting as
+//! an independent pre-processing step on the request hot path.
+
+use crate::llm::types::{InternalRequest, SystemBlock};
+
+/// Adapter trait for provider-specific prompt caching strategies.
+///
+/// Implementations transform an [`InternalRequest`] in place, injecting
+/// provider-specific cache parameters (e.g., Anthropic `cache_control`,
+/// Kimi `prompt_cache_key`).
+pub trait CacheAdapter: Send + Sync {
+    /// Returns the adapter name (for logging / diagnostics).
+    fn name(&self) -> &str;
+
+    /// Apply provider-specific caching transformations to the request.
+    fn apply(&self, request: &mut InternalRequest);
+}
+
+/// No-op adapter — passes requests through unchanged.
+///
+/// Used for providers that do not support explicit prompt caching
+/// (e.g., OpenAI, DeepSeek).
+pub struct NoopCacheAdapter;
+
+impl CacheAdapter for NoopCacheAdapter {
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn apply(&self, _request: &mut InternalRequest) {
+        // intentionally empty
+    }
+}
+
+/// Anthropic cache adapter — splits system prompt into cacheable blocks.
+///
+/// Generates structured [`SystemBlock`] entries from `system_static` and
+/// `system_dynamic`, marking static blocks with `cache: true` so that the
+/// Anthropic protocol layer can emit `cache_control: {"type": "ephemeral"}`.
+pub struct AnthropicCacheAdapter;
+
+impl CacheAdapter for AnthropicCacheAdapter {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    fn apply(&self, request: &mut InternalRequest) {
+        let mut blocks = Vec::new();
+
+        if let Some(ref static_text) = request.system_static {
+            if !static_text.is_empty() {
+                // Split static content by section (double newline) to get
+                // finer-grained cache breakpoints.
+                for section in static_text.split("\n\n") {
+                    let trimmed = section.trim();
+                    if !trimmed.is_empty() {
+                        blocks.push(SystemBlock {
+                            text: trimmed.to_owned(),
+                            cache: true,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(ref dynamic_text) = request.system_dynamic {
+            if !dynamic_text.is_empty() {
+                blocks.push(SystemBlock {
+                    text: dynamic_text.clone(),
+                    cache: false,
+                });
+            }
+        }
+
+        if !blocks.is_empty() {
+            request.system_blocks = Some(blocks);
+        }
+    }
+}
+
+/// Kimi cache adapter — injects `prompt_cache_key` into `extra_body`.
+///
+/// Uses the request's `session_id` as the cache key so that the Kimi
+/// service-side automatic prefix cache can associate requests from the
+/// same session.
+pub struct KimiCacheAdapter;
+
+impl CacheAdapter for KimiCacheAdapter {
+    fn name(&self) -> &str {
+        "kimi"
+    }
+
+    fn apply(&self, request: &mut InternalRequest) {
+        if let Some(ref session_id) = request.session_id {
+            request.extra_body.insert(
+                "prompt_cache_key".to_owned(),
+                serde_json::Value::String(session_id.clone()),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::persistence::ReasoningLevel;
+    use serde_json::Map;
+
+    fn make_request() -> InternalRequest {
+        InternalRequest {
+            model: "test-model".to_owned(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: false,
+            extra_body: Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: ReasoningLevel::default(),
+        }
+    }
+
+    #[test]
+    fn noop_adapter_does_nothing() {
+        let mut req = make_request();
+        let adapter = NoopCacheAdapter;
+        adapter.apply(&mut req);
+        assert!(req.system_blocks.is_none());
+        assert!(req.extra_body.is_empty());
+    }
+
+    #[test]
+    fn noop_adapter_name() {
+        assert_eq!(NoopCacheAdapter.name(), "noop");
+    }
+
+    #[test]
+    fn anthropic_adapter_static_only() {
+        let mut req = make_request();
+        req.system_static = Some("Section A\n\nSection B".to_owned());
+        AnthropicCacheAdapter.apply(&mut req);
+
+        let blocks = req.system_blocks.as_ref().unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].text, "Section A");
+        assert!(blocks[0].cache);
+        assert_eq!(blocks[1].text, "Section B");
+        assert!(blocks[1].cache);
+    }
+
+    #[test]
+    fn anthropic_adapter_static_and_dynamic() {
+        let mut req = make_request();
+        req.system_static = Some("Static content".to_owned());
+        req.system_dynamic = Some("Dynamic content".to_owned());
+        AnthropicCacheAdapter.apply(&mut req);
+
+        let blocks = req.system_blocks.as_ref().unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert!(blocks[0].cache);
+        assert!(!blocks[1].cache);
+        assert_eq!(blocks[1].text, "Dynamic content");
+    }
+
+    #[test]
+    fn anthropic_adapter_empty_fields_no_blocks() {
+        let mut req = make_request();
+        req.system_static = Some("".to_owned());
+        AnthropicCacheAdapter.apply(&mut req);
+        assert!(req.system_blocks.is_none());
+    }
+
+    #[test]
+    fn anthropic_adapter_no_fields_no_blocks() {
+        let mut req = make_request();
+        AnthropicCacheAdapter.apply(&mut req);
+        assert!(req.system_blocks.is_none());
+    }
+
+    #[test]
+    fn anthropic_adapter_name() {
+        assert_eq!(AnthropicCacheAdapter.name(), "anthropic");
+    }
+
+    #[test]
+    fn kimi_adapter_injects_cache_key() {
+        let mut req = make_request();
+        req.session_id = Some("sess-123".to_owned());
+        KimiCacheAdapter.apply(&mut req);
+
+        assert_eq!(
+            req.extra_body.get("prompt_cache_key").unwrap(),
+            &serde_json::Value::String("sess-123".to_owned())
+        );
+    }
+
+    #[test]
+    fn kimi_adapter_no_session_id_no_inject() {
+        let mut req = make_request();
+        KimiCacheAdapter.apply(&mut req);
+        assert!(req.extra_body.is_empty());
+    }
+
+    #[test]
+    fn kimi_adapter_name() {
+        assert_eq!(KimiCacheAdapter.name(), "kimi");
+    }
+}

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 
+use crate::llm::cache_adapter::CacheAdapter;
 use crate::llm::interpreter::InterpreterRegistry;
 use crate::llm::plugin::PluginPipeline;
 use crate::llm::protocol::{ChatProtocol, IncomingSseStream, OutgoingEventStream, ProtocolError};
@@ -87,6 +88,7 @@ pub struct UnifiedChatClient {
     protocol: Arc<dyn ChatProtocol>,
     interpreter_registry: Arc<InterpreterRegistry>,
     plugin_pipeline: Arc<PluginPipeline>,
+    cache_adapter: Arc<dyn CacheAdapter>,
 }
 
 impl std::fmt::Debug for UnifiedChatClient {
@@ -94,24 +96,45 @@ impl std::fmt::Debug for UnifiedChatClient {
         f.debug_struct("UnifiedChatClient")
             .field("provider", &self.provider.id())
             .field("protocol", &self.protocol.protocol_id())
+            .field("cache_adapter", &self.cache_adapter.name())
             .finish()
     }
 }
 
 impl UnifiedChatClient {
-    /// Creates a new `UnifiedChatClient` from its four components.
+    /// Creates a new `UnifiedChatClient` from its components including a
+    /// cache adapter.
     pub fn new(
         provider: Arc<dyn Provider>,
         protocol: Arc<dyn ChatProtocol>,
         interpreter_registry: InterpreterRegistry,
         plugin_pipeline: PluginPipeline,
+        cache_adapter: Arc<dyn CacheAdapter>,
     ) -> Self {
         Self {
             provider,
             protocol,
             interpreter_registry: Arc::new(interpreter_registry),
             plugin_pipeline: Arc::new(plugin_pipeline),
+            cache_adapter,
         }
+    }
+
+    /// Convenience constructor that uses [`NoopCacheAdapter`](crate::llm::cache_adapter::NoopCacheAdapter)
+    /// for backward compatibility.
+    pub fn with_noop_cache_adapter(
+        provider: Arc<dyn Provider>,
+        protocol: Arc<dyn ChatProtocol>,
+        interpreter_registry: InterpreterRegistry,
+        plugin_pipeline: PluginPipeline,
+    ) -> Self {
+        Self::new(
+            provider,
+            protocol,
+            interpreter_registry,
+            plugin_pipeline,
+            Arc::new(crate::llm::cache_adapter::NoopCacheAdapter),
+        )
     }
 
     /// Returns the provider identifier.
@@ -134,6 +157,7 @@ impl UnifiedChatClient {
     pub async fn chat(&self, mut request: InternalRequest) -> Result<UnifiedResponse> {
         let model = request.model.clone();
         let provider_id = self.provider.id();
+        self.cache_adapter.apply(&mut request);
         self.plugin_pipeline.before_request(&mut request);
         let interpreter = self.interpreter_registry.resolve(provider_id, &model);
         interpreter.inject_extra_body(&mut request);
@@ -177,6 +201,7 @@ impl UnifiedChatClient {
     ) -> Result<OutgoingEventStream> {
         let model = request.model.clone();
         let provider_id = self.provider.id();
+        self.cache_adapter.apply(&mut request);
         self.plugin_pipeline.before_request(&mut request);
         let interpreter = self.interpreter_registry.resolve(provider_id, &model);
         interpreter.inject_extra_body(&mut request);

--- a/src/llm/client_test.rs
+++ b/src/llm/client_test.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
+use crate::llm::cache_adapter::NoopCacheAdapter;
 use crate::llm::interpreter::InterpreterRegistry;
 use crate::llm::plugin::PluginPipeline;
 use crate::llm::protocol::{ChatProtocol, IncomingSseStream, OutgoingEventStream};
@@ -72,6 +73,8 @@ impl Provider for StubProvider {
                 prompt_tokens: 1,
                 completion_tokens: 2,
                 total_tokens: Some(3),
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: Some("stop".into()),
         })
@@ -134,6 +137,8 @@ impl ChatProtocol for StubProtocol {
                 prompt_tokens: 0,
                 completion_tokens: 0,
                 total_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: None,
         })
@@ -159,7 +164,7 @@ impl ChatProtocol for StubProtocol {
                 yield StreamEvent::BlockStart { index: 0, block_type: ContentBlockType::Text };
                 yield StreamEvent::BlockDelta { index: 0, delta: ContentDelta::Text { text: "hello".into() } };
                 yield StreamEvent::MessageEnd {
-                    usage: Some(UnifiedUsage { prompt_tokens: 1, completion_tokens: 1, total_tokens: Some(2), reasoning_tokens: None }),
+                    usage: Some(UnifiedUsage { prompt_tokens: 1, completion_tokens: 1, total_tokens: Some(2), reasoning_tokens: None, cache_read_tokens: None, cache_write_tokens: None }),
                     finish_reason: Some("stop".into()),
                 };
             }
@@ -202,12 +207,16 @@ fn make_request() -> InternalRequest {
         max_tokens: Some(256),
         stream: false,
         extra_body: Default::default(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
         reasoning_level: ReasoningLevel::default(),
     }
 }
 
 fn make_client(pipeline: PluginPipeline) -> UnifiedChatClient {
-    UnifiedChatClient::new(
+    UnifiedChatClient::with_noop_cache_adapter(
         Arc::new(StubProvider::new()),
         Arc::new(StubProtocol::new()),
         InterpreterRegistry::default(),
@@ -254,6 +263,8 @@ async fn test_chat_interpreter_resolves() {
                     completion_tokens: 0,
                     total_tokens: Some(0),
                     reasoning_tokens: None,
+                    cache_read_tokens: None,
+                    cache_write_tokens: None,
                 },
                 finish_reason: None,
             }
@@ -263,7 +274,7 @@ async fn test_chat_interpreter_resolves() {
         }
     }
     let registry = InterpreterRegistry::new(vec![(Box::new(CheckInterpreter), "stub/*")]);
-    let client = UnifiedChatClient::new(
+    let client = UnifiedChatClient::with_noop_cache_adapter(
         Arc::new(StubProvider::new()),
         Arc::new(StubProtocol::new()),
         registry,

--- a/src/llm/interpreter.rs
+++ b/src/llm/interpreter.rs
@@ -76,6 +76,8 @@ impl ModelInterpreter for DefaultInterpreter {
             completion_tokens: response.usage.completion_tokens,
             total_tokens: response.usage.total_tokens,
             reasoning_tokens: None,
+            cache_read_tokens: response.usage.cache_read_tokens,
+            cache_write_tokens: response.usage.cache_write_tokens,
         };
         UnifiedResponse {
             content_blocks,
@@ -227,6 +229,8 @@ impl ModelInterpreter for MinimaxInterpreter {
                 completion_tokens: response.usage.completion_tokens,
                 total_tokens: response.usage.total_tokens,
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: response.finish_reason,
         }
@@ -287,6 +291,8 @@ impl ModelInterpreter for GlmInterpreter {
                 completion_tokens: response.usage.completion_tokens,
                 total_tokens: response.usage.total_tokens,
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: response.finish_reason,
         }

--- a/src/llm/interpreter_test.rs
+++ b/src/llm/interpreter_test.rs
@@ -24,6 +24,8 @@ fn test_default_interpreter_response_identity() {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     };
@@ -153,6 +155,8 @@ fn test_minimax_interpreter_empty_content_uses_reasoning() {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     };
@@ -173,6 +177,8 @@ fn test_minimax_interpreter_text_content_preferred() {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: None,
     };
@@ -214,6 +220,8 @@ fn test_glm_interpreter_reasoning_threshold_short() {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: None,
     };
@@ -234,6 +242,8 @@ fn test_glm_interpreter_reasoning_threshold_exact_boundary() {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: None,
     };
@@ -254,6 +264,8 @@ fn test_glm_interpreter_text_preferred_over_reasoning() {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: None,
     };
@@ -300,6 +312,8 @@ fn test_deepseek_interpreter_response_identity() {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     };
@@ -324,6 +338,8 @@ fn test_deepseek_interpreter_stream_event_passthrough() {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
             reasoning_tokens: None,
         }),
         finish_reason: Some("stop".into()),

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod adapter;
 pub mod anthropic;
+pub mod cache_adapter;
 pub mod fallback;
 pub mod glm;
 pub mod glm_stream;
@@ -157,6 +158,8 @@ pub trait LLMProvider: Send + Sync {
                 completion_tokens: response.usage.completion_tokens,
                 total_tokens: Some(response.usage.total_tokens),
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: None,
         })

--- a/src/llm/plugin.rs
+++ b/src/llm/plugin.rs
@@ -219,6 +219,10 @@ mod tests {
             max_tokens: Some(256),
             stream: false,
             extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: ReasoningLevel::default(),
         }
     }
@@ -231,6 +235,8 @@ mod tests {
                 completion_tokens: 5,
                 total_tokens: Some(15),
                 reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
             finish_reason: Some("stop".to_string()),
         }

--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -94,6 +94,32 @@ impl ChatProtocol for AnthropicProtocol {
             );
         }
 
+        // System blocks: if present, serialize as Anthropic's system array format.
+        // Each block with cache=true gets a cache_control marker.
+        if let Some(ref blocks) = request.system_blocks {
+            if !blocks.is_empty() {
+                let system_array: Vec<serde_json::Value> = blocks
+                    .iter()
+                    .map(|b| {
+                        let mut obj = serde_json::json!({
+                            "type": "text",
+                            "text": b.text,
+                        });
+                        if b.cache {
+                            obj.as_object_mut().unwrap().insert(
+                                "cache_control".to_string(),
+                                serde_json::json!({ "type": "ephemeral" }),
+                            );
+                        }
+                        obj
+                    })
+                    .collect();
+                body.as_object_mut()
+                    .unwrap()
+                    .insert("system".to_string(), serde_json::json!(system_array));
+            }
+        }
+
         for (key, value) in &request.extra_body {
             body.as_object_mut()
                 .unwrap()
@@ -191,218 +217,21 @@ fn parse_usage(body: &serde_json::Value) -> RawUsage {
         .and_then(|v| v.as_u64())
         .map(|v| v as u32);
 
+    let cache_read_tokens = usage_obj
+        .and_then(|u| u.get("cache_read_input_tokens"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+
+    let cache_write_tokens = usage_obj
+        .and_then(|u| u.get("cache_creation_input_tokens"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+
     RawUsage {
         prompt_tokens: input_tokens,
         completion_tokens: output_tokens,
         total_tokens,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::llm::types::InternalMessage;
-
-    fn make_request() -> InternalRequest {
-        InternalRequest {
-            model: "claude-3-5-sonnet-20241022".to_string(),
-            messages: vec![InternalMessage {
-                role: "user".to_string(),
-                content: "Hello".to_string(),
-            }],
-            temperature: 0.7,
-            max_tokens: Some(1024),
-            stream: false,
-            extra_body: Default::default(),
-            reasoning_level: ReasoningLevel::default(),
-        }
-    }
-
-    // ── build_request tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn test_build_request_basic() {
-        let proto = AnthropicProtocol::new();
-        let request = make_request();
-        let body = proto.build_request(&request).unwrap();
-
-        assert_eq!(body.get("model").unwrap(), "claude-3-5-sonnet-20241022");
-        assert!(body.get("messages").unwrap().is_array());
-        assert_eq!(body.get("max_tokens").unwrap(), &serde_json::json!(1024));
-    }
-
-    #[test]
-    fn test_build_request_no_max_tokens() {
-        let proto = AnthropicProtocol::new();
-        let mut request = make_request();
-        request.max_tokens = None;
-        let body = proto.build_request(&request).unwrap();
-        assert!(body.get("max_tokens").is_none());
-    }
-
-    #[test]
-    fn test_build_request_stream_flag() {
-        let proto = AnthropicProtocol::new();
-        let mut request = make_request();
-        request.stream = true;
-        let body = proto.build_request(&request).unwrap();
-        // Anthropic /v1/messages does not have a `stream` bool in the body
-        // for the HTTP POST; streaming uses a different endpoint (SSE).
-        assert!(body.get("stream").is_none());
-    }
-
-    // ── parse_response tests ──────────────────────────────────────────────────
-
-    #[test]
-    fn test_parse_response_normal() {
-        let proto = AnthropicProtocol::new();
-        let body = serde_json::json!({
-            "content": [
-                {"type": "text", "text": "Hello, world!"}
-            ],
-            "stop_reason": "end_turn",
-            "usage": {
-                "input_tokens": 10,
-                "output_tokens": 5,
-                "total_tokens": 15
-            }
-        });
-
-        let resp = proto.parse_response(body).unwrap();
-        assert_eq!(resp.content_blocks.len(), 1);
-        assert!(
-            matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == "Hello, world!")
-        );
-        assert_eq!(resp.usage.prompt_tokens, 10);
-        assert_eq!(resp.usage.completion_tokens, 5);
-        assert_eq!(resp.usage.total_tokens, Some(15));
-        assert_eq!(resp.finish_reason, Some("end_turn".to_string()));
-    }
-
-    #[test]
-    fn test_parse_response_thinking_block() {
-        let proto = AnthropicProtocol::new();
-        let body = serde_json::json!({
-            "content": [
-                {"type": "thinking", "thinking": "Let me think..."},
-                {"type": "text", "text": "Final answer."}
-            ],
-            "stop_reason": "end_turn"
-        });
-
-        let resp = proto.parse_response(body).unwrap();
-        assert_eq!(resp.content_blocks.len(), 2);
-        assert!(
-            matches!(resp.content_blocks[0], RawContentBlock::Thinking(ref s) if s == "Let me think...")
-        );
-        assert!(
-            matches!(resp.content_blocks[1], RawContentBlock::Text(ref s) if s == "Final answer.")
-        );
-    }
-
-    #[test]
-    fn test_parse_response_empty_content() {
-        let proto = AnthropicProtocol::new();
-        let body = serde_json::json!({ "content": [], "stop_reason": "end_turn" });
-        let resp = proto.parse_response(body).unwrap();
-        assert!(resp.content_blocks.is_empty());
-        assert_eq!(resp.usage.prompt_tokens, 0);
-        assert_eq!(resp.usage.completion_tokens, 0);
-    }
-
-    #[test]
-    fn test_parse_response_missing_usage_defaults() {
-        let proto = AnthropicProtocol::new();
-        let body = serde_json::json!({
-            "content": [{"type": "text", "text": "Hi"}],
-            "stop_reason": "end_turn"
-        });
-        let resp = proto.parse_response(body).unwrap();
-        assert_eq!(resp.usage.prompt_tokens, 0);
-        assert_eq!(resp.usage.completion_tokens, 0);
-        assert!(resp.usage.total_tokens.is_none());
-    }
-
-    // ── decorate_headers tests ────────────────────────────────────────────────
-
-    #[test]
-    fn test_decorate_headers_api_key() {
-        std::env::remove_var("ANTHROPIC_API_KEY");
-        let proto = AnthropicProtocol::new();
-        let mut headers = HeaderMap::new();
-        proto.decorate_headers(&mut headers).unwrap();
-
-        let key_header = headers.get("x-api-key").unwrap();
-        assert_eq!(key_header.to_str().unwrap(), "");
-    }
-
-    #[test]
-    fn test_decorate_headers_anthropic_version() {
-        let proto = AnthropicProtocol::new();
-        let mut headers = HeaderMap::new();
-        proto.decorate_headers(&mut headers).unwrap();
-
-        assert_eq!(
-            headers.get("anthropic-version").unwrap().to_str().unwrap(),
-            "2023-06-01"
-        );
-    }
-
-    #[test]
-    fn test_decorate_headers_content_type() {
-        let proto = AnthropicProtocol::new();
-        let mut headers = HeaderMap::new();
-        proto.decorate_headers(&mut headers).unwrap();
-
-        assert_eq!(
-            headers.get(CONTENT_TYPE).unwrap().to_str().unwrap(),
-            "application/json"
-        );
-    }
-
-    // ── reasoning_level non-injection tests ─────────────────────────────────
-
-    #[test]
-    fn test_build_request_does_not_inject_reasoning_level_low() {
-        let proto = AnthropicProtocol::new();
-        let mut request = make_request();
-        request.reasoning_level = ReasoningLevel::Low;
-        let body = proto.build_request(&request).unwrap();
-        // Anthropic does not support reasoning_level — no reasoning/thinking field should appear.
-        assert!(body.get("thinking").is_none());
-        assert!(body.get("reasoning_effort").is_none());
-        assert!(body.get("reasoning_level").is_none());
-    }
-
-    #[test]
-    fn test_build_request_does_not_inject_reasoning_level_medium() {
-        let proto = AnthropicProtocol::new();
-        let mut request = make_request();
-        request.reasoning_level = ReasoningLevel::Medium;
-        let body = proto.build_request(&request).unwrap();
-        assert!(body.get("thinking").is_none());
-        assert!(body.get("reasoning_effort").is_none());
-        assert!(body.get("reasoning_level").is_none());
-    }
-
-    #[test]
-    fn test_build_request_does_not_inject_reasoning_level_max() {
-        let proto = AnthropicProtocol::new();
-        let mut request = make_request();
-        request.reasoning_level = ReasoningLevel::Max;
-        let body = proto.build_request(&request).unwrap();
-        assert!(body.get("thinking").is_none());
-        assert!(body.get("reasoning_effort").is_none());
-        assert!(body.get("reasoning_level").is_none());
-    }
-
-    #[test]
-    fn test_build_request_high_reasoning_level_no_injection() {
-        let proto = AnthropicProtocol::new();
-        let request = make_request(); // default is High
-        let body = proto.build_request(&request).unwrap();
-        assert!(body.get("thinking").is_none());
-        assert!(body.get("reasoning_effort").is_none());
-        assert!(body.get("reasoning_level").is_none());
+        cache_read_tokens,
+        cache_write_tokens,
     }
 }

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -1,0 +1,302 @@
+//! Tests for Anthropic ChatProtocol implementation.
+
+use reqwest::header::{HeaderMap, CONTENT_TYPE};
+
+use crate::llm::protocol::{AnthropicProtocol, ChatProtocol};
+use crate::llm::types::{InternalMessage, InternalRequest, RawContentBlock};
+use crate::session::persistence::ReasoningLevel;
+
+fn make_request() -> InternalRequest {
+    InternalRequest {
+        model: "claude-3-5-sonnet-20241022".to_string(),
+        messages: vec![InternalMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+        }],
+        temperature: 0.7,
+        max_tokens: Some(1024),
+        stream: false,
+        extra_body: Default::default(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
+        reasoning_level: ReasoningLevel::default(),
+    }
+}
+
+// ── build_request tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_build_request_basic() {
+    let proto = AnthropicProtocol::new();
+    let request = make_request();
+    let body = proto.build_request(&request).unwrap();
+
+    assert_eq!(body.get("model").unwrap(), "claude-3-5-sonnet-20241022");
+    assert!(body.get("messages").unwrap().is_array());
+    assert_eq!(body.get("max_tokens").unwrap(), &serde_json::json!(1024));
+}
+
+#[test]
+fn test_build_request_no_max_tokens() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.max_tokens = None;
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("max_tokens").is_none());
+}
+
+#[test]
+fn test_build_request_stream_flag() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.stream = true;
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("stream").is_none());
+}
+
+// ── system_blocks serialization tests ─────────────────────────────────────
+
+#[test]
+fn test_build_request_system_blocks_with_cache() {
+    use crate::llm::types::SystemBlock;
+
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.system_blocks = Some(vec![
+        SystemBlock {
+            text: "You are a helpful assistant.".to_string(),
+            cache: true,
+        },
+        SystemBlock {
+            text: "Current date: 2026-01-01".to_string(),
+            cache: false,
+        },
+    ]);
+    let body = proto.build_request(&request).unwrap();
+
+    let system = body.get("system").unwrap().as_array().unwrap();
+    assert_eq!(system.len(), 2);
+
+    let first = &system[0];
+    assert_eq!(first.get("type").unwrap(), "text");
+    assert_eq!(first.get("text").unwrap(), "You are a helpful assistant.");
+    assert_eq!(
+        first.get("cache_control"),
+        Some(&serde_json::json!({ "type": "ephemeral" }))
+    );
+
+    let second = &system[1];
+    assert_eq!(second.get("type").unwrap(), "text");
+    assert_eq!(second.get("text").unwrap(), "Current date: 2026-01-01");
+    assert!(second.get("cache_control").is_none());
+}
+
+#[test]
+fn test_build_request_system_blocks_empty() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.system_blocks = Some(vec![]);
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("system").is_none());
+}
+
+#[test]
+fn test_build_request_no_system_blocks() {
+    let proto = AnthropicProtocol::new();
+    let request = make_request();
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("system").is_none());
+}
+
+// ── parse_response tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_parse_response_normal() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {"type": "text", "text": "Hello, world!"}
+        ],
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15
+        }
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(matches!(
+        resp.content_blocks[0],
+        RawContentBlock::Text(ref s) if s == "Hello, world!"
+    ));
+    assert_eq!(resp.usage.prompt_tokens, 10);
+    assert_eq!(resp.usage.completion_tokens, 5);
+    assert_eq!(resp.usage.total_tokens, Some(15));
+    assert_eq!(resp.finish_reason, Some("end_turn".to_string()));
+}
+
+#[test]
+fn test_parse_response_thinking_block() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {"type": "thinking", "thinking": "Let me think..."},
+            {"type": "text", "text": "Final answer."}
+        ],
+        "stop_reason": "end_turn"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(matches!(
+        resp.content_blocks[0],
+        RawContentBlock::Thinking(ref s) if s == "Let me think..."
+    ));
+    assert!(matches!(
+        resp.content_blocks[1],
+        RawContentBlock::Text(ref s) if s == "Final answer."
+    ));
+}
+
+#[test]
+fn test_parse_response_empty_content() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({ "content": [], "stop_reason": "end_turn" });
+    let resp = proto.parse_response(body).unwrap();
+    assert!(resp.content_blocks.is_empty());
+    assert_eq!(resp.usage.prompt_tokens, 0);
+    assert_eq!(resp.usage.completion_tokens, 0);
+}
+
+#[test]
+fn test_parse_response_missing_usage_defaults() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [{"type": "text", "text": "Hi"}],
+        "stop_reason": "end_turn"
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.usage.prompt_tokens, 0);
+    assert_eq!(resp.usage.completion_tokens, 0);
+    assert!(resp.usage.total_tokens.is_none());
+}
+
+// ── cache usage parsing tests ─────────────────────────────────────────────
+
+#[test]
+fn test_parse_usage_cache_fields() {
+    let body = serde_json::json!({
+        "content": [{"type": "text", "text": "hi"}],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 80,
+            "cache_creation_input_tokens": 20
+        }
+    });
+    let proto = AnthropicProtocol::new();
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.usage.cache_read_tokens, Some(80));
+    assert_eq!(resp.usage.cache_write_tokens, Some(20));
+}
+
+#[test]
+fn test_parse_usage_no_cache_fields() {
+    let body = serde_json::json!({
+        "content": [{"type": "text", "text": "hi"}],
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50
+        }
+    });
+    let proto = AnthropicProtocol::new();
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.usage.cache_read_tokens, None);
+    assert_eq!(resp.usage.cache_write_tokens, None);
+}
+
+// ── decorate_headers tests ────────────────────────────────────────────────
+
+#[test]
+fn test_decorate_headers_api_key() {
+    std::env::remove_var("ANTHROPIC_API_KEY");
+    let proto = AnthropicProtocol::new();
+    let mut headers = HeaderMap::new();
+    proto.decorate_headers(&mut headers).unwrap();
+
+    let key_header = headers.get("x-api-key").unwrap();
+    assert_eq!(key_header.to_str().unwrap(), "");
+}
+
+#[test]
+fn test_decorate_headers_anthropic_version() {
+    let proto = AnthropicProtocol::new();
+    let mut headers = HeaderMap::new();
+    proto.decorate_headers(&mut headers).unwrap();
+
+    assert_eq!(
+        headers.get("anthropic-version").unwrap().to_str().unwrap(),
+        "2023-06-01"
+    );
+}
+
+#[test]
+fn test_decorate_headers_content_type() {
+    let proto = AnthropicProtocol::new();
+    let mut headers = HeaderMap::new();
+    proto.decorate_headers(&mut headers).unwrap();
+
+    assert_eq!(
+        headers.get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+        "application/json"
+    );
+}
+
+// ── reasoning_level non-injection tests ─────────────────────────────────
+
+#[test]
+fn test_build_request_does_not_inject_reasoning_level_low() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.reasoning_level = ReasoningLevel::Low;
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("thinking").is_none());
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning_level").is_none());
+}
+
+#[test]
+fn test_build_request_does_not_inject_reasoning_level_medium() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.reasoning_level = ReasoningLevel::Medium;
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("thinking").is_none());
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning_level").is_none());
+}
+
+#[test]
+fn test_build_request_does_not_inject_reasoning_level_max() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.reasoning_level = ReasoningLevel::Max;
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("thinking").is_none());
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning_level").is_none());
+}
+
+#[test]
+fn test_build_request_high_reasoning_level_no_injection() {
+    let proto = AnthropicProtocol::new();
+    let request = make_request(); // default is High
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("thinking").is_none());
+    assert!(body.get("reasoning_effort").is_none());
+    assert!(body.get("reasoning_level").is_none());
+}

--- a/src/llm/protocol/glm.rs
+++ b/src/llm/protocol/glm.rs
@@ -313,6 +313,8 @@ fn parse_usage(body: &serde_json::Value) -> RawUsage {
         prompt_tokens,
         completion_tokens,
         total_tokens,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
     }
 }
 

--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -13,6 +13,10 @@ fn make_request() -> InternalRequest {
         max_tokens: Some(256),
         stream: false,
         extra_body: Default::default(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
         reasoning_level: ReasoningLevel::default(),
     }
 }
@@ -39,7 +43,6 @@ fn test_build_request_stream() {
     let body = proto.build_request(&request).unwrap();
     assert_eq!(body.get("stream").unwrap(), &serde_json::json!(true));
 }
-// ── parse_response tests ──────────────────────────────────────────────────
 
 #[test]
 fn test_parse_response_normal() {
@@ -124,7 +127,6 @@ fn test_parse_response_empty_choices() {
     assert!(resp.content_blocks.is_empty());
     assert_eq!(resp.usage.prompt_tokens, 0);
 }
-// ── decorate_headers tests ────────────────────────────────────────────────
 
 #[test]
 fn test_decorate_headers_bearer() {
@@ -146,7 +148,6 @@ fn test_decorate_headers_content_type() {
         "application/json"
     );
 }
-// ── SSE parsing tests ──────────────────────────────────────────────────────
 
 fn make_sse_chunk(data: &str) -> RawSseChunk {
     RawSseChunk {
@@ -246,7 +247,6 @@ async fn test_parse_sse_empty_chunk_breaks() {
     assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
     assert!(stream.next().await.is_none());
 }
-// ── SSE tool_calls parsing tests ──────────────────────────────────────────
 
 #[tokio::test]
 async fn test_parse_sse_tool_calls_basic() {

--- a/src/llm/protocol/mod.rs
+++ b/src/llm/protocol/mod.rs
@@ -18,3 +18,6 @@ pub use chat_protocol::{
 pub use anthropic::AnthropicProtocol;
 pub use glm::GlmProtocol;
 pub use openai::OpenAiProtocol;
+
+#[cfg(test)]
+mod anthropic_tests;

--- a/src/llm/protocol/openai.rs
+++ b/src/llm/protocol/openai.rs
@@ -284,10 +284,18 @@ fn parse_usage(body: &serde_json::Value) -> RawUsage {
         .and_then(|v| v.as_u64())
         .map(|v| v as u32);
 
+    let cache_read_tokens = usage_obj
+        .and_then(|u| u.get("prompt_tokens_details"))
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+
     RawUsage {
         prompt_tokens,
         completion_tokens,
         total_tokens,
+        cache_read_tokens,
+        cache_write_tokens: None,
     }
 }
 

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -19,6 +19,10 @@ fn make_request() -> InternalRequest {
         max_tokens: Some(256),
         stream: false,
         extra_body: Default::default(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
         reasoning_level: ReasoningLevel::default(),
     }
 }
@@ -257,4 +261,39 @@ fn test_build_request_default_reasoning_level_is_high() {
     let request = make_request();
     let body = proto.build_request(&request).unwrap();
     assert_eq!(body.get("reasoning_effort").unwrap(), "high");
+}
+
+#[test]
+fn test_parse_response_cached_tokens() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+            "prompt_tokens_details": {
+                "cached_tokens": 80
+            }
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.usage.cache_read_tokens, Some(80));
+    assert_eq!(resp.usage.cache_write_tokens, None);
+}
+
+#[test]
+fn test_parse_response_no_cached_tokens() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.usage.cache_read_tokens, None);
+    assert_eq!(resp.usage.cache_write_tokens, None);
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -184,6 +184,10 @@ mod tests {
             max_tokens: Some(100),
             stream: false,
             extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: ReasoningLevel::default(),
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -217,6 +221,10 @@ mod tests {
             max_tokens: None,
             stream: true,
             extra_body: extra.clone(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: ReasoningLevel::default(),
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -237,6 +245,10 @@ mod tests {
             max_tokens: None,
             stream: false,
             extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: ReasoningLevel::default(),
         };
         let json = serde_json::to_string(&req).unwrap();

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -299,6 +299,10 @@ impl ChatSession for ConversationSession {
             max_tokens: None,
             stream: false,
             extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
             reasoning_level: self.reasoning_level,
         }
     }

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -230,6 +230,8 @@ fn test_append_response_adds_message() {
             completion_tokens: 2,
             total_tokens: Some(3),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     };
@@ -251,6 +253,8 @@ fn test_append_tool_result_increments_turn() {
             completion_tokens: 1,
             total_tokens: Some(2),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });
@@ -272,6 +276,8 @@ fn test_append_response_empty_blocks_no_turn_increment() {
             completion_tokens: 0,
             total_tokens: Some(0),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: None,
     });
@@ -305,6 +311,8 @@ fn test_build_api_request_without_system_prompt() {
             completion_tokens: 1,
             total_tokens: Some(2),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });
@@ -327,6 +335,8 @@ fn test_conversation_session_multiple_turns() {
             completion_tokens: 2,
             total_tokens: Some(3),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });
@@ -343,6 +353,8 @@ fn test_conversation_session_multiple_turns() {
             completion_tokens: 3,
             total_tokens: Some(4),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });
@@ -380,6 +392,8 @@ fn test_replace_messages_overwrites_existing() {
             completion_tokens: 1,
             total_tokens: Some(2),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });
@@ -413,6 +427,8 @@ fn test_replace_messages_empty_vec_clears() {
             completion_tokens: 1,
             total_tokens: Some(2),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });

--- a/src/llm/session/tests/thinking_clean_tests.rs
+++ b/src/llm/session/tests/thinking_clean_tests.rs
@@ -134,6 +134,8 @@ fn test_build_api_request_does_not_modify_self_messages() {
             completion_tokens: 1,
             total_tokens: Some(2),
             reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
         },
         finish_reason: Some("stop".into()),
     });

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -64,6 +64,12 @@ pub struct UnifiedUsage {
     /// Number of tokens used for reasoning (if reported by provider).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u32>,
+    /// Number of tokens read from cache (cache hit).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u32>,
+    /// Number of tokens written to cache (cache creation).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u32>,
 }
 
 /// Unified response structure returned by all LLM providers.
@@ -174,6 +180,12 @@ pub struct RawUsage {
     /// Total tokens used (optional, some providers omit this).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_tokens: Option<u32>,
+    /// Cache read (hit) tokens (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u32>,
+    /// Cache write (creation) tokens (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write_tokens: Option<u32>,
 }
 
 /// Internal response assembled by a Protocol from raw provider output.
@@ -239,6 +251,18 @@ impl From<String> for ProtocolId {
     }
 }
 
+/// A structured system prompt block with cache control metadata.
+///
+/// Used by `CacheAdapter` implementations to produce provider-specific
+/// system block representations (e.g., Anthropic cache_control markers).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemBlock {
+    /// The text content of this system block.
+    pub text: String,
+    /// Whether this block should be marked as cacheable.
+    pub cache: bool,
+}
+
 /// A single message in an `InternalRequest`.
 ///
 /// Contains the role and content of a chat message used internally
@@ -273,6 +297,18 @@ pub struct InternalRequest {
     /// Additional provider-specific parameters.
     #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra_body: serde_json::Map<String, serde_json::Value>,
+    /// Static system prompt content (cacheable portion).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_static: Option<String>,
+    /// Dynamic system prompt content (non-cacheable portion).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_dynamic: Option<String>,
+    /// Structured system blocks produced by a `CacheAdapter`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_blocks: Option<Vec<SystemBlock>>,
+    /// Session identifier used for provider-level cache keys (e.g., Kimi prompt_cache_key).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
     /// Reasoning depth level for the request.
     /// Each protocol maps this to its native parameter (e.g., OpenAI `reasoning_effort`).
     /// Skipped during serialization to avoid leaking to API payloads.
@@ -325,146 +361,4 @@ impl Default for SseStateMachine {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    // ── ContentBlock serde symmetry tests ──────────────────────────────────────
-
-    #[test]
-    fn test_content_block_text_serde_roundtrip() {
-        let original = ContentBlock::Text("hello world".into());
-        let json = serde_json::to_string(&original).unwrap();
-        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    #[test]
-    fn test_content_block_thinking_serde_roundtrip() {
-        let original = ContentBlock::Thinking("let me think...".into());
-        let json = serde_json::to_string(&original).unwrap();
-        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    #[test]
-    fn test_content_block_tool_use_serde_roundtrip() {
-        let original = ContentBlock::ToolUse {
-            id: "call_123".into(),
-            name: "get_weather".into(),
-            input: r#"{"city":"Beijing"}"#.into(),
-        };
-        let json = serde_json::to_string(&original).unwrap();
-        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    #[test]
-    fn test_content_block_tool_result_serde_roundtrip() {
-        let original = ContentBlock::ToolResult {
-            tool_call_id: "call_123".into(),
-            content: "sunny, 25C".into(),
-        };
-        let json = serde_json::to_string(&original).unwrap();
-        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
-        assert_eq!(original, parsed);
-    }
-
-    // ── ContentBlock serde tag verification ───────────────────────────────────
-
-    #[test]
-    fn test_content_block_serialized_contains_type_field() {
-        let blk = ContentBlock::Text("test".into());
-        let json = serde_json::to_string(&blk).unwrap();
-        assert!(
-            json.contains(r#""type":"#),
-            "JSON should contain \"type\" field: {json}"
-        );
-
-        let blk2 = ContentBlock::ToolUse {
-            id: "x".into(),
-            name: "y".into(),
-            input: "{}".into(),
-        };
-        let json2 = serde_json::to_string(&blk2).unwrap();
-        assert!(
-            json2.contains(r#""type":"#),
-            "JSON should contain \"type\" field: {json2}"
-        );
-    }
-
-    // ── StreamEvent variant distinguishable test ───────────────────────────────
-
-    #[test]
-    fn test_stream_event_variants_are_distinguishable() {
-        use StreamEvent::*;
-
-        let events = [
-            BlockStart {
-                index: 0,
-                block_type: ContentBlockType::Text,
-            },
-            BlockDelta {
-                index: 0,
-                delta: ContentDelta::Text { text: "hi".into() },
-            },
-            BlockEnd {
-                index: 0,
-                block_type: ContentBlockType::Thinking,
-            },
-            MessageEnd {
-                usage: None,
-                finish_reason: Some("stop".into()),
-            },
-            Error {
-                message: "oops".into(),
-            },
-        ];
-
-        for e in &events {
-            let json = serde_json::to_string(e).unwrap();
-            let parsed: StreamEvent = serde_json::from_str(&json).unwrap();
-            assert_eq!(e, &parsed, "Roundtrip failed for {e:?}");
-        }
-    }
-
-    // ── UnifiedUsage None serialization test ──────────────────────────────────
-
-    #[test]
-    fn test_unified_usage_optional_fields_none() {
-        let usage = UnifiedUsage {
-            prompt_tokens: 10,
-            completion_tokens: 5,
-            total_tokens: None,
-            reasoning_tokens: None,
-        };
-        let json = serde_json::to_string(&usage).unwrap();
-        let parsed: UnifiedUsage = serde_json::from_str(&json).unwrap();
-        assert_eq!(usage, parsed);
-        // Should not contain the optional fields when None
-        assert!(!json.contains("total_tokens"));
-        assert!(!json.contains("reasoning_tokens"));
-    }
-
-    // ── SseStateMachine initial state test ────────────────────────────────────
-
-    #[test]
-    fn test_sse_state_machine_new_initial_state() {
-        let sm = SseStateMachine::new();
-        assert!(sm.current_block_index.is_none());
-        assert!(sm.current_block_type.is_none());
-        assert!(sm.pending_thinking.is_empty());
-        assert!(sm.pending_signature.is_empty());
-    }
-
-    #[test]
-    fn test_sse_state_machine_default_same_as_new() {
-        let sm = SseStateMachine::default();
-        let sm2 = SseStateMachine::new();
-        assert_eq!(sm.current_block_index, sm2.current_block_index);
-        assert_eq!(sm.current_block_type, sm2.current_block_type);
-        assert_eq!(sm.pending_thinking, sm2.pending_thinking);
-        assert_eq!(sm.pending_signature, sm2.pending_signature);
-    }
-
-    // ── ProtocolId tests ──────────────────────────────────────────────────────
-}
+mod types_tests;

--- a/src/llm/types_tests.rs
+++ b/src/llm/types_tests.rs
@@ -1,0 +1,189 @@
+//! Tests for LLM types (serde, roundtrip, etc.).
+
+use crate::llm::types::{
+    ContentBlock, ContentBlockType, ContentDelta, SseStateMachine, StreamEvent, SystemBlock,
+    UnifiedUsage,
+};
+
+// ── ContentBlock serde symmetry tests ──────────────────────────────────────
+
+#[test]
+fn test_content_block_text_serde_roundtrip() {
+    let original = ContentBlock::Text("hello world".into());
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_content_block_thinking_serde_roundtrip() {
+    let original = ContentBlock::Thinking("let me think...".into());
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_content_block_tool_use_serde_roundtrip() {
+    let original = ContentBlock::ToolUse {
+        id: "call_123".into(),
+        name: "get_weather".into(),
+        input: r#"{"city":"Beijing"}"#.into(),
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, parsed);
+}
+
+#[test]
+fn test_content_block_tool_result_serde_roundtrip() {
+    let original = ContentBlock::ToolResult {
+        tool_call_id: "call_123".into(),
+        content: "sunny, 25C".into(),
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, parsed);
+}
+
+// ── ContentBlock serde tag verification ───────────────────────────────────
+
+#[test]
+fn test_content_block_serialized_contains_type_field() {
+    let blk = ContentBlock::Text("test".into());
+    let json = serde_json::to_string(&blk).unwrap();
+    assert!(
+        json.contains(r#""type":"#),
+        "JSON should contain \"type\" field: {json}"
+    );
+
+    let blk2 = ContentBlock::ToolUse {
+        id: "x".into(),
+        name: "y".into(),
+        input: "{}".into(),
+    };
+    let json2 = serde_json::to_string(&blk2).unwrap();
+    assert!(
+        json2.contains(r#""type":"#),
+        "JSON should contain \"type\" field: {json2}"
+    );
+}
+
+// ── StreamEvent variant distinguishable test ───────────────────────────────
+
+#[test]
+fn test_stream_event_variants_are_distinguishable() {
+    use StreamEvent::*;
+
+    let events = [
+        BlockStart {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        },
+        BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text { text: "hi".into() },
+        },
+        BlockEnd {
+            index: 0,
+            block_type: ContentBlockType::Thinking,
+        },
+        MessageEnd {
+            usage: None,
+            finish_reason: Some("stop".into()),
+        },
+        Error {
+            message: "oops".into(),
+        },
+    ];
+
+    for e in &events {
+        let json = serde_json::to_string(e).unwrap();
+        let parsed: StreamEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, &parsed, "Roundtrip failed for {e:?}");
+    }
+}
+
+// ── UnifiedUsage None serialization test ──────────────────────────────────
+
+#[test]
+fn test_unified_usage_optional_fields_none() {
+    let usage = UnifiedUsage {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: None,
+        reasoning_tokens: None,
+        cache_read_tokens: None,
+        cache_write_tokens: None,
+    };
+    let json = serde_json::to_string(&usage).unwrap();
+    let parsed: UnifiedUsage = serde_json::from_str(&json).unwrap();
+    assert_eq!(usage, parsed);
+    assert!(!json.contains("total_tokens"));
+    assert!(!json.contains("reasoning_tokens"));
+    assert!(!json.contains("cache_read_tokens"));
+    assert!(!json.contains("cache_write_tokens"));
+}
+
+// ── SseStateMachine initial state test ────────────────────────────────────
+
+#[test]
+fn test_sse_state_machine_new_initial_state() {
+    let sm = SseStateMachine::new();
+    assert!(sm.current_block_index.is_none());
+    assert!(sm.current_block_type.is_none());
+    assert!(sm.pending_thinking.is_empty());
+    assert!(sm.pending_signature.is_empty());
+}
+
+#[test]
+fn test_sse_state_machine_default_same_as_new() {
+    let sm = SseStateMachine::default();
+    let sm2 = SseStateMachine::new();
+    assert_eq!(sm.current_block_index, sm2.current_block_index);
+    assert_eq!(sm.current_block_type, sm2.current_block_type);
+    assert_eq!(sm.pending_thinking, sm2.pending_thinking);
+    assert_eq!(sm.pending_signature, sm2.pending_signature);
+}
+
+// ── SystemBlock serde tests ───────────────────────────────────────────────
+
+#[test]
+fn test_system_block_serde_roundtrip() {
+    let block = SystemBlock {
+        text: "You are helpful.".to_string(),
+        cache: true,
+    };
+    let json = serde_json::to_string(&block).unwrap();
+    let parsed: SystemBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(block, parsed);
+}
+
+#[test]
+fn test_system_block_cache_false_serde() {
+    let block = SystemBlock {
+        text: "dynamic".to_string(),
+        cache: false,
+    };
+    let json = serde_json::to_string(&block).unwrap();
+    let parsed: SystemBlock = serde_json::from_str(&json).unwrap();
+    assert_eq!(block, parsed);
+    assert!(json.contains("cache"));
+}
+
+#[test]
+fn test_unified_usage_cache_fields_some() {
+    let usage = UnifiedUsage {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: Some(150),
+        reasoning_tokens: None,
+        cache_read_tokens: Some(80),
+        cache_write_tokens: Some(20),
+    };
+    let json = serde_json::to_string(&usage).unwrap();
+    let parsed: UnifiedUsage = serde_json::from_str(&json).unwrap();
+    assert_eq!(usage, parsed);
+    assert!(json.contains("cache_read_tokens"));
+    assert!(json.contains("cache_write_tokens"));
+}


### PR DESCRIPTION
## 概述

新增 LLM 缓存适配器层，为 Anthropic 和 Kimi 两个 provider 提供提示缓存（prompt caching）能力，降低重复请求的 token 消耗和延迟。

## 主要变更

- **新增 `cache_adapter` 模块**：定义 `CacheAdapter` trait 及 `NoopCacheAdapter` 默认实现，供所有 provider 复用
- **Anthropic `cache_control`**：在 `AnthropicProtocol::build_request` 中为 `system_blocks` 中标记 `cache=true` 的内容块注入 `cache_control: {"type": "ephemeral"}`，并解析响应中的 `cache_creation_input_tokens` / `cache_read_input_tokens` 写入 `UnifiedUsage`
- **Kimi `prompt_cache_key`**：通过 `extra_body` 传递缓存键字段，支持 Kimi 的提示缓存机制
- **测试覆盖**：新增 `anthropic_tests.rs`（system block 缓存装饰、header 校验）、`types_tests.rs`（serde roundtrip）、`cache_adapter` 单元测试

Source: issue #785
Type: feat
