### PR TITLE
feat(llm): 新增 RunningStats 跨轮次缓存命中统计

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -17,6 +17,7 @@ pub mod protocol;
 pub mod provider;
 pub mod retry;
 pub mod session;
+pub mod stats;
 pub mod stub;
 pub mod turn;
 pub mod types;

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -10,8 +10,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use crate::llm::stats::RunningStats;
 use crate::llm::turn::TurnCounter;
-use crate::llm::types::{ContentBlock, InternalMessage, InternalRequest, UnifiedResponse};
+use crate::llm::types::{
+    ContentBlock, InternalMessage, InternalRequest, UnifiedResponse, UnifiedUsage,
+};
 use crate::session::persistence::ReasoningLevel;
 
 /// A single message in a conversation session.
@@ -77,6 +80,7 @@ pub struct ConversationSession {
     pending_messages: VecDeque<crate::session::persistence::PendingMessage>,
     reasoning_level: ReasoningLevel,
     workdir: PathBuf,
+    stats: RunningStats,
 }
 
 impl ConversationSession {
@@ -93,6 +97,7 @@ impl ConversationSession {
             pending_messages: VecDeque::new(),
             reasoning_level: ReasoningLevel::default(),
             workdir,
+            stats: RunningStats::new(),
         }
     }
 
