### PR TITLE
feat(session): 流式输出 session 层接入 — StreamingSink trait + ChatSession 流式路径

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -6,6 +6,7 @@ pub mod approval;
 pub mod message;
 pub mod outbound;
 pub mod session_handler;
+mod session_handler_streaming;
 pub mod session_manager;
 pub mod slash_permission;
 pub mod system_prompt_inject;

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -9,11 +9,12 @@
 
 use crate::gateway::session_manager::SessionManager;
 use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
 use crate::llm::session::ChatSession;
 use crate::llm::types::ContentBlock;
 use crate::llm::types::UnifiedResponse;
-use crate::llm::{ChatRequest, ChatResponse, Message as ChatMessage};
+use crate::llm::{ChatRequest, Message as ChatMessage};
 use crate::session::compaction::{
     execute_compact, CompactConfig, CompactionResult, CompactionService,
 };
@@ -32,7 +33,6 @@ pub struct MessageMetadata {
 }
 
 impl MessageMetadata {
-    /// Create a default `MessageMetadata` with empty sender/channel and current time.
     pub fn default_meta() -> Self {
         Self {
             sender_id: String::new(),
@@ -59,15 +59,17 @@ pub struct SessionMessageHandler {
     fallback_client: Arc<FallbackClient>,
     output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     compaction_service: Arc<std::sync::Mutex<CompactionService>>,
+    unified_client: Arc<UnifiedChatClient>,
 }
 
-// ── Construction ───────────────────────────────────────────────────────────
+// ── Construction ──
 impl SessionMessageHandler {
     /// Create a new handler with an output channel for streaming responses.
     pub fn new(
         session_manager: Arc<SessionManager>,
         fallback_client: Arc<FallbackClient>,
         output_tx: mpsc::Sender<(String, Vec<ContentBlock>)>,
+        unified_client: Arc<UnifiedChatClient>,
     ) -> Self {
         Self {
             session_manager,
@@ -76,13 +78,14 @@ impl SessionMessageHandler {
             compaction_service: Arc::new(std::sync::Mutex::new(CompactionService::new(
                 CompactConfig::default(),
             ))),
+            unified_client,
         }
     }
-
     /// Create a new handler without an output channel (used in tests).
     pub fn new_no_output(
         session_manager: Arc<SessionManager>,
         fallback_client: Arc<FallbackClient>,
+        unified_client: Arc<UnifiedChatClient>,
     ) -> Self {
         Self {
             session_manager,
@@ -91,19 +94,17 @@ impl SessionMessageHandler {
             compaction_service: Arc::new(std::sync::Mutex::new(CompactionService::new(
                 CompactConfig::default(),
             ))),
+            unified_client,
         }
     }
 }
-
-// ── Message dispatch ───────────────────────────────────────────────────────
-
+// ── Message dispatch ──
 impl SessionMessageHandler {
     /// Handle an inbound message using default metadata.
     pub async fn handle_message(&self, session_id: &str, content: String) -> HandleResult {
         self.handle_message_with_meta(session_id, content, MessageMetadata::default_meta())
             .await
     }
-
     /// Handle an inbound message with explicit metadata.
     pub async fn handle_message_with_meta(
         &self,
@@ -130,10 +131,22 @@ impl SessionMessageHandler {
         let content_for_task = content;
         let sm = Arc::clone(&self.session_manager);
         let fc = Arc::clone(&self.fallback_client);
+        let uc = Arc::clone(&self.unified_client);
         let output_tx = Arc::clone(&self.output_tx);
 
         tokio::spawn(async move {
-            let result = Self::call_llm(&fc, &content_for_task, &meta, &sm, &session_id).await;
+            // Check if streaming is enabled for this session
+            let stream_enabled = if let Some(cs) = sm.get_conversation_session(&session_id).await {
+                cs.read().await.stream_enabled()
+            } else {
+                false
+            };
+
+            let result = if stream_enabled {
+                Self::call_llm_streaming(&uc, &content_for_task, &meta, &sm, &session_id).await
+            } else {
+                Self::call_llm(&fc, &content_for_task, &meta, &sm, &session_id).await
+            };
             Self::finish_llm(&sm, &session_id, result, &fc, &output_tx).await;
         });
 
@@ -165,9 +178,7 @@ impl SessionMessageHandler {
         }
     }
 }
-
-// ── Compaction ─────────────────────────────────────────────────────────────
-
+// ── Compaction ──
 impl SessionMessageHandler {
     /// Handle `/compact [instruction]` manual compaction.
     pub async fn handle_compact_command(&self, session_id: &str, content: &str) -> HandleResult {
@@ -232,11 +243,7 @@ impl SessionMessageHandler {
         .await;
     }
 }
-
-// ── Dynamic section building ──────────────────────────────────────────────
-
-// ── LLM calling ───────────────────────────────────────────────────────────
-
+// ── LLM calling ──
 impl SessionMessageHandler {
     /// Make a non-streaming LLM call with full system prompt injection.
     async fn call_llm(
@@ -313,6 +320,11 @@ impl SessionMessageHandler {
         }
         match result {
             Ok(response) => {
+                // Append response to session message history
+                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                    let mut cs_write = cs.write().await;
+                    cs_write.append_response(response.clone());
+                }
                 let text = response
                     .content_blocks
                     .iter()
@@ -364,7 +376,7 @@ impl SessionMessageHandler {
         }
     }
 }
-// ── Compaction helpers ─────────────────────────────────────────────────────
+// ── Compaction helpers ──
 fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
     blocks
         .iter()
@@ -422,7 +434,6 @@ async fn send_output(
         let _ = tx.send((text.to_string(), vec![])).await;
     }
 }
-
 /// Load compaction inputs: (model, llm_messages). Returns None if session not found.
 async fn load_compact_inputs(
     sm: &Arc<SessionManager>,

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -1,18 +1,150 @@
 use super::session_handler::MessageMetadata;
 use super::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
 use super::*;
+use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
+use crate::llm::protocol::{ChatProtocol, IncomingSseStream, OutgoingEventStream};
+use crate::llm::provider::{Provider, ProviderError};
+use crate::llm::types::ProtocolId;
+use crate::llm::types::{
+    InternalRequest, InternalResponse, RawContentBlock, RawSseChunk, RawUsage, SseStateMachine,
+};
 use crate::llm::LLMRegistry;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::system_prompt::sections::{
     clear_append_section, get_append_section, set_append_section, Section,
 };
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+
+#[derive(Debug, Clone)]
+struct TestProvider {
+    client: Client,
+    headers: HeaderMap,
+}
+impl TestProvider {
+    fn new() -> Self {
+        Self {
+            client: Client::new(),
+            headers: HeaderMap::new(),
+        }
+    }
+}
+#[async_trait]
+impl Provider for TestProvider {
+    fn id(&self) -> &str {
+        "test"
+    }
+    fn base_url(&self) -> &str {
+        "http://localhost"
+    }
+    fn api_key(&self) -> &str {
+        ""
+    }
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &[]
+    }
+    fn http_client(&self) -> &Client {
+        &self.client
+    }
+    fn default_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+    async fn send(
+        &self,
+        _req: InternalRequest,
+        _body: serde_json::Value,
+    ) -> std::result::Result<InternalResponse, ProviderError> {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text("test".into())],
+            usage: RawUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            finish_reason: None,
+        })
+    }
+    async fn send_streaming(
+        &self,
+        _req: InternalRequest,
+        _body: serde_json::Value,
+    ) -> std::result::Result<crate::llm::provider::SseStream, ProviderError> {
+        let (_, rx) = tokio::sync::mpsc::channel(1);
+        Ok(rx)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestProtocol {
+    id: ProtocolId,
+}
+impl TestProtocol {
+    fn new() -> Self {
+        Self {
+            id: ProtocolId::new("test"),
+        }
+    }
+}
+#[async_trait]
+impl ChatProtocol for TestProtocol {
+    fn protocol_id(&self) -> &ProtocolId {
+        &self.id
+    }
+    fn path(&self) -> &str {
+        "/chat"
+    }
+    fn build_request(
+        &self,
+        _req: &InternalRequest,
+    ) -> crate::llm::protocol::Result<serde_json::Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn parse_response(
+        &self,
+        _body: serde_json::Value,
+    ) -> crate::llm::protocol::Result<InternalResponse> {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text("test".into())],
+            usage: RawUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            finish_reason: None,
+        })
+    }
+    fn decorate_headers(&self, _h: &mut HeaderMap) -> crate::llm::protocol::Result<()> {
+        Ok(())
+    }
+    fn create_sse_machine(&self) -> SseStateMachine {
+        SseStateMachine::new()
+    }
+    async fn parse_sse_stream(
+        &self,
+        _incoming: IncomingSseStream,
+        _machine: SseStateMachine,
+    ) -> OutgoingEventStream {
+        Box::pin(futures::stream::empty())
+    }
+}
 
 fn handler_with_sm(sm: Arc<SessionManager>) -> SessionMessageHandler {
     let registry = Arc::new(LLMRegistry::new());
     let fallback = Arc::new(FallbackClient::from_strings(registry, vec![]));
-    SessionMessageHandler::new_no_output(sm, fallback)
+    let uc = Arc::new(UnifiedChatClient::with_noop_cache_adapter(
+        Arc::new(TestProvider::new()),
+        Arc::new(TestProtocol::new()),
+        Default::default(),
+        Default::default(),
+    ));
+    SessionMessageHandler::new_no_output(sm, fallback, uc)
 }
 
 fn make_msg() -> crate::gateway::Message {

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -1,0 +1,157 @@
+//! Streaming LLM call implementation for SessionMessageHandler.
+//!
+//! Extracted from `session_handler.rs` to keep file sizes under the
+//! 500-line project limit.
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+
+use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::llm::client::UnifiedChatClient;
+use crate::llm::session::ChatSession;
+use crate::llm::streaming::{StreamDone, StreamingSink};
+use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent, UnifiedResponse, UnifiedUsage};
+use crate::llm::{LLMError, Message as ChatMessage};
+
+impl SessionMessageHandler {
+    /// Make a streaming LLM call using UnifiedChatClient.
+    pub(super) async fn call_llm_streaming(
+        unified_client: &Arc<UnifiedChatClient>,
+        content: &str,
+        meta: &MessageMetadata,
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+    ) -> Result<UnifiedResponse, LLMError> {
+        let (static_prompt_opt, turn_count, workdir_path) =
+            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                let cs_read = cs.read().await;
+                (
+                    cs_read.system_prompt().map(|s| s.to_string()),
+                    cs_read.turn_count(),
+                    cs_read.workdir().to_string_lossy().into_owned(),
+                )
+            } else {
+                (None, 0, String::new())
+            };
+
+        let dynamic_sections =
+            build_dynamic_sections(turn_count, meta, Some(workdir_path.as_str()));
+        let full_prompt = build_full_system_prompt(static_prompt_opt.as_deref(), &dynamic_sections);
+
+        let mut messages = vec![];
+        if !full_prompt.is_empty() {
+            messages.push(ChatMessage {
+                role: "system".to_string(),
+                content: full_prompt,
+            });
+        }
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: content.to_string(),
+        });
+
+        let internal_request = crate::llm::types::InternalRequest {
+            model: String::new(),
+            messages: messages
+                .iter()
+                .map(|m| crate::llm::types::InternalMessage {
+                    role: m.role.clone(),
+                    content: m.content.clone(),
+                })
+                .collect(),
+            temperature: 0.7,
+            max_tokens: None,
+            stream: true,
+            extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+        };
+
+        // Get streaming sink from session
+        let sink: Option<Arc<dyn StreamingSink>> =
+            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                let cs_read = cs.read().await;
+                cs_read.streaming_sink().cloned()
+            } else {
+                None
+            };
+
+        let mut stream = match unified_client.chat_streaming(internal_request).await {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = e.to_string();
+                tracing::error!(error = %msg, "streaming LLM call failed");
+                if let Some(ref s) = sink {
+                    s.send_error(msg.clone());
+                }
+                return Err(LLMError::ApiError(msg));
+            }
+        };
+
+        let mut full_text = String::new();
+        let mut last_usage = None;
+
+        while let Some(event_result) = stream.next().await {
+            match event_result {
+                Ok(StreamEvent::BlockDelta {
+                    delta: ContentDelta::Text { text },
+                    ..
+                }) => {
+                    full_text.push_str(&text);
+                    if let Some(ref s) = sink {
+                        s.send_text(&text);
+                    }
+                }
+                Ok(StreamEvent::MessageEnd { usage, .. }) => {
+                    last_usage = usage;
+                    if let Some(ref s) = sink {
+                        s.send_done(StreamDone {
+                            model: String::new(),
+                            usage: last_usage.clone(),
+                        });
+                    }
+                    break;
+                }
+                Ok(StreamEvent::Error { message }) => {
+                    tracing::error!(error = %message, "streaming LLM call failed");
+                    if let Some(ref s) = sink {
+                        s.send_error(message.clone());
+                    }
+                    return Err(LLMError::ApiError(message));
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    tracing::error!(error = %msg, "streaming LLM call failed");
+                    if let Some(ref s) = sink {
+                        s.send_error(msg.clone());
+                    }
+                    return Err(LLMError::ApiError(msg));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(UnifiedResponse {
+            content_blocks: if full_text.is_empty() {
+                vec![]
+            } else {
+                vec![ContentBlock::Text(full_text)]
+            },
+            usage: last_usage.unwrap_or(UnifiedUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            }),
+            finish_reason: None,
+        })
+    }
+}

