### PR TITLE
feat: 实现 /cd /pwd /git WorkdirHandler 工作目录斜杠指令

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,7 +11,9 @@ use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::FeishuAdapter;
 use crate::slash::dispatcher::SlashDispatcher;
-use crate::slash::handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
+use crate::slash::handlers::{
+    ClearHandler, CompactHandler, ExecHandler, HelpHandler, WorkdirHandler,
+};
 use crate::slash::registry::HandlerRegistry;
 
 use crate::permission::approval_flow::ApprovalFlow;
@@ -166,6 +168,7 @@ impl Daemon {
         slash_registry.register(Arc::new(CompactHandler));
         slash_registry.register(Arc::new(ClearHandler::new(Arc::clone(&session_manager))));
         slash_registry.register(Arc::new(ExecHandler));
+        slash_registry.register(Arc::new(WorkdirHandler::new(Arc::clone(&session_manager))));
         let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
         slash_registry.register(Arc::new(help_handler));
         let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -158,6 +158,7 @@ impl Gateway {
         channel: &str,
     ) -> Option<HandleResult> {
         let ctx = SlashContext {
+            command: cmd_name.to_owned(),
             sender_id: sender_id.unwrap_or("").to_owned(),
             session_id: session_id.to_owned(),
             channel: channel.to_owned(),

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -120,6 +120,7 @@ impl SlashHandler for CapturingHandler {
 
     async fn handle(&self, _args: &str, ctx: &SlashContext) -> SlashResult {
         *self.last_ctx.lock().expect("ctx mutex poisoned") = Some(SlashContext {
+            command: ctx.command.clone(),
             sender_id: ctx.sender_id.clone(),
             session_id: ctx.session_id.clone(),
             channel: ctx.channel.clone(),

--- a/src/slash/context.rs
+++ b/src/slash/context.rs
@@ -1,5 +1,10 @@
 /// Execution context for a slash command invocation.
 pub struct SlashContext {
+    /// The slash command name (without the leading `/`).
+    ///
+    /// For multi-command handlers (e.g. `WorkdirHandler` handling `cd`,
+    /// `pwd`, `git`) this lets `handle()` branch on the invoked subcommand.
+    pub command: String,
     pub sender_id: String,
     pub session_id: String,
     pub channel: String,

--- a/src/slash/dispatcher.rs
+++ b/src/slash/dispatcher.rs
@@ -59,7 +59,13 @@ impl SlashDispatcher {
         let Some(handler) = self.registry.get(cmd) else {
             return SlashResult::Unknown(content.to_owned());
         };
-        handler.handle(args, ctx).await
+        let ctx_with_cmd = SlashContext {
+            command: cmd.to_owned(),
+            sender_id: ctx.sender_id.clone(),
+            session_id: ctx.session_id.clone(),
+            channel: ctx.channel.clone(),
+        };
+        handler.handle(args, &ctx_with_cmd).await
     }
 
     /// Check whether a command is an Immediate command (responds even when

--- a/src/slash/handlers.rs
+++ b/src/slash/handlers.rs
@@ -1,11 +1,13 @@
 //! Built-in slash command handlers.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::gateway::SessionManager;
 use crate::slash::context::SlashContext;
 use crate::slash::handler::{SlashHandler, SlashResult};
 use crate::slash::registry::HandlerRegistry;
+use crate::system_prompt::build_git_status_for;
 
 // ── CompactHandler ──────────────────────────────────────────────────────────
 
@@ -149,6 +151,120 @@ impl SlashHandler for ExecHandler {
     async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
         SlashResult::Exec {
             command: args.to_owned(),
+        }
+    }
+}
+
+// ── WorkdirHandler ──────────────────────────────────────────────────────────
+
+/// `/cd`, `/pwd`, `/git` — operate on the session's working directory.
+///
+/// All three commands are handled by a single struct because they share the
+/// same `SessionManager` dependency. Subcommand dispatch happens inside
+/// [`Self::handle`] by inspecting `ctx.command`.
+///
+/// - `/cd <path>`: validate the path exists, then look up the
+///   `ConversationSession` via `SessionManager::get_conversation_session`,
+///   mutate its workdir in place, and reply with the new path plus the
+///   current git branch (if any).
+/// - `/pwd`: read `ConversationSession::workdir` and reply with the path.
+/// - `/git <args>`: placeholder reply — full implementation will route
+///   through the permission engine for read-only git subcommands.
+///
+/// `immediate()` returns `false` so `/cd` queues behind a running LLM turn
+/// (consistent with the design doc — workdir changes should not interrupt
+/// in-flight LLM work).
+pub struct WorkdirHandler {
+    session_manager: Arc<SessionManager>,
+}
+
+impl WorkdirHandler {
+    /// Create a new WorkdirHandler operating on the given session manager.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+
+    /// Handle `/cd <path>`: validate path, set session workdir, reply with
+    /// path + git status.
+    async fn handle_cd(&self, args: &str, ctx: &SlashContext) -> SlashResult {
+        let path_str = args.trim();
+        if path_str.is_empty() {
+            return SlashResult::Reply("用法：/cd <路径>".to_owned());
+        }
+
+        let path = PathBuf::from(path_str);
+        if !Path::new(&path).exists() {
+            return SlashResult::Reply(format!("目录不存在：{path_str}"));
+        }
+
+        // Inline: look up ConversationSession and mutate its workdir directly.
+        // (Previously this lived on SessionManager::set_session_workdir, which
+        // was a thin wrapper around the same two operations.)
+        let Some(conv) = self
+            .session_manager
+            .get_conversation_session(&ctx.session_id)
+            .await
+        else {
+            return SlashResult::Reply("当前会话未激活".to_owned());
+        };
+        {
+            let mut cs = conv.write().await;
+            cs.set_workdir(path.clone());
+        }
+
+        let git_status = build_git_status_for(&path.to_string_lossy());
+        let mut reply = format!("工作目录已变更为：{}", path.display());
+        if let Some(status) = git_status {
+            reply.push('\n');
+            reply.push_str(&status);
+        }
+        SlashResult::Reply(reply)
+    }
+
+    /// Handle `/pwd`: read the current session workdir and reply with the path.
+    async fn handle_pwd(&self, ctx: &SlashContext) -> SlashResult {
+        let Some(conv) = self
+            .session_manager
+            .get_conversation_session(&ctx.session_id)
+            .await
+        else {
+            return SlashResult::Reply("当前会话未激活".to_owned());
+        };
+        let cs = conv.read().await;
+        SlashResult::Reply(cs.workdir().display().to_string())
+    }
+
+    /// Handle `/git <args>`: placeholder. Real routing through the permission
+    /// engine arrives in a follow-up step.
+    fn handle_git(&self, _args: &str) -> SlashResult {
+        SlashResult::Reply("git 指令即将支持".to_owned())
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for WorkdirHandler {
+    fn commands(&self) -> &[&str] {
+        &["cd", "pwd", "git"]
+    }
+
+    fn description(&self) -> &str {
+        "工作目录操作"
+    }
+
+    fn immediate(&self) -> bool {
+        false
+    }
+
+    async fn handle(&self, args: &str, ctx: &SlashContext) -> SlashResult {
+        match ctx.command.as_str() {
+            "cd" => self.handle_cd(args, ctx).await,
+            "pwd" => self.handle_pwd(ctx).await,
+            "git" => self.handle_git(args),
+            // WorkdirHandler should never be invoked with an unknown command;
+            // the dispatcher only routes registered commands to us.
+            other => SlashResult::Reply(format!(
+                "未知子指令：{other}。WorkdirHandler 支持 cd / pwd / git。"
+            )),
         }
     }
 }

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -2,10 +2,11 @@
 
 use std::sync::Arc;
 
+use crate::gateway::session_manager::SessionManager;
 use crate::slash::context::SlashContext;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handler::{SlashHandler, SlashResult};
-use crate::slash::handlers::{ClearHandler, CompactHandler, HelpHandler};
+use crate::slash::handlers::{ClearHandler, CompactHandler, HelpHandler, WorkdirHandler};
 use crate::slash::registry::HandlerRegistry;
 
 // ── Mock handler ────────────────────────────────────────────────────────────
@@ -35,6 +36,7 @@ impl SlashHandler for MockHandler {
 
 fn dummy_ctx() -> SlashContext {
     SlashContext {
+        command: String::new(),
         sender_id: "test_sender".to_owned(),
         session_id: "test_session".to_owned(),
         channel: "test_channel".to_owned(),
@@ -274,4 +276,165 @@ fn test_dispatcher_all_handlers() {
     let dispatcher = SlashDispatcher::new(registry);
     let handlers = dispatcher.all_handlers();
     assert_eq!(handlers.len(), 2);
+}
+
+// ── WorkdirHandler tests ────────────────────────────────────────────────────
+
+/// Construct a SessionManager the same way `test_clear_handler_handle_returns_reply`
+/// does. Returns just the manager — tests that need a session call
+/// `create_test_session` to obtain a `session_id`.
+fn make_workdir_session_manager() -> std::sync::Arc<SessionManager> {
+    use crate::gateway::DmScope;
+    use crate::session::bootstrap::loader::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
+
+    let gc = crate::gateway::GatewayConfig {
+        name: String::new(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: DmScope::default(),
+    };
+    Arc::new(SessionManager::new(
+        &gc,
+        None, // storage
+        None, // workspace_dir
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
+/// Pre-create a session via `SessionManager::find_or_create` and return its id.
+/// The returned id can be used to build a `SlashContext` so the handler resolves
+/// to a real session for `get_conversation_session`.
+async fn create_test_session(sm: &SessionManager) -> String {
+    use crate::gateway::Message;
+
+    let msg = Message {
+        id: "workdir-test-msg-1".to_string(),
+        from: "user-a".to_string(),
+        to: "agent-b".to_string(),
+        content: "hello".to_string(),
+        channel: "feishu".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+    };
+    let account_id: Option<&str> = None;
+    sm.find_or_create("feishu", &msg, account_id)
+        .await
+        .expect("session")
+}
+
+#[test]
+fn test_workdir_handler_commands_and_description() {
+    let sm = make_workdir_session_manager();
+    let h = WorkdirHandler::new(sm);
+    assert_eq!(h.commands(), &["cd", "pwd", "git"]);
+    assert_eq!(h.description(), "工作目录操作");
+    assert!(!h.immediate());
+}
+
+#[tokio::test]
+async fn test_workdir_handler_cd_valid_path() {
+    let sm = make_workdir_session_manager();
+    let session_id = create_test_session(&sm).await;
+    let handler = WorkdirHandler::new(Arc::clone(&sm));
+
+    let mut ctx = dummy_ctx();
+    ctx.session_id = session_id;
+    ctx.command = "cd".to_owned();
+
+    // Use a portable temp-dir path instead of hardcoding "/tmp" so the test
+    // passes on every platform (e.g. Windows uses %TEMP%).
+    let target_path = std::env::temp_dir();
+    let result = handler.handle(&target_path.to_string_lossy(), &ctx).await;
+    match result {
+        SlashResult::Reply(text) => {
+            assert!(
+                text.contains("工作目录已变更为"),
+                "expected '工作目录已变更为' in reply, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got non-Reply variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_workdir_handler_cd_invalid_path() {
+    let sm = make_workdir_session_manager();
+    let session_id = create_test_session(&sm).await;
+    let handler = WorkdirHandler::new(Arc::clone(&sm));
+
+    let mut ctx = dummy_ctx();
+    ctx.session_id = session_id;
+    ctx.command = "cd".to_owned();
+
+    let result = handler.handle("/nonexistent_xyz_path", &ctx).await;
+    match result {
+        SlashResult::Reply(text) => {
+            assert!(
+                text.contains("目录不存在"),
+                "expected '目录不存在' in reply, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got non-Reply variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_workdir_handler_pwd() {
+    let sm = make_workdir_session_manager();
+    let session_id = create_test_session(&sm).await;
+    let handler = WorkdirHandler::new(Arc::clone(&sm));
+
+    let mut ctx = dummy_ctx();
+    ctx.session_id = session_id;
+    ctx.command = "pwd".to_owned();
+
+    let result = handler.handle("", &ctx).await;
+    match result {
+        SlashResult::Reply(text) => {
+            assert!(!text.is_empty(), "expected non-empty pwd reply");
+        }
+        other => panic!("expected Reply, got non-Reply variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_workdir_handler_git_placeholder() {
+    let sm = make_workdir_session_manager();
+    let handler = WorkdirHandler::new(Arc::clone(&sm));
+
+    let mut ctx = dummy_ctx();
+    ctx.command = "git".to_owned();
+
+    let result = handler.handle("status", &ctx).await;
+    match result {
+        SlashResult::Reply(text) => {
+            assert!(
+                text.contains("git 指令即将支持"),
+                "expected 'git 指令即将支持' in reply, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got non-Reply variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_workdir_handler_cd_no_args() {
+    let sm = make_workdir_session_manager();
+    let handler = WorkdirHandler::new(Arc::clone(&sm));
+
+    let mut ctx = dummy_ctx();
+    ctx.command = "cd".to_owned();
+
+    let result = handler.handle("", &ctx).await;
+    match result {
+        SlashResult::Reply(text) => {
+            assert!(
+                text.contains("用法"),
+                "expected '用法' in reply, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got non-Reply variant"),
+    }
 }


### PR DESCRIPTION
实现 WorkdirHandler，为用户提供 /cd、/pwd、/git 三个斜杠指令操作 session 工作目录。

## 变更内容
- 新增 WorkdirHandler（src/slash/handlers.rs），持有 Arc<SessionManager>
- /cd：校验路径 → set_workdir → 回复路径 + git 分支信息
- /pwd：读取 session.workdir() → 回复路径
- /git：占位回复
- SlashContext 新增 command 字段，dispatcher 传递命令名
- Daemon 注册 WorkdirHandler
- 6 个 UT 覆盖正常/异常/占位/空参场景

Source: issue #813
Type: feat
