### PR TITLE
chore: 抑制 LLMProvider deprecated 编译 warning（含 UT）

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -1,5 +1,7 @@
 //! Config Wizard - interactive CLI configuration flow
 
+#![allow(deprecated)]
+
 pub mod fetch;
 pub mod types;
 

--- a/src/cli/config_wizard/types.rs
+++ b/src/cli/config_wizard/types.rs
@@ -1,5 +1,7 @@
 //! Types for the Config Wizard
 
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 
 use crate::llm::{model_info::ModelInfo, LLMProvider};

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,5 +1,7 @@
 //! Anthropic LLM Provider
 
+#![allow(deprecated)]
+
 use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider};
 use async_trait::async_trait;
 

--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -3,6 +3,8 @@
 //! Uses the DeepSeek API. Chat endpoint is OpenAI-compatible at
 //! `base_url/chat/completions`. Model list is fetched from `base_url/models`.
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};

--- a/src/llm/fake.rs
+++ b/src/llm/fake.rs
@@ -13,6 +13,8 @@
 //!     .build();
 //! ```
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};

--- a/src/llm/fallback.rs
+++ b/src/llm/fallback.rs
@@ -2,6 +2,8 @@
 //!
 //! Wraps LLM calls with retry, cooldown tracking, and model-level fallback.
 
+#![allow(deprecated)]
+
 use crate::llm::retry::{
     backoff_delay, CooldownManager, MAX_TRANSIENT_RETRIES, MAX_UNKNOWN_RETRIES,
     TRANSIENT_BASE_DELAY, TRANSIENT_MAX_DELAY,

--- a/src/llm/glm/mod.rs
+++ b/src/llm/glm/mod.rs
@@ -1,5 +1,7 @@
 //! GLm LLM Provider
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/llm/glm/tests/mock_extra.rs
+++ b/src/llm/glm/tests/mock_extra.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use crate::llm::{ChatRequest, Message};
 use mockito::Server;

--- a/src/llm/glm/tests/mock_integration.rs
+++ b/src/llm/glm/tests/mock_integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use crate::llm::{ChatRequest, Message};
 

--- a/src/llm/glm/tests/mod.rs
+++ b/src/llm/glm/tests/mod.rs
@@ -1,5 +1,7 @@
 //! Unit tests for the GLM provider.
 
+#![allow(deprecated)]
+
 use super::*;
 use crate::llm::http_client::MockTimeoutHttpClient;
 use mockito::Server;

--- a/src/llm/glm_stream/tests/mock_integration.rs
+++ b/src/llm/glm_stream/tests/mock_integration.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use super::*;
 use mockito::Server;
 

--- a/src/llm/glm_stream/tests/mod.rs
+++ b/src/llm/glm_stream/tests/mod.rs
@@ -1,5 +1,7 @@
 //! Unit tests for GLM streaming SSE parsing.
 
+#![allow(deprecated)]
+
 use crate::llm::glm_stream::{parse_sse_line, parse_stream_chunk, process_buffer};
 use crate::llm::{ChatRequest, ChatStreamChunk, GlmProvider, LLMProvider, Message, Usage};
 

--- a/src/llm/http_client.rs
+++ b/src/llm/http_client.rs
@@ -2,6 +2,8 @@
 //!
 //! Provides `HttpClient` trait to allow mock injection in tests.
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use reqwest::Client;
 

--- a/src/llm/legacy/legacy_provider.rs
+++ b/src/llm/legacy/legacy_provider.rs
@@ -3,6 +3,8 @@
 //! Bridges the legacy interface (`ChatRequest`/`ChatResponse`/`Message`) to the
 //! new architecture (`InternalRequest`/`InternalResponse`/`InternalMessage`).
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use reqwest::header::HeaderMap;
 use reqwest::Client;

--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -1,5 +1,7 @@
 //! MiniMax LLM Provider
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for the MiniMax provider.
 
+#![allow(deprecated)]
+
 use super::*;
 use crate::llm::{Message, ReqwestHttpClient};
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,5 +1,7 @@
 //! LLM Interface - Abstract trait for multiple LLM providers
 
+#![allow(deprecated)]
+
 pub mod anthropic;
 pub mod cache_adapter;
 pub mod fallback;

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -1,5 +1,7 @@
 //! OpenAI LLM Provider
 
+#![allow(deprecated)]
+
 use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, Usage};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/llm/stub.rs
