### PR TITLE
refactor(agent): 移除 Agent struct 非级联运行时字段和方法

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -28,8 +28,6 @@ pub struct Agent {
     pub parent_id: Option<String>,
     /// When this agent was created
     pub created_at: DateTime<Utc>,
-    /// Last heartbeat received from this agent
-    pub last_heartbeat: DateTime<Utc>,
 }
 
 impl Agent {
@@ -44,7 +42,6 @@ impl Agent {
             state: AgentState::Idle,
             parent_id,
             created_at: now,
-            last_heartbeat: now,
         }
     }
 
@@ -53,32 +50,9 @@ impl Agent {
         self.state = state;
     }
 
-    /// Update the last heartbeat timestamp
-    pub fn update_heartbeat(&mut self) {
-        self.last_heartbeat = Utc::now();
-    }
-
-    /// Check if the agent is still alive (heartbeat within threshold)
-    pub fn is_alive(&self, heartbeat_timeout_secs: i64) -> bool {
-        let elapsed = Utc::now()
-            .signed_duration_since(self.last_heartbeat)
-            .num_seconds();
-        elapsed < heartbeat_timeout_secs
-    }
-
     /// Check if the agent is in a terminal state
     pub fn is_terminal(&self) -> bool {
         matches!(self.state, AgentState::Stopped | AgentState::Error(_))
-    }
-
-    /// Emit a state transition event for the given state change.
-    pub fn emit_transition(
-        &self,
-        from_state: AgentState,
-        to_state: AgentState,
-        trigger: TransitionTrigger,
-    ) -> AgentStateTransition {
-        AgentStateTransition::new(from_state, to_state, trigger)
     }
 }
 
@@ -102,15 +76,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_alive() {
-        let agent = Agent::new("test".to_string(), None);
-        // Fresh agent should be alive with a reasonable timeout
-        assert!(agent.is_alive(60));
-        // Should not be alive with zero timeout
-        assert!(!agent.is_alive(0));
-    }
-
-    #[test]
     fn test_is_terminal() {
         let mut agent = Agent::new("test".to_string(), None);
         assert!(!agent.is_terminal());
@@ -126,18 +91,5 @@ mod tests {
 
         agent.set_state(AgentState::Suspended(SuspendedReason::Forced));
         assert!(!agent.is_terminal());
-    }
-
-    #[test]
-    fn test_emit_transition() {
-        let agent = Agent::new("test".to_string(), None);
-        let t = agent.emit_transition(
-            AgentState::Idle,
-            AgentState::Running,
-            TransitionTrigger::UserRequest,
-        );
-        assert!(matches!(t.from_state, AgentState::Idle));
-        assert!(matches!(t.to_state, AgentState::Running));
-        assert!(matches!(t.trigger, TransitionTrigger::UserRequest));
     }
 }

--- a/src/agent/registry/lifecycle.rs
+++ b/src/agent/registry/lifecycle.rs
@@ -1,8 +1,8 @@
 //! Lifecycle methods for AgentRegistry
 
 use super::{
-    Agent, AgentProcess, AgentRegistry, AgentState, AgentStateTransition, CleanupResult,
-    RegistryError, RegistryResult, TransitionTrigger,
+    Agent, AgentProcess, AgentRegistry, AgentState, AgentStateTransition, RegistryError,
+    RegistryResult, TransitionTrigger,
 };
 use tracing::{debug, error, info, warn};
 
@@ -113,16 +113,6 @@ impl AgentRegistry {
         let _ = transition;
         Ok(agent.clone())
     }