--- a/src/gateway/session_handler_tests.rs
+++ b/src/gateway/session_handler_tests.rs
@@ -1,14 +1,146 @@
 use super::*;
+use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
+use crate::llm::protocol::{ChatProtocol, IncomingSseStream, OutgoingEventStream};
+use crate::llm::provider::{Provider, ProviderError};
 use crate::llm::session::ChatSession;
+use crate::llm::types::ProtocolId;
+use crate::llm::types::{
+    InternalRequest, InternalResponse, RawContentBlock, RawSseChunk, RawUsage, SseStateMachine,
+};
 use crate::llm::LLMRegistry;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+
+#[derive(Debug, Clone)]
+struct TestProvider {
+    client: Client,
+    headers: HeaderMap,
+}
+impl TestProvider {
+    fn new() -> Self {
+        Self {
+            client: Client::new(),
+            headers: HeaderMap::new(),
+        }
+    }
+}
+#[async_trait]
+impl Provider for TestProvider {
+    fn id(&self) -> &str {
+        "test"
+    }
+    fn base_url(&self) -> &str {
+        "http://localhost"
+    }
+    fn api_key(&self) -> &str {
+        ""
+    }
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &[]
+    }
+    fn http_client(&self) -> &Client {
+        &self.client
+    }
+    fn default_headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+    async fn send(
+        &self,
+        _req: InternalRequest,
+        _body: serde_json::Value,
+    ) -> std::result::Result<InternalResponse, ProviderError> {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text("test".into())],
+            usage: RawUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            finish_reason: None,
+        })
+    }
+    async fn send_streaming(
+        &self,
+        _req: InternalRequest,
+        _body: serde_json::Value,
+    ) -> std::result::Result<crate::llm::provider::SseStream, ProviderError> {
+        let (_, rx) = tokio::sync::mpsc::channel(1);
+        Ok(rx)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TestProtocol {
+    id: ProtocolId,
+}
+impl TestProtocol {
+    fn new() -> Self {
+        Self {
+            id: ProtocolId::new("test"),
+        }
+    }
+}
+#[async_trait]
+impl ChatProtocol for TestProtocol {
+    fn protocol_id(&self) -> &ProtocolId {
+        &self.id
+    }
+    fn path(&self) -> &str {
+        "/chat"
+    }
+    fn build_request(
+        &self,
+        _req: &InternalRequest,
+    ) -> crate::llm::protocol::Result<serde_json::Value> {
+        Ok(serde_json::json!({}))
+    }
+    fn parse_response(
+        &self,
+        _body: serde_json::Value,
+    ) -> crate::llm::protocol::Result<InternalResponse> {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text("test".into())],
+            usage: RawUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            finish_reason: None,
+        })
+    }
+    fn decorate_headers(&self, _h: &mut HeaderMap) -> crate::llm::protocol::Result<()> {
+        Ok(())
+    }
+    fn create_sse_machine(&self) -> SseStateMachine {
+        SseStateMachine::new()
+    }
+    async fn parse_sse_stream(
+        &self,
+        _incoming: IncomingSseStream,
+        _machine: SseStateMachine,
+    ) -> OutgoingEventStream {
+        Box::pin(futures::stream::empty())
+    }
+}
 
 fn handler_with_sm(sm: Arc<SessionManager>) -> SessionMessageHandler {
     let registry = Arc::new(LLMRegistry::new());
     let fallback = Arc::new(FallbackClient::from_strings(registry, vec![]));
-    SessionMessageHandler::new_no_output(sm, fallback)
+    let uc = Arc::new(UnifiedChatClient::with_noop_cache_adapter(
+        Arc::new(TestProvider::new()),
+        Arc::new(TestProtocol::new()),
+        Default::default(),
+        Default::default(),
+    ));
+    SessionMessageHandler::new_no_output(sm, fallback, uc)
 }
 
 fn make_msg() -> crate::gateway::Message {

--- a/src/llm/adapter/legacy_session.rs
+++ b/src/llm/adapter/legacy_session.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::llm::session::{ChatSession, SessionMessage};
+use crate::llm::streaming::StreamingSink;
 use crate::llm::turn::TurnCounter;
 use crate::llm::types::{ContentBlock, InternalMessage, InternalRequest, UnifiedResponse};
 use crate::llm::Message;
@@ -18,7 +19,7 @@ use crate::session::persistence::ReasoningLevel;
 ///
 /// Wraps the old `Vec<Message>` representation so that existing code can be
 /// migrated to the new session trait incrementally.
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct LegacySessionAdapter {
     messages: Vec<SessionMessage>,
     system_prompt: Option<String>,
@@ -26,6 +27,8 @@ pub struct LegacySessionAdapter {
     turn_counter: TurnCounter,
     is_llm_busy: Arc<AtomicBool>,
     reasoning_level: ReasoningLevel,
+    streaming_sink: Option<Arc<dyn StreamingSink>>,
+    stream_enabled: bool,
 }
 
 impl LegacySessionAdapter {
@@ -50,6 +53,8 @@ impl LegacySessionAdapter {
             turn_counter: TurnCounter::new(),
             is_llm_busy: Arc::new(AtomicBool::new(false)),
             reasoning_level: ReasoningLevel::default(),
+            streaming_sink: None,
+            stream_enabled: false,
         }
     }
 
@@ -66,6 +71,24 @@ impl LegacySessionAdapter {
             content_blocks,
             timestamp: Utc::now(),
         });
+    }
+}
+
+impl std::fmt::Debug for LegacySessionAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LegacySessionAdapter")
+            .field("messages", &self.messages)
+            .field("system_prompt", &self.system_prompt)
+            .field("model", &self.model)
+            .field("turn_counter", &self.turn_counter)
+            .field("is_llm_busy", &self.is_llm_busy)
+            .field("reasoning_level", &self.reasoning_level)
+            .field(
+                "streaming_sink",
+                &self.streaming_sink.as_ref().map(|_| "<StreamingSink>"),
+            )
+            .field("stream_enabled", &self.stream_enabled)
+            .finish()
     }
 }
 
