### PR TITLE
fix: AgentConfig name 改为可选字段，默认同 id；id 恢复必填

### DIFF
--- a/src/agent/config/config_tests.rs
+++ b/src/agent/config/config_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+
 use tempfile::TempDir;
 
 #[test]
@@ -7,7 +9,7 @@ fn test_agent_config_save_load() {
     let temp = TempDir::new().unwrap();
     let config = AgentConfig {
         id: "test-id".to_string(),
-        name: "Test Agent".to_string(),
+        name: Some("Test Agent".to_string()),
         parent_id: Some("parent-id".to_string()),
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -74,7 +76,7 @@ fn test_default_communication_config() {
 fn test_communication_allowed() {
     let parent = AgentConfig {
         id: "parent-1".to_string(),
-        name: "Parent".to_string(),
+        name: Some("Parent".to_string()),
         parent_id: None,
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -88,7 +90,7 @@ fn test_communication_allowed() {
 
     let child = AgentConfig {
         id: "child-1".to_string(),
-        name: "Child".to_string(),
+        name: Some("Child".to_string()),
         parent_id: Some("parent-1".to_string()),
         max_child_depth: 1,
         created_at: Utc::now(),
@@ -110,7 +112,7 @@ fn test_communication_allowed() {
 fn test_communication_denied_outbound() {
     let agent_a = AgentConfig {
         id: "agent-a".to_string(),
-        name: "Agent A".to_string(),
+        name: Some("Agent A".to_string()),
         parent_id: None,
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -124,7 +126,7 @@ fn test_communication_denied_outbound() {
 
     let agent_c = AgentConfig {
         id: "agent-c".to_string(),
-        name: "Agent C".to_string(),
+        name: Some("Agent C".to_string()),
         parent_id: None,
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -145,7 +147,7 @@ fn test_communication_denied_outbound() {
 fn test_communication_denied_inbound() {
     let agent_a = AgentConfig {
         id: "agent-a".to_string(),
-        name: "Agent A".to_string(),
+        name: Some("Agent A".to_string()),
         parent_id: None,
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -159,7 +161,7 @@ fn test_communication_denied_inbound() {
 
     let agent_b = AgentConfig {
         id: "agent-b".to_string(),
-        name: "Agent B".to_string(),
+        name: Some("Agent B".to_string()),
         parent_id: None,
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -194,7 +196,7 @@ fn test_agent_config_new_fields_defaults() {
 fn test_agent_config_new_fields_roundtrip() {
     let config = AgentConfig {
         id: "test-agent".to_string(),
-        name: "Test".to_string(),
+        name: Some("Test".to_string()),
         model: Some("gpt-4o".to_string()),
         workspace: Some("/tmp/workspace".to_string()),
         agent_dir: Some("/tmp/agent_dir".to_string()),
@@ -271,7 +273,7 @@ fn test_agent_config_json_with_new_fields() {
     let config: AgentConfig = serde_json::from_str(json).unwrap();
 
     assert_eq!(config.id, "from-json");
-    assert_eq!(config.name, "Json Agent");
+    assert_eq!(config.name, Some("Json Agent".to_string()));
     assert_eq!(config.model, Some("deepseek-v3".to_string()));
     assert_eq!(config.workspace, Some("/home/user/project".to_string()));
     assert_eq!(
@@ -321,7 +323,7 @@ fn test_agent_config_camel_case_parse() {
     let config: AgentConfig = serde_json::from_str(json).unwrap();
 
     assert_eq!(config.id, "code-reviewer");
-    assert_eq!(config.name, "代码审查助手");
+    assert_eq!(config.name, Some("代码审查助手".to_string()));
     assert_eq!(config.parent_id, None);
     assert_eq!(config.model, Some("deepseek/deepseek-chat".to_string()));
     assert_eq!(config.workspace, None);
@@ -346,7 +348,7 @@ fn test_max_depth_allowed() {
     // Root agent with max_child_depth=3, currently at depth 0
     let root = AgentConfig {
         id: "root".to_string(),
-        name: "Root".to_string(),
+        name: Some("Root".to_string()),
         parent_id: None,
         max_child_depth: 3,
         created_at: Utc::now(),
@@ -375,7 +377,7 @@ fn test_max_depth_exceeded() {
     // Agent at depth 3, max_child_depth=2 (already exceeded!)
     let leaf = AgentConfig {
         id: "leaf".to_string(),
-        name: "Leaf".to_string(),
+        name: Some("Leaf".to_string()),
         parent_id: Some("parent".to_string()),
         max_child_depth: 2,
         created_at: Utc::now(),
@@ -388,7 +390,7 @@ fn test_max_depth_exceeded() {
     let get_parent = |id: &str| match id {
         "parent" => Some(AgentConfig {
             id: "parent".to_string(),
-            name: "Parent".to_string(),
+            name: Some("Parent".to_string()),
             parent_id: Some("grandparent".to_string()),
             max_child_depth: 2,
             created_at: Utc::now(),
@@ -398,7 +400,7 @@ fn test_max_depth_exceeded() {
         }),
         "grandparent" => Some(AgentConfig {
             id: "grandparent".to_string(),
-            name: "Grandparent".to_string(),
+            name: Some("Grandparent".to_string()),
             parent_id: None,
             max_child_depth: 3,
             created_at: Utc::now(),
@@ -421,4 +423,75 @@ fn test_max_depth_exceeded() {
         }
         _ => panic!("expected ExceedsMaxDepth"),
     }
+}
+
+// =====================================================================
+// Step 1.5 — Tests for `AgentConfig.name` becoming optional and
+// `ResolvedAgentConfig` falling back to `id` when name is missing/empty.
+// =====================================================================
+
+#[test]
+fn test_agent_config_name_defaults_to_none() {
+    // Minimal JSON with only `id`: `name` must default to `None`.
+    let json = r#"{"id": "x"}"#;
+    let config: AgentConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.id, "x");
+    assert_eq!(config.name, None);
+}
+
+#[test]
+fn test_agent_config_name_empty_string_fallback() {
+    // JSON with `name: ""` is preserved as `Some("")` at the deserialization
+    // layer. The empty-string → id fallback happens later in
+    // `ResolvedAgentConfig::from_single` / `merge`, not in serde.
+    let json = r#"{"id": "x", "name": ""}"#;
+    let config: AgentConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.id, "x");
+    assert_eq!(config.name, Some("".to_string()));
+}
+
+#[test]
+fn test_resolved_config_name_fallback_to_id() {
+    // `name = None` → resolved `name` must equal `id`.
+    let config = AgentConfig {
+        id: "agent-x".to_string(),
+        name: None,
+        ..Default::default()
+    };
+    let resolved = ResolvedAgentConfig::from_single(config, ConfigSource::User, "<test>").unwrap();
+    assert_eq!(resolved.id, "agent-x");
+    assert_eq!(resolved.name, "agent-x");
+}
+
+#[test]
+fn test_resolved_config_name_empty_string_fallback() {
+    // `name = Some("")` → resolved `name` must equal `id`.
+    let config = AgentConfig {
+        id: "agent-y".to_string(),
+        name: Some("".to_string()),
+        ..Default::default()
+    };
+    let resolved = ResolvedAgentConfig::from_single(config, ConfigSource::User, "<test>").unwrap();
+    assert_eq!(resolved.id, "agent-y");
+    assert_eq!(resolved.name, "agent-y");
+}
+
+#[test]
+fn test_resolved_config_merge_name_fallback() {
+    // Both project and user have no usable name → merged name falls back to
+    // the resolved `id`. Project.name is `None`, user.name is `Some("")`.
+    let project = AgentConfig {
+        id: "agent-z".to_string(),
+        name: None,
+        ..Default::default()
+    };
+    let user = AgentConfig {
+        id: "agent-z".to_string(),
+        name: Some("".to_string()),
+        ..Default::default()
+    };
+    let resolved = ResolvedAgentConfig::merge(project, user, "<test>").unwrap();
+    assert_eq!(resolved.id, "agent-z");
+    assert_eq!(resolved.name, "agent-z");
+    assert_eq!(resolved.source, ConfigSource::Merged);
 }

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -21,7 +21,8 @@ pub struct AgentConfig {
     #[serde(default)]
     pub id: String,
     /// Human-readable name.
-    pub name: String,
+    #[serde(default)]
+    pub name: Option<String>,
     /// Parent agent ID (if this agent was spawned by another).
     #[serde(default)]
     pub parent_id: Option<String>,
@@ -138,7 +139,7 @@ impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             id: String::new(),
-            name: String::new(),
+            name: None,
             parent_id: None,
             max_child_depth: default_max_child_depth(),
             created_at: chrono::Utc::now(),

--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -59,15 +59,27 @@ impl AgentDirectoryProvider {
                 .map(|d| d.join(id).join("config.json"));
 
             // Try loading configs from both levels
-            let user_config = Self::load_agent_config(&user_config_path);
-            let project_config = project_config_path
+            let mut user_config = Self::load_agent_config(&user_config_path);
+            let mut project_config = project_config_path
                 .as_ref()
                 .and_then(|p| Self::load_agent_config(p));
 
+            // Backfill `id` from the directory name when missing, and
+            // warn on mismatch. The project layer is processed first so
+            // its injected id wins when both levels have an empty id
+            // (project fields override user fields in the merge below).
+            Self::inject_dirname_id(&mut project_config, id);
+            Self::inject_dirname_id(&mut user_config, id);
+
+            let path_label = id.as_str();
             let resolved = match (project_config, user_config) {
-                (Some(proj), Some(usr)) => ResolvedAgentConfig::merge(proj, usr),
-                (Some(proj), None) => ResolvedAgentConfig::from_single(proj, ConfigSource::Project),
-                (None, Some(usr)) => ResolvedAgentConfig::from_single(usr, ConfigSource::User),
+                (Some(proj), Some(usr)) => ResolvedAgentConfig::merge(proj, usr, path_label)?,
+                (Some(proj), None) => {
+                    ResolvedAgentConfig::from_single(proj, ConfigSource::Project, path_label)?
+                }
+                (None, Some(usr)) => {
+                    ResolvedAgentConfig::from_single(usr, ConfigSource::User, path_label)?
+                }
                 (None, None) => {
                     warn!("Agent '{}' in registry but no config.json found", id);
                     continue;
@@ -104,6 +116,30 @@ impl AgentDirectoryProvider {
         serde_json::from_str(&content).ok()
     }
 
+    /// Backfill the agent's `id` from the directory name when missing,
+    /// and warn when the file's `id` disagrees with the directory name.
+    ///
+    /// `AgentConfig.id` deserializes as an empty string by default, so a
+    /// config.json that omits `id` is not an error here — the directory
+    /// name from the registration list is the canonical id. A non-empty
+    /// `id` that differs from the directory name is almost always a
+    /// misconfiguration, so we log it at WARN level and keep the file's
+    /// value (the downstream merge / `from_single` will use whatever
+    /// `id` is on the config object).
+    fn inject_dirname_id(config: &mut Option<AgentConfig>, dirname: &str) {
+        if let Some(cfg) = config.as_mut() {
+            if cfg.id.is_empty() {
+                cfg.id = dirname.to_string();
+            } else if cfg.id != dirname {
+                warn!(
+                    agent_id = %cfg.id,
+                    dirname = %dirname,
+                    "agent config id does not match directory name; using config id"
+                );
+            }
+        }
+    }
+
     fn load_permissions(path: &std::path::Path) -> Option<AgentPermissions> {
         if !path.exists() {
             return None;
@@ -130,292 +166,5 @@ impl AgentDirectoryProvider {
     /// List all registered agent IDs that have configs.
     pub fn agent_ids(&self) -> Vec<&String> {
         self.entries.keys().collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::agent::config::{ActionPermission, PermissionLimits};
-    use std::path::Path;
-    use tempfile::TempDir;
-
-    /// Write a minimal `config.json` for the given agent ID.
-    fn write_config(dir: &Path, id: &str, name: &str) {
-        let agent_dir = dir.join(id);
-        std::fs::create_dir_all(&agent_dir).unwrap();
-        let json = format!(r#"{{ "id": "{}", "name": "{}" }}"#, id, name);
-        std::fs::write(agent_dir.join("config.json"), json).unwrap();
-    }
-
-    /// Write a minimal `permissions.json` for the given agent ID.
-    fn write_permissions(dir: &Path, id: &str, marker: &str) {
-        let agent_dir = dir.join(id);
-        std::fs::create_dir_all(&agent_dir).unwrap();
-        // Embed `marker` inside the agent_id so we can assert which file won.
-        let json = format!(
-            r#"{{ "agent_id": "{}",
-"permissions": {{ "exec": {{ "allowed": true,
-"limits": {{}} }} }} }}"#,
-            marker
-        );
-        std::fs::write(agent_dir.join("permissions.json"), json).unwrap();
-    }
-
-    #[test]
-    fn test_empty_registry_produces_no_entries() {
-        let user = TempDir::new().unwrap();
-        // Create a stray agent dir that must NOT be picked up.
-        write_config(user.path(), "stray", "Stray Agent");
-
-        let provider =
-            AgentDirectoryProvider::new(Vec::new(), user.path().to_path_buf(), None).unwrap();
-
-        assert!(provider.agent_ids().is_empty());
-        assert!(provider.entries().is_empty());
-        assert!(provider.permissions().is_empty());
-    }
-
-    #[test]
-    fn test_user_only_load() {
-        let user = TempDir::new().unwrap();
-        write_config(user.path(), "alpha", "Alpha Agent");
-
-        let provider =
-            AgentDirectoryProvider::new(vec!["alpha".to_string()], user.path().to_path_buf(), None)
-                .unwrap();
-
-        assert_eq!(provider.agent_ids().len(), 1);
-        let entry = provider.get("alpha").expect("alpha should be loaded");
-        assert_eq!(entry.id, "alpha");
-        assert_eq!(entry.name, "Alpha Agent");
-        assert_eq!(entry.source, ConfigSource::User);
-    }
-
-    #[test]
-    fn test_project_only_load() {
-        let project = TempDir::new().unwrap();
-        write_config(project.path(), "beta", "Beta Agent");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["beta".to_string()],
-            PathBuf::from("/nonexistent/user/agents"),
-            Some(project.path().to_path_buf()),
-        )
-        .unwrap();
-
-        assert_eq!(provider.agent_ids().len(), 1);
-        let entry = provider.get("beta").expect("beta should be loaded");
-        assert_eq!(entry.id, "beta");
-        assert_eq!(entry.name, "Beta Agent");
-        assert_eq!(entry.source, ConfigSource::Project);
-    }
-
-    #[test]
-    fn test_merge_project_overrides_user() {
-        let user = TempDir::new().unwrap();
-        let project = TempDir::new().unwrap();
-        write_config(user.path(), "gamma", "User Name");
-        write_config(project.path(), "gamma", "Project Name");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["gamma".to_string()],
-            user.path().to_path_buf(),
-            Some(project.path().to_path_buf()),
-        )
-        .unwrap();
-
-        let entry = provider.get("gamma").expect("gamma should be loaded");
-        // Project name wins.
-        assert_eq!(entry.name, "Project Name");
-        assert_eq!(entry.source, ConfigSource::Merged);
-    }
-
-    #[test]
-    fn test_ignores_dirs_outside_registry() {
-        let user = TempDir::new().unwrap();
-        // Files in the registry → must be loaded.
-        write_config(user.path(), "registered", "Registered");
-        // Files NOT in the registry → must be ignored.
-        write_config(user.path(), "unregistered", "Unregistered");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["registered".to_string()],
-            user.path().to_path_buf(),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(provider.agent_ids(), vec![&"registered".to_string()]);
-        assert!(provider.get("unregistered").is_none());
-    }
-
-    #[test]
-    fn test_permissions_project_wins_over_user() {
-        let user = TempDir::new().unwrap();
-        let project = TempDir::new().unwrap();
-        write_config(user.path(), "delta", "Delta");
-        write_config(project.path(), "delta", "Delta");
-        write_permissions(user.path(), "delta", "user-marker");
-        write_permissions(project.path(), "delta", "project-marker");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["delta".to_string()],
-            user.path().to_path_buf(),
-            Some(project.path().to_path_buf()),
-        )
-        .unwrap();
-
-        let perms = provider
-            .permissions()
-            .get("delta")
-            .expect("delta permissions should be loaded");
-        // Project permissions win → agent_id carries the project marker.
-        assert_eq!(perms.agent_id, "project-marker");
-    }
-
-    #[test]
-    fn test_permissions_user_fallback_when_no_project_file() {
-        let user = TempDir::new().unwrap();
-        write_config(user.path(), "epsilon", "Epsilon");
-        write_permissions(user.path(), "epsilon", "user-marker");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["epsilon".to_string()],
-            user.path().to_path_buf(),
-            Some(PathBuf::from("/nonexistent/project/agents")),
-        )
-        .unwrap();
-
-        let perms = provider
-            .permissions()
-            .get("epsilon")
-            .expect("epsilon permissions should be loaded from user");
-        assert_eq!(perms.agent_id, "user-marker");
-        assert!(perms.is_allowed("exec"));
-    }
-
-    #[test]
-    fn test_missing_config_json_is_skipped() {
-        let user = TempDir::new().unwrap();
-        // Create the agent directory but leave it empty (no config.json).
-        std::fs::create_dir_all(user.path().join("zeta")).unwrap();
-        // Another agent that DOES have a config file.
-        write_config(user.path(), "eta", "Eta");
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["zeta".to_string(), "eta".to_string()],
-            user.path().to_path_buf(),
-            None,
-        )
-        .unwrap();
-
-        // zeta has no config.json → skipped.
-        assert!(provider.get("zeta").is_none());
-        // eta is still loaded.
-        assert!(provider.get("eta").is_some());
-        assert_eq!(provider.agent_ids().len(), 1);
-    }
-
-    #[test]
-    fn test_reload_picks_up_changes() {
-        let user = TempDir::new().unwrap();
-        let provider =
-            AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
-                .unwrap();
-        assert!(provider.get("theta").is_none());
-
-        // Add a config file and reload.
-        write_config(user.path(), "theta", "Theta");
-        let provider = provider;
-        // Provider has no public `reload` callable here? Yes it does.
-        // We need `&mut self`, so reconstruct via the constructor for the
-        // first call, then mutate via `reload` after the change.
-        // Easier: use the constructor twice.
-        drop(provider);
-
-        let provider =
-            AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
-                .unwrap();
-        assert!(provider.get("theta").is_some());
-    }
-
-    #[test]
-    fn test_no_user_dir_no_project_dir() {
-        // Neither user nor project dir exists. The registry IDs should all
-        // be skipped, and no errors should be raised.
-        let provider = AgentDirectoryProvider::new(
-            vec!["a".to_string(), "b".to_string()],
-            PathBuf::from("/nonexistent/user"),
-            None,
-        )
-        .unwrap();
-        assert!(provider.agent_ids().is_empty());
-        assert!(provider.entries().is_empty());
-    }
-
-    #[test]
-    fn test_merge_falls_back_to_user_field_when_project_empty() {
-        // When the user config sets a field the project config does not,
-        // the user value must be preserved.
-        let user = TempDir::new().unwrap();
-        let project = TempDir::new().unwrap();
-
-        // user: name and a skill; project: only a different name.
-        let user_dir = user.path().join("iota");
-        std::fs::create_dir_all(&user_dir).unwrap();
-        std::fs::write(
-            user_dir.join("config.json"),
-            r#"{ "id": "iota", "name": "Iota", "skills": ["web"] }"#,
-        )
-        .unwrap();
-
-        let project_dir = project.path().join("iota");
-        std::fs::create_dir_all(&project_dir).unwrap();
-        std::fs::write(
-            project_dir.join("config.json"),
-            r#"{ "id": "iota", "name": "Iota Project" }"#,
-        )
-        .unwrap();
-
-        let provider = AgentDirectoryProvider::new(
-            vec!["iota".to_string()],
-            user.path().to_path_buf(),
-            Some(project.path().to_path_buf()),
-        )
-        .unwrap();
-
-        let entry = provider.get("iota").expect("iota must be loaded");
-        // Project name overrides user name.
-        assert_eq!(entry.name, "Iota Project");
-        // User-provided skill survives because the project skills vec is empty.
-        assert_eq!(entry.skills, vec!["web".to_string()]);
-        assert_eq!(entry.source, ConfigSource::Merged);
-    }
-
-    #[test]
-    fn test_no_permissions_file_is_fine() {
-        let user = TempDir::new().unwrap();
-        write_config(user.path(), "kappa", "Kappa");
-
-        let provider =
-            AgentDirectoryProvider::new(vec!["kappa".to_string()], user.path().to_path_buf(), None)
-                .unwrap();
-
-        assert!(provider.get("kappa").is_some());
-        assert!(provider.permissions().get("kappa").is_none());
-    }
-
-    #[test]
-    fn test_action_permission_round_trip() {
-        // Sanity check: ActionPermission is the type used inside
-        // AgentPermissions; this guards against accidental type changes.
-        let perm = ActionPermission {
-            allowed: true,
-            limits: PermissionLimits::default(),
-        };
-        let json = serde_json::to_string(&perm).unwrap();
-        let back: ActionPermission = serde_json::from_str(&json).unwrap();
-        assert!(back.allowed);
     }
 }

--- a/src/config/agents/directory_tests.rs
+++ b/src/config/agents/directory_tests.rs
@@ -1,0 +1,382 @@
+//! Tests for `AgentDirectoryProvider`.
+
+use super::*;
+use crate::agent::config::{ActionPermission, PermissionLimits};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// Write a minimal `config.json` for the given agent ID.
+fn write_config(dir: &Path, id: &str, name: &str) {
+    let agent_dir = dir.join(id);
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    let json = format!(r#"{{ "id": "{}", "name": "{}" }}"#, id, name);
+    std::fs::write(agent_dir.join("config.json"), json).unwrap();
+}
+
+/// Write a minimal `permissions.json` for the given agent ID.
+fn write_permissions(dir: &Path, id: &str, marker: &str) {
+    let agent_dir = dir.join(id);
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    // Embed `marker` inside the agent_id so we can assert which file won.
+    let json = format!(
+        r#"{{ "agent_id": "{}",
+"permissions": {{ "exec": {{ "allowed": true,
+"limits": {{}} }} }} }}"#,
+        marker
+    );
+    std::fs::write(agent_dir.join("permissions.json"), json).unwrap();
+}
+
+#[test]
+fn test_empty_registry_produces_no_entries() {
+    let user = TempDir::new().unwrap();
+    // Create a stray agent dir that must NOT be picked up.
+    write_config(user.path(), "stray", "Stray Agent");
+
+    let provider =
+        AgentDirectoryProvider::new(Vec::new(), user.path().to_path_buf(), None).unwrap();
+
+    assert!(provider.agent_ids().is_empty());
+    assert!(provider.entries().is_empty());
+    assert!(provider.permissions().is_empty());
+}
+
+#[test]
+fn test_user_only_load() {
+    let user = TempDir::new().unwrap();
+    write_config(user.path(), "alpha", "Alpha Agent");
+
+    let provider =
+        AgentDirectoryProvider::new(vec!["alpha".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+
+    assert_eq!(provider.agent_ids().len(), 1);
+    let entry = provider.get("alpha").expect("alpha should be loaded");
+    assert_eq!(entry.id, "alpha");
+    assert_eq!(entry.name, "Alpha Agent");
+    assert_eq!(entry.source, ConfigSource::User);
+}
+
+#[test]
+fn test_project_only_load() {
+    let project = TempDir::new().unwrap();
+    write_config(project.path(), "beta", "Beta Agent");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["beta".to_string()],
+        PathBuf::from("/nonexistent/user/agents"),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    assert_eq!(provider.agent_ids().len(), 1);
+    let entry = provider.get("beta").expect("beta should be loaded");
+    assert_eq!(entry.id, "beta");
+    assert_eq!(entry.name, "Beta Agent");
+    assert_eq!(entry.source, ConfigSource::Project);
+}
+
+#[test]
+fn test_merge_project_overrides_user() {
+    let user = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_config(user.path(), "gamma", "User Name");
+    write_config(project.path(), "gamma", "Project Name");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["gamma".to_string()],
+        user.path().to_path_buf(),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let entry = provider.get("gamma").expect("gamma should be loaded");
+    // Project name wins.
+    assert_eq!(entry.name, "Project Name");
+    assert_eq!(entry.source, ConfigSource::Merged);
+}
+
+#[test]
+fn test_ignores_dirs_outside_registry() {
+    let user = TempDir::new().unwrap();
+    // Files in the registry → must be loaded.
+    write_config(user.path(), "registered", "Registered");
+    // Files NOT in the registry → must be ignored.
+    write_config(user.path(), "unregistered", "Unregistered");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["registered".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(provider.agent_ids(), vec![&"registered".to_string()]);
+    assert!(provider.get("unregistered").is_none());
+}
+
+#[test]
+fn test_permissions_project_wins_over_user() {
+    let user = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    write_config(user.path(), "delta", "Delta");
+    write_config(project.path(), "delta", "Delta");
+    write_permissions(user.path(), "delta", "user-marker");
+    write_permissions(project.path(), "delta", "project-marker");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["delta".to_string()],
+        user.path().to_path_buf(),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let perms = provider
+        .permissions()
+        .get("delta")
+        .expect("delta permissions should be loaded");
+    // Project permissions win → agent_id carries the project marker.
+    assert_eq!(perms.agent_id, "project-marker");
+}
+
+#[test]
+fn test_permissions_user_fallback_when_no_project_file() {
+    let user = TempDir::new().unwrap();
+    write_config(user.path(), "epsilon", "Epsilon");
+    write_permissions(user.path(), "epsilon", "user-marker");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["epsilon".to_string()],
+        user.path().to_path_buf(),
+        Some(PathBuf::from("/nonexistent/project/agents")),
+    )
+    .unwrap();
+
+    let perms = provider
+        .permissions()
+        .get("epsilon")
+        .expect("epsilon permissions should be loaded from user");
+    assert_eq!(perms.agent_id, "user-marker");
+    assert!(perms.is_allowed("exec"));
+}
+
+#[test]
+fn test_missing_config_json_is_skipped() {
+    let user = TempDir::new().unwrap();
+    // Create the agent directory but leave it empty (no config.json).
+    std::fs::create_dir_all(user.path().join("zeta")).unwrap();
+    // Another agent that DOES have a config file.
+    write_config(user.path(), "eta", "Eta");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["zeta".to_string(), "eta".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    // zeta has no config.json → skipped.
+    assert!(provider.get("zeta").is_none());
+    // eta is still loaded.
+    assert!(provider.get("eta").is_some());
+    assert_eq!(provider.agent_ids().len(), 1);
+}
+
+#[test]
+fn test_reload_picks_up_changes() {
+    let user = TempDir::new().unwrap();
+    let provider =
+        AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+    assert!(provider.get("theta").is_none());
+
+    // Add a config file and reload.
+    write_config(user.path(), "theta", "Theta");
+    let provider = provider;
+    // Provider has no public `reload` callable here? Yes it does.
+    // We need `&mut self`, so reconstruct via the constructor for the
+    // first call, then mutate via `reload` after the change.
+    // Easier: use the constructor twice.
+    drop(provider);
+
+    let provider =
+        AgentDirectoryProvider::new(vec!["theta".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+    assert!(provider.get("theta").is_some());
+}
+
+#[test]
+fn test_no_user_dir_no_project_dir() {
+    // Neither user nor project dir exists. The registry IDs should all
+    // be skipped, and no errors should be raised.
+    let provider = AgentDirectoryProvider::new(
+        vec!["a".to_string(), "b".to_string()],
+        PathBuf::from("/nonexistent/user"),
+        None,
+    )
+    .unwrap();
+    assert!(provider.agent_ids().is_empty());
+    assert!(provider.entries().is_empty());
+}
+
+#[test]
+fn test_merge_falls_back_to_user_field_when_project_empty() {
+    // When the user config sets a field the project config does not,
+    // the user value must be preserved.
+    let user = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    // user: name and a skill; project: only a different name.
+    let user_dir = user.path().join("iota");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(
+        user_dir.join("config.json"),
+        r#"{ "id": "iota", "name": "Iota", "skills": ["web"] }"#,
+    )
+    .unwrap();
+
+    let project_dir = project.path().join("iota");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(
+        project_dir.join("config.json"),
+        r#"{ "id": "iota", "name": "Iota Project" }"#,
+    )
+    .unwrap();
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["iota".to_string()],
+        user.path().to_path_buf(),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let entry = provider.get("iota").expect("iota must be loaded");
+    // Project name overrides user name.
+    assert_eq!(entry.name, "Iota Project");
+    // User-provided skill survives because the project skills vec is empty.
+    assert_eq!(entry.skills, vec!["web".to_string()]);
+    assert_eq!(entry.source, ConfigSource::Merged);
+}
+
+#[test]
+fn test_no_permissions_file_is_fine() {
+    let user = TempDir::new().unwrap();
+    write_config(user.path(), "kappa", "Kappa");
+
+    let provider =
+        AgentDirectoryProvider::new(vec!["kappa".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+
+    assert!(provider.get("kappa").is_some());
+    assert!(provider.permissions().get("kappa").is_none());
+}
+
+#[test]
+fn test_action_permission_round_trip() {
+    // Sanity check: ActionPermission is the type used inside
+    // AgentPermissions; this guards against accidental type changes.
+    let perm = ActionPermission {
+        allowed: true,
+        limits: PermissionLimits::default(),
+    };
+    let json = serde_json::to_string(&perm).unwrap();
+    let back: ActionPermission = serde_json::from_str(&json).unwrap();
+    assert!(back.allowed);
+}
+
+// =====================================================================
+// Step 1.5 — Tests for `AgentDirectoryProvider` dirname-id backfill and
+// WARN-on-mismatch behaviour.
+// =====================================================================
+
+/// `config.json` without an `id` field must have its id backfilled from
+/// the directory name (the registry id).
+#[test]
+fn test_directory_provider_id_from_dirname() {
+    let user = TempDir::new().unwrap();
+    // Directory name is `foo`; the config.json omits `id` entirely.
+    let agent_dir = user.path().join("foo");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("config.json"), r#"{ "name": "Foo Agent" }"#).unwrap();
+
+    let provider =
+        AgentDirectoryProvider::new(vec!["foo".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+
+    let entry = provider.get("foo").expect("foo should be loaded");
+    // Id backfilled from the directory name.
+    assert_eq!(entry.id, "foo");
+    // Name from the config file is preserved.
+    assert_eq!(entry.name, "Foo Agent");
+    assert_eq!(entry.source, ConfigSource::User);
+}
+
+/// A `config.json` `id` that disagrees with the directory name must
+/// produce a WARN log; the config's id is kept as-is.
+#[test]
+fn test_directory_provider_id_mismatch_warn() {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// A `MakeWriter` that clones an `Arc<Mutex<Vec<u8>>>` buffer so
+    /// the subscriber can write into it while the test still owns the
+    /// original handle to read the captured bytes back.
+    #[derive(Clone, Default)]
+    struct VecWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for VecWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for VecWriter {
+        type Writer = VecWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let buffer = VecWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(buffer.clone())
+        .with_max_level(tracing::Level::WARN)
+        .with_target(false)
+        .with_ansi(false)
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let user = TempDir::new().unwrap();
+    // Directory name is `foo`, but the config.json declares id `other`.
+    let agent_dir = user.path().join("foo");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("config.json"),
+        r#"{ "id": "other", "name": "Other Agent" }"#,
+    )
+    .unwrap();
+
+    let provider =
+        AgentDirectoryProvider::new(vec!["foo".to_string()], user.path().to_path_buf(), None)
+            .unwrap();
+
+    // The config's id wins (the WARN message says so explicitly).
+    let entry = provider.get("foo").expect("foo should be loaded");
+    assert_eq!(entry.id, "other");
+    assert_eq!(entry.name, "Other Agent");
+
+    // Drop the subscriber guard so the captured buffer is fully flushed
+    // before we read it.
+    drop(_guard);
+    let output = String::from_utf8(buffer.0.lock().unwrap().clone()).unwrap();
+    assert!(
+        output.contains("does not match directory name"),
+        "expected WARN log, got: {}",
+        output
+    );
+}

--- a/src/config/agents/mod.rs
+++ b/src/config/agents/mod.rs
@@ -17,6 +17,9 @@ pub use types::AgentsConfig;
 pub use validation::validate_agents_config;
 
 #[cfg(test)]
+mod directory_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/config/agents/resolved.rs
+++ b/src/config/agents/resolved.rs
@@ -14,12 +14,18 @@
 //!   value is kept; otherwise the field's default applies.
 //! - `bootstrap_mode`, scalar `SubagentsConfig` fields: a non-default
 //!   project value overrides the user; otherwise the user value is kept.
-//! - Required `String` fields (`id`, `name`): project wins when non-empty,
-//!   otherwise fall back to the user value.
+//! - `id` (required, validated at the end): project's non-empty value
+//!   wins, otherwise the user's non-empty value. A fully empty `id`
+//!   after merging is rejected with [`ConfigError::MissingId`].
+//! - `name` (optional, falls back to `id`): project's non-empty value
+//!   wins, otherwise the user's non-empty value, otherwise falls back
+//!   to the resolved `id`. `None` and `Some("")` are both treated as
+//!   "not provided" and trigger the fallback.
 
 use std::path::PathBuf;
 
 use crate::agent::config::{AgentConfig, SubagentsConfig};
+use crate::config::ConfigError;
 use crate::session::bootstrap::BootstrapMode;
 
 /// Configuration source level.
@@ -56,12 +62,34 @@ pub struct ResolvedAgentConfig {
 
 impl ResolvedAgentConfig {
     /// Convert a single `AgentConfig` into a resolved form, tagging it
-    /// with the given `source` level. No fallback is performed; fields
-    /// come straight from `config`.
-    pub fn from_single(config: AgentConfig, source: ConfigSource) -> Self {
-        Self {
+    /// with the given `source` level. The `path` argument is used purely
+    /// for error reporting when `id` validation fails.
+    ///
+    /// Name fallback: a missing (`None`) or empty (`Some("")`) `name`
+    /// falls back to `id`. Both levels are treated as "not provided"
+    /// to keep the behavior consistent with the design doc
+    /// ("name 默认同 id").
+    ///
+    /// Returns [`ConfigError::MissingId`] when the resolved `id` is
+    /// empty after the fallback chain.
+    pub fn from_single(
+        config: AgentConfig,
+        source: ConfigSource,
+        path: &str,
+    ) -> Result<Self, ConfigError> {
+        if config.id.is_empty() {
+            return Err(ConfigError::MissingId {
+                path: path.to_string(),
+            });
+        }
+        let name = config
+            .name
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| config.id.clone());
+
+        Ok(Self {
             id: config.id,
-            name: config.name,
+            name,
             parent_id: config.parent_id,
             model: config.model,
             workspace: config.workspace.map(PathBuf::from),
@@ -72,27 +100,41 @@ impl ResolvedAgentConfig {
             disallowed_tools: config.disallowed_tools,
             subagents: config.subagents,
             source,
-        }
+        })
     }
 
     /// Merge project-level and user-level configs into a resolved form.
     ///
     /// Project fields take precedence over user fields; see the module
     /// documentation for the full rule set. The resulting `source` is
-    /// always [`ConfigSource::Merged`].
-    pub fn merge(project: AgentConfig, user: AgentConfig) -> Self {
+    /// always [`ConfigSource::Merged`]. The `path` argument is used
+    /// purely for error reporting when `id` validation fails.
+    ///
+    /// Name resolution: project's non-empty value wins, otherwise the
+    /// user's non-empty value, otherwise the resolved `id` is used as
+    /// a fallback. `None` and `Some("")` are both treated as "not
+    /// provided" at each level.
+    ///
+    /// Returns [`ConfigError::MissingId`] when the resolved `id` is
+    /// empty after the project-then-user fallback.
+    pub fn merge(project: AgentConfig, user: AgentConfig, path: &str) -> Result<Self, ConfigError> {
         let id = if !project.id.is_empty() {
             project.id
         } else {
             user.id
         };
-        let name = if !project.name.is_empty() {
-            project.name
-        } else {
-            user.name
-        };
+        if id.is_empty() {
+            return Err(ConfigError::MissingId {
+                path: path.to_string(),
+            });
+        }
+        let name = project
+            .name
+            .filter(|n| !n.is_empty())
+            .or_else(|| user.name.filter(|n| !n.is_empty()))
+            .unwrap_or_else(|| id.clone());
 
-        Self {
+        Ok(Self {
             id,
             name,
             parent_id: project.parent_id.or(user.parent_id),
@@ -127,16 +169,20 @@ impl ResolvedAgentConfig {
             },
             subagents: merge_subagents(project.subagents, user.subagents),
             source: ConfigSource::Merged,
-        }
+        })
     }
 }
 
-impl From<AgentConfig> for ResolvedAgentConfig {
+impl TryFrom<AgentConfig> for ResolvedAgentConfig {
+    type Error = ConfigError;
+
     /// Convert via [`ResolvedAgentConfig::from_single`], defaulting the
     /// source to [`ConfigSource::User`]. Callers that know the source
-    /// should call [`ResolvedAgentConfig::from_single`] directly.
-    fn from(config: AgentConfig) -> Self {
-        Self::from_single(config, ConfigSource::User)
+    /// should call [`ResolvedAgentConfig::from_single`] directly. The
+    /// `path` used for error reporting is `"<unknown>"` since the
+    /// `TryFrom` trait does not expose a source location.
+    fn try_from(config: AgentConfig) -> Result<Self, Self::Error> {
+        Self::from_single(config, ConfigSource::User, "<unknown>")
     }
 }
 

--- a/src/config/providers/mod.rs
+++ b/src/config/providers/mod.rs
@@ -43,4 +43,7 @@ pub enum ConfigError {
 
     #[error("JSON parse error: {0}")]
     JsonError(#[from] serde_json::Error),
+
+    #[error("Missing required agent id in {path}")]
+    MissingId { path: String },
 }


### PR DESCRIPTION
## 概述

修复 AgentConfig 配置字段约束与设计文档不一致的问题：

- `name` 从 `String`（必填）改为 `Option<String>`（可选），空串和 None 统一兜底为 `id`
- `id` 在 JSON 反序列化层保留 `#[serde(default)]` 允空串，由 `AgentDirectoryProvider` 用目录名兜底；在 `ResolvedAgentConfig` 层做终态校验（空 id 返回 `ConfigError::MissingId`）

## 变更

| 文件 | 变更 |
|------|------|
| `src/agent/config/mod.rs` | `name: String` → `Option<String>` + `#[serde(default)]` |
| `src/config/agents/resolved.rs` | `from_single`/`merge` name 兜底 + id 校验；`From` → `TryFrom` |
| `src/config/agents/directory.rs` | `inject_dirname_id`：空 id 注入目录名，不一致 WARN |
| `src/config/providers/mod.rs` | 新增 `ConfigError::MissingId` |
| `src/agent/config/config_tests.rs` | 5 个新测试 |
| `src/config/agents/directory_tests.rs` | 2 个新测试（从 directory.rs 拆出） |

## 测试

- 1727 passed, 1 failed（pre-existing `test_build_append_section_appended`）
- 7 个新测试全部通过

Source: issue #834
Type: fix
