### PR TITLE
chore: 恢复 LegacyChatSession e2e 测试文件

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,4 +106,4 @@ name = "closeclaw"
 path = "src/main.rs"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("server"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("server", "chat-legacy"))'] }

--- a/tests/chat_session_tests.rs
+++ b/tests/chat_session_tests.rs
@@ -1,0 +1,281 @@
+#![cfg(feature = "chat-legacy")]
+
+//! Integration tests for LegacyChatSession
+//!
+//! These tests verify session behaviour through the public API.
+//! Shared setup helpers live in `src/chat/session.rs` (pub(crate)).
+
+use closeclaw::chat::protocol::ServerMessage;
+use closeclaw::chat::session::LegacyChatSession;
+use closeclaw::llm::{LLMRegistry, Message, StubProvider};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+/// Set up a `LegacyChatSession` backed by a real TCP pair with `StubProvider`
+/// registered in the `LLMRegistry`.
+///
+/// Returns `(session, client_stream)` where `client_stream` is the write/read
+/// half connected to the session.
+///
+/// Note: This creates a temporary shutdown channel that will be dropped,
+/// causing the session to receive a shutdown signal. For tests that need
+/// to keep the session alive, use `setup_session_with_shutdown_tx` instead.
+async fn setup_session() -> (LegacyChatSession, tokio::net::TcpStream) {
+    std::env::set_var("LLM_FALLBACK_CHAIN", "stub/stub-model");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (accepted, _) = listener.accept().await.unwrap();
+    let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+    let registry = Arc::new(LLMRegistry::new());
+    registry
+        .register("stub".to_string(), Arc::new(StubProvider::new()))
+        .await;
+    let session = LegacyChatSession::new(
+        "test-session".to_string(),
+        "test-agent".to_string(),
+        accepted,
+        shutdown_rx.resubscribe(),
+        registry,
+        None, // config_dir
+    );
+    std::env::remove_var("LLM_FALLBACK_CHAIN");
+    (session, client)
+}
+
+/// Set up a `LegacyChatSession` with an explicit shutdown channel.
+/// Returns `(session, client_stream, shutdown_tx)` where `shutdown_tx` must
+/// be kept alive to prevent premature shutdown.
+async fn setup_session_with_shutdown_tx() -> (
+    LegacyChatSession,
+    tokio::net::TcpStream,
+    broadcast::Sender<()>,
+) {
+    std::env::set_var("LLM_FALLBACK_CHAIN", "stub/stub-model");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (accepted, _) = listener.accept().await.unwrap();
+    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(2);
+    let registry = Arc::new(LLMRegistry::new());
+    registry
+        .register("stub".to_string(), Arc::new(StubProvider::new()))
+        .await;
+    let session = LegacyChatSession::new(
+        "test-session".to_string(),
+        "test-agent".to_string(),
+        accepted,
+        shutdown_rx,
+        registry,
+        None, // config_dir
+    );
+    std::env::remove_var("LLM_FALLBACK_CHAIN");
+    (session, client, shutdown_tx)
+}
+
+/// Drain a single JSON line from `reader` and parse it as `ServerMessage`.
+async fn read_server_message(
+    reader: &mut tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
+) -> ServerMessage {
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let trimmed = line.trim();
+    serde_json::from_str(trimmed)
+        .unwrap_or_else(|e| panic!("failed to parse server message from `{trimmed}`: {e}"))
+}
+
+/// Send a raw JSON client message (caller is responsible for valid JSON).
+async fn send_client_json(writer: &mut tokio::net::tcp::OwnedWriteHalf, json: &str) {
+    writer.write_all(json.as_bytes()).await.unwrap();
+    writer.write_all(b"\n").await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// truncate_history — now calls the actual method on LegacyChatSession
+// ---------------------------------------------------------------------------
+
+/// Verify that `truncate_history` removes the oldest entries when the history
+/// exceeds `max_history`.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_truncate_history_removes_oldest() {
+    let (mut session, _client) = setup_session().await;
+    session.max_history = 5;
+    session.chat_history = (0..10_u32)
+        .map(|i| Message {
+            role: "user".to_string(),
+            content: format!("message {}", i),
+        })
+        .collect();
+
+    session.truncate_history();
+
+    assert_eq!(session.chat_history.len(), 5);
+    assert_eq!(session.chat_history[0].content, "message 5");
+    assert_eq!(session.chat_history[4].content, "message 9");
+}
+
+/// Verify that `truncate_history` is a no-op when the history is under the limit.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_truncate_history_under_limit() {
+    let (mut session, _client) = setup_session().await;
+    session.max_history = 5;
+    session.chat_history = (0..3_u32)
+        .map(|i| Message {
+            role: "user".to_string(),
+            content: format!("message {}", i),
+        })
+        .collect();
+
+    session.truncate_history();
+
+    assert_eq!(session.chat_history.len(), 3);
+}
+
+/// Verify that `truncate_history` is a no-op when the history is exactly at
+/// the limit.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_truncate_history_exact_limit() {
+    let (mut session, _client) = setup_session().await;
+    session.max_history = 5;
+    session.chat_history = (0..5_u32)
+        .map(|i| Message {
+            role: "user".to_string(),
+            content: format!("message {}", i),
+        })
+        .collect();
+
+    session.truncate_history();
+
+    assert_eq!(session.chat_history.len(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// New integration tests
+// ---------------------------------------------------------------------------
+
+/// Verify a complete session lifecycle: chat.start → chat.message → chat.stop,
+/// checking that every step produces the expected server response sequence.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_full_session_lifecycle() {
+    let (session, client, shutdown_tx) = setup_session_with_shutdown_tx().await;
+
+    // Spawn the session so it processes messages concurrently.
+    let session_handle = tokio::spawn(session.run());
+
+    // Keep shutdown_tx alive to prevent premature shutdown
+    let _shutdown_tx_guard = shutdown_tx;
+
+    // Split the client into owned read/write halves.
+    let (reader_half, mut writer_half) = client.into_split();
+    let mut reader = tokio::io::BufReader::new(reader_half);
+
+    // Step 1 — chat.start
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.start","agent_id":"my-agent","id":"req-start"}"#,
+    )
+    .await;
+    let msg1 = read_server_message(&mut reader).await;
+    match msg1 {
+        ServerMessage::ChatStarted { session_id, id } => {
+            assert_eq!(session_id, "test-session");
+            assert_eq!(id, "req-start");
+        }
+        other => panic!("expected ChatStarted, got {other:?}"),
+    }
+
+    // Step 2 — chat.message (StubProvider responds "stub response")
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"hello world","id":"req-msg"}"#,
+    )
+    .await;
+    let msg2a = read_server_message(&mut reader).await;
+    let msg2b = read_server_message(&mut reader).await;
+    match (&msg2a, &msg2b) {
+        (
+            ServerMessage::ChatResponse { content, done, id },
+            ServerMessage::ChatResponseDone { id: id2 },
+        ) => {
+            assert_eq!(*content, "stub response");
+            assert!(done);
+            assert_eq!(id, "req-msg");
+            assert_eq!(id2, "req-msg");
+        }
+        _ => panic!("expected ChatResponse + ChatResponseDone, got {msg2a:?} + {msg2b:?}"),
+    }
+
+    // Step 3 — chat.stop
+    send_client_json(&mut writer_half, r#"{"type":"chat.stop","id":"req-stop"}"#).await;
+    let msg3 = read_server_message(&mut reader).await;
+    match msg3 {
+        ServerMessage::ChatResponseDone { id } => {
+            assert_eq!(id, "req-stop");
+        }
+        other => panic!("expected ChatResponseDone, got {other:?}"),
+    }
+
+    // Clean up.
+    drop(writer_half);
+    let _ = session_handle.await;
+}
+
+/// Verify that when the server shutdown signal is fired, the session responds
+/// with a `ChatError` carrying the message "server shutting down".
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_session_shutdown_signal() {
+    std::env::set_var("LLM_FALLBACK_CHAIN", "stub/stub-model");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (accepted, _) = listener.accept().await.unwrap();
+    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(2);
+    let registry = Arc::new(LLMRegistry::new());
+    registry
+        .register("stub".to_string(), Arc::new(StubProvider::new()))
+        .await;
+    let session = LegacyChatSession::new(
+        "shutdown-session".to_string(),
+        "shutdown-agent".to_string(),
+        accepted,
+        shutdown_rx,
+        registry,
+        None, // config_dir
+    );
+    std::env::remove_var("LLM_FALLBACK_CHAIN");
+
+    // Spawn session and immediately send the shutdown signal by dropping the tx.
+    let session_handle = tokio::spawn(session.run());
+    drop(shutdown_tx);
+
+    // Read the error message from the client.
+    let (reader_half, _) = client.into_split();
+    let mut reader = tokio::io::BufReader::new(reader_half);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let msg: ServerMessage = serde_json::from_str(line.trim()).unwrap();
+
+    match msg {
+        ServerMessage::ChatError { message, .. } => {
+            assert!(
+                message.contains("server shutting down"),
+                "expected 'server shutting down', got: {message}"
+            );
+        }
+        other => panic!("expected ChatError, got {other:?}"),
+    }
+
+    let _ = session_handle.await;
+}

