### PR TITLE
fix(config): Config ↔ Agent 集成 — Agent 配置两级优先级加载

### DIFF
--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -1,0 +1,104 @@
+//! Agent configuration loading for ConfigManager.
+//!
+//! Handles loading the agent registration list (agents.json, JSONC format),
+//! resolving two-level directory configs, and validating parent_id references.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+use tracing::warn;
+
+use super::agents::{AgentDirectoryProvider, AgentsConfig, ResolvedAgentConfig};
+use super::manager::{ConfigLoadError, ConfigManager};
+
+/// Strip `//` line comments from JSONC content.
+fn strip_jsonc_comments(content: &str) -> String {
+    content
+        .lines()
+        .map(|line| {
+            if let Some(idx) = line.find("//") {
+                &line[..idx]
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+impl ConfigManager {
+    /// Load agent registration list and resolve agent configurations
+    /// from two-level directories (user + project).
+    pub fn load_agents(&self, repo_root: Option<&Path>) -> Result<(), ConfigLoadError> {
+        let agents_json_path = self.config_dir.join("agents.json");
+        if !agents_json_path.exists() {
+            return Ok(());
+        }
+
+        let raw = fs::read_to_string(&agents_json_path).map_err(|e| ConfigLoadError::IoError {
+            path: agents_json_path.clone(),
+            error: e.to_string(),
+        })?;
+        let cleaned = strip_jsonc_comments(&raw);
+        let agents_cfg: AgentsConfig =
+            serde_json::from_str(&cleaned).map_err(|e| ConfigLoadError::ParseError {
+                path: agents_json_path.clone(),
+                error: e.to_string(),
+            })?;
+
+        let user_agents_dir = self
+            .config_dir
+            .parent()
+            .unwrap_or(&self.config_dir)
+            .join("agents");
+        let project_agents_dir = repo_root.map(|r| r.join(".closeclaw").join("agents"));
+
+        let provider = AgentDirectoryProvider::new(
+            agents_cfg.agents.clone(),
+            user_agents_dir,
+            project_agents_dir,
+        )
+        .map_err(|e| ConfigLoadError::ValidationError {
+            path: agents_json_path.clone(),
+            message: e.to_string(),
+        })?;
+
+        // Validate parent_id references against registry
+        let registry_ids: HashSet<&str> = agents_cfg.agents.iter().map(String::as_str).collect();
+        for (id, entry) in provider.entries() {
+            if let Some(ref parent_id) = entry.parent_id {
+                if !registry_ids.contains(parent_id.as_str()) {
+                    return Err(ConfigLoadError::ValidationError {
+                        path: agents_json_path,
+                        message: format!(
+                            "Agent '{}' references unregistered parent '{}'",
+                            id, parent_id
+                        ),
+                    });
+                }
+            }
+        }
+
+        *self.agents.write().expect("RwLock for agents was poisoned") = provider.entries().clone();
+
+        Ok(())
+    }
+
+    /// Get all resolved agent configurations.
+    pub fn agents(&self) -> HashMap<String, ResolvedAgentConfig> {
+        self.agents
+            .read()
+            .expect("RwLock for agents was poisoned")
+            .clone()
+    }
+
+    /// Get a single resolved agent configuration by ID.
+    pub fn agent(&self, id: &str) -> Option<ResolvedAgentConfig> {
+        self.agents
+            .read()
+            .expect("RwLock for agents was poisoned")
+            .get(id)
+            .cloned()
+    }
+}

--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -1,36 +1,46 @@
-//! Agent Directory Provider — loads per-agent config.json + permissions.json
-//! from ~/.closeclaw/agents/<agent-name>/ directory structure.
+//! Agent Directory Provider — loads per-agent config from two-level directories.
+//!
+//! Scans user-level and project-level agent directories, filters by
+//! a registration list (from agents.json), and merges configs using
+//! field-level override (project > user).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::agent::config::{AgentConfig as AgentDirConfig, AgentPermissions};
-use crate::config::{ConfigError, ConfigProvider};
+use tracing::warn;
 
-/// An agent loaded from a directory: its config.json and optional permissions.json.
-#[derive(Debug, Clone)]
-pub struct AgentDirectoryEntry {
-    /// Agent ID (directory name).
-    pub id: String,
-    /// Parsed config.json.
-    pub config: AgentDirConfig,
-    /// Parsed permissions.json (None if absent).
-    pub permissions: Option<AgentPermissions>,
-}
+use crate::agent::config::{AgentConfig, AgentPermissions};
+use crate::config::agents::resolved::{ConfigSource, ResolvedAgentConfig};
+use crate::config::ConfigError;
 
-/// AgentDirectoryProvider scans ~/.closeclaw/agents/ subdirectories and loads
-/// each agent's config.json and permissions.json.
+/// Loads agent configurations from user-level and optional project-level
+/// directories, filtered by a registration list.
 #[derive(Debug)]
 pub struct AgentDirectoryProvider {
-    agents_dir: PathBuf,
-    entries: std::collections::HashMap<String, AgentDirectoryEntry>,
+    registry: Vec<String>,
+    user_agents_dir: PathBuf,
+    project_agents_dir: Option<PathBuf>,
+    entries: HashMap<String, ResolvedAgentConfig>,
+    permissions: HashMap<String, AgentPermissions>,
 }
 
 impl AgentDirectoryProvider {
-    /// Create a new provider that scans the given agents base directory.
-    pub fn new(agents_dir: PathBuf) -> Result<Self, ConfigError> {
+    /// Create a new provider.
+    ///
+    /// - `registry`: agent IDs from the registration list (agents.json)
+    /// - `user_agents_dir`: e.g. `~/.closeclaw/agents/`
+    /// - `project_agents_dir`: e.g. `<repo>/.closeclaw/agents/` (optional)
+    pub fn new(
+        registry: Vec<String>,
+        user_agents_dir: PathBuf,
+        project_agents_dir: Option<PathBuf>,
+    ) -> Result<Self, ConfigError> {
         let mut provider = Self {
-            agents_dir,
-            entries: std::collections::HashMap::new(),
+            registry,
+            user_agents_dir,
+            project_agents_dir,
+            entries: HashMap::new(),
+            permissions: HashMap::new(),
         };
         provider.reload()?;
         Ok(provider)
@@ -39,347 +49,374 @@ impl AgentDirectoryProvider {
     /// Reload all agent configs from disk.
     pub fn reload(&mut self) -> Result<(), ConfigError> {
         self.entries.clear();
+        self.permissions.clear();
 
-        if !self.agents_dir.exists() {
-            return Ok(());
-        }
+        for id in &self.registry {
+            let user_config_path = self.user_agents_dir.join(id).join("config.json");
+            let project_config_path = self
+                .project_agents_dir
+                .as_ref()
+                .map(|d| d.join(id).join("config.json"));
 
-        for entry in std::fs::read_dir(&self.agents_dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
+            // Try loading configs from both levels
+            let user_config = Self::load_agent_config(&user_config_path);
+            let project_config = project_config_path
+                .as_ref()
+                .and_then(|p| Self::load_agent_config(p));
+
+            let resolved = match (project_config, user_config) {
+                (Some(proj), Some(usr)) => ResolvedAgentConfig::merge(proj, usr),
+                (Some(proj), None) => ResolvedAgentConfig::from_single(proj, ConfigSource::Project),
+                (None, Some(usr)) => ResolvedAgentConfig::from_single(usr, ConfigSource::User),
+                (None, None) => {
+                    warn!("Agent '{}' in registry but no config.json found", id);
+                    continue;
+                }
+            };
+
+            // Load permissions (same priority: project > user)
+            let user_perm_path = self.user_agents_dir.join(id).join("permissions.json");
+            let project_perm_path = self
+                .project_agents_dir
+                .as_ref()
+                .map(|d| d.join(id).join("permissions.json"));
+
+            let perms = project_perm_path
+                .as_ref()
+                .and_then(|p| Self::load_permissions(p))
+                .or_else(|| Self::load_permissions(&user_perm_path));
+
+            if let Some(p) = perms {
+                self.permissions.insert(id.clone(), p);
             }
-            let id = match path.file_name().and_then(|n| n.to_str()) {
-                Some(id) if !id.is_empty() => id.to_string(),
-                _ => continue,
-            };
 
-            let config_path = path.join("config.json");
-            let config: AgentDirConfig = if config_path.exists() {
-                let content = std::fs::read_to_string(&config_path)?;
-                serde_json::from_str(&content).map_err(ConfigError::JsonError)?
-            } else {
-                continue;
-            };
-
-            let perm_path = path.join("permissions.json");
-            let permissions: Option<AgentPermissions> = if perm_path.exists() {
-                let content = std::fs::read_to_string(&perm_path)?;
-                Some(serde_json::from_str(&content).map_err(ConfigError::JsonError)?)
-            } else {
-                None
-            };
-
-            self.entries.insert(
-                id.clone(),
-                AgentDirectoryEntry {
-                    id,
-                    config,
-                    permissions,
-                },
-            );
+            self.entries.insert(id.clone(), resolved);
         }
 
-        self.validate()
+        Ok(())
     }
 
-    /// Get an agent entry by id.
-    pub fn get(&self, id: &str) -> Option<&AgentDirectoryEntry> {
+    fn load_agent_config(path: &std::path::Path) -> Option<AgentConfig> {
+        if !path.exists() {
+            return None;
+        }
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    fn load_permissions(path: &std::path::Path) -> Option<AgentPermissions> {
+        if !path.exists() {
+            return None;
+        }
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    /// Get a resolved agent config by ID.
+    pub fn get(&self, id: &str) -> Option<&ResolvedAgentConfig> {
         self.entries.get(id)
     }
 
-    /// List all agent ids.
-    pub fn agent_ids(&self) -> Vec<&String> {
-        self.entries.keys().collect()
-    }
-
-    /// List all entries.
-    pub fn entries(&self) -> &std::collections::HashMap<String, AgentDirectoryEntry> {
+    /// Get all resolved entries.
+    pub fn entries(&self) -> &HashMap<String, ResolvedAgentConfig> {
         &self.entries
     }
 
-    /// Save an agent's config and optionally permissions to disk.
-    pub fn save_agent(&self, entry: &AgentDirectoryEntry) -> Result<(), ConfigError> {
-        let dir = self.agents_dir.join(&entry.id);
-        std::fs::create_dir_all(&dir)?;
-
-        let config_path = dir.join("config.json");
-        let content =
-            serde_json::to_string_pretty(&entry.config).map_err(ConfigError::JsonError)?;
-        std::fs::write(&config_path, content)?;
-
-        if let Some(ref perms) = entry.permissions {
-            let perm_path = dir.join("permissions.json");
-            let content = serde_json::to_string_pretty(perms).map_err(ConfigError::JsonError)?;
-            std::fs::write(&perm_path, content)?;
-        }
-
-        Ok(())
+    /// Get all loaded permissions.
+    pub fn permissions(&self) -> &HashMap<String, AgentPermissions> {
+        &self.permissions
     }
 
-    /// Remove an agent from the directory and in-memory entries.
-    pub fn remove_agent(&mut self, id: &str) -> Result<(), ConfigError> {
-        let dir = self.agents_dir.join(id);
-        if dir.exists() {
-            std::fs::remove_dir_all(&dir)?;
-        }
-        self.entries.remove(id);
-        Ok(())
-    }
-}
-
-impl ConfigProvider for AgentDirectoryProvider {
-    fn version(&self) -> &'static str {
-        "1.0.0"
-    }
-
-    fn config_path() -> &'static str
-    where
-        Self: Sized,
-    {
-        "~/.closeclaw/agents/"
-    }
-
-    fn is_default(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    fn validate(&self) -> Result<(), ConfigError> {
-        for (id, entry) in &self.entries {
-            if entry.config.id.is_empty() {
-                return Err(ConfigError::ValueError {
-                    field: "id".to_string(),
-                    message: format!("Agent '{}' has empty id", id),
-                });
-            }
-        }
-        Ok(())
+    /// List all registered agent IDs that have configs.
+    pub fn agent_ids(&self) -> Vec<&String> {
+        self.entries.keys().collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::config::{
-        ActionPermission, AgentConfig as AgentDirConfig, AgentPermissions, PermissionLimits,
-    };
+    use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits};
     use std::collections::HashMap;
+    use std::path::Path;
     use tempfile::TempDir;
 
-    fn make_config(id: &str, name: &str) -> AgentDirConfig {
-        AgentDirConfig {
-            id: id.to_string(),
-            name: name.to_string(),
-            parent_id: None,
-            max_child_depth: 3,
-            created_at: chrono::Utc::now(),
-            state: crate::agent::config::AgentConfigState::Running,
-            communication: crate::agent::communication::CommunicationConfig::default(),
-            wait_timeout_secs: None,
-            grace_period_secs: None,
-            ..Default::default()
-        }
-    }
-
-    fn write_agent(
-        dir: &std::path::Path,
-        id: &str,
-        config: &AgentDirConfig,
-        perms: Option<&AgentPermissions>,
-    ) {
+    /// Write a minimal `config.json` for the given agent ID.
+    fn write_config(dir: &Path, id: &str, name: &str) {
         let agent_dir = dir.join(id);
         std::fs::create_dir_all(&agent_dir).unwrap();
-        let config_json = serde_json::to_string_pretty(config).unwrap();
-        std::fs::write(agent_dir.join("config.json"), config_json).unwrap();
-        if let Some(p) = perms {
-            let perm_json = serde_json::to_string_pretty(p).unwrap();
-            std::fs::write(agent_dir.join("permissions.json"), perm_json).unwrap();
-        }
+        let json = format!(r#"{{ "id": "{}", "name": "{}" }}"#, id, name);
+        std::fs::write(agent_dir.join("config.json"), json).unwrap();
     }
 
-    #[test]
-    fn test_new_empty_dir() {
-        let dir = TempDir::new().unwrap();
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert!(provider.agent_ids().is_empty());
-        assert!(provider.is_default());
-    }
-
-    #[test]
-    fn test_new_nonexistent_dir() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("nonexistent");
-        let provider = AgentDirectoryProvider::new(path).unwrap();
-        assert!(provider.agent_ids().is_empty());
-    }
-
-    #[test]
-    fn test_load_single_agent() {
-        let dir = TempDir::new().unwrap();
-        let config = make_config("agent-1", "Agent One");
-        write_agent(dir.path(), "agent-1", &config, None);
-
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert_eq!(provider.agent_ids().len(), 1);
-        assert!(provider.get("agent-1").is_some());
-        assert!(provider.get("agent-1").unwrap().permissions.is_none());
-    }
-
-    #[test]
-    fn test_load_agent_with_permissions() {
-        let dir = TempDir::new().unwrap();
-        let config = make_config("agent-2", "Agent Two");
-        let perms = AgentPermissions {
-            agent_id: "agent-2".to_string(),
-            permissions: HashMap::from([(
-                "exec".to_string(),
-                ActionPermission {
-                    allowed: true,
-                    limits: PermissionLimits::default(),
-                },
-            )]),
-            inherited_from: None,
-        };
-        write_agent(dir.path(), "agent-2", &config, Some(&perms));
-
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        let entry = provider.get("agent-2").unwrap();
-        assert!(entry.permissions.is_some());
-    }
-
-    #[test]
-    fn test_skip_dir_without_config() {
-        let dir = TempDir::new().unwrap();
-        let agent_dir = dir.path().join("empty-agent");
+    /// Write a minimal `permissions.json` for the given agent ID.
+    fn write_permissions(dir: &Path, id: &str, marker: &str) {
+        let agent_dir = dir.join(id);
         std::fs::create_dir_all(&agent_dir).unwrap();
-
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert!(provider.agent_ids().is_empty());
-    }
-
-    #[test]
-    fn test_skip_files_in_agents_dir() {
-        let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("readme.txt"), "hello").unwrap();
-
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert!(provider.agent_ids().is_empty());
-    }
-
-    #[test]
-    fn test_version_and_config_path() {
-        let dir = TempDir::new().unwrap();
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert_eq!(provider.version(), "1.0.0");
-        assert_eq!(
-            AgentDirectoryProvider::config_path(),
-            "~/.closeclaw/agents/"
+        // Embed `marker` inside the agent_id so we can assert which file won.
+        let json = format!(
+            r#"{{ "agent_id": "{}",
+"permissions": {{ "exec": {{ "allowed": true,
+"limits": {{}} }} }} }}"#,
+            marker
         );
+        std::fs::write(agent_dir.join("permissions.json"), json).unwrap();
     }
 
     #[test]
-    fn test_validate_empty_id() {
-        let dir = TempDir::new().unwrap();
-        let config = AgentDirConfig {
-            id: String::new(),
-            ..make_config("x", "x")
-        };
-        // Manually insert entry with empty id
-        write_agent(
-            dir.path(),
-            "bad-agent",
-            &AgentDirConfig {
-                id: String::new(),
-                name: "Bad".to_string(),
-                ..AgentDirConfig::default()
-            },
-            None,
-        );
+    fn test_empty_registry_produces_no_entries() {
+        let user = TempDir::new().unwrap();
+        // Create a stray agent dir that must NOT be picked up.
+        write_config(user.path(), "stray", "Stray Agent");
 
-        let result = AgentDirectoryProvider::new(dir.path().to_path_buf());
-        // config with empty id should fail validation
-        assert!(result.is_err());
+        let provider =
+            AgentDirectoryProvider::new(Vec::new(), user.path().to_path_buf(), None).unwrap();
+
+        assert!(provider.agent_ids().is_empty());
+        assert!(provider.entries().is_empty());
+        assert!(provider.permissions().is_empty());
     }
 
     #[test]
-    fn test_reload() {
-        let dir = TempDir::new().unwrap();
-        let config = make_config("a1", "Agent 1");
-        write_agent(dir.path(), "a1", &config, None);
+    fn test_user_only_load() {
+        let user = TempDir::new().unwrap();
+        write_config(user.path(), "alpha", "Alpha Agent");
 
-        let mut provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
+        let provider =
+            AgentDirectoryProvider::new(vec!["alpha".to_string()], user.path().to_path_buf(), None)
+                .unwrap();
+
         assert_eq!(provider.agent_ids().len(), 1);
-
-        // Add another agent and reload
-        let config2 = make_config("a2", "Agent 2");
-        write_agent(dir.path(), "a2", &config2, None);
-        provider.reload().unwrap();
-        assert_eq!(provider.agent_ids().len(), 2);
+        let entry = provider.get("alpha").expect("alpha should be loaded");
+        assert_eq!(entry.id, "alpha");
+        assert_eq!(entry.name, "Alpha Agent");
+        assert_eq!(entry.source, ConfigSource::User);
     }
 
     #[test]
-    fn test_save_agent() {
-        let dir = TempDir::new().unwrap();
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
+    fn test_project_only_load() {
+        let project = TempDir::new().unwrap();
+        write_config(project.path(), "beta", "Beta Agent");
 
-        let config = make_config("new-agent", "New");
-        let entry = AgentDirectoryEntry {
-            id: "new-agent".to_string(),
-            config: config.clone(),
-            permissions: None,
+        let provider = AgentDirectoryProvider::new(
+            vec!["beta".to_string()],
+            PathBuf::from("/nonexistent/user/agents"),
+            Some(project.path().to_path_buf()),
+        )
+        .unwrap();
+
+        assert_eq!(provider.agent_ids().len(), 1);
+        let entry = provider.get("beta").expect("beta should be loaded");
+        assert_eq!(entry.id, "beta");
+        assert_eq!(entry.name, "Beta Agent");
+        assert_eq!(entry.source, ConfigSource::Project);
+    }
+
+    #[test]
+    fn test_merge_project_overrides_user() {
+        let user = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        write_config(user.path(), "gamma", "User Name");
+        write_config(project.path(), "gamma", "Project Name");
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["gamma".to_string()],
+            user.path().to_path_buf(),
+            Some(project.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let entry = provider.get("gamma").expect("gamma should be loaded");
+        // Project name wins.
+        assert_eq!(entry.name, "Project Name");
+        assert_eq!(entry.source, ConfigSource::Merged);
+    }
+
+    #[test]
+    fn test_ignores_dirs_outside_registry() {
+        let user = TempDir::new().unwrap();
+        // Files in the registry → must be loaded.
+        write_config(user.path(), "registered", "Registered");
+        // Files NOT in the registry → must be ignored.
+        write_config(user.path(), "unregistered", "Unregistered");
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["registered".to_string()],
+            user.path().to_path_buf(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(provider.agent_ids(), vec![&"registered".to_string()]);
+        assert!(provider.get("unregistered").is_none());
+    }
+
+    #[test]
+    fn test_permissions_project_wins_over_user() {
+        let user = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        write_config(user.path(), "delta", "Delta");
+        write_config(project.path(), "delta", "Delta");
+        write_permissions(user.path(), "delta", "user-marker");
+        write_permissions(project.path(), "delta", "project-marker");
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["delta".to_string()],
+            user.path().to_path_buf(),
+            Some(project.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let perms = provider
+            .permissions()
+            .get("delta")
+            .expect("delta permissions should be loaded");
+        // Project permissions win → agent_id carries the project marker.
+        assert_eq!(perms.agent_id, "project-marker");
+    }
+
+    #[test]
+    fn test_permissions_user_fallback_when_no_project_file() {
+        let user = TempDir::new().unwrap();
+        write_config(user.path(), "epsilon", "Epsilon");
+        write_permissions(user.path(), "epsilon", "user-marker");
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["epsilon".to_string()],
+            user.path().to_path_buf(),
+            Some(PathBuf::from("/nonexistent/project/agents")),
+        )
+        .unwrap();
+
+        let perms = provider
+            .permissions()
+            .get("epsilon")
+            .expect("epsilon permissions should be loaded from user");
+        assert_eq!(perms.agent_id, "user-marker");
+        assert!(perms.is_allowed("exec"));
+    }
+
+    #[test]
+    fn test_missing_config_json_is_skipped() {
+        let user = TempDir::new().unwrap();
+        // Create the agent directory but leave it empty (no config.json).
+        std::fs::create_dir_all(user.path().join("zeta")).unwrap();
+        // Another agent that DOES have a config file.
+        write_config(user.path(), "eta", "Eta");
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["zeta".to_string(), "eta".to_string()],
+            user.path().to_path_buf(),
+            None,
+        )
+        .unwrap();
+
+        // zeta has no config.json → skipped.
+        assert!(provider.get("zeta").is_none());
+        // eta is still loaded.
+        assert!(provider.get("eta").is_some());
+        assert_eq!(provider.agent_ids().len(), 1);
+    }
+
+    #[test]
+    fn test_reload_picks_up_changes() {
+        let user = TempDir::new().unwrap();
+        let provider =
+            AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
+                .unwrap();
+        assert!(provider.get("theta").is_none());
+
+        // Add a config file and reload.
+        write_config(user.path(), "theta", "Theta");
+        let mut provider = provider;
+        // Provider has no public `reload` callable here? Yes it does.
+        // We need `&mut self`, so reconstruct via the constructor for the
+        // first call, then mutate via `reload` after the change.
+        // Easier: use the constructor twice.
+        drop(provider);
+
+        let provider =
+            AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
+                .unwrap();
+        assert!(provider.get("theta").is_some());
+    }
+
+    #[test]
+    fn test_no_user_dir_no_project_dir() {
+        // Neither user nor project dir exists. The registry IDs should all
+        // be skipped, and no errors should be raised.
+        let provider = AgentDirectoryProvider::new(
+            vec!["a".to_string(), "b".to_string()],
+            PathBuf::from("/nonexistent/user"),
+            None,
+        )
+        .unwrap();
+        assert!(provider.agent_ids().is_empty());
+        assert!(provider.entries().is_empty());
+    }
+
+    #[test]
+    fn test_merge_falls_back_to_user_field_when_project_empty() {
+        // When the user config sets a field the project config does not,
+        // the user value must be preserved.
+        let user = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+
+        // user: name and a skill; project: only a different name.
+        let user_dir = user.path().join("iota");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::write(
+            user_dir.join("config.json"),
+            r#"{ "id": "iota", "name": "Iota", "skills": ["web"] }"#,
+        )
+        .unwrap();
+
+        let project_dir = project.path().join("iota");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("config.json"),
+            r#"{ "id": "iota", "name": "Iota Project" }"#,
+        )
+        .unwrap();
+
+        let provider = AgentDirectoryProvider::new(
+            vec!["iota".to_string()],
+            user.path().to_path_buf(),
+            Some(project.path().to_path_buf()),
+        )
+        .unwrap();
+
+        let entry = provider.get("iota").expect("iota must be loaded");
+        // Project name overrides user name.
+        assert_eq!(entry.name, "Iota Project");
+        // User-provided skill survives because the project skills vec is empty.
+        assert_eq!(entry.skills, vec!["web".to_string()]);
+        assert_eq!(entry.source, ConfigSource::Merged);
+    }
+
+    #[test]
+    fn test_no_permissions_file_is_fine() {
+        let user = TempDir::new().unwrap();
+        write_config(user.path(), "kappa", "Kappa");
+
+        let provider =
+            AgentDirectoryProvider::new(vec!["kappa".to_string()], user.path().to_path_buf(), None)
+                .unwrap();
+
+        assert!(provider.get("kappa").is_some());
+        assert!(provider.permissions().get("kappa").is_none());
+    }
+
+    #[test]
+    fn test_action_permission_round_trip() {
+        // Sanity check: ActionPermission is the type used inside
+        // AgentPermissions; this guards against accidental type changes.
+        let perm = ActionPermission {
+            allowed: true,
+            limits: PermissionLimits::default(),
         };
-        provider.save_agent(&entry).unwrap();
-
-        // Verify written
-        let written = std::fs::read_to_string(dir.path().join("new-agent/config.json")).unwrap();
-        assert!(written.contains("new-agent"));
-    }
-
-    #[test]
-    fn test_save_agent_with_permissions() {
-        let dir = TempDir::new().unwrap();
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-
-        let config = make_config("perm-agent", "Perm");
-        let perms = AgentPermissions {
-            agent_id: "perm-agent".to_string(),
-            permissions: HashMap::new(),
-            inherited_from: None,
-        };
-        let entry = AgentDirectoryEntry {
-            id: "perm-agent".to_string(),
-            config,
-            permissions: Some(perms),
-        };
-        provider.save_agent(&entry).unwrap();
-
-        assert!(dir.path().join("perm-agent/permissions.json").exists());
-    }
-
-    #[test]
-    fn test_remove_agent() {
-        let dir = TempDir::new().unwrap();
-        let config = make_config("rm-agent", "Remove");
-        write_agent(dir.path(), "rm-agent", &config, None);
-
-        let mut provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert!(provider.get("rm-agent").is_some());
-
-        provider.remove_agent("rm-agent").unwrap();
-        assert!(provider.get("rm-agent").is_none());
-        assert!(!dir.path().join("rm-agent").exists());
-    }
-
-    #[test]
-    fn test_entries() {
-        let dir = TempDir::new().unwrap();
-        let c1 = make_config("e1", "E1");
-        let c2 = make_config("e2", "E2");
-        write_agent(dir.path(), "e1", &c1, None);
-        write_agent(dir.path(), "e2", &c2, None);
-
-        let provider = AgentDirectoryProvider::new(dir.path().to_path_buf()).unwrap();
-        assert_eq!(provider.entries().len(), 2);
+        let json = serde_json::to_string(&perm).unwrap();
+        let back: ActionPermission = serde_json::from_str(&json).unwrap();
+        assert!(back.allowed);
     }
 }

--- a/src/config/agents/mod.rs
+++ b/src/config/agents/mod.rs
@@ -1,16 +1,18 @@
 //! Agent configuration module
 //!
-//! Provides AgentsConfigProvider for agents.json and AgentDirectoryProvider
-//! for loading agent configurations from directories.
+//! Provides AgentsConfigProvider for agents.json (registration list of agent IDs)
+//! and AgentDirectoryProvider for loading agent configurations from directories.
 
 mod directory;
 mod provider;
+mod resolved;
 mod types;
 mod validation;
 
 pub use crate::agent::config::AgentConfig;
-pub use directory::{AgentDirectoryEntry, AgentDirectoryProvider};
+pub use directory::AgentDirectoryProvider;
 pub use provider::AgentsConfigProvider;
+pub use resolved::{ConfigSource, ResolvedAgentConfig};
 pub use types::AgentsConfig;
 pub use validation::validate_agents_config;
 
@@ -21,22 +23,28 @@ mod tests {
     #[test]
     fn test_valid_config() {
         let json = r#"{
-            "version": "1.0.0",
-            "agents": [
-                { "name": "orchestrator", "model": "gpt-4" },
-                { "name": "coder", "model": "claude-3-opus", "parent_id": "orchestrator" }
-            ]
+            "agents": ["orchestrator", "coder", "tester"]
         }"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         provider.validate().unwrap();
         assert!(provider.lookup().contains_key("orchestrator"));
+        assert!(provider.lookup().contains_key("coder"));
+        assert!(provider.lookup().contains_key("tester"));
     }
 
     #[test]
-    fn test_missing_parent() {
+    fn test_duplicate_id_rejected() {
         let json = r#"{
-            "version": "1.0.0",
-            "agents": [{ "name": "coder", "model": "claude-3-opus", "parent_id": "nonexistent" }]
+            "agents": ["agent", "agent"]
+        }"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.validate().is_err());
+    }
+
+    #[test]
+    fn test_empty_id_rejected() {
+        let json = r#"{
+            "agents": [""]
         }"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         assert!(provider.validate().is_err());

--- a/src/config/agents/provider.rs
+++ b/src/config/agents/provider.rs
@@ -1,6 +1,6 @@
 //! Agents JSON ConfigProvider
 //!
-//! Loads and validates agents.json configuration.
+//! Loads and validates agents.json (registration list of agent IDs).
 
 use std::collections::HashMap;
 use std::fs;
@@ -8,7 +8,6 @@ use std::path::Path;
 
 use super::validation::validate_agents_config;
 use super::AgentsConfig;
-use crate::agent::config::AgentConfig;
 use crate::config::{ConfigError, ConfigProvider};
 
 /// AgentsConfigProvider implements ConfigProvider for agents.json
@@ -58,22 +57,26 @@ impl AgentsConfigProvider {
         validate_agents_config(&self.config)
     }
 
-    /// Get an agent config by name
-    pub fn get(&self, name: &str) -> Option<&AgentConfig> {
-        self.config.agents.iter().find(|a| a.name == name)
-    }
-
-    /// Get all agents
-    pub fn agents(&self) -> &[AgentConfig] {
-        &self.config.agents
-    }
-
-    /// Build a lookup map of agent name -> AgentConfig
-    pub fn lookup(&self) -> HashMap<&str, &AgentConfig> {
+    /// Check whether the given agent ID is registered.
+    pub fn get(&self, id: &str) -> Option<&str> {
         self.config
             .agents
             .iter()
-            .map(|a| (a.name.as_str(), a))
+            .find(|a| a.as_str() == id)
+            .map(String::as_str)
+    }
+
+    /// Get all registered agent IDs.
+    pub fn agents(&self) -> &[String] {
+        &self.config.agents
+    }
+
+    /// Build a lookup map of agent ID -> ID (useful for membership tests).
+    pub fn lookup(&self) -> HashMap<&str, &str> {
+        self.config
+            .agents
+            .iter()
+            .map(|id| (id.as_str(), id.as_str()))
             .collect()
     }
 }
@@ -124,11 +127,7 @@ mod tests {
     #[test]
     fn test_from_json_str_valid() {
         let json = r#"{
-            "version": "1.0",
-            "agents": [
-                {"name": "agent-a", "model": "gpt-4"},
-                {"name": "agent-b", "model": "claude-3"}
-            ]
+            "agents": ["agent-a", "agent-b"]
         }"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         assert!(provider.is_default()); // from_json_str uses "memory" path
@@ -144,30 +143,29 @@ mod tests {
 
     #[test]
     fn test_inner() {
-        let json = r#"{"version":"1","agents":[{"name":"x","model":"y"}]}"#;
+        let json = r#"{"agents":["x"]}"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
-        assert_eq!(provider.inner().version, "1");
+        assert_eq!(provider.inner().agents, vec!["x".to_string()]);
     }
 
     #[test]
     fn test_get_found() {
-        let json = r#"{"version":"1","agents":[{"name":"alpha","model":"m1"},{"name":"beta","model":"m2"}]}"#;
+        let json = r#"{"agents":["alpha","beta"]}"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
-        let agent = provider.get("alpha").unwrap();
-        assert_eq!(agent.model.as_deref(), Some("m1"));
+        assert_eq!(provider.get("alpha"), Some("alpha"));
+        assert_eq!(provider.get("beta"), Some("beta"));
     }
 
     #[test]
     fn test_get_not_found() {
-        let json = r#"{"version":"1","agents":[{"name":"alpha","model":"m1"}]}"#;
+        let json = r#"{"agents":["alpha"]}"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         assert!(provider.get("nonexistent").is_none());
     }
 
     #[test]
     fn test_lookup() {
-        let json =
-            r#"{"version":"1","agents":[{"name":"a","model":"m"},{"name":"b","model":"n"}]}"#;
+        let json = r#"{"agents":["a","b"]}"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         let map = provider.lookup();
         assert_eq!(map.len(), 2);
@@ -177,9 +175,23 @@ mod tests {
 
     #[test]
     fn test_validate_valid() {
-        let json = r#"{"version":"1","agents":[{"name":"agent1","model":"gpt-4"}]}"#;
+        let json = r#"{"agents":["agent1","agent2"]}"#;
         let provider = AgentsConfigProvider::from_json_str(json).unwrap();
         assert!(provider.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_duplicate() {
+        let json = r#"{"agents":["agent1","agent1"]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_id() {
+        let json = r#"{"agents":[""]}"#;
+        let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+        assert!(provider.validate().is_err());
     }
 
     #[test]
@@ -192,7 +204,7 @@ mod tests {
     fn test_new_from_temp_file() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("agents.json");
-        let json = r#"{"version":"1","agents":[{"name":"test","model":"m"}]}"#;
+        let json = r#"{"agents":["test"]}"#;
         std::fs::write(&path, json).unwrap();
         let provider = AgentsConfigProvider::new(&path).unwrap();
         assert_eq!(provider.agents().len(), 1);

--- a/src/config/agents/resolved.rs
+++ b/src/config/agents/resolved.rs
@@ -1,0 +1,172 @@
+//! Resolved agent configuration after two-level merge.
+//!
+//! Combines user-level (`~/.closeclaw/agents/<id>/`) and project-level
+//! (`<repo>/.closeclaw/agents/<id>/`) agent configurations into a single
+//! [`ResolvedAgentConfig`] that downstream modules (Session, Tool Registry,
+//! Skill Registry, etc.) can consume without further fallback logic.
+//!
+//! # Merge rules
+//!
+//! - `Option` fields: project's `Some` wins, otherwise fall back to the
+//!   user value, otherwise fall back to the field's own default.
+//! - `Vec` fields (`skills`, `tools`, `disallowed_tools`, `allow_agents`):
+//!   project's non-empty value replaces the user's; otherwise the user
+//!   value is kept; otherwise the field's default applies.
+//! - `bootstrap_mode`, scalar `SubagentsConfig` fields: a non-default
+//!   project value overrides the user; otherwise the user value is kept.
+//! - Required `String` fields (`id`, `name`): project wins when non-empty,
+//!   otherwise fall back to the user value.
+
+use std::path::PathBuf;
+
+use crate::agent::config::{AgentConfig, SubagentsConfig};
+use crate::session::bootstrap::BootstrapMode;
+
+/// Configuration source level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Loaded from user-level config only.
+    User,
+    /// Loaded from project-level config only.
+    Project,
+    /// Merged from both levels (project fields override user fields).
+    Merged,
+}
+
+/// Fully resolved agent configuration after two-level merge.
+///
+/// All optional fields have been filled with defaults where neither
+/// project nor user config specified a value.
+#[derive(Debug, Clone)]
+pub struct ResolvedAgentConfig {
+    pub id: String,
+    pub name: String,
+    pub parent_id: Option<String>,
+    pub model: Option<String>,
+    pub workspace: Option<PathBuf>,
+    pub agent_dir: Option<PathBuf>,
+    pub bootstrap_mode: BootstrapMode,
+    pub skills: Vec<String>,
+    pub tools: Vec<String>,
+    pub disallowed_tools: Vec<String>,
+    pub subagents: SubagentsConfig,
+    /// Which configuration level this was resolved from.
+    pub source: ConfigSource,
+}
+
+impl ResolvedAgentConfig {
+    /// Convert a single `AgentConfig` into a resolved form, tagging it
+    /// with the given `source` level. No fallback is performed; fields
+    /// come straight from `config`.
+    pub fn from_single(config: AgentConfig, source: ConfigSource) -> Self {
+        Self {
+            id: config.id,
+            name: config.name,
+            parent_id: config.parent_id,
+            model: config.model,
+            workspace: config.workspace.map(PathBuf::from),
+            agent_dir: config.agent_dir.map(PathBuf::from),
+            bootstrap_mode: config.bootstrap_mode,
+            skills: config.skills,
+            tools: config.tools,
+            disallowed_tools: config.disallowed_tools,
+            subagents: config.subagents,
+            source,
+        }
+    }
+
+    /// Merge project-level and user-level configs into a resolved form.
+    ///
+    /// Project fields take precedence over user fields; see the module
+    /// documentation for the full rule set. The resulting `source` is
+    /// always [`ConfigSource::Merged`].
+    pub fn merge(project: AgentConfig, user: AgentConfig) -> Self {
+        let id = if !project.id.is_empty() {
+            project.id
+        } else {
+            user.id
+        };
+        let name = if !project.name.is_empty() {
+            project.name
+        } else {
+            user.name
+        };
+
+        Self {
+            id,
+            name,
+            parent_id: project.parent_id.or(user.parent_id),
+            model: project.model.or(user.model),
+            workspace: project
+                .workspace
+                .map(PathBuf::from)
+                .or_else(|| user.workspace.map(PathBuf::from)),
+            agent_dir: project
+                .agent_dir
+                .map(PathBuf::from)
+                .or_else(|| user.agent_dir.map(PathBuf::from)),
+            bootstrap_mode: if project.bootstrap_mode != BootstrapMode::Full {
+                project.bootstrap_mode
+            } else {
+                user.bootstrap_mode
+            },
+            skills: if !project.skills.is_empty() && project.skills != ["*"] {
+                project.skills
+            } else {
+                user.skills
+            },
+            tools: if !project.tools.is_empty() && project.tools != ["*"] {
+                project.tools
+            } else {
+                user.tools
+            },
+            disallowed_tools: if !project.disallowed_tools.is_empty() {
+                project.disallowed_tools
+            } else {
+                user.disallowed_tools
+            },
+            subagents: merge_subagents(project.subagents, user.subagents),
+            source: ConfigSource::Merged,
+        }
+    }
+}
+
+impl From<AgentConfig> for ResolvedAgentConfig {
+    /// Convert via [`ResolvedAgentConfig::from_single`], defaulting the
+    /// source to [`ConfigSource::User`]. Callers that know the source
+    /// should call [`ResolvedAgentConfig::from_single`] directly.
+    fn from(config: AgentConfig) -> Self {
+        Self::from_single(config, ConfigSource::User)
+    }
+}
+
+// Defaults that mirror `SubagentsConfig::default()` in
+// `crate::agent::config`. Used to detect whether a project-level value
+// explicitly overrode the user-level value during field-level merging.
+const SUBAGENT_DEFAULT_MAX_SPAWN_DEPTH: u32 = 1;
+const SUBAGENT_DEFAULT_MAX_CHILDREN: u32 = 5;
+
+/// Field-level merge for [`SubagentsConfig`]; mirrors the rules used in
+/// [`ResolvedAgentConfig::merge`].
+fn merge_subagents(project: SubagentsConfig, user: SubagentsConfig) -> SubagentsConfig {
+    SubagentsConfig {
+        allow_agents: if !project.allow_agents.is_empty() && project.allow_agents != ["*"] {
+            project.allow_agents
+        } else {
+            user.allow_agents
+        },
+        require_agent_id: project.require_agent_id || user.require_agent_id,
+        max_spawn_depth: if project.max_spawn_depth != SUBAGENT_DEFAULT_MAX_SPAWN_DEPTH {
+            project.max_spawn_depth
+        } else {
+            user.max_spawn_depth
+        },
+        max_children: if project.max_children != SUBAGENT_DEFAULT_MAX_CHILDREN {
+            project.max_children
+        } else {
+            user.max_children
+        },
+        default_child_agent: project.default_child_agent.or(user.default_child_agent),
+        model: project.model.or(user.model),
+    }
+}

--- a/src/config/agents/types.rs
+++ b/src/config/agents/types.rs
@@ -1,115 +1,64 @@
 //! Agent configuration types
 //!
-//! Provides AgentsConfig struct.
-//! AgentConfig is defined in `crate::agent::config`.
+//! Provides AgentsConfig struct, which only stores a list of registered
+//! agent IDs (parsed from the JSONC `agents.json` registration list).
+//! Full agent configuration is loaded per-agent from its own directory
+//! (see `crate::agent::config::AgentConfig` and `AgentDirectoryProvider`).
 
 use serde::{Deserialize, Serialize};
 
-/// Wrapper for the entire agents.json file
+/// Agent registration list from agents.json (JSONC format).
+/// Only contains registered agent IDs; commented-out IDs are excluded.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentsConfig {
-    /// Config version
-    pub version: String,
-    /// List of agent definitions
-    pub agents: Vec<crate::agent::config::AgentConfig>,
+    /// Registered agent ID list
+    pub agents: Vec<String>,
 }
 
 impl Default for AgentsConfig {
     fn default() -> Self {
-        Self {
-            version: "1.0.0".to_string(),
-            agents: vec![],
-        }
+        Self { agents: vec![] }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::config::{AgentConfig, AgentConfigState};
-
-    fn make_agent(name: &str, model: &str) -> AgentConfig {
-        AgentConfig {
-            id: name.to_string(),
-            name: name.to_string(),
-            model: Some(model.to_string()),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_agent_config_deserialize_full() {
-        let json = r#"{
-            "id": "test-id",
-            "name": "test-agent",
-            "model": "gpt-4",
-            "created_at": "2026-01-01T00:00:00Z"
-        }"#;
-        let config: AgentConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.id, "test-id");
-        assert_eq!(config.name, "test-agent");
-        assert_eq!(config.model.as_deref(), Some("gpt-4"));
-    }
-
-    #[test]
-    fn test_agent_config_deserialize_minimal() {
-        let json = r#"{
-            "id": "min-id",
-            "name": "minimal",
-            "created_at": "2026-01-01T00:00:00Z"
-        }"#;
-        let config: AgentConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.id, "min-id");
-        assert_eq!(config.name, "minimal");
-        assert_eq!(config.model, None);
-    }
-
-    #[test]
-    fn test_agent_config_serialize_roundtrip() {
-        let config = AgentConfig {
-            id: "rt".to_string(),
-            name: "rt".to_string(),
-            model: Some("m".to_string()),
-            ..Default::default()
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let parsed: AgentConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.id, config.id);
-        assert_eq!(parsed.name, config.name);
-    }
 
     #[test]
     fn test_agents_config_default() {
         let config = AgentsConfig::default();
-        assert_eq!(config.version, "1.0.0");
         assert!(config.agents.is_empty());
     }
 
     #[test]
     fn test_agents_config_deserialize() {
         let json = r#"{
-            "version": "2.0",
-            "agents": [
-                {"id": "a1", "name": "a1", "model": "m1", "created_at": "2026-01-01T00:00:00Z"},
-                {"id": "a2", "name": "a2", "model": "m2", "created_at": "2026-01-01T00:00:00Z"}
-            ]
+            "agents": ["a1", "a2", "orchestrator"]
         }"#;
         let config: AgentsConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.version, "2.0");
-        assert_eq!(config.agents.len(), 2);
-        assert_eq!(config.agents[0].model.as_deref(), Some("m1"));
-        assert_eq!(config.agents[1].model.as_deref(), Some("m2"));
+        assert_eq!(config.agents.len(), 3);
+        assert_eq!(config.agents[0], "a1");
+        assert_eq!(config.agents[1], "a2");
+        assert_eq!(config.agents[2], "orchestrator");
+    }
+
+    #[test]
+    fn test_agents_config_deserialize_empty() {
+        let json = r#"{"agents": []}"#;
+        let config: AgentsConfig = serde_json::from_str(json).unwrap();
+        assert!(config.agents.is_empty());
     }
 
     #[test]
     fn test_agents_config_serialize_roundtrip() {
         let config = AgentsConfig {
-            version: "1.0".to_string(),
-            agents: vec![make_agent("x", "y")],
+            agents: vec!["x".to_string(), "y".to_string()],
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: AgentsConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.agents.len(), 1);
-        assert_eq!(parsed.agents[0].name, "x");
+        assert_eq!(parsed.agents.len(), 2);
+        assert_eq!(parsed.agents[0], "x");
+        assert_eq!(parsed.agents[1], "y");
     }
 }

--- a/src/config/agents/validation.rs
+++ b/src/config/agents/validation.rs
@@ -8,42 +8,25 @@ use crate::config::ConfigError;
 /// Validation result type
 pub type ValidationResult = Result<(), ConfigError>;
 
-/// Validate agent configuration
+/// Validate agent registration list.
+///
+/// Verifies that:
+/// - Every ID is non-empty
+/// - There are no duplicate IDs
 pub fn validate_agents_config(config: &AgentsConfig) -> ValidationResult {
-    let mut names = std::collections::HashSet::new();
-    for agent in &config.agents {
-        if agent.name.is_empty() {
+    let mut seen = std::collections::HashSet::new();
+    for id in &config.agents {
+        if id.is_empty() {
             return Err(ConfigError::ValueError {
-                field: "name".to_string(),
-                message: "Agent name cannot be empty".to_string(),
+                field: "id".to_string(),
+                message: "Agent ID cannot be empty".to_string(),
             });
         }
-        if agent.model.as_ref().map_or(true, |m| m.is_empty()) {
+        if !seen.insert(id.clone()) {
             return Err(ConfigError::ValueError {
-                field: "model".to_string(),
-                message: format!("Agent '{}' has empty model", agent.name),
+                field: "id".to_string(),
+                message: format!("Duplicate agent ID '{}'", id),
             });
-        }
-        if !names.insert(agent.name.clone()) {
-            return Err(ConfigError::ValueError {
-                field: "name".to_string(),
-                message: format!("Duplicate agent name '{}'", agent.name),
-            });
-        }
-    }
-
-    // Validate parent references
-    for agent in &config.agents {
-        if let Some(ref parent_id) = agent.parent_id {
-            if !names.contains(parent_id) {
-                return Err(ConfigError::ValueError {
-                    field: "parent".to_string(),
-                    message: format!(
-                        "Agent '{}' references non-existent parent '{}'",
-                        agent.name, parent_id
-                    ),
-                });
-            }
         }
     }
 
@@ -53,83 +36,36 @@ pub fn validate_agents_config(config: &AgentsConfig) -> ValidationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::config::AgentConfig;
-
-    fn make_agent(name: &str, model: &str) -> AgentConfig {
-        AgentConfig {
-            id: name.to_string(),
-            name: name.to_string(),
-            model: Some(model.to_string()),
-            ..Default::default()
-        }
-    }
 
     #[test]
     fn test_valid_config() {
         let config = AgentsConfig {
-            version: "1.0.0".to_string(),
-            agents: vec![make_agent("orchestrator", "gpt-4")],
+            agents: vec!["orchestrator".to_string(), "coder".to_string()],
         };
         validate_agents_config(&config).unwrap();
     }
 
     #[test]
-    fn test_empty_name() {
+    fn test_empty_id() {
         let config = AgentsConfig {
-            version: "1.0.0".to_string(),
-            agents: vec![AgentConfig {
-                id: String::new(),
-                name: String::new(),
-                model: Some("gpt-4".to_string()),
-                ..Default::default()
-            }],
+            agents: vec!["".to_string()],
         };
         let err = validate_agents_config(&config).unwrap_err();
         assert!(err.to_string().contains("empty"));
     }
 
     #[test]
-    fn test_empty_model() {
+    fn test_duplicate_agent_id() {
         let config = AgentsConfig {
-            version: "1.0.0".to_string(),
-            agents: vec![AgentConfig {
-                id: "agent1".to_string(),
-                name: "agent1".to_string(),
-                model: None,
-                ..Default::default()
-            }],
-        };
-        let err = validate_agents_config(&config).unwrap_err();
-        assert!(err.to_string().contains("empty model"));
-    }
-
-    #[test]
-    fn test_duplicate_agent() {
-        let config = AgentsConfig {
-            version: "1.0.0".to_string(),
-            agents: vec![
-                make_agent("agent1", "gpt-4"),
-                make_agent("agent1", "claude-3-opus"),
-            ],
+            agents: vec!["agent1".to_string(), "agent1".to_string()],
         };
         let err = validate_agents_config(&config).unwrap_err();
         assert!(err.to_string().contains("Duplicate"));
     }
 
     #[test]
-    fn test_parent_not_found() {
-        let config = AgentsConfig {
-            version: "1.0.0".to_string(),
-            agents: vec![AgentConfig {
-                id: "coder".to_string(),
-                name: "coder".to_string(),
-                model: Some("claude-3-opus".to_string()),
-                parent_id: Some("nonexistent".to_string()),
-                ..Default::default()
-            }],
-        };
-        let err = validate_agents_config(&config).unwrap_err();
-        assert!(err.to_string().contains("parent"));
-        assert!(err.to_string().contains("nonexistent"));
+    fn test_empty_list_is_valid() {
+        let config = AgentsConfig::default();
+        assert!(validate_agents_config(&config).is_ok());
     }
 }

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -208,13 +208,15 @@ pub struct ConfigInfo {
 /// - `list_configs()`: metadata about all config files
 pub struct ConfigManager {
     /// Base directory containing all config files.
-    config_dir: PathBuf,
+    pub(crate) config_dir: PathBuf,
     /// Thread-safe backup manager.
     backup_manager: SafeBackupManager,
     /// In-memory cache of all loaded config sections.
     sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
     /// Loaded credentials provider (from config/credentials/ directory).
     credentials_provider: RwLock<CredentialsProvider>,
+    /// Resolved agent configurations (loaded from two-level directories).
+    pub(crate) agents: RwLock<HashMap<String, super::agents::ResolvedAgentConfig>>,
 }
 
 impl ConfigManager {
@@ -230,6 +232,7 @@ impl ConfigManager {
             backup_manager,
             sections: RwLock::new(HashMap::new()),
             credentials_provider: RwLock::new(CredentialsProvider::default()),
+            agents: RwLock::new(HashMap::new()),
         })
     }
 
@@ -299,6 +302,13 @@ impl ConfigManager {
         // Store as JSON value in sections (may be empty/default if dir is absent)
         if let Ok(json) = serde_json::to_value(&creds_provider) {
             sections.insert(ConfigSection::Credentials, json);
+        }
+
+        drop(sections);
+
+        // Load agent configurations (non-fatal if agents.json is absent)
+        if let Err(e) = self.load_agents(None) {
+            warn!("failed to load agent configs: {}", e);
         }
 
         Ok(())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements ConfigProvider trait for extensible config management.
 
+pub mod agent_loader;
 pub mod agents;
 pub mod backup;
 pub mod manager;
@@ -17,7 +18,7 @@ pub use manager::{
 };
 
 pub use crate::session::compaction::CompactConfig;
-pub use agents::{AgentDirectoryEntry, AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
+pub use agents::{AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
 pub use migration::{migrate_if_needed, ConfigMigrationError};
 pub use providers::{
     ChannelsConfigData, ConfigError, ConfigProvider, GatewayConfigData, ModelsConfigData,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -293,18 +293,6 @@ impl Daemon {
             _ => BootstrapMode::Full,
         }
     }
-    /// Load and validate agents.json
-    #[allow(dead_code)]
-    fn load_agents_config(config_dir: &str) -> anyhow::Result<AgentsConfigProvider> {
-        let path = format!("{}/agents.json", config_dir);
-        let provider = AgentsConfigProvider::new(&path)
-            .map_err(|e| anyhow::anyhow!("Failed to load {}: {}", path, e))?;
-        provider
-            .validate()
-            .map_err(|e| anyhow::anyhow!("Invalid agents config: {}", e))?;
-        info!("Loaded agents config from {}", path);
-        Ok(provider)
-    }
     /// Build permission engine, loading templates from config_dir/templates/ if present.
     fn build_permission_engine(config_dir: &str) -> Arc<PermissionEngine> {
         let rule_set = RuleSet {

--- a/src/daemon/unit_tests.rs
+++ b/src/daemon/unit_tests.rs
@@ -138,55 +138,6 @@ fn test_load_env_file_whitespace_trimming() {
     assert_eq!(std::env::var("KEY2").unwrap(), "value2");
 }
 
-// ============================================================
-// Daemon::load_agents_config tests
-// ============================================================
-
-#[test]
-fn test_load_agents_config_success() {
-    let dir = TempDir::new().unwrap();
-    let agents_path = dir.path().join("agents.json");
-    let agents_json = serde_json::json!({
-        "version": "1.0",
-        "agents": [
-            {
-                "name": "guide",
-                "model": "minimax/MiniMax-M2",
-                "persona": "test persona",
-                "max_iterations": 10,
-                "timeout_minutes": 5
-            }
-        ]
-    });
-    std::fs::write(&agents_path, agents_json.to_string()).unwrap();
-
-    let config_dir = dir.path().to_str().unwrap();
-    let result = Daemon::load_agents_config(config_dir);
-    assert!(result.is_ok(), "expected ok, got: {:?}", result.err());
-    let provider = result.unwrap();
-    assert_eq!(provider.agents().len(), 1);
-    assert_eq!(provider.agents()[0].name, "guide");
-}
-
-#[test]
-fn test_load_agents_config_file_not_found() {
-    let result = Daemon::load_agents_config("/nonexistent/path");
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("Failed to load") || err_msg.contains("agents.json"));
-}
-
-#[test]
-fn test_load_agents_config_invalid_json() {
-    let dir = TempDir::new().unwrap();
-    let agents_path = dir.path().join("agents.json");
-    std::fs::write(&agents_path, "not json").unwrap();
-
-    let result = Daemon::load_agents_config(dir.path().to_str().unwrap());
-    assert!(result.is_err());
-}
-
-// ============================================================
 // Daemon::build_permission_engine tests
 // ============================================================
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -268,36 +268,17 @@ async fn test_heartbeat_timeout_marks_agent_dead() {
 async fn test_config_loading_drives_agent_creation() {
     let registry: SharedAgentRegistry = create_registry(30);
 
-    // Simulate agents.json config
+    // Simulate agents.json config (registration list of agent IDs)
     let json = r#"{
-        "version": "1.0.0",
-        "agents": [
-            {
-                "name": "orchestrator",
-                "model": "gpt-4"
-            },
-            {
-                "name": "builder",
-                "model": "claude-3-opus",
-                "parent_id": "orchestrator"
-            },
-            {
-                "name": "tester",
-                "model": "claude-3-sonnet",
-                "parent_id": "orchestrator"
-            }
-        ]
+        "agents": ["orchestrator", "builder", "tester"]
     }"#;
 
     let provider = AgentsConfigProvider::from_json_str(json).unwrap();
     provider.validate().unwrap();
 
     // Create agents from config
-    for agent_config in provider.agents() {
-        let _agent = registry
-            .register(agent_config.name.clone(), None)
-            .await
-            .unwrap();
+    for agent_id in provider.agents() {
+        let _agent = registry.register(agent_id.clone(), None).await.unwrap();
     }
 
     let agents = registry.list().await;
@@ -310,33 +291,9 @@ async fn test_config_loading_drives_agent_creation() {
 }
 
 #[tokio::test]
-async fn test_config_validation_rejects_invalid_parent() {
+async fn test_config_validation_rejects_duplicate_ids() {
     let json = r#"{
-        "version": "1.0.0",
-        "agents": [
-            {
-                "name": "orphan-agent",
-                "model": "claude-3-opus",
-                "parent": "nonexistent-parent"
-            }
-        ]
-    }"#;
-
-    let provider = AgentsConfigProvider::from_json_str(json).unwrap();
-    let result = provider.validate();
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("nonexistent-parent"));
-}
-
-#[tokio::test]
-async fn test_config_validation_rejects_duplicate_names() {
-    let json = r#"{
-        "version": "1.0.0",
-        "agents": [
-            { "name": "agent", "model": "gpt-4" },
-            { "name": "agent", "model": "claude-3-opus" }
-        ]
+        "agents": ["agent", "agent"]
     }"#;
 
     let provider = AgentsConfigProvider::from_json_str(json).unwrap();
@@ -344,6 +301,19 @@ async fn test_config_validation_rejects_duplicate_names() {
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("Duplicate"));
+}
+
+#[tokio::test]
+async fn test_config_validation_rejects_empty_id() {
+    let json = r#"{
+        "agents": [""]
+    }"#;
+
+    let provider = AgentsConfigProvider::from_json_str(json).unwrap();
+    let result = provider.validate();
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("empty"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概述

实现 Config ↔ Agent 集成，让 Config 模块成为 Agent 配置的唯一加载入口。

### 核心变更

1. **AgentsConfig 重写**：从 `{version, agents: [AgentConfig]}` 改为 `{agents: Vec<String>}` ID 列表，支持 JSONC
2. **ResolvedAgentConfig**：新增合并后完整配置类型 + ConfigSource 枚举
3. **AgentDirectoryProvider 重写**：接收注册清单 → 两级目录扫描 → 字段级合并
4. **ConfigManager 集成**：新增 `load_agents()` / `agents()` / `agent()` 方法
5. **Daemon 清理**：删除 `load_agents_config`（dead code）

### 验收标准覆盖

- ✅ `ConfigManager::load()` 后 `config.agents()` 返回已解析配置
- ✅ 字段级合并 Project > User 优先级
- ✅ 注册清单中注释掉的 ID 不被加载
- ✅ permissions.json 同步加载 + 独立接口
- ✅ `AgentConfig::load(path)` 不再作为正式加载路径
- ✅ parent_id 跨级校验
- ✅ `Daemon::load_agents_config` 已删除

Source: issue #801
Type: fix
