### PR TITLE
feat(renderer): ContentBlock[] typed rendering with block dispatch

### DIFF
--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -65,12 +65,35 @@ impl Gateway {
                 .and_then(|v| v.as_str())
                 .and_then(|s| serde_json::from_str(s).ok());
 
+            // Step 1.2: pass the full ContentBlock stream to the renderer.
+            // The renderer decides per-block rendering (text/thinking/tool_use/tool_result)
+            // and extracts DSL-stripped plain text internally for the single-Text
+            // fast path. Previously this call site derived `clean_content` from
+            // `dsl_result` itself; that responsibility now lives in the renderer.
+            //
+            // Fallback: when content_blocks is empty (e.g. legacy caller that
+            // didn't produce structured blocks), wrap the raw `result.content`
+            // in a single Text block so simple text paths still work.
+            let owned_fallback;
+            let blocks_for_render: &[crate::llm::types::ContentBlock] =
+                if result.content_blocks.is_empty() {
+                    owned_fallback = vec![crate::llm::types::ContentBlock::Text(
+                        result.content.clone(),
+                    )];
+                    &owned_fallback
+                } else {
+                    &result.content_blocks
+                };
+
+            // Preserve a plain-text fallback string in case the renderer's
+            // text branch returns a payload missing the `content.text` field
+            // (defensive: older code paths may rely on it).
             let content = dsl_result
                 .as_ref()
                 .map(|r| r.clean_content.as_str())
                 .unwrap_or(&result.content);
 
-            let rendered = renderer.render(content, dsl_result.as_ref());
+            let rendered = renderer.render(blocks_for_render, dsl_result.as_ref());
             let payload_str =
                 serde_json::to_string(&rendered.payload).unwrap_or_else(|_| "{}".to_string());
 

--- a/src/renderer/feishu.rs
+++ b/src/renderer/feishu.rs
@@ -6,6 +6,7 @@
 
 use serde::Serialize;
 
+use crate::llm::types::ContentBlock;
 use crate::processor_chain::dsl_parser::{DslInstruction, DslParseResult};
 
 use super::code_block::{parse_content_segments, ContentSegment};
@@ -42,6 +43,27 @@ pub enum CardElement {
     Hr,
     #[serde(rename = "action")]
     Action { actions: Vec<CardAction> },
+    /// Feishu card `note` element — used to surface tool-call metadata
+    /// (name + truncated input) inline with the response.
+    #[serde(rename = "note")]
+    Note { elements: Vec<CardNoteElement> },
+}
+
+/// Inner element of a [`CardElement::Note`]. Currently only `plain_text`
+/// is exposed because that's all Feishu's note element supports.
+#[derive(Debug, Clone, Serialize)]
+pub struct CardNoteElement {
+    pub tag: String,
+    pub content: String,
+}
+
+impl CardNoteElement {
+    pub fn plain_text(content: impl Into<String>) -> Self {
+        Self {
+            tag: "plain_text".into(),
+            content: content.into(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -61,7 +83,7 @@ pub struct CardText {
 }
 
 // ---------------------------------------------------------------------------
-// FeishuRenderer
+// FeishuRenderer — helpers
 // ---------------------------------------------------------------------------
 
 /// Renderer implementation for Feishu.
@@ -73,7 +95,8 @@ impl FeishuRenderer {
         Self
     }
 
-    /// Returns true when content needs a card (has DSL, header, newlines, or inline formatting).
+    /// Returns true when content needs a card (has DSL, header, newlines, or
+    /// inline formatting).
     fn should_use_card(content: &str, has_dsl: bool) -> bool {
         let md = content.trim();
         if md.is_empty() {
@@ -83,6 +106,27 @@ impl FeishuRenderer {
             return true;
         }
         contains_inline(md)
+    }
+
+    /// Returns true when the structured content blocks warrant an interactive
+    /// card.
+    fn should_use_card_for_blocks(content_blocks: &[ContentBlock], has_dsl: bool) -> bool {
+        if content_blocks.is_empty() {
+            return false;
+        }
+        if has_dsl {
+            return true;
+        }
+        let has_non_text = content_blocks
+            .iter()
+            .any(|b| !matches!(b, ContentBlock::Text(_)));
+        if content_blocks.len() > 1 || has_non_text {
+            return true;
+        }
+        if let ContentBlock::Text(text) = &content_blocks[0] {
+            return Self::should_use_card(text, false);
+        }
+        true
     }
 
     /// Extracts `# Title` from first line.
@@ -119,6 +163,138 @@ impl FeishuRenderer {
             .collect()
     }
 }
+
+// ---------------------------------------------------------------------------
+// FeishuRenderer — per-block renderers
+// ---------------------------------------------------------------------------
+
+impl FeishuRenderer {
+    /// Render a Text block using the legacy markdown → card-element pipeline.
+    fn render_text_block(
+        &self,
+        text: &str,
+        dsl_result: Option<&DslParseResult>,
+    ) -> (Option<String>, Vec<CardElement>) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return (None, Vec::new());
+        }
+        let (title, body) = Self::extract_header(trimmed);
+        let mut elements = Self::to_elements(&body);
+        if let Some(r) = dsl_result {
+            elements.extend(Self::render_buttons(&r.instructions));
+        }
+        (title, elements)
+    }
+
+    /// Render a Thinking block as a Feishu markdown quote block.
+    fn render_thinking_block(content: &str) -> CardElement {
+        let quoted = content
+            .lines()
+            .map(|line| {
+                if line.is_empty() {
+                    ">".to_string()
+                } else {
+                    format!("> {line}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body = if quoted.is_empty() {
+            "> 💭 Thinking".to_string()
+        } else {
+            format!("> 💭 Thinking\n{quoted}")
+        };
+        CardElement::Markdown { content: body }
+    }
+
+    /// Render a ToolUse block as a Feishu `note` element.
+    fn render_tool_use_block(name: &str, input: &str) -> CardElement {
+        const INPUT_PREVIEW_LIMIT: usize = 200;
+        let preview: String = input.chars().take(INPUT_PREVIEW_LIMIT).collect();
+        let truncated = input.chars().count() > INPUT_PREVIEW_LIMIT;
+        let summary = if truncated {
+            format!("{preview}…")
+        } else {
+            preview
+        };
+        let line = if summary.is_empty() {
+            format!("🔧 {name}")
+        } else {
+            format!("🔧 {name}: {summary}")
+        };
+        CardElement::Note {
+            elements: vec![CardNoteElement::plain_text(line)],
+        }
+    }
+
+    /// Render a ToolResult block as a markdown element.
+    fn render_tool_result_block(content: &str) -> CardElement {
+        const RESULT_LIMIT: usize = 2000;
+        let char_count = content.chars().count();
+        if char_count <= RESULT_LIMIT {
+            return CardElement::Markdown {
+                content: format!("**Result**\n```\n{content}\n```"),
+            };
+        }
+        let preview: String = content.chars().take(RESULT_LIMIT).collect();
+        CardElement::Markdown {
+            content: format!(
+                "**Result**\n```\n{preview}\n```\n\n\
+                 _结果过长，已截断（{char_count} 字符，显示前 {RESULT_LIMIT}）_"
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FeishuRenderer — block dispatch
+// ---------------------------------------------------------------------------
+
+impl FeishuRenderer {
+    /// Dispatch content blocks by type, producing a title and card elements.
+    fn dispatch_blocks(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> (Option<String>, Vec<CardElement>) {
+        let mut title: Option<String> = None;
+        let mut elements: Vec<CardElement> = Vec::new();
+
+        for block in content_blocks {
+            match block {
+                ContentBlock::Text(text) => {
+                    if title.is_none() {
+                        let (t, body) = Self::extract_header(text.trim());
+                        title = t;
+                        elements.extend(Self::to_elements(&body));
+                    } else {
+                        elements.extend(Self::to_elements(text.trim()));
+                    }
+                }
+                ContentBlock::Thinking(content) => {
+                    elements.push(Self::render_thinking_block(content));
+                }
+                ContentBlock::ToolUse { name, input, .. } => {
+                    elements.push(Self::render_tool_use_block(name, input));
+                }
+                ContentBlock::ToolResult { content, .. } => {
+                    elements.push(Self::render_tool_result_block(content));
+                }
+            }
+        }
+
+        if let Some(r) = dsl_result {
+            elements.extend(Self::render_buttons(&r.instructions));
+        }
+
+        (title, elements)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FeishuRenderer — card building
+// ---------------------------------------------------------------------------
 
 impl FeishuRenderer {
     /// Renders DSL instructions as buttons.
@@ -191,14 +367,21 @@ fn contains_inline(s: &str) -> bool {
         || (s.contains('[') && s.contains("]("))
 }
 
+// ---------------------------------------------------------------------------
+// Renderer trait impl
+// ---------------------------------------------------------------------------
+
 impl Renderer for FeishuRenderer {
     fn platform(&self) -> &str {
         "feishu"
     }
 
-    fn render(&self, content: &str, dsl_result: Option<&DslParseResult>) -> RenderedOutput {
-        let trimmed = content.trim();
-        if trimmed.is_empty() {
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        if content_blocks.is_empty() {
             return Self::build_text("");
         }
 
@@ -206,220 +389,27 @@ impl Renderer for FeishuRenderer {
             .as_ref()
             .is_some_and(|r| !r.instructions.is_empty());
 
-        if !Self::should_use_card(trimmed, has_dsl) {
-            return Self::build_text(trimmed);
+        // Backward-compat fast path: single Text block, no card needed.
+        if content_blocks.len() == 1 {
+            if let ContentBlock::Text(text) = &content_blocks[0] {
+                if !has_dsl && !Self::should_use_card(text, false) {
+                    return Self::build_text(text.trim());
+                }
+            }
         }
 
-        let (title, body) = Self::extract_header(trimmed);
-        let elements = Self::to_elements(&body);
-        let mut all = elements;
-
-        if let Some(r) = dsl_result {
-            all.extend(Self::render_buttons(&r.instructions));
+        if !Self::should_use_card_for_blocks(content_blocks, has_dsl) {
+            return Self::build_text("");
         }
 
-        Self::build_card(title, all)
+        let (title, elements) = self.dispatch_blocks(content_blocks, dsl_result);
+        Self::build_card(title, elements)
     }
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests (separate file)
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::processor_chain::dsl_parser::DslParseResult;
-
-    fn btn(label: &str, action: &str, value: &str) -> DslInstruction {
-        DslInstruction::Button {
-            label: label.into(),
-            action: action.into(),
-            value: value.into(),
-        }
-    }
-
-    #[test]
-    fn test_platform() {
-        let r = FeishuRenderer::new();
-        assert_eq!(r.platform(), "feishu");
-    }
-
-    #[test]
-    fn test_empty_content() {
-        let r = FeishuRenderer::new();
-        let out = r.render("", None);
-        assert_eq!(out.msg_type, "text");
-        assert_eq!(out.payload["content"]["text"], "");
-    }
-
-    #[test]
-    fn test_plain_text() {
-        let r = FeishuRenderer::new();
-        let out = r.render("hello world", None);
-        assert_eq!(out.msg_type, "text");
-        assert_eq!(out.payload["content"]["text"], "hello world");
-    }
-
-    #[test]
-    fn test_rich_formatting() {
-        let r = FeishuRenderer::new();
-        let out = r.render("**bold** and _italic_", None);
-        assert_eq!(out.msg_type, "interactive");
-    }
-
-    #[test]
-    fn test_multiline() {
-        let r = FeishuRenderer::new();
-        let out = r.render("Line 1\nLine 2", None);
-        assert_eq!(out.msg_type, "interactive");
-    }
-
-    #[test]
-    fn test_header_extraction() {
-        let r = FeishuRenderer::new();
-        let out = r.render("# My Title\nBody content", None);
-        assert_eq!(out.msg_type, "interactive");
-        assert_eq!(out.payload["card"]["header"]["title"], "My Title");
-        assert_eq!(out.payload["card"]["header"]["template"], "blue");
-    }
-
-    #[test]
-    fn test_hr_element() {
-        let r = FeishuRenderer::new();
-        let out = r.render("Before\n---\nAfter", None);
-        let els = out.payload["card"]["elements"].as_array().unwrap();
-        assert!(els.iter().any(|e| e["tag"] == "hr"));
-    }
-
-    #[test]
-    fn test_dsl_button() {
-        let r = FeishuRenderer::new();
-        let dsl = DslParseResult {
-            clean_content: "Hi".into(),
-            instructions: vec![btn("Yes", "y", "1")],
-        };
-        let out = r.render("Hello", Some(&dsl));
-        assert_eq!(out.msg_type, "interactive");
-        let els = out.payload["card"]["elements"].as_array().unwrap();
-        let action = els.iter().find(|e| e["tag"] == "action").unwrap();
-        assert_eq!(action["actions"][0]["type"], "primary");
-    }
-
-    #[test]
-    fn test_dsl_multi_buttons() {
-        let r = FeishuRenderer::new();
-        let dsl = DslParseResult {
-            clean_content: "Hi".into(),
-            instructions: vec![btn("A", "a", "1"), btn("B", "b", "2")],
-        };
-        let out = r.render("Hello", Some(&dsl));
-        let els = out.payload["card"]["elements"].as_array().unwrap();
-        let action = els.iter().find(|e| e["tag"] == "action").unwrap();
-        assert_eq!(action["actions"][0]["type"], "primary");
-        assert_eq!(action["actions"][1]["type"], "default");
-    }
-
-    #[test]
-    fn test_no_dsl_none() {
-        let r = FeishuRenderer::new();
-        let out = r.render("No DSL here", None);
-        assert_eq!(out.msg_type, "text");
-    }
-
-    // ---- Code block integration tests ----
-
-    /// Helper: extract markdown content strings from CardElement::Markdown items.
-    fn markdown_contents(elements: &[CardElement]) -> Vec<String> {
-        elements
-            .iter()
-            .filter_map(|e| match e {
-                CardElement::Markdown { content } => Some(content.clone()),
-                _ => None,
-            })
-            .collect()
-    }
-
-    #[test]
-    fn test_code_block_with_language() {
-        let els = FeishuRenderer::to_elements("```rust\nfn main() {}\n```");
-        let mds = markdown_contents(&els);
-        assert!(
-            mds.iter().any(|m| m.contains("```rust")),
-            "should contain ```rust marker"
-        );
-        assert!(
-            mds.iter().any(|m| m.contains("fn main()")),
-            "should contain code"
-        );
-    }
-
-    #[test]
-    fn test_code_block_without_language() {
-        let els = FeishuRenderer::to_elements("```\nsome code\n```");
-        let mds = markdown_contents(&els);
-        assert!(
-            mds.iter().any(|m| m.starts_with("```\n")),
-            "should start with ```"
-        );
-        assert!(
-            mds.iter().any(|m| m.contains("some code")),
-            "should contain code"
-        );
-    }
-
-    #[test]
-    fn test_multiple_code_blocks_interleaved() {
-        let input = "Intro text\n```rust\ncode1\n```\nMiddle text\n```python\ncode2\n```";
-        let els = FeishuRenderer::to_elements(input);
-        let mds = markdown_contents(&els);
-        // Should have: "Intro text", code block 1, "Middle text", code block 2
-        assert!(mds.iter().any(|m| m.contains("Intro text")));
-        assert!(mds
-            .iter()
-            .any(|m| m.contains("```rust") && m.contains("code1")));
-        assert!(mds.iter().any(|m| m.contains("Middle text")));
-        assert!(mds
-            .iter()
-            .any(|m| m.contains("```python") && m.contains("code2")));
-    }
-
-    #[test]
-    fn test_code_block_only() {
-        let els = FeishuRenderer::to_elements("```js\nconsole.log(1);\n```");
-        // Should be exactly one Markdown element (the code block)
-        assert_eq!(els.len(), 1);
-        match &els[0] {
-            CardElement::Markdown { content } => {
-                assert!(content.starts_with("```js\n"));
-                assert!(content.ends_with("```"));
-            }
-            other => panic!("expected Markdown, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_empty_code_block() {
-        let els = FeishuRenderer::to_elements("```\n\n```");
-        let mds = markdown_contents(&els);
-        assert!(!mds.is_empty(), "should produce at least one element");
-        assert!(
-            mds.iter().any(|m| m.contains("```")),
-            "should preserve ``` markers"
-        );
-    }
-
-    #[test]
-    fn test_no_code_block_regression() {
-        let els = FeishuRenderer::to_elements("Just plain text\nAnother line");
-        // No element should contain ``` markers
-        for el in &els {
-            if let CardElement::Markdown { content } = el {
-                assert!(
-                    !content.contains("```"),
-                    "plain text should not contain ```"
-                );
-            }
-        }
-    }
-}
+mod feishu_tests;

--- a/src/renderer/feishu/feishu_tests.rs
+++ b/src/renderer/feishu/feishu_tests.rs
@@ -1,0 +1,419 @@
+use super::*;
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::dsl_parser::DslParseResult;
+
+fn btn(label: &str, action: &str, value: &str) -> DslInstruction {
+    DslInstruction::Button {
+        label: label.into(),
+        action: action.into(),
+        value: value.into(),
+    }
+}
+
+fn text_block(s: &str) -> ContentBlock {
+    ContentBlock::Text(s.to_string())
+}
+
+#[test]
+fn test_platform() {
+    let r = FeishuRenderer::new();
+    assert_eq!(r.platform(), "feishu");
+}
+
+#[test]
+fn test_empty_content() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[], None);
+    assert_eq!(out.msg_type, "text");
+    assert_eq!(out.payload["content"]["text"], "");
+}
+
+#[test]
+fn test_plain_text() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("hello world")], None);
+    assert_eq!(out.msg_type, "text");
+    assert_eq!(out.payload["content"]["text"], "hello world");
+}
+
+#[test]
+fn test_rich_formatting() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("**bold** and _italic_")], None);
+    assert_eq!(out.msg_type, "interactive");
+}
+
+#[test]
+fn test_multiline() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("Line 1\nLine 2")], None);
+    assert_eq!(out.msg_type, "interactive");
+}
+
+#[test]
+fn test_header_extraction() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("# My Title\nBody content")], None);
+    assert_eq!(out.msg_type, "interactive");
+    assert_eq!(out.payload["card"]["header"]["title"], "My Title");
+    assert_eq!(out.payload["card"]["header"]["template"], "blue");
+}
+
+#[test]
+fn test_hr_element() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("Before\n---\nAfter")], None);
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    assert!(els.iter().any(|e| e["tag"] == "hr"));
+}
+
+#[test]
+fn test_dsl_button() {
+    let r = FeishuRenderer::new();
+    let dsl = DslParseResult {
+        clean_content: "Hi".into(),
+        instructions: vec![btn("Yes", "y", "1")],
+    };
+    let out = r.render(&[text_block("Hello")], Some(&dsl));
+    assert_eq!(out.msg_type, "interactive");
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    let action = els.iter().find(|e| e["tag"] == "action").unwrap();
+    assert_eq!(action["actions"][0]["type"], "primary");
+}
+
+#[test]
+fn test_dsl_multi_buttons() {
+    let r = FeishuRenderer::new();
+    let dsl = DslParseResult {
+        clean_content: "Hi".into(),
+        instructions: vec![btn("A", "a", "1"), btn("B", "b", "2")],
+    };
+    let out = r.render(&[text_block("Hello")], Some(&dsl));
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    let action = els.iter().find(|e| e["tag"] == "action").unwrap();
+    assert_eq!(action["actions"][0]["type"], "primary");
+    assert_eq!(action["actions"][1]["type"], "default");
+}
+
+#[test]
+fn test_no_dsl_none() {
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("No DSL here")], None);
+    assert_eq!(out.msg_type, "text");
+}
+
+// ---- Code block integration tests ----
+
+/// Helper: extract markdown content strings from CardElement::Markdown items.
+fn markdown_contents(elements: &[CardElement]) -> Vec<String> {
+    elements
+        .iter()
+        .filter_map(|e| match e {
+            CardElement::Markdown { content } => Some(content.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn test_code_block_with_language() {
+    let els = FeishuRenderer::to_elements("```rust\nfn main() {}\n```");
+    let mds = markdown_contents(&els);
+    assert!(
+        mds.iter().any(|m| m.contains("```rust")),
+        "should contain ```rust marker"
+    );
+    assert!(
+        mds.iter().any(|m| m.contains("fn main()")),
+        "should contain code"
+    );
+}
+
+#[test]
+fn test_code_block_without_language() {
+    let els = FeishuRenderer::to_elements("```\nsome code\n```");
+    let mds = markdown_contents(&els);
+    assert!(
+        mds.iter().any(|m| m.starts_with("```\n")),
+        "should start with ```"
+    );
+    assert!(
+        mds.iter().any(|m| m.contains("some code")),
+        "should contain code"
+    );
+}
+
+#[test]
+fn test_multiple_code_blocks_interleaved() {
+    let input = "Intro text\n```rust\ncode1\n```\nMiddle text\n```python\ncode2\n```";
+    let els = FeishuRenderer::to_elements(input);
+    let mds = markdown_contents(&els);
+    // Should have: "Intro text", code block 1, "Middle text", code block 2
+    assert!(mds.iter().any(|m| m.contains("Intro text")));
+    assert!(mds
+        .iter()
+        .any(|m| m.contains("```rust") && m.contains("code1")));
+    assert!(mds.iter().any(|m| m.contains("Middle text")));
+    assert!(mds
+        .iter()
+        .any(|m| m.contains("```python") && m.contains("code2")));
+}
+
+#[test]
+fn test_code_block_only() {
+    let els = FeishuRenderer::to_elements("```js\nconsole.log(1);\n```");
+    // Should be exactly one Markdown element (the code block)
+    assert_eq!(els.len(), 1);
+    match &els[0] {
+        CardElement::Markdown { content } => {
+            assert!(content.starts_with("```js\n"));
+            assert!(content.ends_with("```"));
+        }
+        other => panic!("expected Markdown, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_empty_code_block() {
+    let els = FeishuRenderer::to_elements("```\n\n```");
+    let mds = markdown_contents(&els);
+    assert!(!mds.is_empty(), "should produce at least one element");
+    assert!(
+        mds.iter().any(|m| m.contains("```")),
+        "should preserve ``` markers"
+    );
+}
+
+#[test]
+fn test_no_code_block_regression() {
+    let els = FeishuRenderer::to_elements("Just plain text\nAnother line");
+    // No element should contain ``` markers
+    for el in &els {
+        if let CardElement::Markdown { content } = el {
+            assert!(
+                !content.contains("```"),
+                "plain text should not contain ```"
+            );
+        }
+    }
+}
+
+// ---- ContentBlock[] rendering tests (Step 1.3) ----
+
+fn thinking_block(s: &str) -> ContentBlock {
+    ContentBlock::Thinking(s.to_string())
+}
+
+fn tool_use_block(id: &str, name: &str, input: &str) -> ContentBlock {
+    ContentBlock::ToolUse {
+        id: id.to_string(),
+        name: name.to_string(),
+        input: input.to_string(),
+    }
+}
+
+fn tool_result_block(tool_call_id: &str, content: &str) -> ContentBlock {
+    ContentBlock::ToolResult {
+        tool_call_id: tool_call_id.to_string(),
+        content: content.to_string(),
+    }
+}
+
+/// Helper: collect all string content (markdown + note plain_text) from a card payload.
+fn collect_payload_strings(payload: &serde_json::Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(els) = payload["card"]["elements"].as_array() {
+        for el in els {
+            match el["tag"].as_str() {
+                Some("markdown") => {
+                    if let Some(c) = el["content"].as_str() {
+                        out.push(c.to_string());
+                    }
+                }
+                Some("note") => {
+                    if let Some(inner) = el["elements"].as_array() {
+                        for n in inner {
+                            if let Some(c) = n["content"].as_str() {
+                                out.push(c.to_string());
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn test_single_text_block_compat() {
+    // Single Text block with simple content → text output, backward compat
+    // (no card, payload follows the legacy {"content": {"text": ...}} shape).
+    let r = FeishuRenderer::new();
+    let out = r.render(&[text_block("hello world")], None);
+    assert_eq!(out.msg_type, "text");
+    assert_eq!(out.payload["content"]["text"], "hello world");
+}
+
+#[test]
+fn test_thinking_block() {
+    // Single Thinking block → interactive card whose elements contain
+    // the quote-block format `> 💭 Thinking\n> {content}`.
+    let r = FeishuRenderer::new();
+    let out = r.render(&[thinking_block("reasoning...")], None);
+    assert_eq!(out.msg_type, "interactive");
+
+    let strings = collect_payload_strings(&out.payload);
+    let joined = strings.join("\n");
+    assert!(
+        joined.contains("> 💭"),
+        "expected quote-block marker `> 💭` in elements, got: {joined}"
+    );
+    assert!(
+        joined.contains("Thinking"),
+        "expected label `Thinking` in elements, got: {joined}"
+    );
+    assert!(
+        joined.contains("reasoning..."),
+        "expected thinking content in elements, got: {joined}"
+    );
+
+    // The Thinking block must be rendered as a markdown element (so
+    // Feishu interprets the `>` blockquote syntax).
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    assert!(
+        els.iter().any(|e| e["tag"] == "markdown"),
+        "expected at least one markdown element"
+    );
+}
+
+#[test]
+fn test_tool_use_block() {
+    // Single ToolUse block → interactive card whose elements surface
+    // the tool name (in a `note` element).
+    let r = FeishuRenderer::new();
+    let out = r.render(
+        &[tool_use_block("call_1", "search_web", "{\"q\":\"rust\"}")],
+        None,
+    );
+    assert_eq!(out.msg_type, "interactive");
+
+    let strings = collect_payload_strings(&out.payload);
+    let joined = strings.join("\n");
+    assert!(
+        joined.contains("search_web"),
+        "expected tool name `search_web` in elements, got: {joined}"
+    );
+
+    // Tool use should be rendered as a `note` element (per design).
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    let note = els
+        .iter()
+        .find(|e| e["tag"] == "note")
+        .expect("expected a note element for ToolUse");
+    let inner = note["elements"].as_array().unwrap();
+    assert!(!inner.is_empty(), "note element must have inner content");
+    assert_eq!(inner[0]["tag"], "plain_text");
+    assert!(
+        inner[0]["content"].as_str().unwrap().contains("search_web"),
+        "note content should contain tool name"
+    );
+}
+
+#[test]
+fn test_tool_result_block() {
+    // Single ToolResult block → interactive card whose markdown elements
+    // contain the result content.
+    let r = FeishuRenderer::new();
+    let out = r.render(&[tool_result_block("call_1", "42 files matched")], None);
+    assert_eq!(out.msg_type, "interactive");
+
+    let strings = collect_payload_strings(&out.payload);
+    let joined = strings.join("\n");
+    assert!(
+        joined.contains("42 files matched"),
+        "expected result content in elements, got: {joined}"
+    );
+    // ToolResult is rendered as a markdown code-block, so the
+    // `**Result**` label should appear.
+    assert!(
+        joined.contains("**Result**"),
+        "expected `**Result**` label in markdown, got: {joined}"
+    );
+}
+
+#[test]
+fn test_mixed_blocks() {
+    // Text + Thinking + ToolUse → interactive card with multiple element
+    // types (markdown body, quote, note).
+    let r = FeishuRenderer::new();
+    let out = r.render(
+        &[
+            text_block("# Answer\nHere is the answer."),
+            thinking_block("Let me think..."),
+            tool_use_block("call_1", "lookup", "{\"k\":\"v\"}"),
+        ],
+        None,
+    );
+    assert_eq!(out.msg_type, "interactive");
+
+    // Header extracted from the first Text block.
+    assert_eq!(out.payload["card"]["header"]["title"], "Answer");
+
+    let els = out.payload["card"]["elements"].as_array().unwrap();
+    let tags: Vec<&str> = els.iter().filter_map(|e| e["tag"].as_str()).collect();
+    assert!(
+        tags.contains(&"markdown"),
+        "expected at least one markdown element, got tags: {tags:?}"
+    );
+    assert!(
+        tags.contains(&"note"),
+        "expected a note element for ToolUse, got tags: {tags:?}"
+    );
+
+    // All three block contents should appear somewhere in the payload.
+    let strings = collect_payload_strings(&out.payload);
+    let joined = strings.join("\n");
+    assert!(joined.contains("Here is the answer."), "text missing");
+    assert!(
+        joined.contains("Let me think...") || joined.contains("> 💭"),
+        "thinking content / quote marker missing"
+    );
+    assert!(joined.contains("lookup"), "tool name missing");
+}
+
+#[test]
+fn test_empty_blocks() {
+    // Empty Vec → text output with empty content (preserves legacy behavior).
+    let r = FeishuRenderer::new();
+    let out = r.render(&[], None);
+    assert_eq!(out.msg_type, "text");
+    assert_eq!(out.payload["content"]["text"], "");
+}
+
+#[test]
+fn test_tool_result_truncated() {
+    // ToolResult content above the truncation threshold (impl uses 2000)
+    // → the rendered markdown must include the truncation marker.
+    let r = FeishuRenderer::new();
+    // 3000 ASCII chars, well above the 2000-char RESULT_LIMIT.
+    let long_content: String = std::iter::repeat('a').take(3000).collect();
+    let out = r.render(&[tool_result_block("call_1", &long_content)], None);
+
+    assert_eq!(out.msg_type, "interactive");
+
+    let strings = collect_payload_strings(&out.payload);
+    let joined = strings.join("\n");
+    assert!(
+        joined.contains("结果过长") && joined.contains("已截断"),
+        "expected truncation marker (`结果过长`, `已截断`) in elements, got: {}",
+        &joined[..joined.len().min(200)]
+    );
+    // Sanity: the full 3000-char body must NOT be in the payload verbatim
+    // (otherwise truncation didn't actually happen).
+    assert!(
+        !joined.contains(&long_content),
+        "full content should have been truncated"
+    );
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -9,12 +9,13 @@
 //! ```
 //! use closeclaw::renderer::{Renderer, RenderedOutput};
 //! use closeclaw::renderer::feishu::FeishuRenderer;
+//! use closeclaw::llm::types::ContentBlock;
 //!
 //! let renderer = FeishuRenderer::new();
-//! // "Hello **world**" contains inline formatting (**), so renderer returns
-//! // `"interactive"` card instead of `"text"`. With dsl_result=None there are
-//! // no DSL buttons in the payload.
-//! let output = renderer.render("Hello **world**", None);
+//! // A single Text block containing inline formatting (**) → interactive card.
+//! // With dsl_result=None there are no DSL buttons in the payload.
+//! let blocks = vec![ContentBlock::Text("Hello **world**".to_string())];
+//! let output = renderer.render(&blocks, None);
 //! assert_eq!(output.msg_type, "interactive");
 //! // No DSL → no action/button elements in the card
 //! let elements = output.payload.get("card").and_then(|c| c.get("elements")).and_then(|e| e.as_array());
@@ -27,6 +28,7 @@ pub mod feishu;
 
 use serde::{Deserialize, Serialize};
 
+use crate::llm::types::ContentBlock;
 use crate::processor_chain::DslParseResult;
 
 // ---------------------------------------------------------------------------
@@ -53,9 +55,17 @@ pub trait Renderer: Send + Sync {
     /// Returns the platform name, e.g. `"feishu"` or `"wecom"`.
     fn platform(&self) -> &str;
 
-    /// Renders `content` (markdown text from LLM) to a platform-specific output.
+    /// Renders structured LLM output (`content_blocks`) to a platform-specific
+    /// [`RenderedOutput`].
     ///
     /// `dsl_result` carries parsed DSL instructions from the processor chain
-    /// and may be `None` when no DSL was extracted.
-    fn render(&self, content: &str, dsl_result: Option<&DslParseResult>) -> RenderedOutput;
+    /// and may be `None` when no DSL was extracted. Renderers are expected to
+    /// dispatch by [`ContentBlock`] variant: Text/Thinking/ToolUse/ToolResult
+    /// each get their own rendering path. A single Text block with simple
+    /// content should produce a `"text"` output for backward compatibility.
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput;
 }


### PR DESCRIPTION
feat(renderer): FeishuRenderer ContentBlock[] 类型化渲染

Renderer trait 签名从 `render(&str, ...)` 更新为 `render(&[ContentBlock], ...)`，FeishuRenderer 按块类型分派渲染：
- Text → 现有 markdown 路径（向下兼容）
- Thinking → 引用块格式 `> 💭 Thinking`
- ToolUse → note 元素（工具名 + input 摘要）
- ToolResult → markdown 代码块（过长截断）

Gateway::send_outbound 传入完整 content_blocks 给 Renderer，不再提取 clean_content。

测试：32 个 renderer 测试全部通过（含 7 个新增 ContentBlock 渲染测试），95 个 gateway 测试全部通过。

Source: issue #827
Type: feat
