### PR TITLE
chore: 配置 deny(warnings) 防止新增 warning 混入

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-D", "warnings"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Strict warning check
+        run: cargo check -- -D warnings
+
       - name: Run clippy
         run: cargo clippy --all 2>&1 | tee clippy-output.txt
         continue-on-error: true


### PR DESCRIPTION
## 变更说明

- 新增 `.cargo/config.toml`，设置 `[build] rustflags = ["-D", "warnings"]`，本地编译时 warning 视为 error
- CI 新增 `Strict warning check` 步骤（`cargo check -- -D warnings`）作为双保险

## 关联

Closes #627
Depends on #626（已 CLOSED）

## 验收标准

- [x] `.cargo/config.toml` 中添加 `-D warnings`
- [x] CI 配置中添加 `cargo check -- -D warnings`
- [x] `cargo build` 零 warning 零 error

Source: issue #627
Type: chore