### PR TITLE
feat: Tool 动态提示词生成 — generate_prompt + PromptGenerationContext

### DIFF
--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -6,6 +6,7 @@ use super::sections::{
     get_cached_section, invalidate_all_sections, load_cached_file_section, read_file_section,
     Section,
 };
+use super::tools_section::build_tools_section;
 use crate::skills::DiskSkillRegistry;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -155,17 +156,7 @@ fn append_append_section(base: String, append: Option<String>) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tools section builder
-// ---------------------------------------------------------------------------
-
 use crate::tools::{ToolContext, ToolRegistry};
-
-/// Build the Tools section content from a registry.
-pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> Section {
-    let content = registry.build_tools_section(ctx).await;
-    Section::ToolsSection(content)
-}
 
 // ---------------------------------------------------------------------------
 // Convenience: build from file-based workspace sections
@@ -245,9 +236,6 @@ mod tests {
     use super::*;
     use crate::permission::engine::engine_eval::PermissionEngine;
     use crate::permission::rules::RuleSetBuilder;
-    use crate::skills::DiskSkillRegistry;
-    use crate::tools::builtin::register_builtin_tools;
-    use crate::tools::ToolRegistry;
     use std::sync::Arc;
 
     /// Helper to create a test PermissionEngine.
@@ -379,119 +367,5 @@ mod tests {
         let result1 = build_system_prompt(sections.clone(), None);
         let result2 = build_system_prompt(sections, None);
         assert_eq!(result1, result2);
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_returns_tools_section() {
-        let registry = ToolRegistry::new();
-        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
-        let ctx = crate::tools::ToolContext {
-            agent_id: "test".to_string(),
-            workdir: None,
-        };
-        let section = build_tools_section(&registry, &ctx).await;
-        match section {
-            Section::ToolsSection(_) => {}
-            _ => panic!("expected ToolsSection, got {:?}", section),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_contains_group_headers() {
-        let registry = ToolRegistry::new();
-        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
-        let ctx = crate::tools::ToolContext {
-            agent_id: "test".to_string(),
-            workdir: None,
-        };
-        let section = build_tools_section(&registry, &ctx).await;
-        let content = match section {
-            Section::ToolsSection(c) => c,
-            _ => panic!("expected ToolsSection"),
-        };
-        // Should contain file_ops and meta group headers
-        assert!(
-            content.contains("file_ops"),
-            "missing file_ops group: {}",
-            content
-        );
-        assert!(content.contains("meta"), "missing meta group: {}", content);
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_contains_tool_names() {
-        let registry = ToolRegistry::new();
-        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
-        let ctx = crate::tools::ToolContext {
-            agent_id: "test".to_string(),
-            workdir: None,
-        };
-        let section = build_tools_section(&registry, &ctx).await;
-        let content = match section {
-            Section::ToolsSection(c) => c,
-            _ => panic!("expected ToolsSection"),
-        };
-        // All 7 tool names should appear
-        for name in &[
-            "Read",
-            "Write",
-            "Edit",
-            "Grep",
-            "Ls",
-            "ToolSearch",
-            "PermissionQuery",
-        ] {
-            assert!(
-                content.contains(name),
-                "tool {} not found in: {}",
-                name,
-                content
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_respects_max_length() {
-        let registry = ToolRegistry::new();
-        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
-        let ctx = crate::tools::ToolContext {
-            agent_id: "test".to_string(),
-            workdir: None,
-        };
-        let section = build_tools_section(&registry, &ctx).await;
-        let content = match section {
-            Section::ToolsSection(c) => c,
-            _ => panic!("expected ToolsSection"),
-        };
-        // With all builtin tools + detail the section should be well under 15000 chars
-        assert!(
-            content.chars().count() <= 15000,
-            "section too long: {}",
-            content
-        );
-    }
-
-    #[tokio::test]
-    async fn test_build_tools_section_empty_registry() {
-        let registry = ToolRegistry::new();
-        let ctx = crate::tools::ToolContext {
-            agent_id: "test".to_string(),
-            workdir: None,
-        };
-        let section = build_tools_section(&registry, &ctx).await;
-        let content = match section {
-            Section::ToolsSection(c) => c,
-            _ => panic!("expected ToolsSection"),
-        };
-        // Empty registry should produce empty content
-        assert!(
-            content.is_empty(),
-            "expected empty content, got: {}",
-            content
-        );
     }
 }

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -10,16 +10,18 @@
 
 pub mod builder;
 pub mod sections;
+pub mod tools_section;
 pub mod workdir;
 
 pub use builder::{
-    build_from_workspace, build_system_prompt, build_tools_section, set_agent_prompt,
-    set_custom_prompt, set_override_prompt, WorkspaceBuildConfig,
+    build_from_workspace, build_system_prompt, set_agent_prompt, set_custom_prompt,
+    set_override_prompt, WorkspaceBuildConfig,
 };
 pub use sections::{
     clear_append_section, get_append_section, get_cached_section, invalidate_all_sections,
     invalidate_section, set_append_section, Section,
 };
+pub use tools_section::build_tools_section;
 pub use workdir::{build_git_status_for, build_workdir_context, WorkdirContext};
 
 /// Maximum character length for append_section content

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -1,0 +1,159 @@
+//! Tools section builder for the system prompt.
+//!
+//! Owns the `build_tools_section` function and its tests. Extracted from
+//! `builder.rs` to keep that file under the 500-line limit.
+
+use super::sections::Section;
+use crate::tools::{PromptGenerationContext, ToolContext, ToolRegistry};
+
+/// Build the Tools section content from a registry.
+///
+/// The registry's `build_tools_section` requires a [`PromptGenerationContext`]
+/// (which carries the list of available tool names, the agent id, and the
+/// workdir). We acquire that list via a single short-lived lock on
+/// `list_descriptors`, release it, and then call the registry's
+/// `build_tools_section` with the freshly-built context. This keeps locks
+/// non-overlapping.
+pub async fn build_tools_section(registry: &ToolRegistry, ctx: &ToolContext) -> Section {
+    // 1. Independent lock: get available tool names, then drop the lock.
+    let descriptors = registry.list_descriptors(ctx).await;
+    let available_tool_names: Vec<String> = descriptors.into_iter().map(|d| d.name).collect();
+
+    // 2. Build the prompt-generation context from the names + the existing
+    //    execution context.
+    let prompt_ctx = PromptGenerationContext {
+        agent_id: ctx.agent_id.clone(),
+        workdir: ctx.workdir.clone(),
+        available_tool_names,
+    };
+
+    // 3. Acquire the registry lock again and render the section.
+    let content = registry.build_tools_section(&prompt_ctx).await;
+    Section::ToolsSection(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permission::engine::engine_eval::PermissionEngine;
+    use crate::permission::rules::RuleSetBuilder;
+    use crate::skills::DiskSkillRegistry;
+    use crate::tools::builtin::register_builtin_tools;
+    use std::sync::Arc;
+
+    fn test_permission_engine() -> Arc<PermissionEngine> {
+        Arc::new(PermissionEngine::new_with_default_data_root(
+            RuleSetBuilder::new().build().unwrap(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_returns_tools_section() {
+        let registry = ToolRegistry::new();
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        match section {
+            Section::ToolsSection(_) => {}
+            _ => panic!("expected ToolsSection, got {:?}", section),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_contains_group_headers() {
+        let registry = ToolRegistry::new();
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        assert!(
+            content.contains("file_ops"),
+            "missing file_ops group: {}",
+            content
+        );
+        assert!(content.contains("meta"), "missing meta group: {}", content);
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_contains_tool_names() {
+        let registry = ToolRegistry::new();
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        for name in &[
+            "Read",
+            "Write",
+            "Edit",
+            "Grep",
+            "Ls",
+            "ToolSearch",
+            "PermissionQuery",
+        ] {
+            assert!(
+                content.contains(name),
+                "tool {} not found in: {}",
+                name,
+                content
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_respects_max_length() {
+        let registry = ToolRegistry::new();
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        register_builtin_tools(&registry, disk_registry, test_permission_engine()).await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        assert!(
+            content.chars().count() <= 15000,
+            "section too long: {}",
+            content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_tools_section_empty_registry() {
+        let registry = ToolRegistry::new();
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+        };
+        let section = build_tools_section(&registry, &ctx).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        assert!(
+            content.is_empty(),
+            "expected empty content, got: {}",
+            content
+        );
+    }
+}

--- a/src/tools/builtin/bash.rs
+++ b/src/tools/builtin/bash.rs
@@ -7,7 +7,9 @@ use crate::permission::engine::engine_types::PermissionResponse;
 use crate::tasks::BackgroundTaskManager;
 use crate::tools::builtin::bash_classify;
 use crate::tools::security::{BashSecurityAnalyzer, TrustLevel};
-use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use crate::tools::{
+    PromptGenerationContext, Tool, ToolCallError, ToolContext, ToolFlags, ToolResult,
+};
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -83,6 +85,19 @@ impl Tool for BashTool {
          output exceeds threshold. Supports run_in_background for async \
          execution. Commands exceeding 15s are auto-backgrounded."
             .to_string()
+    }
+
+    #[rustfmt::skip]
+    fn generate_prompt(&self, context: &PromptGenerationContext) -> String {
+        let Some(wd) = &context.workdir else { return self.detail() };
+        let mut s = format!(" Working directory: {}.", wd.path);
+        if wd.has_git {
+            if let Some(b) = &wd.branch { s.push_str(&format!(" Branch: {}.", b)); }
+            if wd.recent_changes > 0 {
+                s.push_str(&format!(" {} uncommitted change(s).", wd.recent_changes));
+            }
+        }
+        format!("{}{}", self.detail(), s)
     }
 
     fn input_schema(&self) -> Value {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -66,6 +66,30 @@ pub struct ToolContext {
 }
 
 // ---------------------------------------------------------------------------
+// PromptGenerationContext —动态提示词生成上下文
+// ---------------------------------------------------------------------------
+
+/// Runtime context for dynamic tool prompt generation.
+///
+/// Distinct from [`ToolContext`]: `ToolContext` carries execution-time
+/// information used when the LLM *calls* a tool, while
+/// `PromptGenerationContext` carries information used when the system
+/// prompt *describes* a tool. The two contexts evolve independently.
+#[derive(Debug, Clone)]
+pub struct PromptGenerationContext {
+    /// ID of the agent for which the prompt is being built.
+    pub agent_id: String,
+    /// Current working directory context (if set).
+    pub workdir: Option<crate::system_prompt::WorkdirContext>,
+    /// Names of all tools currently available to the LLM.
+    ///
+    /// Only names are passed (not descriptors) to avoid coupling
+    /// `PromptGenerationContext` back to [`ToolDescriptor`] and to
+    /// keep the context cheap to construct.
+    pub available_tool_names: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
 // ToolDescriptor —一级摘要数据
 // ---------------------------------------------------------------------------
 
@@ -193,6 +217,18 @@ pub trait Tool: Send + Sync {
     /// Shown when the LLM requests second-level detail (via ToolSearch).
     fn detail(&self) -> String;
 
+    /// Returns the prompt-layer description for this tool.
+    ///
+    /// Unlike [`Tool::detail`] (which is a static string), `generate_prompt`
+    /// can adapt its output to runtime context: current permissions, the set
+    /// of available tools, the working directory, etc.
+    ///
+    /// The default implementation falls back to [`Tool::detail`], so existing
+    /// tools behave identically until they opt in to a custom Prompt layer.
+    fn generate_prompt(&self, _context: &PromptGenerationContext) -> String {
+        self.detail()
+    }
+
     /// Returns the JSON Schema for this tool's input parameters.
     fn input_schema(&self) -> Value;
 
@@ -206,6 +242,9 @@ pub trait Tool: Send + Sync {
     /// Returns this tool's runtime flags.
     fn flags(&self) -> ToolFlags;
 }
+
+#[cfg(test)]
+mod prompt_generation_tests;
 
 #[cfg(test)]
 mod tests {
@@ -248,5 +287,55 @@ mod tests {
         let err = ToolError::NotFound("Read".to_string());
         assert!(err.to_string().contains("Read"));
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_prompt_generation_context_construction() {
+        let ctx = PromptGenerationContext {
+            agent_id: "agent-1".to_string(),
+            workdir: None,
+            available_tool_names: vec!["Read".to_string(), "Bash".to_string()],
+        };
+        assert_eq!(ctx.agent_id, "agent-1");
+        assert!(ctx.workdir.is_none());
+        assert_eq!(ctx.available_tool_names.len(), 2);
+    }
+
+    /// Minimal test tool for verifying `generate_prompt` default behavior.
+    struct StaticTool;
+
+    #[async_trait]
+    impl Tool for StaticTool {
+        fn name(&self) -> &str {
+            "StaticTool"
+        }
+        fn group(&self) -> &str {
+            "test"
+        }
+        fn summary(&self) -> String {
+            "summary".to_string()
+        }
+        fn detail(&self) -> String {
+            "static-detail".to_string()
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        fn flags(&self) -> ToolFlags {
+            ToolFlags::default()
+        }
+    }
+
+    #[test]
+    fn test_generate_prompt_default_falls_back_to_detail() {
+        let tool = StaticTool;
+        let ctx = PromptGenerationContext {
+            agent_id: "agent-1".to_string(),
+            workdir: None,
+            available_tool_names: vec![],
+        };
+        // Default implementation should return exactly the value of `detail()`.
+        assert_eq!(tool.generate_prompt(&ctx), tool.detail());
+        assert_eq!(tool.generate_prompt(&ctx), "static-detail");
     }
 }

--- a/src/tools/prompt_generation_tests.rs
+++ b/src/tools/prompt_generation_tests.rs
@@ -1,0 +1,129 @@
+//! Unit tests for dynamic prompt generation across tools.
+//!
+//! These tests verify that the `generate_prompt` method on `BashTool`
+//! adapts its output to the runtime context: it embeds the workdir
+//! path when one is present, and the git branch / uncommitted changes
+//! when the workdir carries git information. Without a workdir, the
+//! implementation must fall back to the static `detail()` string.
+//!
+//! These tests live in a separate file (rather than inside
+//! `src/tools/mod.rs`'s inline `mod tests`) so they can be run in
+//! isolation via `cargo test --lib prompt_generation_tests`.
+
+use std::sync::Arc;
+
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::rules::RuleSetBuilder;
+use crate::system_prompt::WorkdirContext;
+use crate::tasks::BackgroundTaskManager;
+use crate::tools::builtin::BashTool;
+use crate::tools::{PromptGenerationContext, Tool};
+
+// --- Helpers (mirror the helpers in src/tools/builtin/bash_tests.rs) ---
+
+fn test_permission_engine() -> Arc<PermissionEngine> {
+    Arc::new(PermissionEngine::new_with_default_data_root(
+        RuleSetBuilder::new().build().unwrap(),
+    ))
+}
+
+fn test_bg_manager() -> Arc<BackgroundTaskManager> {
+    Arc::new(BackgroundTaskManager::new())
+}
+
+fn test_bash_tool() -> BashTool {
+    BashTool::new(test_permission_engine(), test_bg_manager())
+}
+
+// --- generate_prompt: workdir-aware behavior ---
+
+/// `generate_prompt` should embed the workdir path into the
+/// returned prompt when one is present in the context.
+#[test]
+fn test_generate_prompt_with_workdir() {
+    let tool = test_bash_tool();
+    let ctx = PromptGenerationContext {
+        agent_id: "agent-1".to_string(),
+        workdir: Some(WorkdirContext {
+            path: "/tmp/example-workdir".to_string(),
+            has_git: false,
+            branch: None,
+            recent_changes: 0,
+        }),
+        available_tool_names: vec!["Bash".to_string()],
+    };
+
+    let prompt = tool.generate_prompt(&ctx);
+
+    // Primary assertion: the workdir path is in the rendered prompt.
+    assert!(
+        prompt.contains("/tmp/example-workdir"),
+        "expected prompt to contain workdir path, got: {}",
+        prompt
+    );
+
+    // Sanity check: the static `detail()` body is preserved as a prefix.
+    assert_eq!(
+        prompt,
+        format!("{} Working directory: /tmp/example-workdir.", tool.detail())
+    );
+}
+
+/// `generate_prompt` should fall back to the static `detail()` body
+/// when no workdir is set in the context.
+#[test]
+fn test_generate_prompt_without_workdir() {
+    let tool = test_bash_tool();
+    let ctx = PromptGenerationContext {
+        agent_id: "agent-1".to_string(),
+        workdir: None,
+        available_tool_names: vec!["Bash".to_string()],
+    };
+
+    let prompt = tool.generate_prompt(&ctx);
+
+    // Without a workdir, generate_prompt must return exactly the same
+    // string as `detail()`.
+    assert_eq!(prompt, tool.detail());
+}
+
+/// `generate_prompt` should surface git information (branch name and
+/// the number of uncommitted changes) when the workdir context is a
+/// git repository.
+#[test]
+fn test_bash_prompt_includes_git_info() {
+    let tool = test_bash_tool();
+    let ctx = PromptGenerationContext {
+        agent_id: "agent-1".to_string(),
+        workdir: Some(WorkdirContext {
+            path: "/tmp/git-repo".to_string(),
+            has_git: true,
+            branch: Some("feat/dynamic-prompt-generation".to_string()),
+            recent_changes: 3,
+        }),
+        available_tool_names: vec!["Bash".to_string()],
+    };
+
+    let prompt = tool.generate_prompt(&ctx);
+
+    // The branch name must be present in the rendered prompt.
+    assert!(
+        prompt.contains("feat/dynamic-prompt-generation"),
+        "expected prompt to contain branch name, got: {}",
+        prompt
+    );
+
+    // The uncommitted changes count must be reported.
+    assert!(
+        prompt.contains("3 uncommitted change(s)"),
+        "expected prompt to mention 3 uncommitted changes, got: {}",
+        prompt
+    );
+
+    // And the workdir path itself must still be present.
+    assert!(
+        prompt.contains("/tmp/git-repo"),
+        "expected prompt to contain workdir path, got: {}",
+        prompt
+    );
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use crate::tools::{Tool, ToolContext, ToolDescriptor, ToolError};
+use crate::tools::{PromptGenerationContext, Tool, ToolContext, ToolDescriptor, ToolError};
 
 use serde_json::Value;
 
@@ -23,12 +23,13 @@ struct ToolInfo {
 }
 
 impl ToolInfo {
-    fn from_tool(tool: &Arc<dyn Tool>) -> Self {
+    fn from_tool(tool: &Arc<dyn Tool>, context: &PromptGenerationContext) -> Self {
         let flags = tool.flags();
         Self {
             name: tool.name().to_string(),
             group: tool.group().to_string(),
-            detail: tool.detail(),
+            // Use the dynamic Prompt layer (default falls back to `detail()`).
+            detail: tool.generate_prompt(context),
             input_schema: tool.input_schema(),
             is_deferred: flags.is_deferred_by_default,
             is_read_only: flags.is_read_only,
@@ -184,11 +185,20 @@ impl ToolRegistry {
     ///
     /// Groups tools by `group()`, formats each group with a header and tool
     /// list, then truncates at `TOOLS_SECTION_MAX_LEN` if needed.
-    pub async fn build_tools_section(&self, _ctx: &ToolContext) -> String {
+    ///
+    /// `ctx` is the prompt-generation context: it carries agent identity,
+    /// workdir, and the list of currently available tool names. Each tool's
+    /// `detail` field is produced by [`Tool::generate_prompt`], so a tool that
+    /// has opted into a custom Prompt layer will see a tailored description
+    /// here; otherwise the static `detail()` string is used.
+    pub async fn build_tools_section(&self, ctx: &PromptGenerationContext) -> String {
         let guard = self.tools.read().await;
 
         // Collect ToolInfo from all registered tools
-        let tool_infos: Vec<ToolInfo> = guard.values().map(|t| ToolInfo::from_tool(t)).collect();
+        let tool_infos: Vec<ToolInfo> = guard
+            .values()
+            .map(|t| ToolInfo::from_tool(t, ctx))
+            .collect();
 
         // Group by group name
         let mut groups_map: std::collections::HashMap<String, Vec<ToolInfo>> =

--- a/src/tools/registry_tests.rs
+++ b/src/tools/registry_tests.rs
@@ -42,6 +42,15 @@ fn make_ctx() -> ToolContext {
     }
 }
 
+/// Build a `PromptGenerationContext` for the named tools.
+fn make_prompt_ctx(names: &[&str]) -> PromptGenerationContext {
+    PromptGenerationContext {
+        agent_id: "test-agent".to_string(),
+        workdir: None,
+        available_tool_names: names.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
 #[tokio::test]
 async fn test_register_and_get_detail() {
     let reg = ToolRegistry::new();
@@ -183,7 +192,7 @@ async fn test_tool_info_from_tool() {
 
     let guard = reg.tools.read().await;
     let tool = guard.get("Read").unwrap();
-    let info = ToolInfo::from_tool(tool);
+    let info = ToolInfo::from_tool(tool, &make_prompt_ctx(&["Read"]));
     assert_eq!(info.name, "Read");
     assert_eq!(info.group, "file_ops");
     assert_eq!(info.detail, "detail for Read");
@@ -217,7 +226,7 @@ async fn test_build_tools_section() {
     .await
     .unwrap();
 
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&["Read", "ToolSearch"]);
     let section = reg.build_tools_section(&ctx).await;
     assert!(section.contains("file_ops"), "section: {section}");
     assert!(
@@ -259,7 +268,7 @@ async fn test_build_tools_section_with_detail() {
     .await
     .unwrap();
 
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&["Read", "Write"]);
     let section = reg.build_tools_section(&ctx).await;
     // Eager: bold name + detail
     assert!(
@@ -304,7 +313,7 @@ async fn test_build_tools_section_deferred_group() {
     .await
     .unwrap();
 
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&["SlowOp", "Cleanup"]);
     let section = reg.build_tools_section(&ctx).await;
     // Deferred group header must show "(deferred)"
     assert!(
@@ -385,7 +394,7 @@ async fn test_build_tools_section_danger_marks() {
     .await
     .unwrap();
 
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&["Viewer", "Deleter", "Lister", "DReader", "DDeleter"]);
     let section = reg.build_tools_section(&ctx).await;
     // Eager read-only: bold name + "(read-only)" + detail
     assert!(
@@ -451,7 +460,7 @@ async fn test_build_tools_section_eager_and_deferred_group() {
     .await
     .unwrap();
 
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&["Query", "Purge", "Compute"]);
     let section = reg.build_tools_section(&ctx).await;
     // Mixed group (eager + deferred): should say "(always loaded)"
     assert!(
@@ -478,7 +487,7 @@ async fn test_build_tools_section_eager_and_deferred_group() {
 #[tokio::test]
 async fn test_build_tools_section_empty() {
     let reg = ToolRegistry::new();
-    let ctx = make_ctx();
+    let ctx = make_prompt_ctx(&[]);
     let section = reg.build_tools_section(&ctx).await;
     assert!(section.is_empty());
 }


### PR DESCRIPTION
## 变更内容

实现工具提示词的动态生成机制，使工具的 LLM 说明能根据运行时上下文动态调整。

- 新增 `PromptGenerationContext` struct（agent_id、workdir、available_tool_names）
- `Tool` trait 新增 `generate_prompt()` 方法，默认回退到 `detail()`
- `build_tools_section` 改用 `generate_prompt()` 替代 `detail()`
- `BashTool` 实现 Prompt 层，根据工作目录动态调整描述
- 新增 3 个单元测试覆盖动态生成逻辑
- 提取 `build_tools_section` 到独立 `tools_section.rs`（builder.rs 行数控制）

Source: issue #788
Type: feat
