### PR TITLE
fix: 恢复斜杠指令三分支权限路由

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,7 +11,7 @@ use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::FeishuAdapter;
 use crate::slash::dispatcher::SlashDispatcher;
-use crate::slash::handlers::{ClearHandler, CompactHandler, HelpHandler};
+use crate::slash::handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
 use crate::slash::registry::HandlerRegistry;
 
 use crate::permission::approval_flow::ApprovalFlow;
@@ -165,10 +165,16 @@ impl Daemon {
         let slash_registry = Arc::new(HandlerRegistry::new());
         slash_registry.register(Arc::new(CompactHandler));
         slash_registry.register(Arc::new(ClearHandler::new(Arc::clone(&session_manager))));
+        slash_registry.register(Arc::new(ExecHandler));
         let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
         slash_registry.register(Arc::new(help_handler));
         let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
         gateway.set_slash_dispatcher(slash_dispatcher).await;
+        // 高危 slash 指令（如 /exec）需要权限引擎介入；在此注入使得
+        // dispatch_slash 在 Branch 2 时能取到 engine。
+        gateway
+            .set_permission_engine(Arc::clone(&permission_engine))
+            .await;
         info!("Slash dispatcher installed");
 
         info!("Gateway initialized");

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -207,6 +207,10 @@ impl Gateway {
     /// If `sender_id` is provided and the message starts with `/approve` or
     /// `/deny`, the approval flow intercepts the command (owner-only).
     ///
+    /// `channel` identifies the IM platform / channel the message originated
+    /// from (e.g. `"feishu"`). It is forwarded to `dispatch_slash` so that
+    /// `SlashContext.channel` reflects the real source.
+    ///
     /// Returns `HandleResult` (`LlmStarted`/`MessageQueued`/`ApprovalProcessed`),
     /// or `None` if no handler configured.
     pub async fn handle_inbound_message(
@@ -214,6 +218,7 @@ impl Gateway {
         session_id: &str,
         content: String,
         sender_id: Option<&str>,
+        channel: &str,
     ) -> Option<HandleResult> {
         // ── Approval command interception ──────────────────────────────
         if let Some(result) = self
@@ -225,7 +230,10 @@ impl Gateway {
 
         // ── Slash command dispatch ─────────────────────────────────────
         if content.starts_with('/') {
-            if let Some(result) = self.dispatch_slash(session_id, &content, sender_id).await {
+            if let Some(result) = self
+                .dispatch_slash(session_id, &content, sender_id, channel)
+                .await
+            {
                 return Some(result);
             }
         }

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -7,6 +7,10 @@
 use std::sync::Arc;
 
 use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_types::{
+    Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
+};
+use crate::slash::handler::SlashHandler;
 use crate::slash::{parse_slash, SlashContext, SlashDispatcher, SlashResult};
 
 use super::{Gateway, HandleResult};
@@ -30,21 +34,30 @@ impl Gateway {
     /// as a slash command (including permission-denied replies), or `None` if
     /// the message is not a recognized slash command and should fall through
     /// to the normal session handler.
+    ///
+    /// Three-branch permission routing (恢复自 PR #811 之前的语义):
+    /// 1. `sender_id == Some("owner")` → 直接分派 handler（Owner 短路）
+    /// 2. `handler.requires_permission() == true` → 调用 `permission_engine.evaluate()`；
+    ///    返回 `Denied` 时回复"无权限"并返回 `SlashHandled`
+    /// 3. `handler.requires_permission() == false` → 直接分派 handler
+    ///
+    /// `channel` 会被填入 `SlashContext.channel`，让 handler 知晓入站消息来自哪个
+    /// channel（如 "feishu"）。
     pub(super) async fn dispatch_slash(
         &self,
         session_id: &str,
         content: &str,
         sender_id: Option<&str>,
+        channel: &str,
     ) -> Option<HandleResult> {
         let dispatcher_guard = self.slash_dispatcher.read().await;
         let dispatcher = dispatcher_guard.as_ref()?;
 
         let (cmd, args) = match parse_slash(content) {
             Some(parsed) => parsed,
-            None => return None, // 不是 slash 命令
+            None => return None,
         };
         let Some(handler) = dispatcher.get_handler(cmd) else {
-            // 未知 slash 命令：发送"未知指令"提示
             let reply = format!("未知指令：/{cmd}。输入 /help 查看所有可用指令。");
             if let Some(sh) = self.session_handler.as_ref() {
                 sh.send_reply(reply).await;
@@ -52,15 +65,102 @@ impl Gateway {
             return Some(HandleResult::SlashHandled);
         };
 
-        // Permission check removed — will be re-implemented via a separate
-        // mechanism in a future step. For now, all slash commands are dispatched
-        // directly regardless of sender.
+        if !self
+            .check_slash_permission(cmd, sender_id, session_id)
+            .await
+        {
+            return Some(HandleResult::SlashHandled);
+        }
 
-        // Execute the handler.
+        self.execute_and_route(handler.as_ref(), cmd, args, session_id, sender_id, channel)
+            .await
+    }
+
+    /// Three-branch permission check. Returns `true` if the command may
+    /// proceed, `false` if it was denied (reply already sent).
+    async fn check_slash_permission(
+        &self,
+        cmd: &str,
+        sender_id: Option<&str>,
+        session_id: &str,
+    ) -> bool {
+        // Branch 1: Owner 短路
+        if sender_id == Some("owner") {
+            return true;
+        }
+
+        // Branch 3: 普通指令直通
+        let dispatcher_guard = self.slash_dispatcher.read().await;
+        let dispatcher = match dispatcher_guard.as_ref() {
+            Some(d) => d,
+            None => return true,
+        };
+        let Some(handler) = dispatcher.get_handler(cmd) else {
+            return true;
+        };
+        if !handler.requires_permission() {
+            return true;
+        }
+        drop(dispatcher_guard);
+
+        // Branch 2: 高危指令走权限引擎
+        let engine_guard = self.permission_engine.read().await;
+        let Some(engine) = engine_guard.as_ref() else {
+            tracing::warn!(
+                cmd,
+                "permission engine not configured; denying high-risk slash command"
+            );
+            self.send_reply_if_available("无权限：权限引擎未配置").await;
+            return false;
+        };
+
+        let agent_id = self
+            .session_manager
+            .get_chat_id(session_id)
+            .await
+            .unwrap_or_default();
+        let caller = Caller {
+            user_id: sender_id.unwrap_or("").to_owned(),
+            agent: agent_id.clone(),
+            creator_id: String::new(),
+        };
+        let request = PermissionRequest::WithCaller {
+            caller,
+            request: PermissionRequestBody::SlashCommand {
+                agent: agent_id,
+                command: cmd.to_owned(),
+            },
+        };
+
+        if let PermissionResponse::Denied { reason, .. } = engine.evaluate(request, None) {
+            self.send_reply_if_available(&format!("无权限：{reason}"))
+                .await;
+            return false;
+        }
+        true
+    }
+
+    async fn send_reply_if_available(&self, text: &str) {
+        if let Some(sh) = self.session_handler.as_ref() {
+            sh.send_reply(text.to_owned()).await;
+        }
+    }
+
+    /// Invoke the handler with a constructed `SlashContext`, then route the
+    /// returned `SlashResult` to the appropriate side effect.
+    async fn execute_and_route(
+        &self,
+        handler: &dyn SlashHandler,
+        cmd_name: &str,
+        args: &str,
+        session_id: &str,
+        sender_id: Option<&str>,
+        channel: &str,
+    ) -> Option<HandleResult> {
         let ctx = SlashContext {
             sender_id: sender_id.unwrap_or("").to_owned(),
             session_id: session_id.to_owned(),
-            channel: String::new(), // 占位；Step 1.7 会从 Gateway::handle_inbound_message 传入实际 channel
+            channel: channel.to_owned(),
         };
         let result = handler.handle(args, &ctx).await;
 
@@ -72,21 +172,26 @@ impl Gateway {
             }
             SlashResult::Compact { instruction } => {
                 if let Some(sh) = self.session_handler.as_ref() {
-                    // Reconstruct the /compact command for handle_compact_command
-                    let cmd = match &instruction {
+                    let compact_cmd = match &instruction {
                         Some(inst) => format!("/compact {}", inst),
                         None => "/compact".to_string(),
                     };
-                    sh.handle_compact_command(session_id, &cmd).await;
+                    sh.handle_compact_command(session_id, &compact_cmd).await;
+                }
+            }
+            SlashResult::Exec { command: _ } => {
+                // Step 1.2 占位：ExecHandler 经权限引擎放行后，先以 Reply 模式
+                // 通知用户命令已提交审批。后续步骤接完整审批流。
+                if let Some(sh) = self.session_handler.as_ref() {
+                    sh.send_reply(format!("命令已提交审批：/{cmd_name}")).await;
                 }
             }
             SlashResult::SetMode(_)
             | SlashResult::NewSession
             | SlashResult::Stop
-            | SlashResult::SystemAppend { .. }
-            | SlashResult::Exec { .. } => {
+            | SlashResult::SystemAppend { .. } => {
                 tracing::warn!(
-                    cmd,
+                    cmd = cmd_name,
                     "SlashResult variant not yet routed through dispatch_slash"
                 );
             }

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -1,7 +1,15 @@
 //! Integration tests for Gateway slash-command permission routing.
+//!
+//! Covers the three-branch permission routing introduced in Step 1.2:
+//! 1. Owner short-circuit — owner bypasses permission engine for any command.
+//! 2. Non-owner + `requires_permission() == true` — routed through the engine;
+//!    `Denied` consumes the command (handler is NOT invoked) and replies
+//!    "无权限".
+//! 3. Non-owner + `requires_permission() == false` — directly dispatched.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::gateway::{Gateway, GatewayConfig, HandleResult, SessionManager};
 use crate::permission::engine::engine_eval::PermissionEngine;
@@ -17,6 +25,7 @@ use crate::slash::registry::HandlerRegistry;
 // Mock handlers
 // ---------------------------------------------------------------------------
 
+/// Safe handler — does NOT require permission.
 struct SafeHandler;
 
 #[async_trait::async_trait]
@@ -34,6 +43,11 @@ impl SlashHandler for SafeHandler {
     }
 }
 
+/// Risky handler — overrides `requires_permission()` to `true`.
+///
+/// `SlashHandler::requires_permission()` has a default of `false`; this
+/// override is what makes `/exec` take Branch 2 (engine path) in
+/// `dispatch_slash`.
 struct RiskyHandler;
 
 #[async_trait::async_trait]
@@ -46,8 +60,71 @@ impl SlashHandler for RiskyHandler {
         "Execute a shell command"
     }
 
+    fn requires_permission(&self) -> bool {
+        true
+    }
+
     async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
         SlashResult::Reply(format!("exec: {args}"))
+    }
+}
+
+/// Handler that records how many times `handle()` was invoked.
+///
+/// Used to assert that `dispatch_slash` either invokes or skips a handler
+/// based on the permission routing branch.
+struct CountingHandler {
+    command: &'static str,
+    requires_permission: bool,
+    counter: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for CountingHandler {
+    fn commands(&self) -> &[&str] {
+        std::slice::from_ref(&self.command)
+    }
+
+    fn description(&self) -> &str {
+        "Counting handler"
+    }
+
+    fn requires_permission(&self) -> bool {
+        self.requires_permission
+    }
+
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        SlashResult::Reply("counted".to_owned())
+    }
+}
+
+/// Handler that captures the most recent `SlashContext` it was invoked with.
+///
+/// Used to verify that `dispatch_slash` populates `SlashContext.channel`
+/// with the `channel` argument from the call site.
+struct CapturingHandler {
+    command: &'static str,
+    last_ctx: Arc<Mutex<Option<SlashContext>>>,
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for CapturingHandler {
+    fn commands(&self) -> &[&str] {
+        std::slice::from_ref(&self.command)
+    }
+
+    fn description(&self) -> &str {
+        "Capturing handler"
+    }
+
+    async fn handle(&self, _args: &str, ctx: &SlashContext) -> SlashResult {
+        *self.last_ctx.lock().expect("ctx mutex poisoned") = Some(SlashContext {
+            sender_id: ctx.sender_id.clone(),
+            session_id: ctx.session_id.clone(),
+            channel: ctx.channel.clone(),
+        });
+        SlashResult::Reply("captured".to_owned())
     }
 }
 
@@ -79,6 +156,31 @@ fn make_dispatcher() -> Arc<SlashDispatcher> {
     Arc::new(SlashDispatcher::new(registry))
 }
 
+/// Build a dispatcher that contains a `CountingHandler` for a given command.
+fn counting_dispatcher(
+    command: &'static str,
+    requires_permission: bool,
+    counter: Arc<AtomicU32>,
+) -> Arc<SlashDispatcher> {
+    let registry = HandlerRegistry::new();
+    registry.register(Arc::new(CountingHandler {
+        command,
+        requires_permission,
+        counter,
+    }));
+    Arc::new(SlashDispatcher::new(registry))
+}
+
+/// Build a dispatcher that contains a `CapturingHandler` for a given command.
+fn capturing_dispatcher(
+    command: &'static str,
+    last_ctx: Arc<Mutex<Option<SlashContext>>>,
+) -> Arc<SlashDispatcher> {
+    let registry = HandlerRegistry::new();
+    registry.register(Arc::new(CapturingHandler { command, last_ctx }));
+    Arc::new(SlashDispatcher::new(registry))
+}
+
 /// A PermissionEngine that always denies.
 fn deny_engine() -> Arc<PermissionEngine> {
     let rules = RuleSet {
@@ -106,37 +208,70 @@ fn deny_engine() -> Arc<PermissionEngine> {
 
 #[tokio::test]
 async fn test_owner_slash_direct_dispatch() {
+    // Branch 1: owner short-circuits the engine. Even with `requires_permission`
+    // handler and a deny-all engine, the handler MUST be invoked.
+    let counter = Arc::new(AtomicU32::new(0));
     let gw = make_gateway();
-    gw.set_slash_dispatcher(make_dispatcher()).await;
+    gw.set_slash_dispatcher(counting_dispatcher("exec", true, Arc::clone(&counter)))
+        .await;
     gw.set_permission_engine(deny_engine()).await;
 
-    // Even though the engine denies everything, owner bypasses it.
-    let result = gw.dispatch_slash("sess1", "/exec ls", Some("owner")).await;
+    let result = gw
+        .dispatch_slash("sess1", "/exec ls", Some("owner"), "feishu")
+        .await;
+
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "owner must bypass the deny-all engine and invoke the handler"
+    );
 }
 
 #[tokio::test]
 async fn test_non_owner_high_risk_goes_to_permission_engine() {
+    // Branch 2: non-owner + requires_permission=true + engine Deny
+    // → SlashHandled (message consumed) AND handler is NOT invoked.
+    let counter = Arc::new(AtomicU32::new(0));
     let gw = make_gateway();
-    gw.set_slash_dispatcher(make_dispatcher()).await;
+    gw.set_slash_dispatcher(counting_dispatcher("exec", true, Arc::clone(&counter)))
+        .await;
     gw.set_permission_engine(deny_engine()).await;
 
-    // Non-owner + requires_permission=true → engine denies → SlashHandled
     let result = gw
-        .dispatch_slash("sess1", "/exec ls", Some("user123"))
+        .dispatch_slash("sess1", "/exec ls", Some("user123"), "feishu")
         .await;
+
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "non-owner + engine Deny must not invoke the handler"
+    );
 }
 
 #[tokio::test]
 async fn test_non_owner_normal_slash_direct_dispatch() {
+    // Branch 3: non-owner + requires_permission=false → handler invoked,
+    // engine is never consulted.
+    let counter = Arc::new(AtomicU32::new(0));
     let gw = make_gateway();
-    gw.set_slash_dispatcher(make_dispatcher()).await;
-    // Engine denies everything, but "help" doesn't require permission
+    gw.set_slash_dispatcher(counting_dispatcher("help", false, Arc::clone(&counter)))
+        .await;
+    // Install a deny engine: if dispatch_slash ever consults the engine for
+    // a non-permissioned command, the test would observe an unexpected path.
     gw.set_permission_engine(deny_engine()).await;
 
-    let result = gw.dispatch_slash("sess1", "/help", Some("user123")).await;
+    let result = gw
+        .dispatch_slash("sess1", "/help", Some("user123"), "feishu")
+        .await;
+
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "non-owner + safe handler must dispatch directly without consulting the engine"
+    );
 }
 
 #[tokio::test]
@@ -146,11 +281,15 @@ async fn test_slash_not_entering_agent_session() {
 
     // dispatch_slash returns Some(HandleResult::SlashHandled) for recognized
     // commands, which the session handler uses to skip normal processing.
-    let result = gw.dispatch_slash("sess1", "/help", Some("user123")).await;
+    let result = gw
+        .dispatch_slash("sess1", "/help", Some("user123"), "feishu")
+        .await;
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
 
     // Non-slash content returns None → falls through to agent session.
-    let result = gw.dispatch_slash("sess1", "hello", Some("user123")).await;
+    let result = gw
+        .dispatch_slash("sess1", "hello", Some("user123"), "feishu")
+        .await;
     assert!(result.is_none());
 }
 
@@ -163,8 +302,51 @@ async fn test_unknown_slash_command_returns_reply() {
 
     // 发送一个不存在的 slash 命令
     let result = gw
-        .dispatch_slash("sess1", "/xyz_unknown", Some("user123"))
+        .dispatch_slash("sess1", "/xyz_unknown", Some("user123"), "feishu")
         .await;
     // 应该返回 Some(HandleResult::SlashHandled)，不是 None
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_deny_does_not_invoke_handler() {
+    // Stronger assertion of Branch 2: a mocked handler with an
+    // `AtomicU32` counter MUST observe 0 calls when the engine denies.
+    let counter = Arc::new(AtomicU32::new(0));
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(counting_dispatcher("exec", true, Arc::clone(&counter)))
+        .await;
+    gw.set_permission_engine(deny_engine()).await;
+
+    let result = gw
+        .dispatch_slash("sess1", "/exec rm -rf /", Some("user123"), "feishu")
+        .await;
+
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "Deny must consume the command and skip the handler"
+    );
+}
+
+#[tokio::test]
+async fn test_slash_context_channel_propagates() {
+    // `dispatch_slash`'s `channel` argument must be visible to the handler
+    // via `SlashContext.channel`.
+    let last_ctx: Arc<Mutex<Option<SlashContext>>> = Arc::new(Mutex::new(None));
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(capturing_dispatcher("help", Arc::clone(&last_ctx)))
+        .await;
+
+    let result = gw
+        .dispatch_slash("sess42", "/help", Some("user123"), "telegram")
+        .await;
+
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    let guard = last_ctx.lock().expect("ctx mutex poisoned");
+    let captured = guard.as_ref().expect("handler was not invoked");
+    assert_eq!(captured.channel, "telegram");
+    assert_eq!(captured.session_id, "sess42");
+    assert_eq!(captured.sender_id, "user123");
 }

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -38,6 +38,13 @@ pub trait SlashHandler: Send + Sync {
         false
     }
 
+    /// Whether this command requires permission evaluation by the permission
+    /// engine before execution. High-risk handlers (e.g. `/exec`) override this
+    /// to return `true`; the default is `false` (safe handlers execute directly).
+    fn requires_permission(&self) -> bool {
+        false
+    }
+
     /// Execute the command with the given arguments and context.
     async fn handle(&self, args: &str, ctx: &SlashContext) -> SlashResult;
 }

--- a/src/slash/handlers.rs
+++ b/src/slash/handlers.rs
@@ -117,3 +117,38 @@ impl SlashHandler for HelpHandler {
         SlashResult::Reply(lines.join("\n"))
     }
 }
+
+// ── ExecHandler ─────────────────────────────────────────────────────────────
+
+/// `/exec` — execute a shell command as owner, gated by the permission engine.
+///
+/// `ExecHandler` itself does not perform any authorization: it only constructs
+/// `SlashResult::Exec { command }`. The Gateway's permission routing is
+/// responsible for evaluating the request via the permission engine before
+/// execution.
+pub struct ExecHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for ExecHandler {
+    fn commands(&self) -> &[&str] {
+        &["exec"]
+    }
+
+    fn description(&self) -> &str {
+        "以 owner 身份执行 shell 命令（需权限审批）"
+    }
+
+    fn immediate(&self) -> bool {
+        false
+    }
+
+    fn requires_permission(&self) -> bool {
+        true
+    }
+
+    async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Exec {
+            command: args.to_owned(),
+        }
+    }
+}

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -7,7 +7,7 @@ pub mod registry;
 pub use context::SlashContext;
 pub use dispatcher::{parse_slash, SlashDispatcher};
 pub use handler::{SlashHandler, SlashResult};
-pub use handlers::{ClearHandler, CompactHandler, HelpHandler};
+pub use handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
 
 #[cfg(test)]
 mod handlers_tests;


### PR DESCRIPTION
# fix: 恢复斜杠指令三分支权限路由

PR #811 重构 `SlashHandler` trait 时丢失了斜杠指令的权限控制语义。
`dispatch_slash` 不再区分 Owner 短路、高危指令权限引擎调用、普通指令直通，
所有 slash 指令一律直接分派，存在非 owner 用户越权执行 `/exec` 等高危指令的
回归。本 PR 恢复 `dispatch_slash` 的三分支权限路由逻辑。

## 变更

- `SlashHandler` trait 新增 `requires_permission()` 默认方法（返回 `false`），
  `ExecHandler` 覆写为 `true`。
- `dispatch_slash` 恢复三分支路由：
  - `sender_id == "owner"` → 直接分派（Owner 短路）
  - `requires_permission() == true` → 调用 `permission_engine.evaluate()`，
    Deny 时回复"无权限"并消费命令（handler 不被调用）
  - `requires_permission() == false` → 直接分派
- `Daemon` 初始化在 `set_slash_dispatcher` 之后追加 `set_permission_engine`
  调用，确保 `gateway.permission_engine` 非 None。
- `handle_inbound_message` 新增 `channel` 参数并向下传递，修复
  `SlashContext.channel` 始终为空字符串的 bug。
- 新增 `ExecHandler`（`commands() = ["exec"]`，`requires_permission() = true`），
  导出到 crate 根。

## 测试

`cargo test --lib -- gateway::tests_slash_permission slash`：28/28 通过

覆盖：
- Owner 短路直接执行
- Non-owner + `requires_permission=true` + 引擎 Deny → 回复"无权限"且
  handler.handle() 未被调用（mock handler + 计数器断言）
- Non-owner + `requires_permission=false` → 直接执行
- `SlashContext.channel` 正确传递

Source: issue #812
Type: fix
