### PR TITLE
fix(llm): 修复 types_tests 模块路径 — 从 types.rs 移至 mod.rs

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -20,6 +20,8 @@ pub mod session;
 pub mod stub;
 pub mod turn;
 pub mod types;
+#[cfg(test)]
+mod types_tests;
 
 pub mod deepseek;
 pub mod volcengine;

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -359,6 +359,3 @@ impl Default for SseStateMachine {
         Self::new()
     }
 }
-
-#[cfg(test)]
-mod types_tests;


### PR DESCRIPTION
## 概述

修复 master CI 编译失败（run 26697932923）：`error[E0583]: file not found for module 'types_tests'`。

PR #806 在 `src/llm/types.rs` 末尾添加 `mod types_tests;`，但 Rust 2021 edition 将其解析为 `src/llm/types/types_tests.rs`（子目录），实际文件位于 `src/llm/types_tests.rs`（同级目录）。

## 修复方案

将 `#[cfg(test)] mod types_tests;` 从 `src/llm/types.rs` 移至 `src/llm/mod.rs`，与 `openai_tests`、`anthropic_tests` 等测试模块的组织方式一致。

Source: CI
Type: fix
