### PR TITLE
fix: 接入 accumulate_usage 调用 (#816)

### DIFF
--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -324,6 +324,7 @@ impl SessionMessageHandler {
                 if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                     let mut cs_write = cs.write().await;
                     cs_write.append_response(response.clone());
+                    cs_write.accumulate_usage(&response.usage);
                 }
                 let text = response
                     .content_blocks


### PR DESCRIPTION
## 变更

在 `clear_busy_and_send` 的 `Ok(response)` 分支中，`append_response` 之后追加 `cs_write.accumulate_usage(&response.usage)` 调用，使 LLM 响应处理完成后正确累计 token 用量统计。

## 影响范围

- 流式/非流式/排队三条 LLM 调用路径均覆盖
- 失败路径（Err 分支）不累加 stats
- 不新增文件、不改类型定义、不改 design doc

## 测试

- `cargo test --lib`：1718 passed, 1 failed (pre-existing flaky: test_build_append_section_appended)
- stats_integration 8 个测试全部通过

Source: issue #816
Type: fix