--- a/tests/e2e_session_compact_tests.rs
+++ b/tests/e2e_session_compact_tests.rs
@@ -1,0 +1,296 @@
+#![cfg(feature = "chat-legacy")]
+
+//! E2E tests for session compaction via /compact command.
+//!
+//! Verifies the complete integration path:
+//! multi-round conversation → /compact → LLM summary → boundary message → session continues.
+//!
+//! Run with: `cargo test --features fake-llm --test e2e_session_compact_tests`
+
+#![cfg(feature = "fake-llm")]
+
+use closeclaw::chat::protocol::ServerMessage;
+use closeclaw::chat::session::LegacyChatSession;
+use closeclaw::llm::LLMRegistry;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Set up a `LegacyChatSession` backed by a TCP pair with a FakeProvider
+/// registered in the LLMRegistry.
+async fn setup_session_with_fake(
+    scenarios: Vec<(String, String)>,
+) -> (
+    LegacyChatSession,
+    tokio::net::TcpStream,
+    broadcast::Sender<()>,
+) {
+    use closeclaw::llm::fake::FakeProvider;
+
+    let mut builder = FakeProvider::builder();
+    for (content, model) in scenarios {
+        builder = builder.then_ok(content, model);
+    }
+    std::env::set_var("LLM_FALLBACK_CHAIN", "fake/glm-5");
+    let fake_provider = builder.or_else("fallback response").build();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (accepted, _) = listener.accept().await.unwrap();
+    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(2);
+
+    let registry = Arc::new(LLMRegistry::new());
+    registry
+        .register("fake".to_string(), Arc::new(fake_provider))
+        .await;
+
+    let session = LegacyChatSession::new(
+        "test-session".to_string(),
+        "test-agent".to_string(),
+        accepted,
+        shutdown_rx,
+        registry,
+        None, // config_dir
+    );
+    std::env::remove_var("LLM_FALLBACK_CHAIN");
+
+    (session, client, shutdown_tx)
+}
+
+/// Drain a single JSON line from `reader` and parse it as `ServerMessage`.
+async fn read_server_message(
+    reader: &mut tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
+) -> ServerMessage {
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let trimmed = line.trim();
+    serde_json::from_str(trimmed)
+        .unwrap_or_else(|e| panic!("failed to parse server message from `{trimmed}`: {e}"))
+}
+
+/// Send a raw JSON client message.
+async fn send_client_json(writer: &mut tokio::net::tcp::OwnedWriteHalf, json: &str) {
+    writer.write_all(json.as_bytes()).await.unwrap();
+    writer.write_all(b"\n").await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Test: 3 rounds of conversation → /compact → boundary message replaces history
+/// → continue conversation → second /compact.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_session_compact_e2e() {
+    let scenarios = vec![
+        ("reply 1".to_string(), "glm-5".to_string()),
+        ("reply 2".to_string(), "glm-5".to_string()),
+        ("reply 3".to_string(), "glm-5".to_string()),
+        (
+            "<summary>User and assistant discussed various topics.\n[boundary]</summary>"
+                .to_string(),
+            "glm-5".to_string(),
+        ),
+        ("reply after compact".to_string(), "glm-5".to_string()),
+        (
+            "<summary>Second summary.\n[boundary]</summary>".to_string(),
+            "glm-5".to_string(),
+        ),
+    ];
+
+    let (session, client, shutdown_tx) = setup_session_with_fake(scenarios).await;
+
+    let session_handle = tokio::spawn(session.run());
+    let _shutdown_guard = shutdown_tx;
+
+    let (reader_half, mut writer_half) = client.into_split();
+    let mut reader = tokio::io::BufReader::new(reader_half);
+
+    // Start session
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.start","agent_id":"my-agent","id":"req-start"}"#,
+    )
+    .await;
+    let start_msg = read_server_message(&mut reader).await;
+    assert!(
+        matches!(start_msg, ServerMessage::ChatStarted { .. }),
+        "expected ChatStarted, got {start_msg:?}"
+    );
+
+    // Round 1: user → assistant
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"hello","id":"req-msg-1"}"#,
+    )
+    .await;
+    let resp1a = read_server_message(&mut reader).await;
+    let resp1b = read_server_message(&mut reader).await;
+    assert!(
+        matches!(
+            (&resp1a, &resp1b),
+            (ServerMessage::ChatResponse { content, .. }, ServerMessage::ChatResponseDone { .. })
+                if content == "reply 1"
+        ),
+        "round 1: expected 'reply 1', got resp1a={resp1a:?}, resp1b={resp1b:?}"
+    );
+
+    // Round 2
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"how are you","id":"req-msg-2"}"#,
+    )
+    .await;
+    let resp2a = read_server_message(&mut reader).await;
+    let resp2b = read_server_message(&mut reader).await;
+    assert!(
+        matches!(
+            (&resp2a, &resp2b),
+            (ServerMessage::ChatResponse { content, .. }, ServerMessage::ChatResponseDone { .. })
+                if content == "reply 2"
+        ),
+        "round 2: expected 'reply 2', got resp2a={resp2a:?}, resp2b={resp2b:?}"
+    );
+
+    // Round 3
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"tell me more","id":"req-msg-3"}"#,
+    )
+    .await;
+    let resp3a = read_server_message(&mut reader).await;
+    let resp3b = read_server_message(&mut reader).await;
+    assert!(
+        matches!(
+            (&resp3a, &resp3b),
+            (ServerMessage::ChatResponse { content, .. }, ServerMessage::ChatResponseDone { .. })
+                if content == "reply 3"
+        ),
+        "round 3: expected 'reply 3', got resp3a={resp3a:?}, resp3b={resp3b:?}"
+    );
+
+    // Step 3 — Trigger /compact
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"/compact","id":"req-compact-1"}"#,
+    )
+    .await;
+
+    // Expect: success message (contains "压缩成功") + ChatResponseDone
+    let compact1a = read_server_message(&mut reader).await;
+    let compact1b = read_server_message(&mut reader).await;
+    let compact1_content = match &compact1a {
+        ServerMessage::ChatResponse { content, .. } => content.clone(),
+        other => panic!("expected ChatResponse for /compact, got {other:?}"),
+    };
+    assert!(
+        compact1_content.contains("压缩成功"),
+        "/compact should report success, got: {compact1_content}"
+    );
+    assert!(
+        matches!(compact1b, ServerMessage::ChatResponseDone { .. }),
+        "expected ChatResponseDone after /compact, got {compact1b:?}"
+    );
+
+    // Step 4 — Continue conversation after compact
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"continue","id":"req-msg-4"}"#,
+    )
+    .await;
+    let resp4a = read_server_message(&mut reader).await;
+    let resp4b = read_server_message(&mut reader).await;
+    // After /compact: round 4 — uses scenario 5
+    assert!(
+        matches!(
+            (&resp4a, &resp4b),
+            (ServerMessage::ChatResponse { content, .. }, ServerMessage::ChatResponseDone { .. })
+                if content == "reply after compact"
+        ),
+        "round 4 after compact: expected 'reply after compact', got resp4a={resp4a:?}, resp4b={resp4b:?}"
+    );
+
+    // Step 5 — Second /compact
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"/compact","id":"req-compact-2"}"#,
+    )
+    .await;
+    let compact2a = read_server_message(&mut reader).await;
+    let compact2b = read_server_message(&mut reader).await;
+    let compact2_content = match &compact2a {
+        ServerMessage::ChatResponse { content, .. } => content.clone(),
+        other => panic!("expected ChatResponse for /compact, got {other:?}"),
+    };
+    assert!(
+        compact2_content.contains("压缩成功"),
+        "second /compact should report success, got: {compact2_content}"
+    );
+    assert!(
+        matches!(compact2b, ServerMessage::ChatResponseDone { .. }),
+        "expected ChatResponseDone for second /compact, got {compact2b:?}"
+    );
+
+    // Clean up
+    drop(writer_half);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), session_handle).await;
+}
+
+/// Test: /compact with extra arguments returns error.
+#[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+#[tokio::test]
+async fn test_compact_invalid_syntax_returns_error() {
+    let scenarios = vec![(
+        "<summary>summary text</summary>".to_string(),
+        "glm-5".to_string(),
+    )];
+
+    let (session, client, shutdown_tx) = setup_session_with_fake(scenarios).await;
+
+    let session_handle = tokio::spawn(session.run());
+    let _shutdown_guard = shutdown_tx;
+
+    let (reader_half, mut writer_half) = client.into_split();
+    let mut reader = tokio::io::BufReader::new(reader_half);
+
+    // Start session
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.start","agent_id":"my-agent","id":"req-start"}"#,
+    )
+    .await;
+    let _start_msg = read_server_message(&mut reader).await;
+
+    // Send /compact with invalid syntax (e.g., /compact extra-arg not supported)
+    send_client_json(
+        &mut writer_half,
+        r#"{"type":"chat.message","content":"/compact extra arg","id":"req-invalid"}"#,
+    )
+    .await;
+
+    let err_a = read_server_message(&mut reader).await;
+    let err_b = read_server_message(&mut reader).await;
+    let err_content = match &err_a {
+        ServerMessage::ChatResponse { content, .. } => content.clone(),
+        other => panic!("expected ChatResponse for invalid /compact, got {other:?}"),
+    };
+    assert!(
+        err_content.contains("[error]"),
+        "invalid /compact should return error, got: {err_content}"
+    );
+    assert!(
+        matches!(err_b, ServerMessage::ChatResponseDone { .. }),
+        "expected ChatResponseDone after error, got {err_b:?}"
+    );
+
+    drop(writer_half);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), session_handle).await;
+}