@@ -156,6 +161,16 @@ impl ConversationSession {
     /// Returns the number of pending messages.
     pub fn pending_count(&self) -> usize {
         self.pending_messages.len()
+    }
+
+    /// Returns a read-only reference to the running usage statistics.
+    pub fn stats(&self) -> &RunningStats {
+        &self.stats
+    }
+
+    /// Accumulates a single API call's usage into the session stats.
+    pub fn accumulate_usage(&mut self, usage: &UnifiedUsage) {
+        self.stats.accumulate(usage);
     }
 
     /// Returns the model name.

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -480,6 +480,7 @@ fn test_build_api_request_default_reasoning_level() {
     assert_eq!(req.reasoning_level, ReasoningLevel::High);
 }
 
+mod stats_integration;
 mod thinking_clean_tests;
 
 #[test]

--- a/src/llm/session/tests/stats_integration.rs
+++ b/src/llm/session/tests/stats_integration.rs
@@ -1,0 +1,140 @@
+//! Integration tests for ConversationSession + RunningStats.
+
+use super::*;
+use crate::llm::types::UnifiedUsage;
+use std::path::PathBuf;
+
+fn make_usage(
+    prompt: u32,
+    completion: u32,
+    total: Option<u32>,
+    cache_read: Option<u32>,
+    cache_write: Option<u32>,
+) -> UnifiedUsage {
+    UnifiedUsage {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: total,
+        reasoning_tokens: None,
+        cache_read_tokens: cache_read,
+        cache_write_tokens: cache_write,
+    }
+}
+
+#[test]
+fn test_session_stats_initial_state() {
+    let session = ConversationSession::new(
+        "sess_stats_init".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    let stats = session.stats();
+    assert_eq!(stats.total_prompt_tokens, 0);
+    assert_eq!(stats.total_completion_tokens, 0);
+    assert_eq!(stats.total_tokens, 0);
+    assert_eq!(stats.total_cache_read_tokens, 0);
+    assert_eq!(stats.total_cache_write_tokens, 0);
+    assert_eq!(stats.request_count, 0);
+}
+
+#[test]
+fn test_session_accumulate_usage_single_call() {
+    let mut session = ConversationSession::new(
+        "sess_stats_single".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    session.accumulate_usage(&make_usage(100, 50, Some(150), Some(30), Some(20)));
+    let stats = session.stats();
+    assert_eq!(stats.total_prompt_tokens, 100);
+    assert_eq!(stats.total_completion_tokens, 50);
+    assert_eq!(stats.total_tokens, 150);
+    assert_eq!(stats.total_cache_read_tokens, 30);
+    assert_eq!(stats.total_cache_write_tokens, 20);
+    assert_eq!(stats.request_count, 1);
+}
+
+#[test]
+fn test_session_accumulate_usage_multiple_calls() {
+    let mut session = ConversationSession::new(
+        "sess_stats_multi".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    session.accumulate_usage(&make_usage(100, 50, Some(150), Some(30), Some(20)));
+    session.accumulate_usage(&make_usage(200, 80, Some(280), Some(60), None));
+    session.accumulate_usage(&make_usage(50, 20, None, None, Some(10)));
+
+    let stats = session.stats();
+    assert_eq!(stats.total_prompt_tokens, 350);
+    assert_eq!(stats.total_completion_tokens, 150);
+    assert_eq!(stats.total_tokens, 500); // 150 + 280 + 70
+    assert_eq!(stats.total_cache_read_tokens, 90);
+    assert_eq!(stats.total_cache_write_tokens, 30);
+    assert_eq!(stats.request_count, 3);
+}
+
+#[test]
+fn test_session_cache_hit_rate() {
+    let mut session = ConversationSession::new(
+        "sess_stats_rate".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    // 100 prompt, 30 cache_read → rate = 0.3
+    session.accumulate_usage(&make_usage(100, 50, Some(150), Some(30), None));
+    let rate = session.stats().cache_hit_rate();
+    assert!((rate - 0.3).abs() < f64::EPSILON);
+
+    // Add 200 more prompt, 70 more cache_read → 100/300 ≈ 0.333...
+    session.accumulate_usage(&make_usage(200, 50, Some(250), Some(70), None));
+    let rate = session.stats().cache_hit_rate();
+    assert!((rate - (100.0 / 300.0)).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_session_cache_hit_rate_zero_prompt() {
+    let session = ConversationSession::new(
+        "sess_stats_zero".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    assert_eq!(session.stats().cache_hit_rate(), 0.0);
+}
+
+#[test]
+fn test_session_accumulate_usage_with_all_none_cache() {
+    let mut session = ConversationSession::new(
+        "sess_stats_no_cache".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    session.accumulate_usage(&make_usage(50, 25, Some(75), None, None));
+    let stats = session.stats();
+    assert_eq!(stats.total_cache_read_tokens, 0);
+    assert_eq!(stats.total_cache_write_tokens, 0);
+    assert_eq!(stats.cache_hit_rate(), 0.0);
+    assert_eq!(stats.request_count, 1);
+}
+
+#[test]
+fn test_session_accumulate_usage_total_none_computed() {
+    let mut session = ConversationSession::new(
+        "sess_stats_total_none".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    session.accumulate_usage(&make_usage(40, 10, None, Some(5), None));
+    assert_eq!(session.stats().total_tokens, 50);
+}
+
+#[test]
+fn test_session_total_cache_saved() {
+    let mut session = ConversationSession::new(
+        "sess_stats_saved".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    session.accumulate_usage(&make_usage(100, 50, Some(150), Some(42), Some(10)));
+    assert_eq!(session.stats().total_cache_saved(), 42);
+}

--- a/src/llm/stats.rs
+++ b/src/llm/stats.rs
@@ -1,0 +1,194 @@
+//! Running statistics accumulator for cross-turn LLM usage tracking.
+//!
+//! `RunningStats` accumulates token usage across multiple API calls within
+//! a session, including cache hit/write metrics, and exposes derived
+//! statistics like cache hit rate.
+
+use super::types::UnifiedUsage;
+
+/// Accumulated token usage statistics across multiple LLM API calls.
+///
+/// All fields use `u64` to avoid overflow in long sessions that may
+/// exceed 4 billion tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningStats {
+    /// Cumulative prompt tokens across all calls.
+    pub total_prompt_tokens: u64,
+    /// Cumulative completion tokens across all calls.
+    pub total_completion_tokens: u64,
+    /// Cumulative total tokens across all calls.
+    pub total_tokens: u64,
+    /// Cumulative cache-read (hit) tokens.
+    pub total_cache_read_tokens: u64,
+    /// Cumulative cache-write (creation) tokens.
+    pub total_cache_write_tokens: u64,
+    /// Number of API calls accumulated.
+    pub request_count: u64,
+}
+
+impl RunningStats {
+    /// Creates a new `RunningStats` with all counters zeroed.
+    pub fn new() -> Self {
+        Self {
+            total_prompt_tokens: 0,
+            total_completion_tokens: 0,
+            total_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_write_tokens: 0,
+            request_count: 0,
+        }
+    }
+
+    /// Accumulates a single API call's usage into the running totals.
+    ///
+    /// `Option<u32>` fields that are `None` are treated as 0.
+    /// When `total_tokens` is `None`, it is computed as
+    /// `prompt_tokens + completion_tokens`.
+    pub fn accumulate(&mut self, usage: &UnifiedUsage) {
+        let prompt = u64::from(usage.prompt_tokens);
+        let completion = u64::from(usage.completion_tokens);
+        let total = usage
+            .total_tokens
+            .map(u64::from)
+            .unwrap_or(prompt + completion);
+        let cache_read = usage.cache_read_tokens.map_or(0u64, u64::from);
+        let cache_write = usage.cache_write_tokens.map_or(0u64, u64::from);
+
+        self.total_prompt_tokens += prompt;
+        self.total_completion_tokens += completion;
+        self.total_tokens += total;
+        self.total_cache_read_tokens += cache_read;
+        self.total_cache_write_tokens += cache_write;
+        self.request_count += 1;
+    }
+
+    /// Returns the cache hit rate as a fraction in `[0.0, 1.0]`.
+    ///
+    /// Computed as `total_cache_read_tokens / total_prompt_tokens`.
+    /// Returns `0.0` when `total_prompt_tokens` is zero to avoid
+    /// division by zero.
+    pub fn cache_hit_rate(&self) -> f64 {
+        if self.total_prompt_tokens == 0 {
+            return 0.0;
+        }
+        self.total_cache_read_tokens as f64 / self.total_prompt_tokens as f64
+    }
+
+    /// Returns the total number of tokens saved by cache hits.
+    ///
+    /// This is an alias for `total_cache_read_tokens`, provided
+    /// for readability at call sites.
+    pub fn total_cache_saved(&self) -> u64 {
+        self.total_cache_read_tokens
+    }
+}
+
+impl Default for RunningStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_usage(
+        prompt: u32,
+        completion: u32,
+        total: Option<u32>,
+        cache_read: Option<u32>,
+        cache_write: Option<u32>,
+    ) -> UnifiedUsage {
+        UnifiedUsage {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            total_tokens: total,
+            reasoning_tokens: None,
+            cache_read_tokens: cache_read,
+            cache_write_tokens: cache_write,
+        }
+    }
+
+    #[test]
+    fn test_new_is_zeroed() {
+        let stats = RunningStats::new();
+        assert_eq!(stats.total_prompt_tokens, 0);
+        assert_eq!(stats.total_completion_tokens, 0);
+        assert_eq!(stats.total_tokens, 0);
+        assert_eq!(stats.total_cache_read_tokens, 0);
+        assert_eq!(stats.total_cache_write_tokens, 0);
+        assert_eq!(stats.request_count, 0);
+    }
+
+    #[test]
+    fn test_accumulate_basic() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, Some(150), Some(30), Some(20)));
+        assert_eq!(stats.total_prompt_tokens, 100);
+        assert_eq!(stats.total_completion_tokens, 50);
+        assert_eq!(stats.total_tokens, 150);
+        assert_eq!(stats.total_cache_read_tokens, 30);
+        assert_eq!(stats.total_cache_write_tokens, 20);
+        assert_eq!(stats.request_count, 1);
+
+        stats.accumulate(&make_usage(200, 80, Some(280), Some(60), None));
+        assert_eq!(stats.total_prompt_tokens, 300);
+        assert_eq!(stats.total_completion_tokens, 130);
+        assert_eq!(stats.total_tokens, 430);
+        assert_eq!(stats.total_cache_read_tokens, 90);
+        assert_eq!(stats.total_cache_write_tokens, 20);
+        assert_eq!(stats.request_count, 2);
+    }
+
+    #[test]
+    fn test_accumulate_all_none_cache_fields() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, Some(150), None, None));
+        assert_eq!(stats.total_cache_read_tokens, 0);
+        assert_eq!(stats.total_cache_write_tokens, 0);
+    }
+
+    #[test]
+    fn test_accumulate_total_none_computed() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, None, None, None));
+        assert_eq!(stats.total_tokens, 150);
+    }
+
+    #[test]
+    fn test_accumulate_partial_none() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, None, Some(40), None));
+        assert_eq!(stats.total_tokens, 150);
+        assert_eq!(stats.total_cache_read_tokens, 40);
+        assert_eq!(stats.total_cache_write_tokens, 0);
+    }
+
+    #[test]
+    fn test_cache_hit_rate_normal() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, Some(150), Some(30), None));
+        let rate = stats.cache_hit_rate();
+        assert!((rate - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_cache_hit_rate_division_by_zero() {
+        let stats = RunningStats::new();
+        assert_eq!(stats.cache_hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_total_cache_saved() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, Some(150), Some(42), Some(10)));
+        assert_eq!(stats.total_cache_saved(), 42);
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let stats = RunningStats::default();
+        assert_eq!(stats.request_count, 0);
+    }
+}


### PR DESCRIPTION
## 概述

实现 `RunningStats` 跨轮次累加器，记录所有 LLM API 调用的累计用量（含缓存命中/写入 token），支持查询缓存命中率。

## 变更

- **新增 `src/llm/stats.rs`**：`RunningStats` 结构体，支持 `accumulate`（累加用量）、`cache_hit_rate`（缓存命中率）、`total_cache_saved`（缓存节省量）
- **修改 `src/llm/session.rs`**：`ConversationSession` 新增 `stats` 字段和 `stats()` / `accumulate_usage()` 公开方法
- **新增 `src/llm/session/tests/stats_integration.rs`**：8 个集成测试覆盖 session 层统计功能

## 设计决策

- `RunningStats` 使用 `u64` 避免多轮对话溢出
- `cache_hit_rate` 分母为 `total_prompt_tokens`（缓存只影响输入侧），除零返回 0.0
- `Option<u32>` 字段为 `None` 时安全降级为 0
- 调用方（session_handler / gateway 层）在 LLM 响应完成后调用 `accumulate_usage` 注入用量

Source: issue #792
Type: feat
