### PR TITLE
chore: 消除编译 warning（非 deprecated 类）

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,3 +104,6 @@ path = "src/lib.rs"
 [[bin]]
 name = "closeclaw"
 path = "src/main.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("server"))'] }

--- a/src/agent/inbox/manager.rs
+++ b/src/agent/inbox/manager.rs
@@ -1,6 +1,6 @@
 //! Inbox manager implementation
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, Utc};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::fs;

--- a/src/agent/inbox/mod.rs
+++ b/src/agent/inbox/mod.rs
@@ -7,7 +7,8 @@
 //! - Stats and monitoring
 
 pub mod manager;
-pub mod tests;
+#[cfg(test)]
+mod tests;
 pub mod types;
 
 pub use manager::InboxManager;

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -11,7 +11,7 @@ use crate::config::providers::{
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
 use crate::llm::{
-    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelDiscovery, ModelInfo,
+    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelDiscovery,
     ProviderModelKnowledge, VolcEngineProvider,
 };
 use dialoguer::{Input, Select};
@@ -19,6 +19,9 @@ use dialoguer::{Input, Select};
 use std::panic;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+#[cfg(test)]
+use crate::llm::ModelInfo;
 
 /// Parse user input for model selection into a vector of 0-based indices.
 ///

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -7,8 +7,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
-use tracing::warn;
-
 use super::agents::{AgentDirectoryProvider, AgentsConfig, ResolvedAgentConfig};
 use super::manager::{ConfigLoadError, ConfigManager};
 

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -3,7 +3,6 @@
 //! Watches config files for changes and automatically reloads them.
 //! Validates new config before applying, maintains backup of last known good config.
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -45,6 +44,7 @@ pub enum ReloadResult {
 ///
 /// # Type Parameters
 /// * `P` - The ConfigProvider implementation type
+#[allow(dead_code)] // `watcher_handle` is reserved for future lifecycle management
 pub struct ConfigReloadManager<P> {
     /// Inner provider (wrapped in Arc<Mutex> for interior mutability)
     provider: Arc<std::sync::Mutex<P>>,

--- a/src/daemon/llm_init.rs
+++ b/src/daemon/llm_init.rs
@@ -13,6 +13,7 @@ impl Daemon {
     /// For each provider (openai, anthropic, minimax):
     /// 1. Try to load api_key from `config_dir/config/credentials/<provider>.json`
     /// 2. Fall back to the corresponding env var if the file does not have it
+    #[allow(dead_code)] // only invoked from `#[cfg(test)] mod unit_tests`
     pub(crate) async fn init_llm_registry(config_dir: &Path) -> Arc<LLMRegistry> {
         let registry = Arc::new(LLMRegistry::new());
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4,7 +4,6 @@
 //! Handles graceful shutdown via ShutdownCoordinator.
 pub mod shutdown;
 pub mod skill_reload;
-use crate::config::agents::AgentsConfigProvider;
 use crate::config::migration::migrate_if_needed;
 use crate::config::providers::ConfigProvider;
 use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -6,6 +6,7 @@ use closeclaw::permission::{Defaults, PermissionEngine, RuleSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[allow(dead_code)] // pub API for masking secrets in CLI output (covered by tests)
 pub fn mask_key(key: &str) -> String {
     if key.len() <= 8 {
         "****".to_string()

--- a/src/im/processor/cleaner.rs
+++ b/src/im/processor/cleaner.rs
@@ -1,7 +1,6 @@
 //! FeishuMessageCleaner — inbound MessageProcessor for feishu webhook events.
 
 use async_trait::async_trait;
-use std::collections::BTreeMap;
 
 use super::{MessageContext, MessageProcessor, ProcessError, ProcessPhase, ProcessedMessage};
 use serde_json::Value;

--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -24,6 +24,7 @@ struct DeepSeekRequest<'a> {
 }
 
 /// DeepSeek chat response body (OpenAI-compatible)
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct DeepSeekResponse {
     id: Option<String>,
@@ -35,6 +36,7 @@ struct DeepSeekResponse {
     error: Option<DeepSeekErrorBody>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct DeepSeekChoice {
     message: DeepSeekMessage,
@@ -42,6 +44,7 @@ struct DeepSeekChoice {
     finish_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct DeepSeekMessage {
     role: String,
@@ -77,6 +80,7 @@ struct DeepSeekModelsResponse {
 }
 
 /// A single model entry from the /models API
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct DeepSeekModel {
     id: String,
@@ -103,6 +107,7 @@ struct DeepSeekModel {
     pricing: Option<DeepSeekModelPricing>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default)]
 struct DeepSeekModelPricing {
     #[serde(default)]

--- a/src/llm/glm/mod.rs
+++ b/src/llm/glm/mod.rs
@@ -1,7 +1,6 @@
 //! GLm LLM Provider
 
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -97,6 +96,7 @@ struct GlmErrorBody {
 // ---------------------------------------------------------------------------//
 
 /// Response from GET /api/coding/paas/v4/models (GLM model list API)
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct GlmModelsResponse {
     data: Vec<GlmModel>,
@@ -105,6 +105,7 @@ struct GlmModelsResponse {
 }
 
 /// A single model entry from the /models API
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct GlmModel {
     id: String,

--- a/src/llm/glm_stream.rs
+++ b/src/llm/glm_stream.rs
@@ -14,9 +14,7 @@
 
 use serde::Deserialize;
 
-use crate::llm::{
-    ChatRequest, ChatStreamChunk, GlmProvider, HttpClient, LLMError, StreamingResponse, Usage,
-};
+use crate::llm::{ChatRequest, ChatStreamChunk, GlmProvider, LLMError, StreamingResponse, Usage};
 
 use serde::Serialize;
 
@@ -44,6 +42,7 @@ pub(crate) struct GlmStreamChunk {
     error: Option<GlmStreamError>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct GlmStreamChoice {
     #[serde(default)]
@@ -54,6 +53,7 @@ pub(crate) struct GlmStreamChoice {
     finish_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct GlmStreamDelta {
     #[serde(default)]
@@ -64,6 +64,7 @@ pub(crate) struct GlmStreamDelta {
     reasoning_content: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct GlmStreamUsage {
     #[serde(default)]
@@ -78,12 +79,14 @@ pub(crate) struct GlmStreamUsage {
     prompt_tokens_details: Option<GlmStreamPromptTokensDetails>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct GlmStreamCompletionTokensDetails {
     #[serde(default)]
     reasoning_tokens: Option<u32>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct GlmStreamPromptTokensDetails {
     #[serde(default)]

--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -1,7 +1,6 @@
 //! MiniMax LLM Provider
 
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,6 +56,7 @@ struct MiniMaxMessage {
     reasoning_content: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Default)]
 struct MiniMaxUsage {
     #[serde(default)]
@@ -70,6 +70,7 @@ struct MiniMaxUsage {
 }
 
 /// MiniMax completion tokens details
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct MiniMaxCompletionTokensDetails {
     #[serde(default)]
@@ -84,6 +85,7 @@ struct MiniMaxBaseResp {
 }
 
 /// Response from GET /v1/models (MiniMax model list API, OpenAI-compatible)
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct MiniMaxModelsResponse {
     data: Vec<MiniMaxModel>,
@@ -92,6 +94,7 @@ struct MiniMaxModelsResponse {
 }
 
 /// A single model entry from the /models API
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct MiniMaxModel {
     id: String,

--- a/src/llm/minimax_stream.rs
+++ b/src/llm/minimax_stream.rs
@@ -30,6 +30,7 @@ pub(crate) struct MiniMaxStreamRequest<'a> {
 }
 
 /// A single SSE chunk from MiniMax streaming API.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamChunk {
     #[serde(default)]
@@ -44,6 +45,7 @@ pub(crate) struct MiniMaxStreamChunk {
     pub(crate) object: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamChoice {
     #[serde(default)]
@@ -57,6 +59,7 @@ pub(crate) struct MiniMaxStreamChoice {
     pub(crate) message: Option<MiniMaxStreamMessage>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamDelta {
     #[serde(default)]
@@ -67,6 +70,7 @@ pub(crate) struct MiniMaxStreamDelta {
     pub(crate) reasoning_content: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamMessage {
     #[serde(default)]
@@ -77,6 +81,7 @@ pub(crate) struct MiniMaxStreamMessage {
     pub(crate) reasoning_content: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamUsage {
     #[serde(default)]
@@ -89,6 +94,7 @@ pub(crate) struct MiniMaxStreamUsage {
     pub(crate) completion_tokens_details: Option<MiniMaxStreamCompletionTokensDetails>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct MiniMaxStreamCompletionTokensDetails {
     #[serde(default)]

--- a/src/llm/stub.rs
+++ b/src/llm/stub.rs
@@ -2,7 +2,10 @@
 
 use async_trait::async_trait;
 
-use super::{ChatRequest, ChatResponse, LLMError, LLMProvider, Message, Usage};
+use super::{ChatRequest, ChatResponse, LLMError, LLMProvider, Usage};
+
+#[cfg(test)]
+use super::Message;
 
 /// A stub LLM provider that returns fixed responses.
 /// Always returns `is_stub() == true` so callers can detect test configurations.

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -329,7 +329,6 @@ fn default_temperature() -> f32 {
 /// Tracks the current state during SSE parsing to correctly assemble
 /// incremental deltas into complete content blocks.
 #[derive(Debug, Clone)]
-#[allow(unexpected_cfgs)]
 #[cfg_attr(feature = "server", derive(serde::Serialize, serde::Deserialize))]
 pub struct SseStateMachine {
     /// Index of the currently active content block being parsed.

--- a/src/llm/volcengine.rs
+++ b/src/llm/volcengine.rs
@@ -24,6 +24,7 @@ struct VolcEngineRequest<'a> {
 }
 
 /// VolcEngine chat response body (OpenAI-compatible)
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct VolcEngineResponse {
     id: Option<String>,
@@ -35,6 +36,7 @@ struct VolcEngineResponse {
     error: Option<VolcEngineErrorBody>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct VolcEngineChoice {
     message: VolcEngineMessage,
@@ -42,6 +44,7 @@ struct VolcEngineChoice {
     finish_reason: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct VolcEngineMessage {
     role: String,

--- a/src/processor_chain/loader.rs
+++ b/src/processor_chain/loader.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 
 use crate::renderer::feishu::FeishuRenderer;
-use crate::renderer::{RenderedOutput, Renderer};
+use crate::renderer::Renderer;
 
 use super::dsl_parser::DslParser;
 use super::error::ProcessError;

--- a/src/processor_chain/message_cleaner.rs
+++ b/src/processor_chain/message_cleaner.rs
@@ -42,6 +42,7 @@ struct PostContent {
 }
 
 /// A single segment within a post paragraph.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct PostSegment {
     tag: String,

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -11,9 +11,11 @@
 //! - [`ProcessError`] — error types
 
 pub mod context;
-pub mod context_tests;
+#[cfg(test)]
+mod context_tests;
 pub mod dsl_parser;
-pub mod dsl_parser_tests;
+#[cfg(test)]
+mod dsl_parser_tests;
 pub mod error;
 pub mod loader;
 pub mod markdown_normalizer;
@@ -21,7 +23,8 @@ pub mod message_cleaner;
 pub mod processor;
 pub mod raw_log_processor;
 pub mod registry;
-pub mod registry_tests;
+#[cfg(test)]
+mod registry_tests;
 
 pub use dsl_parser::{DslInstruction, DslParseResult, DslParser};
 pub use loader::{ProcessorChainConfig, ProcessorChainLoader, ProcessorConfig, RendererConfig};

--- a/src/renderer/feishu.rs
+++ b/src/renderer/feishu.rs
@@ -170,6 +170,7 @@ impl FeishuRenderer {
 
 impl FeishuRenderer {
     /// Render a Text block using the legacy markdown → card-element pipeline.
+    #[allow(dead_code)] // legacy per-block renderer kept for potential future use
     fn render_text_block(
         &self,
         text: &str,

--- a/src/session/bootstrap/mod.rs
+++ b/src/session/bootstrap/mod.rs
@@ -24,7 +24,8 @@ pub mod context;
 pub mod helpers;
 pub mod loader;
 pub mod protection;
-pub mod tests;
+#[cfg(test)]
+mod tests;
 pub mod types;
 
 // Re-exports for convenience

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -262,7 +262,7 @@ impl PersistenceService for SqliteStorage {
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
             let status = status_to_db(&checkpoint.status);
-            let mode = mode_to_db(&checkpoint.mode);
+            let _mode = mode_to_db(&checkpoint.mode);
             let mode_state_json = serde_json::to_string(&checkpoint.mode_state)
                 .map_err(PersistenceError::Serialization)?;
             let pending_json = serde_json::to_string(&checkpoint.pending_messages)

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -1,6 +1,5 @@
 //! Skill discovery skill - allows agents to search and install skills from ClawHub
 use crate::permission::approval_flow::ApprovalFlow;
-use crate::permission::engine::engine_risk::RiskLevel;
 use crate::permission::engine::Caller;
 use crate::permission::engine::PermissionRequestBody;
 use crate::permission::{PermissionRequest, PermissionResponse};

--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -1,6 +1,5 @@
 //! File operations skill
 use crate::permission::approval_flow::ApprovalFlow;
-use crate::permission::engine::engine_risk::RiskLevel;
 use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -2,14 +2,14 @@
 //!
 //! Orchestrates section assembly and renders the final system prompt string.
 
-use super::sections::{
-    get_cached_section, invalidate_all_sections, load_cached_file_section, read_file_section,
-    Section,
-};
+use super::sections::{get_cached_section, load_cached_file_section, read_file_section, Section};
 use super::tools_section::build_tools_section;
 use crate::skills::DiskSkillRegistry;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
+
+#[cfg(test)]
+use crate::system_prompt::sections::invalidate_all_sections;
 
 /// Static override: if set, replaces the entire prompt
 static OVERRIDE_PROMPT: RwLock<Option<String>> = RwLock::new(None);

--- a/src/tools/builtin/coding_agent.rs
+++ b/src/tools/builtin/coding_agent.rs
@@ -2,9 +2,12 @@
 //!
 //! This is a placeholder stub. Full implementation tracked in issue #282.
 
-use crate::tools::{Tool, ToolContext, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
+
+#[cfg(test)]
+use crate::tools::ToolContext;
 
 // ---------------------------------------------------------------------------
 // CodingAgentTool

--- a/src/tools/builtin/file_ops.rs
+++ b/src/tools/builtin/file_ops.rs
@@ -3,10 +3,12 @@
 //! Each tool is an independent [`Tool`] implementation, completely separate
 //! from the [`crate::skills`] module.
 
-use crate::tools::{Tool, ToolContext, ToolError, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
-use std::path::Path;
+
+#[cfg(test)]
+use crate::tools::ToolContext;
 
 // ---------------------------------------------------------------------------
 // ReadTool

--- a/src/tools/builtin/git_ops.rs
+++ b/src/tools/builtin/git_ops.rs
@@ -3,9 +3,12 @@
 //! Each tool wraps a git subcommand via `std::process::Command`,
 //! independent from the [`crate::skills`] module.
 
-use crate::tools::{Tool, ToolContext, ToolError, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
+
+#[cfg(test)]
+use crate::tools::ToolContext;
 
 // ---------------------------------------------------------------------------
 // Shared helper

--- a/src/tools/builtin/permission.rs
+++ b/src/tools/builtin/permission.rs
@@ -2,7 +2,7 @@
 //!
 //! Allows the LLM to query which tools the current agent is permitted to use.
 
-use crate::tools::{Tool, ToolContext, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
 

--- a/src/tools/builtin/search.rs
+++ b/src/tools/builtin/search.rs
@@ -3,9 +3,12 @@
 //! Allows the LLM to dynamically retrieve second-level tool detail
 //! by keyword or exact name match.
 
-use crate::tools::{Tool, ToolContext, ToolError, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
+
+#[cfg(test)]
+use crate::tools::ToolContext;
 
 // ---------------------------------------------------------------------------
 // ToolSearchTool

--- a/src/tools/builtin/skill_creator.rs
+++ b/src/tools/builtin/skill_creator.rs
@@ -2,9 +2,12 @@
 //!
 //! This is a placeholder stub. Full implementation tracked in issue #282.
 
-use crate::tools::{Tool, ToolContext, ToolFlags};
+use crate::tools::{Tool, ToolFlags};
 
 use serde_json::Value;
+
+#[cfg(test)]
+use crate::tools::ToolContext;
 
 // ---------------------------------------------------------------------------
 // SkillCreatorTool


### PR DESCRIPTION
## 概述

消除 closeclaw 项目中 68 个非 deprecated 类编译 warning（lib 67 + bin 1）。

## 变更内容

- 移除 23 个 unused imports
- 测试模块加 `#[cfg(test)]`（5 个模块）
- serde 反序列化结构体加 `#[allow(dead_code)]`（26 个结构体）
- 非 serde dead code 加 `#[allow(dead_code)]`（4 处）
- `Cargo.toml` 加 `check-cfg` 声明 `server` feature

## 效果

- `cargo check` warning：105 → 38（全部为 deprecated LLMProvider，不在本 PR 范围）
- `cargo test`：1738 passed, 2 failed（pre-existing）

## 不包含

- deprecated `LLMProvider` trait 相关 warning（~38 处，需单独 PR 迁移）

Source: user
Type: chore