--- a/tests/e2e_thinking.rs
+++ b/tests/e2e_thinking.rs
@@ -1,0 +1,12 @@
+//! E2E/008 — Thinking tag persistence and compact boundary tests
+//!
+//! Verifies that `<thinking>` tags survive `chat_history` storage,
+//! are stripped from Compact boundary messages, and correctly
+//! traverse the TCP wire protocol.
+//!
+//! Run with: `cargo test --features fake-llm --test e2e_thinking -- --test-threads=1`
+
+#![allow(deprecated)]
+
+#[path = "e2e_thinking/mod.rs"]
+mod e2e_thinking;

--- a/tests/e2e_thinking/mod.rs
+++ b/tests/e2e_thinking/mod.rs
@@ -1,0 +1,474 @@
+#![cfg(feature = "chat-legacy")]
+
+//! e2e_thinking module — all helpers and tests
+//!
+//! Tests 1, 2 use unit-style (direct session manipulation without spawn).
+//! Tests 3-5 use protocol-level TCP style (spawn session.run() + TCP client).
+
+#[cfg(feature = "fake-llm")]
+mod tests {
+    use std::sync::Arc;
+
+    use closeclaw::chat::protocol::ServerMessage;
+    use closeclaw::chat::session::LegacyChatSession;
+    use closeclaw::llm::fake::{FakeProvider, Scenario};
+    use closeclaw::llm::LLMRegistry;
+    use closeclaw::llm::Message;
+    use closeclaw::session::compaction::execute_compact;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::broadcast;
+
+    // ---------------------------------------------------------------------------
+    // Shared helpers for protocol-level tests
+    // ---------------------------------------------------------------------------
+
+    async fn setup_session_with_fake(
+        scenarios: Vec<Scenario>,
+    ) -> (
+        LegacyChatSession,
+        tokio::net::TcpStream,
+        broadcast::Sender<()>,
+    ) {
+        let fake_provider = build_fake_provider(scenarios);
+        std::env::set_var("LLM_FALLBACK_CHAIN", "fake/glm-5");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (accepted, _) = listener.accept().await.unwrap();
+        let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(2);
+
+        let registry = Arc::new(LLMRegistry::new());
+        registry
+            .register("fake".to_string(), Arc::new(fake_provider))
+            .await;
+
+        let session = LegacyChatSession::new(
+            "test-session".to_string(),
+            "test-agent".to_string(),
+            accepted,
+            shutdown_rx,
+            registry,
+            None,
+        );
+
+        std::env::remove_var("LLM_FALLBACK_CHAIN");
+        (session, client, shutdown_tx)
+    }
+
+    fn build_fake_provider(scenarios: Vec<Scenario>) -> FakeProvider {
+        let mut provider = FakeProvider::builder().stub(false).or_else("");
+        for s in scenarios {
+            match s {
+                Scenario::Ok { content, model, .. } => {
+                    provider = provider.then_ok(content, model);
+                }
+                Scenario::Err { error, .. } => {
+                    provider = provider.then_err(error);
+                }
+                Scenario::Delay { duration, inner } => {
+                    provider = provider.then_delay(duration, (*inner).clone());
+                }
+            }
+        }
+        provider.build()
+    }
+
+    async fn read_msg(
+        reader: &mut tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
+    ) -> ServerMessage {
+        let mut line = String::new();
+        reader.read_line(&mut line).await.unwrap();
+        serde_json::from_str(line.trim())
+            .unwrap_or_else(|e| panic!("parse error from `{line}`: {e}"))
+    }
+
+    async fn send_json(writer: &mut tokio::net::tcp::OwnedWriteHalf, json: &str) {
+        writer.write_all(json.as_bytes()).await.unwrap();
+        writer.write_all(b"\n").await.unwrap();
+        writer.flush().await.unwrap();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 1: thinking tag string is transparently stored in chat_history
+    // ---------------------------------------------------------------------------
+
+    #[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+    #[tokio::test]
+    async fn test_thinking_tag_persistence_in_history() {
+        // Build FakeProvider with thinking-tagged responses
+        let fake_provider = build_fake_provider(vec![
+            Scenario::ok("<thinking>analyzing...</thinking> Turn 1 answer", "glm-5"),
+            Scenario::ok("<thinking>formulating...</thinking> Turn 2 answer", "glm-5"),
+            Scenario::ok("<thinking>verifying...</thinking> Turn 3 answer", "glm-5"),
+        ]);
+
+        std::env::set_var("LLM_FALLBACK_CHAIN", "fake/glm-5");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (accepted, _) = listener.accept().await.unwrap();
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(2);
+
+        let registry = Arc::new(LLMRegistry::new());
+        registry
+            .register("fake".to_string(), Arc::new(fake_provider))
+            .await;
+
+        // Create session but do NOT call run() — keep it alive via Arc.
+        // Hold a mutable reference to inspect chat_history directly.
+        let mut session = LegacyChatSession::new(
+            "test-session".to_string(),
+            "test-agent".to_string(),
+            accepted,
+            shutdown_rx,
+            Arc::clone(&registry),
+            None,
+        );
+
+        std::env::remove_var("LLM_FALLBACK_CHAIN");
+
+        // Simulate 3 turns by directly pushing to chat_history (no spawn/run)
+        for (user_content, assistant_content) in [
+            (
+                "problem A",
+                "<thinking>analyzing...</thinking> Turn 1 answer",
+            ),
+            (
+                "problem B",
+                "<thinking>formulating...</thinking> Turn 2 answer",
+            ),
+            (
+                "problem C",
+                "<thinking>verifying...</thinking> Turn 3 answer",
+            ),
+        ] {
+            session.chat_history.push(Message {
+                role: "user".to_string(),
+                content: user_content.to_string(),
+            });
+            session.chat_history.push(Message {
+                role: "assistant".to_string(),
+                content: assistant_content.to_string(),
+            });
+        }
+
+        // Verify: 3 assistant messages all contain thinking tags
+        let assistant_msgs: Vec<_> = session
+            .chat_history
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .collect();
+        assert_eq!(assistant_msgs.len(), 3);
+        for (i, msg) in assistant_msgs.iter().enumerate() {
+            assert!(
+                msg.content.contains("<thinking>"),
+                "assistant message {} should contain thinking tag: {:?}",
+                i,
+                msg.content
+            );
+        }
+
+        drop(client);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 2: execute_compact output does NOT contain original thinking tags
+    // ---------------------------------------------------------------------------
+
+    #[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+    #[tokio::test]
+    async fn test_compact_boundary_excludes_thinking_tags() {
+        let fake_provider = build_fake_provider(vec![Scenario::ok(
+            "<summary>User discussed a problem and received step-by-step analysis.</summary>.",
+            "glm-5",
+        )]);
+
+        std::env::set_var("LLM_FALLBACK_CHAIN", "fake/glm-5");
+
+        let registry = Arc::new(LLMRegistry::new());
+        registry
+            .register("fake".to_string(), Arc::new(fake_provider))
+            .await;
+
+        let llm = registry.get("fake").await.unwrap();
+
+        let messages = vec![
+            Message {
+                role: "user".to_string(),
+                content: "problem A".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "<thinking>analyzing...</thinking> answer A".to_string(),
+            },
+            Message {
+                role: "user".to_string(),
+                content: "problem B".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "<thinking>formulating...</thinking> answer B".to_string(),
+            },
+            Message {
+                role: "user".to_string(),
+                content: "problem C".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "<thinking>verifying...</thinking> answer C".to_string(),
+            },
+        ];
+
+        let result = execute_compact(&messages, llm.as_ref(), "glm-5", None, false)
+            .await
+            .expect("execute_compact should succeed");
+
+        assert!(
+            result.boundary_message.contains("User discussed"),
+            "Boundary should contain summary, got: {}",
+            result.boundary_message
+        );
+        assert!(
+            !result.boundary_message.contains("<thinking>"),
+            "Boundary must NOT contain thinking tags, got: {}",
+            result.boundary_message
+        );
+        assert!(!result.boundary_message.contains("analyzing"));
+        assert!(!result.boundary_message.contains("formulating"));
+        assert!(!result.boundary_message.contains("verifying"));
+
+        std::env::remove_var("LLM_FALLBACK_CHAIN");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 3: thinking tag response traverses the wire via TCP protocol
+    // ---------------------------------------------------------------------------
+
+    #[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+    #[tokio::test]
+    async fn test_thinking_tag_traverses_tcp_protocol() {
+        let scenarios = vec![Scenario::ok(
+            "<thinking>analyzing the query...</thinking> final answer",
+            "glm-5",
+        )];
+
+        let (session, client, _shutdown_tx) = setup_session_with_fake(scenarios).await;
+        let session_handle = tokio::spawn(session.run());
+
+        let (reader_half, mut writer_half) = client.into_split();
+        let mut reader = tokio::io::BufReader::new(reader_half);
+
+        // Start
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.start","agent_id":"test-agent","id":"req-start"}"#,
+        )
+        .await;
+        let msg = read_msg(&mut reader).await;
+        assert!(matches!(msg, ServerMessage::ChatStarted { .. }));
+
+        // Send message
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"hello","id":"req-1"}"#,
+        )
+        .await;
+
+        let resp = read_msg(&mut reader).await;
+        let done = read_msg(&mut reader).await;
+
+        assert!(
+            matches!(
+                &resp,
+                ServerMessage::ChatResponse { content, .. }
+                    if content.contains("<thinking>") && content.contains("analyzing the query")
+            ),
+            "Response should contain thinking tag from wire, got: {:?}",
+            resp
+        );
+        assert!(matches!(done, ServerMessage::ChatResponseDone { .. }));
+
+        drop(writer_half);
+        let _ = session_handle.await;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 4: post-compact conversation continues with new session context
+    // ---------------------------------------------------------------------------
+
+    #[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+    #[tokio::test]
+    async fn test_conversation_continues_after_compact() {
+        let scenarios = vec![
+            Scenario::ok("reply 1", "glm-5"),
+            Scenario::ok("reply 2", "glm-5"),
+            Scenario::ok("<summary>topics discussed.</summary>.", "glm-5"),
+            Scenario::ok("post-compact response", "glm-5"),
+        ];
+
+        let (session, client, _shutdown_tx) = setup_session_with_fake(scenarios).await;
+        let session_handle = tokio::spawn(session.run());
+
+        let (reader_half, mut writer_half) = client.into_split();
+        let mut reader = tokio::io::BufReader::new(reader_half);
+
+        // Start
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.start","agent_id":"test-agent","id":"req-start"}"#,
+        )
+        .await;
+        let _msg = read_msg(&mut reader).await;
+
+        // 2 normal turns
+        for (i, text) in ["hello", "continue"].iter().enumerate() {
+            send_json(
+                &mut writer_half,
+                &format!(
+                    r#"{{"type":"chat.message","content":"{}","id":"req-{}"}}"#,
+                    text,
+                    i + 1
+                ),
+            )
+            .await;
+            let _resp = read_msg(&mut reader).await;
+            let _done = read_msg(&mut reader).await;
+        }
+
+        // /compact
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"/compact","id":"req-compact"}"#,
+        )
+        .await;
+        let compact_resp = read_msg(&mut reader).await;
+        let compact_done = read_msg(&mut reader).await;
+        assert!(
+            matches!(
+                &compact_resp,
+                ServerMessage::ChatResponse { content, .. }
+                    if content.contains("压缩成功")
+            ),
+            "Compact should return success, got: {:?}",
+            compact_resp
+        );
+        assert!(matches!(
+            compact_done,
+            ServerMessage::ChatResponseDone { .. }
+        ));
+
+        // Post-compact message
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"what were we discussing?","id":"req-after"}"#,
+        )
+        .await;
+        let after_resp = read_msg(&mut reader).await;
+        let after_done = read_msg(&mut reader).await;
+
+        assert!(
+            matches!(
+                &after_resp,
+                ServerMessage::ChatResponse { content, .. }
+                    if content.contains("post-compact")
+            ),
+            "Post-compact response should come from scenario 4, got: {:?}",
+            after_resp
+        );
+        assert!(matches!(after_done, ServerMessage::ChatResponseDone { .. }));
+
+        drop(writer_half);
+        let _ = session_handle.await;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 5: session remains functional after compact
+    // ---------------------------------------------------------------------------
+
+    #[ignore = "chat module removed in #725; rewrite against new interface (see new issue)"]
+    #[tokio::test]
+    async fn test_session_stable_after_compact() {
+        let scenarios = vec![
+            Scenario::ok("first reply", "glm-5"),
+            Scenario::ok("<summary>first topic covered.</summary>.", "glm-5"),
+            Scenario::ok("second reply after compact", "glm-5"),
+        ];
+
+        let (session, client, _shutdown_tx) = setup_session_with_fake(scenarios).await;
+        let session_handle = tokio::spawn(session.run());
+
+        let (reader_half, mut writer_half) = client.into_split();
+        let mut reader = tokio::io::BufReader::new(reader_half);
+
+        // Start
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.start","agent_id":"test-agent","id":"req-start"}"#,
+        )
+        .await;
+        let msg = read_msg(&mut reader).await;
+        assert!(matches!(msg, ServerMessage::ChatStarted { .. }));
+
+        // First message
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"start","id":"req-1"}"#,
+        )
+        .await;
+        let resp1 = read_msg(&mut reader).await;
+        let done1 = read_msg(&mut reader).await;
+        assert!(matches!(
+            &resp1,
+            ServerMessage::ChatResponse { content, .. }
+                if content.contains("first reply")
+        ));
+        assert!(matches!(done1, ServerMessage::ChatResponseDone { .. }));
+
+        // /compact
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"/compact","id":"req-compact"}"#,
+        )
+        .await;
+        let compact_resp = read_msg(&mut reader).await;
+        let compact_done = read_msg(&mut reader).await;
+        assert!(
+            matches!(
+                &compact_resp,
+                ServerMessage::ChatResponse { content, .. }
+                    if content.contains("压缩成功")
+            ),
+            "Compact should succeed, got: {:?}",
+            compact_resp
+        );
+        assert!(matches!(
+            compact_done,
+            ServerMessage::ChatResponseDone { .. }
+        ));
+
+        // Second message after compact
+        send_json(
+            &mut writer_half,
+            r#"{"type":"chat.message","content":"continue","id":"req-2"}"#,
+        )
+        .await;
+        let resp2 = read_msg(&mut reader).await;
+        let done2 = read_msg(&mut reader).await;
+        assert!(
+            matches!(
+                &resp2,
+                ServerMessage::ChatResponse { content, .. }
+                    if content.contains("second reply after compact")
+            ),
+            "Post-compact response should contain 'second reply after compact', got: {:?}",
+            resp2
+        );
+        assert!(matches!(done2, ServerMessage::ChatResponseDone { .. }));
+
+        drop(writer_half);
+        let _ = session_handle.await;
+    }
+}


### PR DESCRIPTION
恢复 PR #841 中删除的 3 个 e2e 测试文件（共 1051 行），在 Cargo.toml 中注册 `chat-legacy` cfg 以消除 `unexpected_cfgs` warning。

文件因 `LegacyChatSession` 已移除而无法编译，通过 `#![cfg(feature = "chat-legacy")]` 门控，待质量 review。

Source: user
Type: chore
