### PR TITLE
feat(gateway): 统一插件注册表 — 替换 adapters+renderer 为 platform→IMPlugin 映射

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -9,7 +9,8 @@ use crate::config::migration::migrate_if_needed;
 use crate::config::providers::ConfigProvider;
 use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
-use crate::im::feishu::FeishuAdapter;
+use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
+use crate::renderer::feishu::FeishuRenderer;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{
     ClearHandler, CompactHandler, ExecHandler, HelpHandler, WorkdirHandler,
@@ -181,7 +182,7 @@ impl Daemon {
         info!("Slash dispatcher installed");
 
         info!("Gateway initialized");
-        Self::init_feishu_adapter(config_dir, &gateway).await?;
+        Self::init_feishu_plugin(config_dir, &gateway).await?;
         let shutdown = shutdown::ShutdownHandle::new();
         info!("Shutdown coordinator initialized");
         // Initialize skill hot reload system
@@ -333,8 +334,15 @@ impl Daemon {
 }
 // --- Service init helpers ---
 impl Daemon {
-    /// Initialize Feishu adapter from env or config.
-    async fn init_feishu_adapter(_config_dir: &str, gateway: &Arc<Gateway>) -> anyhow::Result<()> {
+    /// Initialize Feishu IM plugin from env or config.
+    ///
+    /// Reads `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, and `FEISHU_VERIFICATION_TOKEN`
+    /// from the environment. If all three are present, builds a [`FeishuAdapter`]
+    /// and [`FeishuRenderer`], wraps them in a [`FeishuPlugin`], and registers
+    /// the plugin with the gateway via [`Gateway::register_plugin`]. When any
+    /// credential is missing the plugin is skipped and the gateway operates
+    /// without Feishu support.
+    async fn init_feishu_plugin(_config_dir: &str, gateway: &Arc<Gateway>) -> anyhow::Result<()> {
         let app_id = std::env::var("FEISHU_APP_ID").ok();
         let app_secret = std::env::var("FEISHU_APP_SECRET").ok();
         let verification_token = std::env::var("FEISHU_VERIFICATION_TOKEN").ok();
@@ -342,12 +350,13 @@ impl Daemon {
             (app_id, app_secret, verification_token)
         {
             let adapter = Arc::new(FeishuAdapter::new(app_id, app_secret, verification_token));
-            gateway
-                .register_adapter("feishu".to_string(), adapter)
-                .await;
-            info!("Feishu adapter registered");
+            let renderer = Arc::new(FeishuRenderer::new());
+            let plugin: Arc<dyn crate::im::IMPlugin> =
+                Arc::new(FeishuPlugin::new(adapter, renderer));
+            gateway.register_plugin(plugin).await;
+            info!("Feishu plugin registered");
         } else {
-            info!("Feishu credentials not found in env — Feishu adapter not registered");
+            info!("Feishu credentials not found in env — Feishu plugin not registered");
         }
         Ok(())
     }

--- a/src/gateway/approval.rs
+++ b/src/gateway/approval.rs
@@ -7,28 +7,32 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use serde_json::json;
+
+use crate::im::IMPlugin;
 use crate::permission::approval::ApprovalMode;
 use crate::permission::approval_flow::{ApprovalFlow, ApprovalNotification};
+use crate::renderer::RenderedOutput;
 
-use super::{Gateway, HandleResult, Message};
+use super::{Gateway, HandleResult};
 
 impl Gateway {
     /// Set the approval flow for intercepting `/approve` / `/deny` commands.
     ///
     /// Also installs the `on_notify_owner` callback that sends approval
-    /// notifications to the owner via the Gateway's adapters.
+    /// notifications to the owner via the Gateway's plugins.
     pub async fn set_approval_flow(&self, flow: Arc<tokio::sync::Mutex<ApprovalFlow>>) {
         let handle = tokio::runtime::Handle::current();
-        let adapters = self.adapters.read().await;
-        // Clone Arc adapter refs for each channel so the callback can send messages.
-        let adapter_clones: HashMap<String, Arc<dyn crate::im::IMAdapter>> = adapters
+        let plugins = self.plugins.read().await;
+        // Clone Arc plugin refs for each channel so the callback can send messages.
+        let plugin_clones: HashMap<String, Arc<dyn IMPlugin>> = plugins
             .iter()
             .map(|(k, v)| (k.clone(), Arc::clone(v)))
             .collect();
-        drop(adapters);
+        drop(plugins);
 
         // Build the on_notify_owner callback.
-        // This closure captures the adapter clones and runtime handle to send
+        // This closure captures the plugin clones and runtime handle to send
         // approval notifications asynchronously.
         let notify_cb = move |notification: ApprovalNotification| {
             let request_id = notification.request_id;
@@ -42,23 +46,18 @@ impl Gateway {
                 request_id, agent, user, op, risk, request_id, request_id
             );
 
-            // Find the first available adapter and send to the owner.
-            // The owner channel is determined by the adapter's default target.
-            let adapters = adapter_clones.clone();
+            // Find the first available plugin and send to the owner.
+            // The owner channel is determined by the plugin's default target.
+            let plugins = plugin_clones.clone();
             let handle = handle.clone();
             handle.spawn(async move {
-                // Try each registered adapter until one succeeds.
-                for (channel_name, adapter) in &adapters {
-                    let msg = Message {
-                        id: format!("approval-notify-{}", chrono::Utc::now().timestamp_millis()),
-                        from: "system".to_string(),
-                        to: "owner".to_string(),
-                        content: text.clone(),
-                        channel: channel_name.clone(),
-                        timestamp: chrono::Utc::now().timestamp(),
-                        metadata: std::collections::HashMap::new(),
+                // Try each registered plugin until one succeeds.
+                for (channel_name, plugin) in &plugins {
+                    let output = RenderedOutput {
+                        msg_type: "text".into(),
+                        payload: json!({"content": {"text": text}}),
                     };
-                    match adapter.send_message(&msg).await {
+                    match plugin.send(&output, "owner", None).await {
                         Ok(()) => break,
                         Err(e) => {
                             tracing::warn!(

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -12,14 +12,18 @@ pub mod slash_permission;
 pub mod system_prompt_inject;
 
 #[cfg(test)]
+mod tests_plugin;
+#[cfg(test)]
 mod tests_slash_permission;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::permission::approval_flow::ApprovalFlow;
 use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::renderer::RenderedOutput;
 use crate::session::checkpoint_manager::CheckpointManager;
 use crate::session::persistence::PersistenceService;
 use crate::slash::SlashDispatcher;
@@ -105,13 +109,12 @@ pub struct Session {
     pub created_at: i64,
 }
 
-/// Gateway - routes messages between IM adapters and agents
+/// Gateway - routes messages between IM plugins and agents
 pub struct Gateway {
     config: GatewayConfig,
-    adapters: RwLock<HashMap<String, Arc<dyn super::im::IMAdapter>>>,
+    plugins: RwLock<HashMap<String, Arc<dyn super::im::IMPlugin>>>,
     session_manager: Arc<SessionManager>,
     processor_registry: Option<Arc<ProcessorRegistry>>,
-    renderer: Option<Arc<dyn crate::renderer::Renderer>>,
     checkpoint_manager: Option<Arc<CheckpointManager<dyn PersistenceService>>>,
     session_handler: Option<Arc<SessionMessageHandler>>,
     /// Daemon-level approval flow for intercepting `/approve` / `/deny` commands.
@@ -127,10 +130,9 @@ impl Gateway {
     pub fn new(config: GatewayConfig, session_manager: Arc<SessionManager>) -> Self {
         Self {
             config,
-            adapters: RwLock::new(HashMap::new()),
+            plugins: RwLock::new(HashMap::new()),
             session_manager,
             processor_registry: None,
-            renderer: None,
             checkpoint_manager: None,
             session_handler: None,
             approval_flow: RwLock::new(None),
@@ -147,35 +149,9 @@ impl Gateway {
     ) -> Self {
         Self {
             config,
-            adapters: RwLock::new(HashMap::new()),
+            plugins: RwLock::new(HashMap::new()),
             session_manager,
             processor_registry: Some(registry),
-            renderer: None,
-            checkpoint_manager: None,
-            session_handler: None,
-            approval_flow: RwLock::new(None),
-            slash_dispatcher: RwLock::new(None),
-            permission_engine: RwLock::new(None),
-        }
-    }
-
-    /// Create a new Gateway with a renderer.
-    ///
-    /// The renderer is used in `send_outbound` to render LLM output to
-    /// platform-specific formats (card or text). Optionally takes a
-    /// processor registry for preprocessing.
-    pub fn with_renderer(
-        config: GatewayConfig,
-        session_manager: Arc<SessionManager>,
-        renderer: Arc<dyn crate::renderer::Renderer>,
-        registry: Option<Arc<ProcessorRegistry>>,
-    ) -> Self {
-        Self {
-            config,
-            adapters: RwLock::new(HashMap::new()),
-            session_manager,
-            processor_registry: registry,
-            renderer: Some(renderer),
             checkpoint_manager: None,
             session_handler: None,
             approval_flow: RwLock::new(None),
@@ -254,17 +230,28 @@ impl Gateway {
         self.session_manager.flush_all().await
     }
 
-    /// Register an IM adapter.
-    pub async fn register_adapter(&self, name: String, adapter: Arc<dyn super::im::IMAdapter>) {
-        let mut adapters = self.adapters.write().await;
-        adapters.insert(name, adapter);
+    /// Register an IM plugin.
+    ///
+    /// The plugin's [`platform`](super::im::IMPlugin::platform) identifier is
+    /// used as the registry key. Re-registering the same platform replaces
+    /// the previous plugin.
+    pub async fn register_plugin(&self, plugin: Arc<dyn super::im::IMPlugin>) {
+        let key = plugin.platform().to_string();
+        let mut plugins = self.plugins.write().await;
+        plugins.insert(key, plugin);
+    }
+
+    /// Get a registered IM plugin by platform identifier.
+    pub async fn get_plugin(&self, platform: &str) -> Option<Arc<dyn super::im::IMPlugin>> {
+        let plugins = self.plugins.read().await;
+        plugins.get(platform).cloned()
     }
 
     /// Route an incoming message to the appropriate agent.
     ///
     /// Reads `session_id` from `message.metadata`. Returns `MissingSessionId`
     /// if absent. Validates the session exists in the active sessions table
-    /// before forwarding to the adapter.
+    /// before forwarding to the registered IM plugin.
     pub async fn route_message(
         &self,
         channel: &str,
@@ -282,10 +269,10 @@ impl Gateway {
             return Err(GatewayError::MissingSessionId);
         }
 
-        // Find the adapter for this channel.
-        let adapters = self.adapters.read().await;
-        let adapter = adapters
-            .get(channel)
+        // Find the IM plugin registered for this channel.
+        let plugin = self
+            .get_plugin(channel)
+            .await
             .ok_or(GatewayError::UnknownChannel(channel.to_string()))?;
 
         // Validate message size.
@@ -293,8 +280,12 @@ impl Gateway {
             return Err(GatewayError::MessageTooLarge);
         }
 
-        // Forward to adapter for delivery.
-        adapter.send_message(&message).await?;
+        // Build a text RenderedOutput and forward to the plugin.
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: json!({"content": {"text": message.content}}),
+        };
+        plugin.send(&output, &message.to, None).await?;
 
         Ok(())
     }

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -1,227 +1,181 @@
 //! Outbound message routing for the Gateway.
 //!
-//! Handles rendering and dispatching agent responses to IM adapters.
+//! Handles rendering and dispatching agent responses through the unified
+//! [`IMPlugin`](crate::im::IMPlugin) registry.
 
 use super::{Gateway, GatewayError, Message};
+use crate::im::IMPlugin;
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::{DslParseResult, ProcessedMessage};
+use crate::renderer::RenderedOutput;
+
+/// Per-call context for dispatching a rendered output and persisting its
+/// checkpoint. Bundled into a struct to keep the helper's parameter list short.
+struct DispatchCtx<'a> {
+    plugin: &'a std::sync::Arc<dyn IMPlugin>,
+    rendered: &'a RenderedOutput,
+    /// Plain-text fallback used when the rendered payload does not carry a
+    /// `content.text` field. Typically the processed chain's `content`.
+    fallback_text: &'a str,
+    session_id: &'a str,
+    channel: &'a str,
+    chat_id: String,
+}
 
 impl Gateway {
-    /// Send an outbound message (agent response) through the processor chain.
+    /// Send an outbound message (agent response) via the registered IM plugin.
     ///
+    /// Flow (single path; legacy renderer / processor-only / bypass branches
+    /// are unified here):
     /// 1. Resolve `chat_id` from `session_id` via `SessionManager::get_chat_id`.
-    /// 2. If `renderer` is present → run processor chain, deserialize
-    ///    `dsl_result` from `processed.metadata["dsl_result"]`, call
-    ///    `renderer.render(clean_content, dsl_result)`, dispatch by `msg_type`.
-    /// 3. If `renderer` is absent but `processor_registry` is present → inspect
-    ///    `msg_type` from processed content JSON (existing behavior).
-    /// 4. If neither is present → send `raw_output` as plain text (bypass).
-    /// 5. If `suppress == true` → return `Ok` without sending.
-    /// 6. After each successful send, trigger checkpoint persistence.
+    /// 2. Resolve the [`IMPlugin`](super::im::IMPlugin) registered for `channel`
+    ///    through `self.plugins`.
+    /// 3. Run the processor chain (if `processor_registry` is configured) to
+    ///    produce a [`ProcessedMessage`]; otherwise bypass with a synthetic
+    ///    `ProcessedMessage` wrapping the raw input.
+    /// 4. Honor `processed.suppress` — return `Ok(())` without sending.
+    /// 5. Extract `dsl_result` from `processed.metadata["dsl_result"]` (stored
+    ///    as a JSON-encoded string by the DSL processor).
+    /// 6. Call `plugin.render(blocks, dsl_result)` to obtain a
+    ///    [`RenderedOutput`](crate::renderer::RenderedOutput); fall back to a
+    ///    single `ContentBlock::Text` block when `content_blocks` is empty.
+    /// 7. Dispatch by `msg_type` (`"text"` / `"interactive"`) through
+    ///    `plugin.send`. Any other type is an [`GatewayError::OutboundError`].
+    /// 8. After each successful send, trigger checkpoint persistence.
+    /// 9. `thread_id` is not yet wired through — `None` is passed to
+    ///    `plugin.send`.
     pub async fn send_outbound(
         &self,
         session_id: &str,
         channel: &str,
         raw_output: &str,
-        content_blocks: Vec<crate::llm::types::ContentBlock>,
+        content_blocks: Vec<ContentBlock>,
     ) -> Result<(), GatewayError> {
-        // Step 1: resolve chat_id
+        // 1. Resolve chat_id and plugin.
         let chat_id = self
             .session_manager
             .get_chat_id(session_id)
             .await
             .ok_or(GatewayError::MissingSessionId)?;
+        let plugin = self
+            .get_plugin(channel)
+            .await
+            .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?;
 
-        // Step 2: resolve adapter
-        let adapter = {
-            let adapters = self.adapters.read().await;
-            adapters
-                .get(channel)
-                .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?
-                .clone()
-        };
-
-        // Step 3: bypass, renderer path, or processor-chain path
-        let processed_content = if let Some(ref renderer) = self.renderer {
-            let registry = self.processor_registry.as_ref().ok_or_else(|| {
-                GatewayError::OutboundError("renderer requires processor registry".into())
-            })?;
-            let processed = crate::processor_chain::ProcessedMessage {
-                content: raw_output.to_string(),
-                metadata: serde_json::Map::new(),
-                suppress: false,
-                content_blocks: content_blocks.clone(),
-            };
-            let result = registry
-                .process_outbound(processed)
-                .await
-                .map_err(|e| GatewayError::OutboundError(e.to_string()))?;
-            if result.suppress {
-                return Ok(());
-            }
-
-            // Deserialize dsl_result from metadata
-            let dsl_result: Option<crate::processor_chain::DslParseResult> = result
-                .metadata
-                .get("dsl_result")
-                .and_then(|v| v.as_str())
-                .and_then(|s| serde_json::from_str(s).ok());
-
-            // Step 1.2: pass the full ContentBlock stream to the renderer.
-            // The renderer decides per-block rendering (text/thinking/tool_use/tool_result)
-            // and extracts DSL-stripped plain text internally for the single-Text
-            // fast path. Previously this call site derived `clean_content` from
-            // `dsl_result` itself; that responsibility now lives in the renderer.
-            //
-            // Fallback: when content_blocks is empty (e.g. legacy caller that
-            // didn't produce structured blocks), wrap the raw `result.content`
-            // in a single Text block so simple text paths still work.
-            let owned_fallback;
-            let blocks_for_render: &[crate::llm::types::ContentBlock] =
-                if result.content_blocks.is_empty() {
-                    owned_fallback = vec![crate::llm::types::ContentBlock::Text(
-                        result.content.clone(),
-                    )];
-                    &owned_fallback
-                } else {
-                    &result.content_blocks
-                };
-
-            // Preserve a plain-text fallback string in case the renderer's
-            // text branch returns a payload missing the `content.text` field
-            // (defensive: older code paths may rely on it).
-            let content = dsl_result
-                .as_ref()
-                .map(|r| r.clean_content.as_str())
-                .unwrap_or(&result.content);
-
-            let rendered = renderer.render(blocks_for_render, dsl_result.as_ref());
-            let payload_str =
-                serde_json::to_string(&rendered.payload).unwrap_or_else(|_| "{}".to_string());
-
-            match rendered.msg_type.as_str() {
-                "text" => {
-                    let text = rendered
-                        .payload
-                        .get("content")
-                        .and_then(|v| v.get("text"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(content)
-                        .to_string();
-                    let msg = Message {
-                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                        from: "agent".to_string(),
-                        to: chat_id.clone(),
-                        content: text,
-                        channel: channel.to_string(),
-                        timestamp: chrono::Utc::now().timestamp(),
-                        metadata: std::collections::HashMap::new(),
-                    };
-                    adapter.send_message(&msg).await?;
-                    self.persist_outbound_checkpoint(session_id, &msg).await;
-                    return Ok(());
-                }
-                "interactive" => {
-                    adapter.send_card_json(&chat_id, &payload_str).await?;
-                    let msg = Message {
-                        id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                        from: "agent".to_string(),
-                        to: chat_id.clone(),
-                        content: payload_str.clone(),
-                        channel: channel.to_string(),
-                        timestamp: chrono::Utc::now().timestamp(),
-                        metadata: std::collections::HashMap::new(),
-                    };
-                    self.persist_outbound_checkpoint(session_id, &msg).await;
-                    return Ok(());
-                }
-                _ => {
-                    return Err(GatewayError::OutboundError(format!(
-                        "unknown msg_type: {}",
-                        rendered.msg_type
-                    )))
-                }
-            }
-        } else if let Some(ref registry) = self.processor_registry {
-            let processed = crate::processor_chain::ProcessedMessage {
-                content: raw_output.to_string(),
-                metadata: serde_json::Map::new(),
-                suppress: false,
-                content_blocks: content_blocks.clone(),
-            };
-            let result = registry.process_outbound(processed).await;
-            match result {
-                Ok(p) => {
-                    if p.suppress {
-                        return Ok(());
-                    }
-                    p.content
-                }
-                Err(e) => return Err(GatewayError::OutboundError(e.to_string())),
-            }
-        } else {
-            raw_output.to_string()
-        };
-
-        // Step 4: inspect msg_type and dispatch
-        if let Ok(json) =
-            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&processed_content)
-        {
-            if let Some(msg_type) = json.get("msg_type") {
-                match msg_type.as_str().unwrap_or("") {
-                    "text" => {
-                        let msg = Message {
-                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                            from: "agent".to_string(),
-                            to: chat_id.clone(),
-                            content: json
-                                .get("content")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(&processed_content)
-                                .to_string(),
-                            channel: channel.to_string(),
-                            timestamp: chrono::Utc::now().timestamp(),
-                            metadata: std::collections::HashMap::new(),
-                        };
-                        adapter.send_message(&msg).await?;
-                        self.persist_outbound_checkpoint(session_id, &msg).await;
-                        return Ok(());
-                    }
-                    "interactive" => {
-                        let card_json = json
-                            .get("content")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(&processed_content)
-                            .to_string();
-                        adapter.send_card_json(&chat_id, &card_json).await?;
-                        let msg = Message {
-                            id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
-                            from: "agent".to_string(),
-                            to: chat_id.clone(),
-                            content: card_json,
-                            channel: channel.to_string(),
-                            timestamp: chrono::Utc::now().timestamp(),
-                            metadata: std::collections::HashMap::new(),
-                        };
-                        self.persist_outbound_checkpoint(session_id, &msg).await;
-                        return Ok(());
-                    }
-                    _ => {}
-                }
-            }
+        // 2. Run processor chain (or bypass) and honor suppress.
+        let processed = self.process_or_bypass(raw_output, content_blocks).await?;
+        if processed.suppress {
+            return Ok(());
         }
 
-        // Fallback: treat as plain text
-        let msg = Message {
+        // 3. Extract dsl_result (serialized as a JSON string by DslParser).
+        let dsl_result: Option<DslParseResult> = processed
+            .metadata
+            .get("dsl_result")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(s).ok());
+
+        // 4. Render via the plugin; fall back to a single Text block when
+        // content_blocks is empty.
+        let rendered = {
+            let owned_fallback;
+            let blocks: &[ContentBlock] = if processed.content_blocks.is_empty() {
+                owned_fallback = vec![ContentBlock::Text(processed.content.clone())];
+                &owned_fallback
+            } else {
+                &processed.content_blocks
+            };
+            plugin.render(blocks, dsl_result.as_ref())
+        };
+
+        // 5. Dispatch by msg_type and persist checkpoint on success.
+        self.dispatch_and_persist(DispatchCtx {
+            plugin: &plugin,
+            rendered: &rendered,
+            fallback_text: &processed.content,
+            session_id,
+            channel,
+            chat_id,
+        })
+        .await
+    }
+
+    /// Dispatch a rendered output to its destination plugin and persist the
+    /// outbound checkpoint. `msg_type` drives the dispatch:
+    /// - `"text"`: extract text from `rendered.payload`, build a [`Message`],
+    ///   call `plugin.send`.
+    /// - `"interactive"`: call `plugin.send` directly, build a [`Message`]
+    ///   from the serialized payload for checkpointing.
+    /// - any other: return [`GatewayError::OutboundError`].
+    async fn dispatch_and_persist(&self, ctx: DispatchCtx<'_>) -> Result<(), GatewayError> {
+        match ctx.rendered.msg_type.as_str() {
+            "text" => {
+                let text = ctx
+                    .rendered
+                    .payload
+                    .get("content")
+                    .and_then(|v| v.get("text"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(ctx.fallback_text)
+                    .to_string();
+                let msg = Self::make_outbound_msg(ctx.channel, ctx.chat_id.clone(), text);
+                ctx.plugin.send(ctx.rendered, &ctx.chat_id, None).await?;
+                self.persist_outbound_checkpoint(ctx.session_id, &msg).await;
+                Ok(())
+            }
+            "interactive" => {
+                let payload_str = serde_json::to_string(&ctx.rendered.payload)
+                    .unwrap_or_else(|_| "{}".to_string());
+                ctx.plugin.send(ctx.rendered, &ctx.chat_id, None).await?;
+                let msg = Self::make_outbound_msg(ctx.channel, ctx.chat_id, payload_str);
+                self.persist_outbound_checkpoint(ctx.session_id, &msg).await;
+                Ok(())
+            }
+            _ => Err(GatewayError::OutboundError(format!(
+                "unknown msg_type: {}",
+                ctx.rendered.msg_type
+            ))),
+        }
+    }
+
+    /// Run the outbound processor chain if configured, otherwise bypass with
+    /// a synthetic [`ProcessedMessage`] wrapping the raw input.
+    async fn process_or_bypass(
+        &self,
+        raw_output: &str,
+        content_blocks: Vec<ContentBlock>,
+    ) -> Result<ProcessedMessage, GatewayError> {
+        let Some(ref registry) = self.processor_registry else {
+            return Ok(ProcessedMessage {
+                content: raw_output.to_string(),
+                metadata: serde_json::Map::new(),
+                suppress: false,
+                content_blocks,
+            });
+        };
+        let input = ProcessedMessage {
+            content: raw_output.to_string(),
+            metadata: serde_json::Map::new(),
+            suppress: false,
+            content_blocks,
+        };
+        registry
+            .process_outbound(input)
+            .await
+            .map_err(|e| GatewayError::OutboundError(e.to_string()))
+    }
+
+    /// Build a [`Message`] for checkpoint persistence from outbound fields.
+    fn make_outbound_msg(channel: &str, to: String, content: String) -> Message {
+        Message {
             id: format!("out-{}", chrono::Utc::now().timestamp_millis()),
             from: "agent".to_string(),
-            to: chat_id,
-            content: processed_content,
+            to,
+            content,
             channel: channel.to_string(),
             timestamp: chrono::Utc::now().timestamp(),
             metadata: std::collections::HashMap::new(),
-        };
-        adapter.send_message(&msg).await?;
-        self.persist_outbound_checkpoint(session_id, &msg).await;
-        Ok(())
+        }
     }
 
     /// Persist outbound message to checkpoint if checkpoint_manager is configured.

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -3,46 +3,77 @@
 //! All tests live here so that src/gateway/mod.rs stays under 500 lines.
 
 use crate::gateway::{DmScope, GatewayConfig, GatewayError, Message, SessionManager};
-use crate::im::{AdapterError, IMAdapter};
+use crate::im::{AdapterError, IMPlugin, NormalizedMessage};
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::DslParseResult;
+use crate::renderer::RenderedOutput;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use async_trait::async_trait;
+use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-// ── Mock adapter ────────────────────────────────────────────────────────────
+// ── Mock plugin ─────────────────────────────────────────────────────────────
 
-struct MockAdapter {
+/// Mock IM plugin used to exercise Gateway's plugin registry and dispatch
+/// paths. `platform` is configurable so the same struct can be registered
+/// under different keys (e.g. `"mock"`, `"ch"`, `"feishu"`) per test.
+struct MockPlugin {
+    platform: String,
     should_fail: bool,
 }
 
+impl MockPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            should_fail: false,
+        }
+    }
+
+    fn failing(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            should_fail: true,
+        }
+    }
+}
+
 #[async_trait]
-impl IMAdapter for MockAdapter {
-    fn name(&self) -> &str {
-        "mock"
+impl IMPlugin for MockPlugin {
+    fn platform(&self) -> &str {
+        &self.platform
     }
 
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Message, AdapterError> {
-        Ok(Message {
-            id: "1".into(),
-            from: "a".into(),
-            to: "b".into(),
-            content: "hi".into(),
-            channel: "mock".into(),
-            timestamp: 0,
-            metadata: HashMap::new(),
-        })
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
     }
 
-    async fn send_message(&self, _message: &Message) -> Result<(), AdapterError> {
+    fn render(
+        &self,
+        _content_blocks: &[ContentBlock],
+        _dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: json!({"content": {"text": ""}}),
+        }
+    }
+
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
         if self.should_fail {
             return Err(AdapterError::SendFailed("mock error".into()));
         }
         Ok(())
-    }
-
-    async fn validate_signature(&self, _signature: &str, _payload: &[u8]) -> bool {
-        true
     }
 }
 
@@ -81,17 +112,13 @@ fn make_gw(config: GatewayConfig) -> (crate::gateway::Gateway, Arc<SessionManage
     (gw, sm)
 }
 
-/// Setup: gateway + session_manager + registered mock adapter.
+/// Setup: gateway + session_manager + registered mock plugin under `channel`.
 async fn setup(
     config: GatewayConfig,
     channel: &str,
 ) -> (crate::gateway::Gateway, Arc<SessionManager>) {
     let (gw, sm) = make_gw(config);
-    gw.register_adapter(
-        channel.to_string(),
-        Arc::new(MockAdapter { should_fail: false }),
-    )
-    .await;
+    gw.register_plugin(Arc::new(MockPlugin::new(channel))).await;
     (gw, sm)
 }
 
@@ -251,7 +278,7 @@ async fn test_route_message_too_large() {
 #[tokio::test]
 async fn test_route_adapter_error() {
     let (gw, sm) = make_gw(make_config());
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter { should_fail: true }))
+    gw.register_plugin(Arc::new(MockPlugin::failing("mock")))
         .await;
     let msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
     let result = gw.route_message("mock", msg, None).await;

--- a/src/gateway/tests_dmscope.rs
+++ b/src/gateway/tests_dmscope.rs
@@ -1,52 +1,67 @@
 //! Tests for DmScope Feishu isolation variants.
 
 use crate::gateway::{DmScope, GatewayConfig, SessionManager};
-use crate::im::IMAdapter;
+use crate::im::{AdapterError, IMPlugin, NormalizedMessage};
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::DslParseResult;
+use crate::renderer::RenderedOutput;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use async_trait::async_trait;
+use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-// ── Mock adapter ────────────────────────────────────────────────────────────
+// ── Mock plugin ─────────────────────────────────────────────────────────────
 
-struct MockAdapter {
+/// Mock IM plugin used by DmScope isolation tests. `platform` is configurable
+/// so the same struct can be registered under different keys per test.
+struct MockPlugin {
+    platform: String,
+    #[allow(dead_code)]
     should_fail: bool,
 }
 
+impl MockPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            should_fail: false,
+        }
+    }
+}
+
 #[async_trait]
-impl IMAdapter for MockAdapter {
-    fn name(&self) -> &str {
-        "mock"
+impl IMPlugin for MockPlugin {
+    fn platform(&self) -> &str {
+        &self.platform
     }
 
-    async fn handle_webhook(
+    async fn parse_inbound(
         &self,
         _payload: &[u8],
-    ) -> Result<crate::gateway::Message, crate::im::AdapterError> {
-        Ok(crate::gateway::Message {
-            id: "1".into(),
-            from: "a".into(),
-            to: "b".into(),
-            content: "hi".into(),
-            channel: "mock".into(),
-            timestamp: 0,
-            metadata: HashMap::new(),
-        })
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
     }
 
-    async fn send_message(
+    fn render(
         &self,
-        _message: &crate::gateway::Message,
-    ) -> Result<(), crate::im::AdapterError> {
-        if self.should_fail {
-            return Err(crate::im::AdapterError::SendFailed("mock error".into()));
+        _content_blocks: &[ContentBlock],
+        _dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: json!({"content": {"text": ""}}),
         }
-        Ok(())
     }
 
-    async fn validate_signature(&self, _signature: &str, _payload: &[u8]) -> bool {
-        true
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        Ok(())
     }
 }
 
@@ -85,17 +100,13 @@ fn make_gw(config: GatewayConfig) -> (crate::gateway::Gateway, Arc<SessionManage
     (gw, sm)
 }
 
-/// Setup: gateway + session_manager + registered mock adapter.
+/// Setup: gateway + session_manager + registered mock plugin under `channel`.
 async fn setup(
     config: GatewayConfig,
     channel: &str,
 ) -> (crate::gateway::Gateway, Arc<SessionManager>) {
     let (gw, sm) = make_gw(config);
-    gw.register_adapter(
-        channel.to_string(),
-        Arc::new(MockAdapter { should_fail: false }),
-    )
-    .await;
+    gw.register_plugin(Arc::new(MockPlugin::new(channel))).await;
     (gw, sm)
 }
 

--- a/src/gateway/tests_plugin.rs
+++ b/src/gateway/tests_plugin.rs
@@ -1,0 +1,144 @@
+//! Tests for Gateway plugin registry (register_plugin / get_plugin).
+
+use crate::gateway::{Gateway, GatewayConfig, SessionManager};
+use crate::im::{AdapterError, IMPlugin, NormalizedMessage};
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::DslParseResult;
+use crate::renderer::RenderedOutput;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+struct MockPlugin {
+    platform_name: String,
+    fail: bool,
+}
+
+impl MockPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform_name: platform.to_string(),
+            fail: false,
+        }
+    }
+    fn failing(platform: &str) -> Self {
+        Self {
+            platform_name: platform.to_string(),
+            fail: true,
+        }
+    }
+}
+
+#[async_trait]
+impl IMPlugin for MockPlugin {
+    fn platform(&self) -> &str {
+        &self.platform_name
+    }
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
+    }
+    fn render(
+        &self,
+        _content_blocks: &[ContentBlock],
+        _dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({"content": {"text": "mock"}}),
+        }
+    }
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        if self.fail {
+            Err(AdapterError::SendFailed("mock failure".into()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn make_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: crate::gateway::DmScope::default(),
+    }
+}
+
+fn make_gw(config: GatewayConfig) -> (Gateway, Arc<SessionManager>) {
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+        ReasoningLevel::default(),
+    ));
+    let gw = Gateway::new(config, Arc::clone(&sm));
+    (gw, sm)
+}
+
+// ── Plugin registry tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_register_plugin_inserts_into_registry() {
+    let (gw, _sm) = make_gw(make_config());
+    let plugin = Arc::new(MockPlugin::new("alpha"));
+    gw.register_plugin(plugin).await;
+    let retrieved = gw.get_plugin("alpha").await;
+    assert!(retrieved.is_some(), "registered plugin must be retrievable");
+    assert_eq!(retrieved.unwrap().platform(), "alpha");
+}
+
+#[tokio::test]
+async fn test_get_plugin_unknown_returns_none() {
+    let (gw, _sm) = make_gw(make_config());
+    let result = gw.get_plugin("not-registered").await;
+    assert!(
+        result.is_none(),
+        "unknown platform must yield None from get_plugin"
+    );
+}
+
+#[tokio::test]
+async fn test_register_plugin_replaces_existing_entry() {
+    let (gw, _sm) = make_gw(make_config());
+    let p1: Arc<dyn IMPlugin> = Arc::new(MockPlugin::new("shared"));
+    let p2: Arc<dyn IMPlugin> = Arc::new(MockPlugin::failing("shared"));
+    gw.register_plugin(p1.clone()).await;
+    gw.register_plugin(p2.clone()).await;
+
+    // Re-registering the same platform must replace the prior Arc.
+    let retrieved = gw.get_plugin("shared").await.expect("plugin must exist");
+    assert!(
+        Arc::ptr_eq(&retrieved, &p2),
+        "second registration must replace the first"
+    );
+    assert!(
+        !Arc::ptr_eq(&retrieved, &p1),
+        "first plugin should no longer be reachable"
+    );
+}
+
+#[tokio::test]
+async fn test_register_plugin_uses_plugin_platform_as_key() {
+    // The registry key is derived from the plugin's `platform()` method,
+    // not from any caller-supplied string. Registering a plugin that reports
+    // `"beta"` should NOT be reachable under any other key.
+    let (gw, _sm) = make_gw(make_config());
+    let plugin = Arc::new(MockPlugin::new("beta"));
+    gw.register_plugin(plugin).await;
+    assert!(gw.get_plugin("beta").await.is_some());
+    assert!(gw.get_plugin("BETA").await.is_none());
+    assert!(gw.get_plugin("").await.is_none());
+}

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -2,8 +2,12 @@
 //!
 //! Implements IMAdapter for Feishu messaging platform.
 
-use super::{AdapterError, IMAdapter};
+use super::{AdapterError, IMAdapter, IMPlugin, NormalizedMessage};
 use crate::gateway::Message;
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::DslParseResult;
+use crate::renderer::feishu::FeishuRenderer;
+use crate::renderer::{RenderedOutput, Renderer};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -295,5 +299,95 @@ impl IMAdapter for FeishuAdapter {
         let result = hasher.finalize();
         let expected = format!("{:x}", result);
         expected == signature
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FeishuPlugin — IMPlugin wrapper for the Feishu platform
+// ---------------------------------------------------------------------------
+
+/// Unified IM plugin for Feishu, wrapping a [`FeishuAdapter`] (HTTP I/O) and a
+/// [`FeishuRenderer`] (LLM `ContentBlock`s → card / text payloads) behind a
+/// single [`IMPlugin`] implementation. The gateway registers one instance per
+/// platform via `IMPlugin::platform()` and routes all inbound / outbound calls
+/// through it.
+pub struct FeishuPlugin {
+    adapter: Arc<FeishuAdapter>,
+    renderer: Arc<FeishuRenderer>,
+}
+
+impl FeishuPlugin {
+    /// Build a new [`FeishuPlugin`] from a Feishu adapter and renderer.
+    pub(crate) fn new(adapter: Arc<FeishuAdapter>, renderer: Arc<FeishuRenderer>) -> Self {
+        Self { adapter, renderer }
+    }
+}
+
+#[async_trait]
+impl IMPlugin for FeishuPlugin {
+    fn platform(&self) -> &str {
+        "feishu"
+    }
+
+    async fn parse_inbound(
+        &self,
+        payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        let message = self.adapter.handle_webhook(payload).await?;
+        Ok(Some(NormalizedMessage {
+            platform: message.channel,
+            sender_id: message.from,
+            peer_id: message.to,
+            content: message.content,
+            timestamp: message.timestamp,
+            thread_id: None,
+            account_id: message.metadata.get("account_id").cloned(),
+        }))
+    }
+
+    async fn validate_signature(&self, signature: &str, payload: &[u8]) -> bool {
+        self.adapter.validate_signature(signature, payload).await
+    }
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        self.renderer.render(content_blocks, dsl_result)
+    }
+
+    async fn send(
+        &self,
+        output: &RenderedOutput,
+        peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        match output.msg_type.as_str() {
+            "text" => {
+                let text = output
+                    .payload
+                    .get("content")
+                    .and_then(|c| c.get("text"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("");
+                let message = Message {
+                    id: String::new(),
+                    from: String::new(),
+                    to: peer_id.to_string(),
+                    content: text.to_string(),
+                    channel: "feishu".to_string(),
+                    timestamp: chrono::Utc::now().timestamp(),
+                    metadata: HashMap::new(),
+                };
+                self.adapter.send_message(&message).await
+            }
+            "interactive" => {
+                let card_json = serde_json::to_string(&output.payload)
+                    .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+                self.adapter.send_card_json(peer_id, &card_json).await
+            }
+            _ => Err(AdapterError::UnsupportedOperation),
+        }
     }
 }

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -2,10 +2,13 @@
 
 use async_trait::async_trait;
 use closeclaw::gateway::{DmScope, Gateway, GatewayConfig, GatewayError, Message, SessionManager};
-use closeclaw::im::{AdapterError, IMAdapter};
+use closeclaw::im::{AdapterError, IMAdapter, IMPlugin, NormalizedMessage};
+use closeclaw::llm::types::ContentBlock;
+use closeclaw::processor_chain::dsl_parser::DslParseResult;
 use closeclaw::processor_chain::{
     MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage,
 };
+use closeclaw::renderer::RenderedOutput;
 use closeclaw::session::bootstrap::BootstrapMode;
 use closeclaw::session::persistence::ReasoningLevel;
 use std::collections::HashMap;
@@ -43,38 +46,101 @@ impl MessageProcessor for MockOutboundProcessor {
     }
 }
 
-/// MockAdapter that tracks send_message and send_card_json calls.
+/// TrackingPlugin — test plugin for the outbound chain.
+///
+/// Implements [`IMPlugin`]. Records `send()` invocations, the rendered
+/// `msg_type` from the most recent `render()` call, the joined text content
+/// of the rendered content blocks, and the dsl_result forwarded to
+/// `render()`. `forced_msg_type` lets each test pin the rendered output to a
+/// specific `msg_type` (`"text"` by default).
 #[derive(Debug, Default)]
-struct TrackingAdapter {
-    send_message_called: Mutex<bool>,
-    send_card_json_called: Mutex<bool>,
+struct TrackingPlugin {
+    /// Tracks whether `send()` has been called at least once.
+    send_called: Mutex<bool>,
+    /// Last `msg_type` returned by `render()`.
+    last_msg_type: Mutex<Option<String>>,
+    /// Last joined text content extracted from `render()`'s content blocks.
+    last_content: Mutex<Option<String>>,
+    /// Last `dsl_result` observed by `render()`.
+    last_dsl_result: Mutex<Option<DslParseResult>>,
+    /// Optional override for the rendered `msg_type`. Defaults to `"text"`.
+    forced_msg_type: Option<String>,
+}
+
+impl TrackingPlugin {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_msg_type(msg_type: &str) -> Self {
+        Self {
+            forced_msg_type: Some(msg_type.to_string()),
+            ..Default::default()
+        }
+    }
 }
 
 #[async_trait]
-impl IMAdapter for TrackingAdapter {
-    fn name(&self) -> &str {
+impl IMPlugin for TrackingPlugin {
+    fn platform(&self) -> &str {
         "tracking"
     }
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Message, AdapterError> {
-        Ok(Message {
-            id: "1".into(),
-            from: "a".into(),
-            to: "b".into(),
-            content: "hi".into(),
-            channel: "tracking".into(),
+
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(Some(NormalizedMessage {
+            platform: "tracking".to_string(),
+            sender_id: "user_1".to_string(),
+            peer_id: "chat_1".to_string(),
+            content: "hi".to_string(),
             timestamp: 0,
-            metadata: HashMap::new(),
-        })
+            thread_id: None,
+            account_id: None,
+        }))
     }
-    async fn send_message(&self, _message: &Message) -> Result<(), AdapterError> {
-        *self.send_message_called.lock().unwrap() = true;
-        Ok(())
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        let content: String = content_blocks
+            .iter()
+            .filter_map(|b| {
+                if let ContentBlock::Text(s) = b {
+                    Some(s.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        *self.last_content.lock().unwrap() = Some(content.clone());
+        *self.last_dsl_result.lock().unwrap() = dsl_result.cloned();
+
+        let msg_type = self
+            .forced_msg_type
+            .clone()
+            .unwrap_or_else(|| "text".to_string());
+        *self.last_msg_type.lock().unwrap() = Some(msg_type.clone());
+
+        let payload = match msg_type.as_str() {
+            "text" => serde_json::json!({"content": {"text": content}}),
+            "interactive" => serde_json::json!({"card": {"elements": []}}),
+            _ => serde_json::Value::Null,
+        };
+        RenderedOutput { msg_type, payload }
     }
-    async fn validate_signature(&self, _: &str, _: &[u8]) -> bool {
-        true
-    }
-    async fn send_card_json(&self, _chat_id: &str, _card_json: &str) -> Result<(), AdapterError> {
-        *self.send_card_json_called.lock().unwrap() = true;
+
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        *self.send_called.lock().unwrap() = true;
         Ok(())
     }
 }
@@ -116,8 +182,8 @@ pub(crate) fn make_outbound_gw(config: GatewayConfig) -> (Gateway, Arc<SessionMa
 async fn test_send_outbound_no_registry_bypass() {
     let config = make_config();
     let (gw, sm) = make_outbound_gw(config);
-    gw.register_adapter("tracking".into(), Arc::new(TrackingAdapter::default()))
-        .await;
+    let plugin = Arc::new(TrackingPlugin::new());
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -125,6 +191,12 @@ async fn test_send_outbound_no_registry_bypass() {
     gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
+
+    assert!(*plugin.send_called.lock().unwrap());
+    assert_eq!(
+        plugin.last_msg_type.lock().unwrap().clone(),
+        Some("text".to_string())
+    );
 }
 
 #[tokio::test]
@@ -141,14 +213,14 @@ async fn test_send_outbound_text_path() {
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
             name: "text_processor".into(),
-            output_content: r#"{"msg_type":"text","content":"processed text"}"#.into(),
+            output_content: "processed text".into(),
             output_suppress: false,
         }));
         r
     });
     let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
-    gw.register_adapter("tracking".into(), Arc::new(TrackingAdapter::default()))
-        .await;
+    let plugin = Arc::new(TrackingPlugin::new());
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -156,6 +228,12 @@ async fn test_send_outbound_text_path() {
     gw.send_outbound(&sid, "tracking", "raw output", vec![])
         .await
         .unwrap();
+
+    assert!(*plugin.send_called.lock().unwrap());
+    assert_eq!(
+        plugin.last_msg_type.lock().unwrap().clone(),
+        Some("text".to_string())
+    );
 }
 
 #[tokio::test]
@@ -172,15 +250,14 @@ async fn test_send_outbound_interactive_path() {
         let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
         r.register(Arc::new(MockOutboundProcessor {
             name: "card_processor".into(),
-            output_content: r#"{"msg_type":"interactive","content":"{\"elements\":[]}"}"#.into(),
+            output_content: r#"{"elements":[]}"#.into(),
             output_suppress: false,
         }));
         r
     });
     let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    let plugin = Arc::new(TrackingPlugin::with_msg_type("interactive"));
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -189,13 +266,10 @@ async fn test_send_outbound_interactive_path() {
         .await
         .unwrap();
 
-    assert!(
-        *adapter.send_card_json_called.lock().unwrap(),
-        "send_card_json should be called"
-    );
-    assert!(
-        !*adapter.send_message_called.lock().unwrap(),
-        "send_message should NOT be called"
+    assert!(*plugin.send_called.lock().unwrap());
+    assert_eq!(
+        plugin.last_msg_type.lock().unwrap().clone(),
+        Some("interactive".to_string())
     );
 }
 
@@ -219,9 +293,8 @@ async fn test_send_outbound_suppress() {
         r
     });
     let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    let plugin = Arc::new(TrackingPlugin::new());
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -230,20 +303,23 @@ async fn test_send_outbound_suppress() {
         .await
         .unwrap();
 
-    assert!(!*adapter.send_message_called.lock().unwrap());
-    assert!(!*adapter.send_card_json_called.lock().unwrap());
+    // Suppress short-circuits before render() and send() are called.
+    assert!(!*plugin.send_called.lock().unwrap());
+    assert!(plugin.last_content.lock().unwrap().is_none());
+    assert!(plugin.last_msg_type.lock().unwrap().is_none());
 }
 
 #[tokio::test]
 async fn test_send_outbound_unknown_session() {
     let (gw, _sm) = make_outbound_gw(make_config());
-    gw.register_adapter("tracking".into(), Arc::new(TrackingAdapter::default()))
-        .await;
+    let plugin = Arc::new(TrackingPlugin::new());
+    gw.register_plugin(plugin.clone()).await;
 
     let result = gw
         .send_outbound("nonexistent-session", "tracking", "raw", vec![])
         .await;
     assert!(matches!(result, Err(GatewayError::MissingSessionId)));
+    assert!(!*plugin.send_called.lock().unwrap());
 }
 
 #[tokio::test]
@@ -258,6 +334,9 @@ async fn test_send_outbound_unknown_channel() {
 
 #[tokio::test]
 async fn test_feishu_adapter_send_card_json_default() {
+    // The IMAdapter trait still ships a default send_card_json impl that
+    // returns UnsupportedOperation. This test pins that behavior so any
+    // future change is caught.
     struct DummyAdapter;
     #[async_trait]
     impl IMAdapter for DummyAdapter {

--- a/tests/gateway_send_outbound_renderer.rs
+++ b/tests/gateway_send_outbound_renderer.rs
@@ -1,26 +1,34 @@
-//! Tests for Gateway::send_outbound — renderer integration tests (issue #469).
+//! Tests for Gateway::send_outbound — plugin integration tests (issue #829).
+//!
+//! Verifies that the unified plugin path (render → send) works correctly
+//! for text, interactive, suppress, and dsl_result scenarios.
 
 mod gateway_send_outbound_basic;
 
 use async_trait::async_trait;
-use closeclaw::gateway::{Gateway, GatewayError, Message, SessionManager};
-use closeclaw::im::IMAdapter;
+use closeclaw::gateway::{Gateway, GatewayError, SessionManager};
+use closeclaw::im::{AdapterError, IMPlugin, NormalizedMessage};
+use closeclaw::llm::types::ContentBlock;
 use closeclaw::processor_chain::{
     dsl_parser::DslParseResult, MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage,
 };
-use closeclaw::renderer::{RenderedOutput, Renderer};
+use closeclaw::renderer::RenderedOutput;
 use closeclaw::session::bootstrap::BootstrapMode;
 use closeclaw::session::persistence::ReasoningLevel;
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// MockOutboundProcessor — test processor for outbound chain.
+use gateway_send_outbound_basic::{make_config, make_outbound_gw, make_outbound_message};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/// MockOutboundProcessor — test processor for the outbound chain.
 #[derive(Debug)]
 struct MockOutboundProcessor {
     name: String,
     output_content: String,
     output_suppress: bool,
-    #[allow(dead_code)]
     dsl_result_json: Option<String>,
 }
 
@@ -55,22 +63,27 @@ impl MessageProcessor for MockOutboundProcessor {
     }
 }
 
-/// MockRenderer — records render calls and returns configurable output.
-#[derive(Debug)]
-struct MockRenderer {
+/// TrackingPlugin — records render and send calls for assertion.
+///
+/// `render()` returns a preconfigured [`RenderedOutput`].
+/// `send()` records that it was called.
+struct TrackingPlugin {
     platform_name: String,
-    render_content: Mutex<Option<String>>,
-    render_dsl_result: Mutex<Option<DslParseResult>>,
-    output: RenderedOutput,
+    /// Captured render inputs: (content text from first Text block, dsl_result)
+    render_called: Mutex<Option<(String, Option<DslParseResult>)>>,
+    /// Whether `send()` was called
+    send_called: Mutex<bool>,
+    /// The RenderedOutput returned by `render()`
+    render_output: RenderedOutput,
 }
 
-impl MockRenderer {
-    fn new(msg_type: &str, payload: serde_json::Value) -> Self {
+impl TrackingPlugin {
+    fn new(platform: &str, msg_type: &str, payload: serde_json::Value) -> Self {
         Self {
-            platform_name: "mock".to_string(),
-            render_content: Mutex::new(None),
-            render_dsl_result: Mutex::new(None),
-            output: RenderedOutput {
+            platform_name: platform.to_string(),
+            render_called: Mutex::new(None),
+            send_called: Mutex::new(false),
+            render_output: RenderedOutput {
                 msg_type: msg_type.to_string(),
                 payload,
             },
@@ -78,60 +91,67 @@ impl MockRenderer {
     }
 }
 
-impl Renderer for MockRenderer {
+#[async_trait]
+impl IMPlugin for TrackingPlugin {
     fn platform(&self) -> &str {
         &self.platform_name
     }
-    fn render(&self, content: &str, dsl_result: Option<&DslParseResult>) -> RenderedOutput {
-        *self.render_content.lock().unwrap() = Some(content.to_string());
-        *self.render_dsl_result.lock().unwrap() = dsl_result.cloned();
-        self.output.clone()
-    }
-}
 
-/// MockAdapter that tracks send_message and send_card_json calls.
-#[derive(Debug, Default)]
-struct TrackingAdapter {
-    send_message_called: Mutex<bool>,
-    send_card_json_called: Mutex<bool>,
-}
-
-#[async_trait]
-impl IMAdapter for TrackingAdapter {
-    fn name(&self) -> &str {
-        "tracking"
-    }
-    async fn handle_webhook(
+    async fn parse_inbound(
         &self,
         _payload: &[u8],
-    ) -> Result<Message, closeclaw::im::AdapterError> {
-        Ok(Message {
-            id: "1".into(),
-            from: "a".into(),
-            to: "b".into(),
-            content: "hi".into(),
-            channel: "tracking".into(),
-            timestamp: 0,
-            metadata: HashMap::new(),
-        })
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
     }
-    async fn send_message(&self, _message: &Message) -> Result<(), closeclaw::im::AdapterError> {
-        *self.send_message_called.lock().unwrap() = true;
-        Ok(())
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        // Capture the text from the first Text block for assertion.
+        let text = content_blocks
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::Text(t) => Some(t.clone()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        *self.render_called.lock().unwrap() = Some((text, dsl_result.cloned()));
+        self.render_output.clone()
     }
-    async fn validate_signature(&self, _: &str, _: &[u8]) -> bool {
-        true
-    }
-    async fn send_card_json(&self, _: &str, _: &str) -> Result<(), closeclaw::im::AdapterError> {
-        *self.send_card_json_called.lock().unwrap() = true;
+
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        *self.send_called.lock().unwrap() = true;
         Ok(())
     }
 }
 
-use gateway_send_outbound_basic::{make_config, make_outbound_gw, make_outbound_message};
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_registry_with_processor(
+    processor: MockOutboundProcessor,
+) -> Arc<closeclaw::processor_chain::ProcessorRegistry> {
+    Arc::new({
+        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
+        r.register(Arc::new(processor));
+        r
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_send_outbound_with_renderer_text() {
+async fn test_plugin_text_path() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -140,24 +160,19 @@ async fn test_send_outbound_with_renderer_text() {
         BootstrapMode::Minimal,
         ReasoningLevel::default(),
     ));
-    let registry = Arc::new({
-        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
-        r.register(Arc::new(MockOutboundProcessor {
-            name: "clean".into(),
-            output_content: "plain text content".to_string(),
-            output_suppress: false,
-            dsl_result_json: None,
-        }));
-        r
+    let registry = make_registry_with_processor(MockOutboundProcessor {
+        name: "clean".into(),
+        output_content: "plain text content".to_string(),
+        output_suppress: false,
+        dsl_result_json: None,
     });
-    let renderer = Arc::new(MockRenderer::new(
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
         "text",
-        serde_json::json!({"msg_type": "text", "content": {"text": "rendered text"}}),
+        serde_json::json!({"content": {"text": "rendered text"}}),
     ));
-    let gw = Gateway::with_renderer(config, Arc::clone(&sm), renderer.clone(), Some(registry));
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -166,17 +181,18 @@ async fn test_send_outbound_with_renderer_text() {
         .await
         .unwrap();
 
-    assert_eq!(
-        renderer.render_content.lock().unwrap().clone(),
-        Some("plain text content".to_string())
-    );
-    assert!(renderer.render_dsl_result.lock().unwrap().is_none());
-    assert!(*adapter.send_message_called.lock().unwrap());
-    assert!(!*adapter.send_card_json_called.lock().unwrap());
+    // render() was called with the processor's output content
+    let render = plugin.render_called.lock().unwrap().clone();
+    let (ref text, ref dsl) = render.as_ref().expect("render should have been called");
+    assert_eq!(text, "plain text content");
+    assert!(dsl.is_none());
+
+    // send() was called
+    assert!(*plugin.send_called.lock().unwrap());
 }
 
 #[tokio::test]
-async fn test_send_outbound_with_renderer_interactive() {
+async fn test_plugin_interactive_path() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -185,24 +201,19 @@ async fn test_send_outbound_with_renderer_interactive() {
         BootstrapMode::Minimal,
         ReasoningLevel::default(),
     ));
-    let registry = Arc::new({
-        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
-        r.register(Arc::new(MockOutboundProcessor {
-            name: "rich".into(),
-            output_content: "# Title\nBody content".to_string(),
-            output_suppress: false,
-            dsl_result_json: None,
-        }));
-        r
+    let registry = make_registry_with_processor(MockOutboundProcessor {
+        name: "rich".into(),
+        output_content: "# Title\nBody".to_string(),
+        output_suppress: false,
+        dsl_result_json: None,
     });
-    let renderer = Arc::new(MockRenderer::new(
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
         "interactive",
-        serde_json::json!({"msg_type": "interactive", "card": {"elements": []}}),
+        serde_json::json!({"card": {"elements": []}}),
     ));
-    let gw = Gateway::with_renderer(config, Arc::clone(&sm), renderer.clone(), Some(registry));
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -211,12 +222,11 @@ async fn test_send_outbound_with_renderer_interactive() {
         .await
         .unwrap();
 
-    assert!(*adapter.send_card_json_called.lock().unwrap());
-    assert!(!*adapter.send_message_called.lock().unwrap());
+    assert!(*plugin.send_called.lock().unwrap());
 }
 
 #[tokio::test]
-async fn test_send_outbound_with_renderer_dsl_result_passed() {
+async fn test_plugin_dsl_result_passed_to_render() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -230,23 +240,19 @@ async fn test_send_outbound_with_renderer_dsl_result_passed() {
         instructions: vec![],
     })
     .unwrap();
-    let registry = Arc::new({
-        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
-        r.register(Arc::new(MockOutboundProcessor {
-            name: "with_dsl".into(),
-            output_content: "Raw with DSL".to_string(),
-            output_suppress: false,
-            dsl_result_json: Some(dsl_json),
-        }));
-        r
+    let registry = make_registry_with_processor(MockOutboundProcessor {
+        name: "with_dsl".into(),
+        output_content: "Raw with DSL".to_string(),
+        output_suppress: false,
+        dsl_result_json: Some(dsl_json),
     });
-    let renderer = Arc::new(MockRenderer::new(
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
         "text",
-        serde_json::json!({"msg_type": "text", "content": {"text": "rendered"}}),
+        serde_json::json!({"content": {"text": "rendered"}}),
     ));
-    let gw = Gateway::with_renderer(config, Arc::clone(&sm), renderer.clone(), Some(registry));
-    gw.register_adapter("tracking".into(), Arc::new(TrackingAdapter::default()))
-        .await;
+    let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -255,16 +261,14 @@ async fn test_send_outbound_with_renderer_dsl_result_passed() {
         .await
         .unwrap();
 
-    let captured_dsl = renderer.render_dsl_result.lock().unwrap().clone();
-    assert!(captured_dsl.is_some());
-    assert_eq!(
-        captured_dsl.as_ref().unwrap().clean_content,
-        "Clean content"
-    );
+    let render = plugin.render_called.lock().unwrap().clone();
+    let (_, ref dsl) = render.as_ref().expect("render should have been called");
+    let dsl = dsl.as_ref().expect("dsl_result should have been passed");
+    assert_eq!(dsl.clean_content, "Clean content");
 }
 
 #[tokio::test]
-async fn test_send_outbound_no_renderer_fallback_text() {
+async fn test_plugin_suppress_skips_send() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -273,20 +277,19 @@ async fn test_send_outbound_no_renderer_fallback_text() {
         BootstrapMode::Minimal,
         ReasoningLevel::default(),
     ));
-    let registry = Arc::new({
-        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
-        r.register(Arc::new(MockOutboundProcessor {
-            name: "plain".into(),
-            output_content: "plain fallback".to_string(),
-            output_suppress: false,
-            dsl_result_json: None,
-        }));
-        r
+    let registry = make_registry_with_processor(MockOutboundProcessor {
+        name: "suppressor".into(),
+        output_content: "ignored".to_string(),
+        output_suppress: true,
+        dsl_result_json: None,
     });
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
+        "text",
+        serde_json::json!({"content": {"text": "should not send"}}),
+    ));
     let gw = Gateway::with_processor_registry(config, Arc::clone(&sm), registry);
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -295,17 +298,21 @@ async fn test_send_outbound_no_renderer_fallback_text() {
         .await
         .unwrap();
 
-    assert!(*adapter.send_message_called.lock().unwrap());
-    assert!(!*adapter.send_card_json_called.lock().unwrap());
+    // Suppress → neither render nor send should be called
+    assert!(plugin.render_called.lock().unwrap().is_none());
+    assert!(!*plugin.send_called.lock().unwrap());
 }
 
 #[tokio::test]
-async fn test_send_outbound_no_renderer_no_registry_bypass() {
+async fn test_no_registry_bypass_uses_plugin() {
     let config = make_config();
     let (gw, sm) = make_outbound_gw(config);
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
+        "text",
+        serde_json::json!({"content": {"text": "bypass"}}),
+    ));
+    gw.register_plugin(plugin.clone()).await;
 
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
@@ -314,72 +321,35 @@ async fn test_send_outbound_no_renderer_no_registry_bypass() {
         .await
         .unwrap();
 
-    assert!(*adapter.send_message_called.lock().unwrap());
-    assert!(!*adapter.send_card_json_called.lock().unwrap());
+    // Even without a processor registry, the plugin should be used
+    assert!(plugin.render_called.lock().unwrap().is_some());
+    assert!(*plugin.send_called.lock().unwrap());
 }
 
 #[tokio::test]
-async fn test_send_outbound_renderer_with_suppress() {
+async fn test_unknown_channel_returns_error() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(
-        &config,
-        None,
-        None,
-        BootstrapMode::Minimal,
-        ReasoningLevel::default(),
-    ));
-    let registry = Arc::new({
-        let mut r = closeclaw::processor_chain::ProcessorRegistry::new();
-        r.register(Arc::new(MockOutboundProcessor {
-            name: "suppressor".into(),
-            output_content: "ignored".to_string(),
-            output_suppress: true,
-            dsl_result_json: None,
-        }));
-        r
-    });
-    let renderer = Arc::new(MockRenderer::new(
-        "text",
-        serde_json::json!({"msg_type": "text", "content": {"text": "should not send"}}),
-    ));
-    let gw = Gateway::with_renderer(config, Arc::clone(&sm), renderer.clone(), Some(registry));
-    let adapter = Arc::new(TrackingAdapter::default());
-    gw.register_adapter("tracking".into(), adapter.clone())
-        .await;
-
+    let (gw, sm) = make_outbound_gw(config);
     let msg = make_outbound_message("agent-1", "hello");
     let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
 
-    gw.send_outbound(&sid, "tracking", "raw output", vec![])
-        .await
-        .unwrap();
-
-    assert!(!*adapter.send_message_called.lock().unwrap());
-    assert!(!*adapter.send_card_json_called.lock().unwrap());
-    assert!(renderer.render_content.lock().unwrap().is_none());
+    let result = gw.send_outbound(&sid, "unknown", "raw", vec![]).await;
+    assert!(matches!(result, Err(GatewayError::UnknownChannel(_))));
 }
 
 #[tokio::test]
-async fn test_send_outbound_renderer_requires_registry() {
+async fn test_unknown_session_returns_error() {
     let config = make_config();
-    let sm = Arc::new(SessionManager::new(
-        &config,
-        None,
-        None,
-        BootstrapMode::Minimal,
-        ReasoningLevel::default(),
-    ));
-    let renderer = Arc::new(MockRenderer::new(
+    let (gw, _sm) = make_outbound_gw(config);
+    let plugin = Arc::new(TrackingPlugin::new(
+        "tracking",
         "text",
-        serde_json::json!({"msg_type": "text", "content": {"text": "x"}}),
+        serde_json::json!({"content": {"text": "x"}}),
     ));
-    let gw = Gateway::with_renderer(config, Arc::clone(&sm), renderer, None);
-    gw.register_adapter("tracking".into(), Arc::new(TrackingAdapter::default()))
+    gw.register_plugin(plugin).await;
+
+    let result = gw
+        .send_outbound("nonexistent-session", "tracking", "raw", vec![])
         .await;
-
-    let msg = make_outbound_message("agent-1", "hello");
-    let sid = sm.find_or_create("tracking", &msg, None).await.unwrap();
-
-    let result = gw.send_outbound(&sid, "tracking", "raw", vec![]).await;
-    assert!(matches!(result, Err(GatewayError::OutboundError(_))));
+    assert!(matches!(result, Err(GatewayError::MissingSessionId)));
 }


### PR DESCRIPTION
## Summary

Gateway 统一插件注册表：替换 `adapters` + `renderer` 为 `platform → IMPlugin` 映射。

### 变更

- **Gateway struct**：删除 `adapters: RwLock<HashMap<String, Arc<IMAdapter>>>` 和 `renderer: Option<Arc<Renderer>>`，新增 `plugins: RwLock<HashMap<String, Arc<dyn IMPlugin>>>`
- **注册接口**：删除 `register_adapter()` 和 `with_renderer()`，新增 `register_plugin()` 和 `get_plugin()`
- **send_outbound**：统一为单一路径 — Processor Chain → `plugin.render()` → `plugin.send()`，删除三条旧分支
- **route_message**：通过 `plugin.send()` 分发，不再引用 `self.adapters`
- **set_approval_flow**：通过 `self.plugins` 发送审批通知
- **Daemon 初始化**：创建 `FeishuPlugin`（包装 FeishuAdapter + FeishuRenderer），通过 `register_plugin` 注册
- **测试**：新增 `MockPlugin` / `TrackingPlugin`，更新 gateway lib tests 和 integration tests

### 保留不动

- `IMAdapter` trait、`Renderer` trait 保留，后续 issue 逐步迁移
- `SessionManager.adapters` 保留（用于 restore 通知）
- `with_processor_registry` 保留

### 测试结果

- `cargo build`: 0 errors
- `cargo test --lib`: 1738 passed / 2 pre-existing failed
- Integration tests: 14/14 passed

Source: issue #829
Type: feat
