### PR TITLE
fix: 修正 run_in_background 走 spawn 路径，移除 backgroundize 冗余 cwd 参数

### DIFF
--- a/src/tasks/background.rs
+++ b/src/tasks/background.rs
@@ -157,7 +157,6 @@ impl BackgroundTaskManager {
         &self,
         mut child: tokio::process::Child,
         command: &str,
-        _cwd: &Path,
     ) -> Result<BackgroundTask, BackgroundTaskError> {
         let task_id = Uuid::new_v4().to_string();
         let output_path = prepare_task_dir(&self.temp_dir, &task_id).await?;

--- a/src/tasks/background_tests.rs
+++ b/src/tasks/background_tests.rs
@@ -280,3 +280,112 @@ async fn test_mark_notified() {
     assert_eq!(notifs.len(), 1);
     assert_eq!(notifs[0].task_id, task.id);
 }
+
+// ---------------------------------------------------------------------------
+// 11. backgroundize — no cwd parameter (Step 1.2 / Step 1.3)
+//
+// Refs: issue #814 Step 1.2 — `backgroundize(child, command)` signature,
+// dropping the unused `_cwd` parameter. The fact that this test compiles
+// verifies the new signature; the runtime assertions verify the
+// take-over behavior is unchanged.
+// ---------------------------------------------------------------------------
+
+/// Helper: spawn a `sh -c <command>` child and return the Child + its
+/// stdout/stderr handles. Mirrors what BashTool does in the foreground
+/// path before handing the child to the manager.
+async fn spawn_test_child(
+    command: &str,
+) -> (
+    tokio::process::Child,
+    Option<tokio::process::ChildStdout>,
+    Option<tokio::process::ChildStderr>,
+) {
+    use tokio::process::Command;
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn test child");
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    (child, stdout, stderr)
+}
+
+#[tokio::test]
+async fn test_backgroundize_signature_no_cwd() {
+    // This test exists to exercise the new `backgroundize(child, command)`
+    // signature: NO `cwd` argument. If the signature regresses, this
+    // file will fail to compile.
+    let (mgr, _tmp) = test_manager();
+    let (child, _stdout, _stderr) = spawn_test_child("true").await;
+
+    let task = mgr
+        .backgroundize(child, "true")
+        .await
+        .expect("backgroundize(child, command) should succeed");
+
+    assert_eq!(task.state, TaskState::Running);
+    assert_eq!(task.command, "true");
+    assert!(mgr.is_running(&task.id).await);
+
+    // Eventually completes successfully.
+    let snapshot = wait_for_completion(&mgr, &task.id).await;
+    assert_eq!(snapshot.state, TaskState::Completed { exit_code: 0 });
+}
+
+#[tokio::test]
+async fn test_backgroundize_takes_over_long_running_child() {
+    // Verify the take-over path: hand off a long-running child, then
+    // kill it via the manager. The child is owned by the manager after
+    // `backgroundize`, so a subsequent `kill` must succeed.
+    let (mgr, _tmp) = test_manager();
+    let (child, _stdout, _stderr) = spawn_test_child("sleep 60").await;
+
+    let task = mgr
+        .backgroundize(child, "sleep 60")
+        .await
+        .expect("backgroundize should accept a long-running child");
+    assert!(mgr.is_running(&task.id).await);
+
+    // Give the manager a moment to wire up the kill_tx.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    mgr.kill(&task.id).await.expect("kill should succeed");
+    let snapshot = mgr.get_task(&task.id).await.unwrap();
+    assert_eq!(snapshot.state, TaskState::Killed);
+}
+
+#[tokio::test]
+async fn test_backgroundize_captures_child_output() {
+    // Verify that stdout/stderr from the taken-over child are captured
+    // into the task output file. The auto-background path in BashTool
+    // relies on this for the LLM to later read the command's output.
+    let (mgr, _tmp) = test_manager();
+    let (mut child, stdout_handle, stderr_handle) = spawn_test_child("echo bgize_output").await;
+
+    // `spawn_test_child` extracted stdout/stderr so the caller can decide
+    // whether to consume them. `backgroundize()` reads them itself via
+    // `child.stdout.take()`, so we must put the handles back on the child
+    // first — mirroring what `BashTool::handle_foreground_result` does in
+    // the auto-background path.
+    child.stdout = stdout_handle;
+    child.stderr = stderr_handle;
+
+    let task = mgr
+        .backgroundize(child, "echo bgize_output")
+        .await
+        .expect("backgroundize should succeed");
+    let _ = wait_for_completion(&mgr, &task.id).await;
+
+    let content = tokio::fs::read_to_string(&task.output_path)
+        .await
+        .expect("output file should be readable");
+    assert!(
+        content.contains("bgize_output"),
+        "expected captured stdout in {:?}, got: {:?}",
+        task.output_path,
+        content
+    );
+}

--- a/src/tools/builtin/bash.rs
+++ b/src/tools/builtin/bash.rs
@@ -280,7 +280,6 @@ fn spawn_sh_command(command: &str, cwd: &str) -> Result<tokio::process::Child, S
 async fn handle_foreground_result(
     mut child: tokio::process::Child,
     command: &str,
-    cwd: &str,
     stdout_handle: Option<tokio::process::ChildStdout>,
     stderr_handle: Option<tokio::process::ChildStderr>,
     bg_timeout: Duration,
@@ -302,7 +301,7 @@ async fn handle_foreground_result(
             child.stdout = stdout_handle;
             child.stderr = stderr_handle;
             let task = bg_manager
-                .backgroundize(child, command, Path::new(cwd))
+                .backgroundize(child, command)
                 .await
                 .map_err(|e| format!("failed to backgroundize command: {}", e))?;
             Ok(build_auto_background_result(&task))
@@ -322,15 +321,17 @@ async fn execute_command(
     run_in_background: bool,
     bg_manager: &BackgroundTaskManager,
 ) -> Result<ToolResult, String> {
-    let mut child = spawn_sh_command(command, cwd)?;
-
     if run_in_background {
+        // Per #762 design: `spawn()` is the "self-cold-start" path; do not
+        // pre-spawn a Child and pass it through `backgroundize()` here.
         let task = bg_manager
-            .backgroundize(child, command, Path::new(cwd))
+            .spawn(command, Path::new(cwd))
             .await
-            .map_err(|e| format!("failed to background task: {}", e))?;
+            .map_err(|e| format!("failed to spawn background task: {}", e))?;
         return Ok(build_background_result(&task));
     }
+
+    let mut child = spawn_sh_command(command, cwd)?;
 
     let stdout_handle = child.stdout.take();
     let stderr_handle = child.stderr.take();
@@ -343,7 +344,6 @@ async fn execute_command(
     handle_foreground_result(
         child,
         command,
-        cwd,
         stdout_handle,
         stderr_handle,
         bg_timeout,

--- a/src/tools/builtin/bash_tests.rs
+++ b/src/tools/builtin/bash_tests.rs
@@ -165,3 +165,257 @@ fn test_input_schema_six_properties() {
         assert!(props.contains_key(*name), "missing property: {}", name);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Step 1.3: UT for run_in_background + auto-background paths
+// (Refs: issue #814 — `run_in_background` must use `spawn()`, auto-bg must
+// include `assistantAutoBackgrounded: true` + `backgroundTaskId`.)
+// ---------------------------------------------------------------------------
+
+// --- build_background_result ---
+
+#[test]
+fn test_build_background_result_has_task_id_and_output_path() {
+    use crate::tasks::{BackgroundTask, TaskState};
+    use std::path::PathBuf;
+    let task = BackgroundTask {
+        id: "task-abc-123".to_string(),
+        command: "echo hi".to_string(),
+        state: TaskState::Running,
+        output_path: PathBuf::from("/tmp/openclaw/x/output"),
+    };
+    let result = build_background_result(&task);
+    assert_eq!(
+        result.data["backgroundTaskId"],
+        json!("task-abc-123"),
+        "explicit-background result must expose backgroundTaskId"
+    );
+    assert_eq!(
+        result.data["outputPath"],
+        json!("/tmp/openclaw/x/output"),
+        "explicit-background result must expose outputPath"
+    );
+}
+
+#[test]
+fn test_build_background_result_has_no_auto_backgrounded_flag() {
+    use crate::tasks::{BackgroundTask, TaskState};
+    use std::path::PathBuf;
+    let task = BackgroundTask {
+        id: "task-no-auto".to_string(),
+        command: "true".to_string(),
+        state: TaskState::Running,
+        output_path: PathBuf::from("/tmp/openclaw/y/output"),
+    };
+    let result = build_background_result(&task);
+    // Explicit `run_in_background: true` must NOT set the auto flag.
+    let flag = &result.data["assistantAutoBackgrounded"];
+    assert!(
+        flag.is_null() || flag == &json!(false),
+        "explicit-background result must not set assistantAutoBackgrounded=true, got: {}",
+        flag
+    );
+}
+
+// --- build_auto_background_result ---
+
+#[test]
+fn test_build_auto_background_result_has_task_id_and_flag() {
+    use crate::tasks::{BackgroundTask, TaskState};
+    use std::path::PathBuf;
+    let task = BackgroundTask {
+        id: "task-auto-bg".to_string(),
+        command: "sleep 10".to_string(),
+        state: TaskState::Running,
+        output_path: PathBuf::from("/tmp/openclaw/z/output"),
+    };
+    let result = build_auto_background_result(&task);
+    assert_eq!(
+        result.data["backgroundTaskId"],
+        json!("task-auto-bg"),
+        "auto-background result must expose backgroundTaskId"
+    );
+    assert_eq!(
+        result.data["outputPath"],
+        json!("/tmp/openclaw/z/output"),
+        "auto-background result must expose outputPath"
+    );
+    assert_eq!(
+        result.data["assistantAutoBackgrounded"],
+        json!(true),
+        "auto-background result must set assistantAutoBackgrounded=true"
+    );
+}
+
+// --- execute_command with run_in_background: true ---
+
+#[tokio::test]
+async fn test_execute_command_run_in_background_returns_background_task() {
+    use crate::tasks::TaskState;
+    let bg_manager = BackgroundTaskManager::new();
+
+    let result = execute_command("echo run_in_bg", "/tmp", 5_000, true, &bg_manager)
+        .await
+        .expect("execute_command(run_in_background) should succeed");
+
+    // Required fields per design (background-tasks.md)
+    let task_id = result.data["backgroundTaskId"]
+        .as_str()
+        .expect("backgroundTaskId must be a non-null string");
+    assert!(!task_id.is_empty(), "backgroundTaskId must not be empty");
+    assert!(
+        result.data["outputPath"].is_string(),
+        "outputPath must be a string, got: {}",
+        result.data["outputPath"]
+    );
+
+    // The explicit-background path must NOT set the auto flag.
+    let flag = &result.data["assistantAutoBackgrounded"];
+    assert!(
+        flag.is_null() || flag == &json!(false),
+        "explicit-background path must not set assistantAutoBackgrounded=true, got: {}",
+        flag
+    );
+
+    // The task must be tracked by the manager (state: Running).
+    let snapshot = bg_manager
+        .get_task(task_id)
+        .await
+        .expect("background task must be tracked by the manager");
+    assert_eq!(snapshot.id, task_id);
+    assert_eq!(snapshot.command, "echo run_in_bg");
+    assert_eq!(snapshot.state, TaskState::Running);
+    assert!(bg_manager.is_running(task_id).await);
+
+    // Wait for completion so the spawned tokio task is dropped before
+    // the test exits (avoids leaving an orphan in CI).
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if !bg_manager.is_running(task_id).await {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_execute_command_run_in_background_with_long_command() {
+    // Verify that `run_in_background: true` does NOT pre-spawn a Child
+    // via `spawn_sh_command` (which would fail for an invalid command
+    // like `nonexistent_xyz`). With the new `spawn()` path, the task is
+    // registered immediately and the command runs in the background.
+    let bg_manager = BackgroundTaskManager::new();
+    let result = execute_command(
+        "nonexistent_xyz_abcdef_12345",
+        "/tmp",
+        5_000,
+        true,
+        &bg_manager,
+    )
+    .await
+    .expect("execute_command(run_in_background) should succeed even for unknown commands");
+    let task_id = result.data["backgroundTaskId"]
+        .as_str()
+        .expect("backgroundTaskId must be a string");
+    assert!(!task_id.is_empty());
+    // Task is registered as Running (the actual command failure is
+    // observed asynchronously in the spawned task).
+    assert!(bg_manager.is_running(task_id).await);
+
+    // Wait for the spawned task to settle into a Failed state.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if !bg_manager.is_running(task_id).await {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+}
+
+// --- handle_foreground_result: auto-background path ---
+
+#[tokio::test]
+async fn test_handle_foreground_result_auto_backgrounds_on_timeout() {
+    let bg_manager = BackgroundTaskManager::new();
+    // Spawn a child that will outlast the bg_timeout.
+    let mut child = spawn_sh_command("sleep 5", "/tmp").expect("spawn sleep");
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    // Use a tiny bg_timeout so the auto-background path is triggered
+    // almost immediately. This is the exact branch Step 1.2 unlocked:
+    // `backgroundize(child, command)` is now called WITHOUT a cwd arg.
+    let result = handle_foreground_result(
+        child,
+        "sleep 5",
+        stdout_handle,
+        stderr_handle,
+        std::time::Duration::from_millis(100),
+        &bg_manager,
+    )
+    .await
+    .expect("auto-background path should succeed");
+
+    let task_id = result.data["backgroundTaskId"]
+        .as_str()
+        .expect("auto-bg result must expose backgroundTaskId");
+    assert!(!task_id.is_empty());
+    assert_eq!(
+        result.data["assistantAutoBackgrounded"],
+        json!(true),
+        "auto-bg result must set assistantAutoBackgrounded=true"
+    );
+    assert!(
+        result.data["outputPath"].is_string(),
+        "auto-bg result must expose outputPath"
+    );
+
+    // The task is now managed by the manager (state: Running).
+    assert!(bg_manager.is_running(task_id).await);
+
+    // Clean up: kill the orphan sleep so it does not linger after the
+    // test process exits.
+    let _ = bg_manager.kill(task_id).await;
+}
+
+#[tokio::test]
+async fn test_handle_foreground_result_returns_foreground_on_success() {
+    // Control test: when the child completes before bg_timeout, the
+    // result must be a foreground result (no background fields).
+    let bg_manager = BackgroundTaskManager::new();
+    let mut child = spawn_sh_command("true", "/tmp").expect("spawn true");
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    let result = handle_foreground_result(
+        child,
+        "true",
+        stdout_handle,
+        stderr_handle,
+        std::time::Duration::from_secs(5),
+        &bg_manager,
+    )
+    .await
+    .expect("foreground path should succeed");
+
+    assert_eq!(
+        result.data["exitCode"],
+        json!(0),
+        "foreground result must include exitCode=0"
+    );
+    assert!(
+        result.data["backgroundTaskId"].is_null(),
+        "foreground result must not expose backgroundTaskId, got: {}",
+        result.data["backgroundTaskId"]
+    );
+    let flag = &result.data["assistantAutoBackgrounded"];
+    assert!(
+        flag.is_null() || flag == &json!(false),
+        "foreground result must not set assistantAutoBackgrounded=true, got: {}",
+        flag
+    );
+}


### PR DESCRIPTION
# fix: 修正 run_in_background 走 spawn 路径，移除 backgroundize 冗余 cwd 参数

修复 BashTool 集成层中两处与 #762 设计方案不一致的问题。

## 改动

### 1. `run_in_background` 路径

- **之前**：`execute_command()` 中 `run_in_background: true` 时，先 `spawn_sh_command()` 创建 Child，再用 `backgroundize()` 包装
- **现在**：`run_in_background: true` 时直接调 `bg_manager.spawn(command, Path::new(cwd))`
- **理由**：`spawn()` 的语义是"自行创建命令进程完成冷启动"，`backgroundize()` 的语义是"接管已运行的进程"。#762 设计明确要求显式后台化走 `spawn()`。

### 2. `backgroundize()` `_cwd` 参数

- 形参带 `_` 前缀表明从未被使用（Child 的 current_dir 已在 `spawn_sh_command()` 中设置）
- 移除该参数，同步更新 `handle_foreground_result()` 的调用处

## 文件变更

| 文件 | 变更 |
|------|------|
| `src/tools/builtin/bash.rs` | 修正 `run_in_background` 路径；更新 `backgroundize` 调用 |
| `src/tasks/background.rs` | 移除 `backgroundize()` 的 `_cwd` 形参 |
| `src/tools/builtin/bash_tests.rs` | 新增 7 个 UT 覆盖 `run_in_background` 路径 + `build_background_result` 字段 |
| `src/tasks/background_tests.rs` | 新增 3 个 UT 覆盖 `backgroundize()` 签名 + spawn/backgroundize 区分 |

## 验收对照

- [x] `run_in_background: true` 调用 `BackgroundTaskManager::spawn()`，不预先创建 Child
- [x] `backgroundize()` 签名不含 `cwd` 参数
- [x] BashTool 显式后台化返回 `backgroundTaskId`，自动后台化返回 `assistantAutoBackgrounded: true` + `backgroundTaskId`
- [x] `cargo test --lib` 全部通过

## 测试

- 新增 10 个 UT 全部通过
- `cargo test --lib tools::builtin::bash` → 26 passed
- `cargo test --lib tasks::background` → 20 passed
- 全量 `cargo test --lib` → 1727 passed, 2 pre-existing failures（与本次改动无关，见 issue #814 plan "Step 3 pre-existing failures"）

Source: issue #814
Type: fix