-
-    /// Update heartbeat for an agent
-    pub async fn update_heartbeat(&self, id: &str) -> RegistryResult<()> {
-        let mut agents = self.agents.write().await;
-        let agent = agents
-            .get_mut(id)
-            .ok_or_else(|| RegistryError::AgentNotFound(id.to_string()))?;
-        agent.update_heartbeat();
-        Ok(())
-    }
 }
 
 impl AgentRegistry {
@@ -168,35 +158,6 @@ impl AgentRegistry {
         let mut process = process.ok_or_else(|| RegistryError::AgentNotFound(id.to_string()))?;
         process.send_message(message).await?;
         Ok(())
-    }
-
-    /// Check for dead agents and clean them up
-    pub async fn cleanup_dead(&self) -> CleanupResult {
-        let mut dead_ids = Vec::new();
-        {
-            let agents = self.agents.read().await;
-            for (id, agent) in agents.iter() {
-                if agent.is_terminal() {
-                    continue;
-                }
-                if !agent.is_alive(self.heartbeat_timeout_secs) {
-                    warn!(agent_id = %id, "agent heartbeat expired, marking for cleanup");
-                    dead_ids.push(id.clone());
-                }
-            }
-        }
-        let mut cleaned = Vec::new();
-        let mut failed = Vec::new();
-        for id in &dead_ids {
-            match self.remove(id).await {
-                Ok(_) => cleaned.push(id.clone()),
-                Err(e) => {
-                    error!(agent_id = %id, error = %e, "failed to cleanup dead agent");
-                    failed.push((id.clone(), e));
-                }
-            }
-        }
-        CleanupResult { cleaned, failed }
     }
 }
 

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -34,15 +34,6 @@ pub enum RegistryError {
 /// Result type for registry operations
 pub type RegistryResult<T> = Result<T, RegistryError>;
 
-/// Result of a cleanup operation
-#[derive(Debug)]
-pub struct CleanupResult {
-    /// Agents that were successfully cleaned up
-    pub cleaned: Vec<String>,
-    /// Agent IDs that failed to be removed, with their errors
-    pub failed: Vec<(String, RegistryError)>,
-}
-
 /// Thread-safe agent registry for managing all agent lifecycles
 #[derive(Debug)]
 pub struct AgentRegistry {
@@ -50,8 +41,6 @@ pub struct AgentRegistry {
     pub(super) agents: RwLock<HashMap<String, Agent>>,
     /// Map of agent ID to running process handle
     pub(super) processes: RwLock<HashMap<String, AgentProcessHandle>>,
-    /// Heartbeat timeout in seconds
-    pub(super) heartbeat_timeout_secs: i64,
     /// Graceful shutdown: wait timeout in seconds
     pub(super) wait_timeout_secs: u64,
     /// Graceful shutdown: grace period in seconds
@@ -65,21 +54,26 @@ impl Default for AgentRegistry {
 }
 
 impl AgentRegistry {
-    /// Create a new registry with specified heartbeat timeout.
-    pub fn new(heartbeat_timeout_secs: i64) -> Self {
-        Self::new_with_graceful_shutdown(heartbeat_timeout_secs, 30, 10)
+    /// Create a new registry. The `heartbeat_timeout_secs` parameter is
+    /// retained for backward compatibility (20+ existing call sites) but
+    /// is no longer used; runtime heartbeat/liveness tracking is owned by
+    /// the session module.
+    pub fn new(_heartbeat_timeout_secs: i64) -> Self {
+        Self::new_with_graceful_shutdown(30, 30, 10)
     }
 
     /// Create a new registry with graceful shutdown configuration.
+    /// `heartbeat_timeout_secs` is retained for backward compatibility but
+    /// is no longer used; runtime heartbeat/liveness tracking is owned by
+    /// the session module.
     pub fn new_with_graceful_shutdown(
-        heartbeat_timeout_secs: i64,
+        _heartbeat_timeout_secs: i64,
         wait_timeout_secs: u64,
         grace_period_secs: u64,
     ) -> Self {
         Self {
             agents: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
-            heartbeat_timeout_secs,
             wait_timeout_secs,
             grace_period_secs,
         }

--- a/src/agent/registry/query.rs
+++ b/src/agent/registry/query.rs
@@ -1,7 +1,6 @@
 //! Query methods for AgentRegistry
 
-use super::{Agent, AgentRegistry, AgentState, RegistryError, RegistryResult};
-use tracing::warn;
+use super::{Agent, AgentRegistry, RegistryError, RegistryResult};
 
 impl AgentRegistry {
     /// Get an agent by ID
@@ -13,40 +12,10 @@ impl AgentRegistry {
             .ok_or_else(|| RegistryError::AgentNotFound(id.to_string()))
     }
 
-    /// Get an agent by ID, checking if alive (heartbeat)
-    pub async fn get_alive(&self, id: &str) -> RegistryResult<Agent> {
-        let agent = self.get(id).await?;
-        if !agent.is_alive(self.heartbeat_timeout_secs) {
-            warn!(agent_id = %id, "agent heartbeat expired");
-            return Err(RegistryError::AgentNotFound(id.to_string()));
-        }
-        Ok(agent)
-    }
-
     /// List all registered agents
     pub async fn list(&self) -> Vec<Agent> {
         let agents = self.agents.read().await;
         agents.values().cloned().collect()
-    }
-
-    /// List only alive agents (heartbeat within threshold)
-    pub async fn list_alive(&self) -> Vec<Agent> {
-        let agents = self.agents.read().await;
-        agents
-            .values()
-            .filter(|a| a.is_alive(self.heartbeat_timeout_secs))
-            .cloned()
-            .collect()
-    }
-
-    /// List agents by state
-    pub async fn list_by_state(&self, state: AgentState) -> Vec<Agent> {
-        let agents = self.agents.read().await;
-        agents
-            .values()
-            .filter(|a| a.state == state)
-            .cloned()
-            .collect()
     }
 }
 

--- a/tests/e2e_agent_registry_tests.rs
+++ b/tests/e2e_agent_registry_tests.rs
@@ -60,7 +60,7 @@ async fn test_hierarchy_get_children() {
     );
 }
 
-/// Hierarchy queries: get_parent, get_ancestors, count, list_by_state
+/// Hierarchy queries: get_parent, get_ancestors, count, list() + filter by state
 #[tokio::test]
 async fn test_hierarchy_get_ancestors() {
     let registry = create_registry(30);
@@ -84,9 +84,19 @@ async fn test_hierarchy_get_ancestors() {
     assert_eq!(ancestors[1].name, "root");
 
     assert_eq!(registry.count().await, 3);
-    let idle = registry.list_by_state(AgentState::Idle).await;
+    let idle = registry
+        .list()
+        .await
+        .into_iter()
+        .filter(|a| a.state == AgentState::Idle)
+        .collect::<Vec<_>>();
     assert_eq!(idle.len(), 3);
-    let running = registry.list_by_state(AgentState::Running).await;
+    let running = registry
+        .list()
+        .await
+        .into_iter()
+        .filter(|a| a.state == AgentState::Running)
+        .collect::<Vec<_>>();
     assert!(running.is_empty());
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -227,35 +227,22 @@ async fn test_agent_parent_child_hierarchy() {
     let all = registry.list().await;
     assert_eq!(all.len(), 3);
 
-    // List by state
-    let running = registry.list_by_state(AgentState::Running).await;
+    // Filter agents by state
+    let running = registry
+        .list()
+        .await
+        .into_iter()
+        .filter(|a| a.state == AgentState::Running)
+        .collect::<Vec<_>>();
     assert!(running.is_empty());
 
-    let idle = registry.list_by_state(AgentState::Idle).await;
-    assert_eq!(idle.len(), 3);
-}
-
-#[tokio::test]
-async fn test_heartbeat_timeout_marks_agent_dead() {
-    // Create registry with very short timeout (1 second)
-    let registry: SharedAgentRegistry = create_registry(1);
-
-    let agent = registry
-        .register("test-agent".to_string(), None)
+    let idle = registry
+        .list()
         .await
-        .unwrap();
-    let agent_id = agent.id.clone();
-
-    // Agent should be alive immediately
-    let alive = registry.get_alive(&agent_id).await;
-    assert!(alive.is_ok());
-
-    // Wait for heartbeat to expire
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-    // Agent should now be considered dead
-    let alive = registry.get_alive(&agent_id).await;
-    assert!(alive.is_err());
+        .into_iter()
+        .filter(|a| a.state == AgentState::Idle)
+        .collect::<Vec<_>>();
+    assert_eq!(idle.len(), 3);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
移除 Agent 模块中不被 cascade.rs 依赖链使用的运行时字段和方法，符合设计文档「Agent 本身不管理运行时状态」的约定。

## 变更内容
- Agent struct: 移除 last_heartbeat 字段、update_heartbeat/is_alive/emit_transition 方法
- AgentRegistry: 移除 heartbeat_timeout_secs 字段、update_heartbeat/get_alive/list_alive/list_by_state/cleanup_dead 方法及 CleanupResult struct
- create_registry 签名保留（参数不再使用），外部测试 20+ 处调用无需修改
- 外部测试改用 list() + filter 等价替换 list_by_state

## 设计依据
- docs/design/agent/README.md: "Agent 本身不管理运行时状态"
- docs/design/session/session-lifecycle.md: Sweeper 通过 last_message_at 做 idle 检测

Source: issue #839
Type: refactor