@@ -138,7 +161,7 @@ impl ChatSession for LegacySessionAdapter {
             messages: msgs,
             temperature: 0.0,
             max_tokens: None,
-            stream: false,
+            stream: self.stream_enabled,
             extra_body: Default::default(),
             system_static: None,
             system_dynamic: None,
@@ -146,6 +169,18 @@ impl ChatSession for LegacySessionAdapter {
             session_id: None,
             reasoning_level: self.reasoning_level,
         }
+    }
+
+    fn set_streaming_sink(&mut self, sink: Arc<dyn StreamingSink>) {
+        self.streaming_sink = Some(sink);
+    }
+
+    fn stream_enabled(&self) -> bool {
+        self.stream_enabled
+    }
+
+    fn set_stream_enabled(&mut self, enabled: bool) {
+        self.stream_enabled = enabled;
     }
 
     fn is_llm_busy(&self) -> bool {

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -18,6 +18,7 @@ pub mod provider;
 pub mod retry;
 pub mod session;
 pub mod stats;
+pub mod streaming;
 pub mod stub;
 pub mod turn;
 pub mod types;
@@ -60,6 +61,7 @@ pub use client::UnifiedChatClient;
 pub use interpreter::{DefaultInterpreter, InterpreterRegistry, ModelInterpreter};
 pub use plugin::PluginPipeline;
 pub use session::{ChatSession, ConversationSession, SessionMessage};
+pub use streaming::{StreamDone, StreamingSink};
 pub use turn::TurnCounter;
 pub use types::{InternalRequest, ProtocolId};
 

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::llm::stats::RunningStats;
+use crate::llm::streaming::StreamingSink;
 use crate::llm::turn::TurnCounter;
 use crate::llm::types::{
     ContentBlock, InternalMessage, InternalRequest, UnifiedResponse, UnifiedUsage,
@@ -62,12 +63,21 @@ pub trait ChatSession: Send + Sync {
     /// and max_tokens.
     fn build_api_request(&self) -> InternalRequest;
 
+    /// Sets the streaming sink for this session.
+    fn set_streaming_sink(&mut self, sink: Arc<dyn StreamingSink>);
+
+    /// Returns whether streaming is enabled for this session.
+    fn stream_enabled(&self) -> bool;
+
+    /// Enables or disables streaming for this session.
+    fn set_stream_enabled(&mut self, enabled: bool);
+
     /// Returns whether the LLM is currently busy (processing a request).
     fn is_llm_busy(&self) -> bool;
 }
 
 /// A simple in-memory implementation of `ChatSession`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[allow(dead_code)]
 pub struct ConversationSession {
     session_id: String,
@@ -81,6 +91,8 @@ pub struct ConversationSession {
     reasoning_level: ReasoningLevel,
     workdir: PathBuf,
     stats: RunningStats,
+    streaming_sink: Option<Arc<dyn StreamingSink>>,
+    stream_enabled: bool,
 }
 
 impl ConversationSession {
@@ -98,6 +110,8 @@ impl ConversationSession {
             reasoning_level: ReasoningLevel::default(),
             workdir,
             stats: RunningStats::new(),
+            streaming_sink: None,
+            stream_enabled: false,
         }
     }
 
@@ -166,6 +180,11 @@ impl ConversationSession {
     /// Returns a read-only reference to the running usage statistics.
     pub fn stats(&self) -> &RunningStats {
         &self.stats
+    }
+
+    /// Returns the streaming sink, if set.
+    pub fn streaming_sink(&self) -> Option<&Arc<dyn StreamingSink>> {
+        self.streaming_sink.as_ref()
     }
 
     /// Accumulates a single API call's usage into the session stats.
@@ -244,6 +263,29 @@ impl ConversationSession {
     }
 }
 
+impl std::fmt::Debug for ConversationSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConversationSession")
+            .field("session_id", &self.session_id)
+            .field("messages", &self.messages)
+            .field("system_prompt", &self.system_prompt)
+            .field("turn_counter", &self.turn_counter)
+            .field("model", &self.model)
+            .field("compaction_state", &self.compaction_state)
+            .field("is_llm_busy", &self.is_llm_busy)
+            .field("pending_messages", &self.pending_messages)
+            .field("reasoning_level", &self.reasoning_level)
+            .field("workdir", &self.workdir)
+            .field("stats", &self.stats)
+            .field(
+                "streaming_sink",
+                &self.streaming_sink.as_ref().map(|_| "<StreamingSink>"),
+            )
+            .field("stream_enabled", &self.stream_enabled)
+            .finish()
+    }
+}
+
 impl ChatSession for ConversationSession {
     fn messages(&self) -> &[SessionMessage] {
         &self.messages
@@ -312,7 +354,7 @@ impl ChatSession for ConversationSession {
             messages: msgs,
             temperature: 0.0,
             max_tokens: None,
-            stream: false,
+            stream: self.stream_enabled,
             extra_body: Default::default(),
             system_static: None,
             system_dynamic: None,
@@ -320,6 +362,18 @@ impl ChatSession for ConversationSession {
             session_id: None,
             reasoning_level: self.reasoning_level,
         }
+    }
+
+    fn set_streaming_sink(&mut self, sink: Arc<dyn StreamingSink>) {
+        self.streaming_sink = Some(sink);
+    }
+
+    fn stream_enabled(&self) -> bool {
+        self.stream_enabled
+    }
+
+    fn set_stream_enabled(&mut self, enabled: bool) {
+        self.stream_enabled = enabled;
     }
 
     fn is_llm_busy(&self) -> bool {

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 
+mod streaming_tests;
+
 // ── llm_busy state ─────────────────────────────────────────────────────────
 
 #[test]

--- a/src/llm/session/tests/streaming_tests.rs
+++ b/src/llm/session/tests/streaming_tests.rs
@@ -1,0 +1,74 @@
+// ── Streaming integration tests ─────────────────────────────────────────────
+
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn test_conversation_session_stream_defaults() {
+    let session = ConversationSession::new("s1".into(), "m".into(), PathBuf::from("/tmp"));
+    assert!(!session.stream_enabled());
+    assert!(session.streaming_sink().is_none());
+}
+
+#[test]
+fn test_set_stream_enabled() {
+    let mut session = ConversationSession::new("s1".into(), "m".into(), PathBuf::from("/tmp"));
+    assert!(!session.stream_enabled());
+    session.set_stream_enabled(true);
+    assert!(session.stream_enabled());
+    session.set_stream_enabled(false);
+    assert!(!session.stream_enabled());
+}
+
+#[test]
+fn test_build_api_request_stream_flag_reflects_state() {
+    let mut session = ConversationSession::new("s1".into(), "m".into(), PathBuf::from("/tmp"));
+    // Default: stream = false
+    let req = session.build_api_request();
+    assert!(!req.stream);
+
+    // Enable streaming
+    session.set_stream_enabled(true);
+    let req = session.build_api_request();
+    assert!(req.stream);
+
+    // Disable streaming
+    session.set_stream_enabled(false);
+    let req = session.build_api_request();
+    assert!(!req.stream);
+}
+
+#[test]
+fn test_set_streaming_sink() {
+    use crate::llm::streaming::{StreamDone, StreamingSink};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug)]
+    struct MockSink {
+        texts: Mutex<Vec<String>>,
+    }
+    impl MockSink {
+        fn new() -> Self {
+            Self {
+                texts: Mutex::new(Vec::new()),
+            }
+        }
+    }
+    impl StreamingSink for MockSink {
+        fn send_text(&self, delta: &str) {
+            self.texts.lock().unwrap().push(delta.to_string());
+        }
+        fn send_done(&self, _done: StreamDone) {}
+        fn send_error(&self, _error: String) {}
+    }
+
+    let mut session = ConversationSession::new("s1".into(), "m".into(), PathBuf::from("/tmp"));
+    assert!(session.streaming_sink().is_none());
+
+    let sink: Arc<dyn StreamingSink> = Arc::new(MockSink::new());
+    session.set_streaming_sink(sink);
+    assert!(session.streaming_sink().is_some());
+
+    // Verify sink works through session
+    session.streaming_sink().unwrap().send_text("hello");
+}

--- a/src/llm/streaming.rs
+++ b/src/llm/streaming.rs
@@ -1,0 +1,138 @@
+//! Platform-agnostic streaming sink for LLM output.
+//!
+//! Session layer holds a [`StreamingSink`] handle and pushes incremental
+//! text deltas, completion notifications (carrying model + usage), and
+//! error notifications as the underlying [`crate::llm::UnifiedChatClient`]
+//! produces [`crate::llm::StreamEvent`]s. Implementations forward these to
+//! a downstream transport (Feishu card update, CLI stdout, etc.) without
+//! the session needing to know which one is in use.
+//!
+//! See `docs/design/session/llm-session-enhancements.md` for the full
+//! streaming architecture rationale.
+
+use serde::{Deserialize, Serialize};
+
+use crate::llm::types::UnifiedUsage;
+
+/// Notification emitted by a streaming LLM call when the stream completes
+/// successfully.
+///
+/// Carries the model name that produced the final response and the
+/// provider-reported token usage (when available). `UnifiedUsage` is
+/// `Option` because some providers omit usage on streaming responses.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StreamDone {
+    /// Model name that produced the final response.
+    pub model: String,
+    /// Token usage statistics reported by the provider, if available.
+    pub usage: Option<UnifiedUsage>,
+}
+
+impl StreamDone {
+    /// Creates a new `StreamDone` notification.
+    pub fn new(model: impl Into<String>, usage: Option<UnifiedUsage>) -> Self {
+        Self {
+            model: model.into(),
+            usage,
+        }
+    }
+}
+
+/// Platform-agnostic sink for streaming LLM output.
+///
+/// Implementations forward incremental text deltas, completion
+/// notifications (with model + usage), and error notifications to a
+/// downstream transport. The session layer drives this trait as
+/// [`crate::llm::StreamEvent`]s arrive; it never inspects the concrete
+/// transport.
+///
+/// ## Contract
+///
+/// - `send_text` is called once per textual delta. Implementations must
+///   be non-blocking; long-running work should be enqueued internally.
+/// - `send_done` is called **exactly once** at the end of a successful
+///   stream, after the last `send_text`. No further `send_text` calls
+///   follow on the same stream.
+/// - `send_error` is called **at most once** per stream invocation when
+///   the provider reports an error or the underlying connection is
+///   unrecoverable. No further `send_text` / `send_done` calls follow on
+///   the same stream.
+///
+/// ## Threading
+///
+/// `Send + Sync` is required so the sink can be shared across async
+/// tasks and held in `Arc<dyn StreamingSink>`.
+pub trait StreamingSink: Send + Sync {
+    /// Push a single text delta (incremental content fragment).
+    fn send_text(&self, delta: &str);
+
+    /// Notify that the stream completed successfully.
+    fn send_done(&self, done: StreamDone);
+
+    /// Notify that the stream failed.
+    fn send_error(&self, error: String);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal no-op sink used to verify trait usability.
+    struct NoopSink {
+        text: std::sync::Mutex<String>,
+    }
+
+    impl StreamingSink for NoopSink {
+        fn send_text(&self, delta: &str) {
+            let mut buf = self.text.lock().unwrap();
+            buf.push_str(delta);
+        }
+
+        fn send_done(&self, _done: StreamDone) {}
+
+        fn send_error(&self, _error: String) {}
+    }
+
+    #[test]
+    fn test_stream_done_construction_and_equality() {
+        let usage = UnifiedUsage {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: Some(30),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        };
+        let a = StreamDone::new("gpt-4o", Some(usage.clone()));
+        let b = StreamDone {
+            model: "gpt-4o".to_string(),
+            usage: Some(usage),
+        };
+        assert_eq!(a, b);
+        assert_eq!(a.model, "gpt-4o");
+        assert!(a.usage.is_some());
+    }
+
+    #[test]
+    fn test_stream_done_without_usage() {
+        let done = StreamDone::new("claude-opus-4", None);
+        assert_eq!(done.model, "claude-opus-4");
+        assert!(done.usage.is_none());
+    }
+
+    #[test]
+    fn test_noop_sink_collects_text() {
+        let sink = NoopSink {
+            text: std::sync::Mutex::new(String::new()),
+        };
+        sink.send_text("hello ");
+        sink.send_text("world");
+        assert_eq!(*sink.text.lock().unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_sink_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NoopSink>();
+    }
+}


### PR DESCRIPTION
feat(session): 流式输出 session 层接入 — StreamingSink trait + ChatSession 流式路径

## 变更内容

- 新增 `StreamingSink` trait（`send_text`/`send_done`/`send_error`）+ `StreamDone` 类型，定义在 `src/llm/streaming.rs`
- `ChatSession` trait 新增 `set_streaming_sink()`/`stream_enabled()`/`set_stream_enabled()` 方法
- `ConversationSession` 和 `LegacySessionAdapter` 实现流式字段，`build_api_request()` 读取 `stream_enabled` 设置 `request.stream`
- `SessionMessageHandler` 新增 `UnifiedChatClient` 字段，`dispatch_llm_call()` 按 `stream_enabled` 分流：流式路径调用 `chat_streaming()` 逐 chunk 推送，非流式路径保持不变
- 流式错误处理含 `tracing::error!` 日志 + `sink.send_error()` 通知
- `session_handler.rs` 拆分至 500 行限制内（流式逻辑提取到 `session_handler_streaming.rs`）
- 4 个新增单元测试覆盖流式默认值、标志切换、stream flag 反映、sink 设置

## 不变更

- 非流式路径（`call_llm()`）不做任何修改
- 不实现具体平台的 StreamingSink（飞书/CLI 由后续 issue 负责）
- 不修改 design doc

Source: issue #796
Type: feat
