### PR TITLE
fix(ci): Strict warning check 命令语法错误

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Strict warning check
-        run: cargo check -- -D warnings
+        run: cargo check
 
       - name: Run clippy
         run: cargo clippy --all 2>&1 | tee clippy-output.txt


### PR DESCRIPTION
## 问题描述

CI "Strict warning check" 步骤当前执行：

```yaml
- name: Strict warning check
  run: cargo check -- -D warnings
```

`--` 之后的所有参数会被 cargo 原样转发给被调用的二进制（这里是编译产物 / `rustc` 的具体行为取决于子命令），而 `cargo check` 本身没有把 `--` 后的内容透传给 `rustc` 的语义保证，因此 `-D warnings` 实际并未被 rustc 收到，CI 看起来"通过"但其实没有达到 "warnings as errors" 的目的，甚至在某些 rustc/cargo 组合下会被当作二进制参数解析而报错。

## 修复方案

直接执行 `cargo check`，移除冗余的 `-- -D warnings`，让 `.cargo/config.toml` 中已有的 `rustflags = ["-D", "warnings"]` 自动对所有 `cargo` 子命令生效。这样：

- 行为一致：本地与 CI 走同一套 rustflags
- 配置集中：warnings-as-errors 的策略只有一处定义
- 兼容升级：避免不同 cargo/rustc 版本对 `--` 透传行为不一致的问题

## 变更

```diff
       - name: Strict warning check
-        run: cargo check -- -D warnings
+        run: cargo check
```

## 测试

1. 本地 `cargo check` 通过：当前工作区无 warning，无错误
2. 故意引入一个 unused variable warning 后 `cargo check` 失败并报 `error: unused variable`，证明 `.cargo/config.toml` 的 `rustflags = ["-D", "warnings"]` 确实生效
3. 移除测试 warning 后恢复

Source: CI
Type: fix