+++ b/src/llm/stub.rs
@@ -1,5 +1,7 @@
 //! Stub LLM Provider - Returns fixed responses for testing
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 
 use super::{ChatRequest, ChatResponse, LLMError, LLMProvider, Usage};

--- a/src/llm/volcengine.rs
+++ b/src/llm/volcengine.rs
@@ -3,6 +3,8 @@
 //! Uses the Volcano Ark (方舟) API. Chat endpoint is OpenAI-compatible at
 //! `base_url/chat/completions`. Model list is fetched from `base_url/models`.
 
+#![allow(deprecated)]
+
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};

--- a/src/session/compaction.rs
+++ b/src/session/compaction.rs
@@ -3,6 +3,8 @@
 //! Provides token estimation, auto-compaction threshold detection, and circuit breaker
 //! for LLM context window management.
 
+#![allow(deprecated)]
+
 use serde::{Deserialize, Serialize};
 
 use crate::llm::Message;

--- a/tests/llm_tests.rs
+++ b/tests/llm_tests.rs
@@ -3,6 +3,8 @@
 //! Tests the StubProvider and LLMRegistry integration.
 //! These tests verify that the agent+LLM call chain works in CI.
 
+#![allow(deprecated)]
+
 use std::sync::Arc;
 
 use closeclaw::llm::{ChatRequest, LLMProvider, LLMRegistry, Message, StubProvider};

--- a/tests/minimax_mock_tests.rs
+++ b/tests/minimax_mock_tests.rs
@@ -3,6 +3,8 @@
 //! Each test spins up a mockito server, points MiniMaxProvider at it,
 //! sends a chat request, and validates the deserialized response.
 
+#![allow(deprecated)]
+
 use closeclaw::llm::MiniMaxProvider;
 use closeclaw::llm::{ChatRequest, LLMProvider, Message as LLMMessage};
 use mockito::Server;

--- a/tests/minimax_stream_mock_tests.rs
+++ b/tests/minimax_stream_mock_tests.rs
@@ -3,6 +3,8 @@
 //! Error fixture tests: base_resp error mapping (AuthFailed, ModelNotFound, InvalidRequest).
 //! Streaming fixture tests: SSE delta merging and usage extraction.
 
+#![allow(deprecated)]
+
 use closeclaw::llm::MiniMaxProvider;
 use closeclaw::llm::{ChatRequest, LLMProvider, Message as LLMMessage};
 use mockito::Server;


### PR DESCRIPTION
## 概述

在所有使用 `LLMProvider`（deprecated trait）的 24 个文件添加 `#![allow(deprecated)]`，消除 `cargo build` 和 `cargo test` 中 ~160 条 deprecated 编译 warning。

## 改动

- 24 个文件，每个文件仅新增 1 行 `#![allow(deprecated)]` + 1 行空行（+48 行，-0 行）
- 零业务逻辑变更，零 design doc 修改

## 涉及文件

| 类别 | 文件 |
|------|------|
| Provider 实现 | `src/llm/{openai,anthropic,deepseek,volcengine,minimax,glm/mod,stub,fake}.rs` |
| Bridge | `src/llm/legacy/legacy_provider.rs` |
| 基础设施 | `src/llm/mod.rs`、`src/llm/fallback.rs`、`src/llm/http_client.rs` |
| 调用方 | `src/session/compaction.rs`、`src/cli/config_wizard/{mod,types}.rs` |
| 测试 | `tests/{llm_tests,minimax_mock_tests,minimax_stream_mock_tests}.rs`、`src/llm/{minimax/tests,glm/tests/*,glm_stream/tests/*}.rs` |

## 验证

- `cargo build` → 零 warning ✅
- `cargo test` → 零 deprecated warning，1738 passed / 2 failed（pre-existing flaky test，master 同样失败）✅

## 技术债

完整迁移 `LLMProvider` → `Provider` trait 见 issue #843。

Source: user
Type: chore
