### PR TITLE
fix: AgentConfig/SubagentsConfig JSON 字段命名统一为 camelCase

### DIFF
--- a/src/agent/config/config_tests.rs
+++ b/src/agent/config/config_tests.rs
@@ -253,17 +253,17 @@ fn test_agent_config_json_with_new_fields() {
         "name": "Json Agent",
         "model": "deepseek-v3",
         "workspace": "/home/user/project",
-        "agent_dir": "/home/user/.agents/my-agent",
-        "bootstrap_mode": "minimal",
+        "agentDir": "/home/user/.agents/my-agent",
+        "bootstrapMode": "minimal",
         "skills": ["coding", "search"],
         "tools": ["read", "write", "exec"],
-        "disallowed_tools": ["web_search"],
+        "disallowedTools": ["web_search"],
         "subagents": {
-            "allow_agents": ["coding-agent", "review-agent"],
-            "require_agent_id": true,
-            "max_spawn_depth": 2,
-            "max_children": 8,
-            "default_child_agent": "coding-agent",
+            "allowAgents": ["coding-agent", "review-agent"],
+            "requireAgentId": true,
+            "maxSpawnDepth": 2,
+            "maxChildren": 8,
+            "defaultChildAgent": "coding-agent",
             "model": "gpt-4o-mini"
         }
     }"#;
@@ -294,6 +294,51 @@ fn test_agent_config_json_with_new_fields() {
         Some("coding-agent".to_string())
     );
     assert_eq!(config.subagents.model, Some("gpt-4o-mini".to_string()));
+}
+
+#[test]
+fn test_agent_config_camel_case_parse() {
+    // JSON 示例直接取自设计文档 docs/design/agent/agent-config.md，
+    // 验证用户按设计文档编写的 camelCase 配置能被正确解析。
+    let json = r#"{
+        "id": "code-reviewer",
+        "name": "代码审查助手",
+        "parentId": null,
+        "model": "deepseek/deepseek-chat",
+        "workspace": null,
+        "agentDir": null,
+        "bootstrapMode": "minimal",
+        "skills": ["code-review"],
+        "tools": ["read", "grep", "glob", "web_search", "web_fetch"],
+        "disallowedTools": [],
+        "subagents": {
+            "allowAgents": [],
+            "maxSpawnDepth": 0,
+            "maxChildren": 0
+        }
+    }"#;
+
+    let config: AgentConfig = serde_json::from_str(json).unwrap();
+
+    assert_eq!(config.id, "code-reviewer");
+    assert_eq!(config.name, "代码审查助手");
+    assert_eq!(config.parent_id, None);
+    assert_eq!(config.model, Some("deepseek/deepseek-chat".to_string()));
+    assert_eq!(config.workspace, None);
+    assert_eq!(config.agent_dir, None);
+    assert_eq!(config.bootstrap_mode, BootstrapMode::Minimal);
+    assert_eq!(config.skills, vec!["code-review"]);
+    assert_eq!(
+        config.tools,
+        vec!["read", "grep", "glob", "web_search", "web_fetch"]
+    );
+    assert!(config.disallowed_tools.is_empty());
+    assert!(config.subagents.allow_agents.is_empty());
+    assert!(!config.subagents.require_agent_id);
+    assert_eq!(config.subagents.max_spawn_depth, 0);
+    assert_eq!(config.subagents.max_children, 0);
+    assert_eq!(config.subagents.default_child_agent, None);
+    assert_eq!(config.subagents.model, None);
 }
 
 #[test]

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -15,6 +15,7 @@ use crate::session::bootstrap::BootstrapMode;
 
 /// Agent's own configuration (stored as config.json in the agent's directory).
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AgentConfig {
     /// Unique identifier for this agent.
     #[serde(default)]
@@ -90,6 +91,7 @@ fn default_bootstrap_mode() -> BootstrapMode {
 
 /// Sub-agent spawn control configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubagentsConfig {
     /// Whitelist of allowed target agent IDs; `["*"]` means no restriction.
     #[serde(default = "default_all")]


### PR DESCRIPTION
## 概述

`AgentConfig` 和 `SubagentsConfig` 之前使用 serde 默认 `snake_case` 序列化,与设计文档 `docs/design/agent/agent-config.md` 中的 camelCase 约定不一致。用户按设计文档编写 camelCase JSON 配置时,serde 静默忽略不认识的键,字段回落默认值,行为与预期不符。

## 改动

### `src/agent/config/mod.rs`
- `AgentConfig` 追加 `#[serde(rename_all = "camelCase")]`
- `SubagentsConfig` 追加 `#[serde(rename_all = "camelCase")]`
- `AgentConfigState` 枚举保留独立的 `#[serde(rename_all = "snake_case")]`,不受影响
- Rust 字段名保持 snake_case 不变(惯例),仅改变 JSON 序列化/反序列化的键名格式

### `src/agent/config/config_tests.rs`
- `test_agent_config_json_with_new_fields` 的 JSON 字面量键从 snake_case 同步改为 camelCase(`agent_dir` → `agentDir`、`bootstrap_mode` → `bootstrapMode`、`disallowed_tools` → `disallowedTools`、`allow_agents` → `allowAgents`、`require_agent_id` → `requireAgentId`、`max_spawn_depth` → `maxSpawnDepth`、`max_children` → `maxChildren`、`default_child_agent` → `defaultChildAgent`)
- 新增 `test_agent_config_camel_case_parse`,用设计文档的 camelCase JSON 验证解析正确

## 不在范围内

- `AgentPermissions` / `PermissionLimits` / `ActionPermission`:不在 issue 范围内,未修改
- 设计文档 `docs/design/agent/agent-config.md`:未修改(红线)

## 测试

- `cargo test -p closeclaw` → 1717 passed, 0 新增失败
- CI 既有 7 个 pre-existing failure 已确认与本次改动无关(基线 7 个 → 改动后仍 7 个,无新增)

## 关联

- Issue: #815

Source: issue #815
Type: fix
