### PR TITLE
feat(agent): 实现子 session announce 推送与消费链路

### DIFF
--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -108,6 +108,7 @@ async fn fill_children(mgr: &SessionManager, parent_id: &str, count: usize) {
             parent_id,
             ChildSessionInfo {
                 session_id: format!("child-{}", i),
+                parent_session_id: parent_id.to_string(),
                 agent_id: "child".to_string(),
                 depth: 1,
                 mode: SpawnMode::Run,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -6,6 +6,7 @@ pub mod approval;
 pub mod message;
 pub mod outbound;
 pub mod session_handler;
+mod session_handler_announce;
 mod session_handler_streaming;
 pub mod session_manager;
 pub mod slash_permission;

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -246,7 +246,7 @@ impl SessionMessageHandler {
 // ── LLM calling ──
 impl SessionMessageHandler {
     /// Make a non-streaming LLM call with full system prompt injection.
-    async fn call_llm(
+    pub(super) async fn call_llm(
         fallback_client: &Arc<FallbackClient>,
         content: &str,
         meta: &MessageMetadata,
@@ -294,87 +294,6 @@ impl SessionMessageHandler {
         };
         let response = fallback_client.chat_unified(request).await?;
         Ok(response)
-    }
-
-    /// Clear busy flag, send output, and drain pending messages.
-    async fn finish_llm(
-        session_manager: &Arc<SessionManager>,
-        session_id: &str,
-        result: Result<UnifiedResponse, crate::llm::LLMError>,
-        fallback_client: &Arc<FallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
-    ) {
-        Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
-        Self::drain_pending_loop(session_manager, session_id, fallback_client, output_tx).await;
-    }
-
-    async fn clear_busy_and_send(
-        session_manager: &Arc<SessionManager>,
-        session_id: &str,
-        result: Result<UnifiedResponse, crate::llm::LLMError>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
-    ) {
-        if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-            let cs = cs.write().await;
-            cs.set_llm_busy(false);
-        }
-        match result {
-            Ok(response) => {
-                // Append response to session message history
-                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                    let mut cs_write = cs.write().await;
-                    cs_write.append_response(response.clone());
-                    cs_write.accumulate_usage(&response.usage);
-                }
-                let text = response
-                    .content_blocks
-                    .iter()
-                    .filter_map(|b| match b {
-                        ContentBlock::Text(t) => Some(t.as_str()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join("");
-                let guard = output_tx.read().await;
-                if let Some(tx) = guard.as_ref() {
-                    let _ = tx.send((text, response.content_blocks)).await;
-                }
-            }
-            Err(err) => {
-                tracing::warn!(session_id, error = %err, "LLM call failed");
-            }
-        }
-    }
-
-    async fn drain_pending_loop(
-        session_manager: &Arc<SessionManager>,
-        session_id: &str,
-        fallback_client: &Arc<FallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
-    ) {
-        loop {
-            // Get next pending message
-            let Some(pending) = session_manager.pop_pending_message(session_id).await else {
-                break;
-            };
-
-            // Set busy before calling LLM
-            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                let cs = cs.write().await;
-                cs.set_llm_busy(true);
-            }
-
-            let meta = MessageMetadata::default_meta();
-            let result = Self::call_llm(
-                fallback_client,
-                &pending.content,
-                &meta,
-                session_manager,
-                session_id,
-            )
-            .await;
-            Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
-        }
     }
 }
 // ── Compaction helpers ──

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -1,0 +1,139 @@
+//! Announce integration and LLM-finishing helpers for SessionMessageHandler.
+//!
+//! Extracted from `session_handler.rs` to keep the file under the
+//! 500-line project limit. This module hosts two closely related
+//! concerns that share the same call sites:
+//!
+//! 1. **Announce integration** (Step 1.5) — `maybe_push_announce` and
+//!    `drain_announce_events` wrap the two `SessionManager` methods
+//!    that let run-mode child sessions notify their parent and let
+//!    parents drain queued announces before processing the next
+//!    pending user message.
+//! 2. **LLM finishing** — `finish_llm`, `clear_busy_and_send`, and
+//!    `drain_pending_loop` are the post-LLM completion pipeline that
+//!    clears the busy flag, surfaces the response, pushes the
+//!    announce, and processes any queued pending messages. They were
+//!    co-located with the announce calls and grew large enough that
+//!    moving them together was the natural fix for the line-count
+//!    constraint.
+
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use crate::gateway::session_manager::SessionManager;
+use crate::llm::fallback::FallbackClient;
+use crate::llm::session::ChatSession;
+use crate::llm::types::ContentBlock;
+use crate::llm::types::UnifiedResponse;
+
+impl SessionMessageHandler {
+    /// Clear busy flag, send output, and drain pending messages.
+    pub(super) async fn finish_llm(
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+        result: Result<UnifiedResponse, crate::llm::LLMError>,
+        fallback_client: &Arc<FallbackClient>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    ) {
+        Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
+        Self::drain_pending_loop(session_manager, session_id, fallback_client, output_tx).await;
+    }
+
+    async fn clear_busy_and_send(
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+        result: Result<UnifiedResponse, crate::llm::LLMError>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    ) {
+        if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+            let cs = cs.write().await;
+            cs.set_llm_busy(false);
+        }
+        match result {
+            Ok(response) => {
+                // Append response to session message history
+                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                    let mut cs_write = cs.write().await;
+                    cs_write.append_response(response.clone());
+                    cs_write.accumulate_usage(&response.usage);
+                }
+                let text = response
+                    .content_blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text(t) => Some(t.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                let guard = output_tx.read().await;
+                if let Some(tx) = guard.as_ref() {
+                    let _ = tx.send((text, response.content_blocks)).await;
+                }
+            }
+            Err(err) => {
+                tracing::warn!(session_id, error = %err, "LLM call failed");
+            }
+        }
+        Self::maybe_push_announce(session_manager, session_id).await; // Step 1.5: best-effort announce to parent (run-mode child).
+    }
+
+    async fn drain_pending_loop(
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+        fallback_client: &Arc<FallbackClient>,
+        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    ) {
+        Self::drain_announce_events(session_manager, session_id).await; // Step 1.5: drain queued announces.
+        loop {
+            // Get next pending message
+            let Some(pending) = session_manager.pop_pending_message(session_id).await else {
+                break;
+            };
+
+            // Set busy before calling LLM
+            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                let cs = cs.write().await;
+                cs.set_llm_busy(true);
+            }
+
+            let meta = MessageMetadata::default_meta();
+            let result = Self::call_llm(
+                fallback_client,
+                &pending.content,
+                &meta,
+                session_manager,
+                session_id,
+            )
+            .await;
+            Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
+        }
+    }
+
+    /// Step 1.5: best-effort announce to parent (run-mode child).
+    ///
+    /// Invoked at the end of `clear_busy_and_send` so a finished
+    /// run-mode child session can notify its parent that new output
+    /// is available. Wraps `SessionManager::try_push_announce`.
+    pub(super) async fn maybe_push_announce(
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+    ) {
+        session_manager.try_push_announce(session_id).await;
+    }
+
+    /// Step 1.5: drain queued announces before processing the next
+    /// pending message.
+    ///
+    /// Invoked at the start of `drain_pending_loop` so any announces
+    /// queued during the previous LLM turn are injected into the
+    /// session before the next pending user message is processed.
+    /// Wraps `SessionManager::drain_and_inject_announces`.
+    pub(super) async fn drain_announce_events(
+        session_manager: &Arc<SessionManager>,
+        session_id: &str,
+    ) {
+        session_manager.drain_and_inject_announces(session_id).await;
+    }
+}

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::warn;
 
+mod announce;
 mod rebuild;
 mod spawn;
 pub use spawn::{ChildSessionInfo, SpawnMode};
@@ -440,10 +441,14 @@ impl SessionManager {
 
 // Unit tests
 #[cfg(test)]
+mod announce_tests;
+#[cfg(test)]
 mod flush_tests;
 #[cfg(test)]
 mod rebuild_tests;
 #[cfg(test)]
 mod spawn_tests;
+#[cfg(test)]
+mod test_helpers;
 #[cfg(test)]
 mod tests;

--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -1,0 +1,238 @@
+//! Announce pipeline: child → parent push-based completion notification.
+//!
+//! When a run-mode child session completes, the gateway calls
+//! `SessionManager::try_push_announce` to read the child's final assistant
+//! message, build an `AnnounceEvent`, and push it onto the parent session's
+//! `announce_queue`. The parent session drains the queue at the start of
+//! its next turn and injects each event as a `role="system"` message.
+//!
+//! Step 1.2 introduces the `AnnounceEvent` type and queue storage on
+//! `ConversationSession` (see `crate::llm::session`). This module adds
+//! the `SessionManager`-level accessors (`push_announce`, `drain_announces`)
+//! in Step 1.3 and `try_push_announce` in Step 1.4.
+
+use super::spawn::SpawnMode;
+use super::SessionManager;
+use crate::llm::session::{AnnounceEvent, ChatSession, ConversationSession};
+use crate::llm::types::ContentBlock;
+use chrono::Utc;
+use tracing::warn;
+
+// ── Queue accessors (push / drain) ─────────────────────────────────────────
+
+impl SessionManager {
+    /// Push an announce event onto the parent session's in-memory queue.
+    ///
+    /// Called by `try_push_announce` (Step 1.4) after a run-mode child
+    /// session completes. The parent session drains the queue at the
+    /// start of its next turn via `drain_announces`.
+    ///
+    /// If the parent session does not exist, this logs a warning and
+    /// returns an error — the caller (typically `clear_busy_and_send` in
+    /// the gateway) should not block on announce delivery, but a missing
+    /// parent is a programming error worth surfacing.
+    pub async fn push_announce(
+        &self,
+        parent_session_id: &str,
+        event: AnnounceEvent,
+    ) -> Result<(), String> {
+        let cs = self
+            .get_conversation_session(parent_session_id)
+            .await
+            .ok_or_else(|| {
+                format!(
+                    "push_announce: parent session not found: {}",
+                    parent_session_id
+                )
+            })?;
+        let mut cs = cs.write().await;
+        cs.push_announce_to_queue(event);
+        Ok(())
+    }
+
+    /// Drain all queued announce events for a session.
+    ///
+    /// Called by `drain_pending_loop` (Step 1.5) at the start of each
+    /// turn. If the session does not exist, returns an empty `Vec` so
+    /// callers can treat "no session" and "empty queue" identically.
+    pub async fn drain_announces(&self, session_id: &str) -> Vec<AnnounceEvent> {
+        let Some(cs) = self.get_conversation_session(session_id).await else {
+            warn!(
+                session_id = %session_id,
+                "drain_announces: session not found, returning empty list"
+            );
+            return Vec::new();
+        };
+        let mut cs = cs.write().await;
+        cs.drain_announce_queue()
+    }
+
+    /// Drain all queued announce events and inject each one as a
+    /// `role="system"` message at the head of the parent's next turn.
+    ///
+    /// Called by `SessionMessageHandler::drain_pending_loop` (Step 1.5)
+    /// before processing user-pending messages. Loops until the queue
+    /// is empty so bursts of child completions accumulated during LLM
+    /// calls are all consumed in a single call. If the session is
+    /// missing mid-drain, logs a warning and returns — the next turn
+    /// will retry from an empty queue.
+    pub async fn drain_and_inject_announces(&self, session_id: &str) {
+        loop {
+            let events = self.drain_announces(session_id).await;
+            if events.is_empty() {
+                break;
+            }
+            let Some(cs) = self.get_conversation_session(session_id).await else {
+                warn!(
+                    session_id = %session_id,
+                    "drain_and_inject_announces: session missing mid-drain"
+                );
+                return;
+            };
+            let mut cs_write = cs.write().await;
+            for event in events {
+                let text = format!(
+                    "[子 agent {}] 任务已完成：\n{}",
+                    event.child_agent_id, event.result_text
+                );
+                cs_write.inject_system_message(text);
+            }
+        }
+    }
+}
+
+// ── try_push_announce + private helpers ─────────────────────────────────────
+
+impl SessionManager {
+    /// Try to push an announce event from a completed child session to
+    /// its parent's in-memory queue.
+    ///
+    /// Called by `SessionMessageHandler::clear_busy_and_send` (Step 1.5)
+    /// after a child session finishes `append_response`. Behavior:
+    ///
+    /// 1. Walk the `children` table to find the entry where
+    ///    `child.session_id == child_session_id` and `mode == Run`.
+    ///    A non-child session (not present in the table) or a child
+    ///    with `mode == Session` is a no-op — no announce is produced.
+    /// 2. Read the child's last `role="assistant"` message and
+    ///    concatenate its `ContentBlock::Text` blocks into
+    ///    `result_text`. `ContentBlock::Thinking` blocks are
+    ///    intentionally excluded.
+    /// 3. Drop the child read lock before acquiring the parent write
+    ///    lock to avoid holding two session locks at once (which could
+    ///    deadlock if another task is doing the reverse).
+    /// 4. Push a fresh `AnnounceEvent` onto the parent session's
+    ///    `announce_queue` via `push_announce_to_queue`.
+    ///
+    /// Errors are logged but not propagated — announce delivery is a
+    /// best-effort signal and must not block child completion.
+    pub async fn try_push_announce(&self, child_session_id: &str) {
+        let Some((parent_session_id, child_agent_id)) =
+            self.find_run_mode_parent(child_session_id).await
+        else {
+            // Not a child, or mode != Run: nothing to do.
+            return;
+        };
+
+        let Some(result_text) = self.extract_last_assistant_text(child_session_id).await else {
+            warn!(
+                child_session_id = %child_session_id,
+                "try_push_announce: no assistant message on child, skipping"
+            );
+            return;
+        };
+
+        let event = build_announce_event(child_session_id, child_agent_id, result_text);
+        if let Err(e) = self.push_announce(&parent_session_id, event).await {
+            warn!(
+                parent_session_id = %parent_session_id,
+                error = %e,
+                "try_push_announce: push_announce failed"
+            );
+        }
+    }
+
+    /// Find the (parent_session_id, child_agent_id) of a child whose
+    /// `mode == Run` in the children table. Returns `None` for
+    /// non-children or session-mode children.
+    ///
+    /// The children-table lock is acquired and dropped within this
+    /// helper — we never hold it while touching any session lock.
+    async fn find_run_mode_parent(&self, child_session_id: &str) -> Option<(String, String)> {
+        let children = self.children.read().await;
+        for infos in children.values() {
+            if let Some(info) = infos
+                .iter()
+                .find(|i| i.session_id == child_session_id && i.mode == SpawnMode::Run)
+            {
+                return Some((info.parent_session_id.clone(), info.agent_id.clone()));
+            }
+        }
+        None
+    }
+
+    /// Extract the concatenated `Text` blocks from the child's last
+    /// `role="assistant"` message. Returns `None` if the child has no
+    /// `ConversationSession` or no assistant message.
+    ///
+    /// The session read lock is acquired and dropped within this
+    /// helper — callers must not already hold it.
+    async fn extract_last_assistant_text(&self, child_session_id: &str) -> Option<String> {
+        let child_cs = self
+            .get_conversation_session(child_session_id)
+            .await
+            .or_else(|| {
+                warn!(
+                    child_session_id = %child_session_id,
+                    "try_push_announce: child ConversationSession missing, skipping"
+                );
+                None
+            })?;
+        let child_cs = child_cs.read().await;
+        ConversationSession::collect_last_assistant_text(child_cs.messages())
+    }
+}
+
+// ── Free helpers ────────────────────────────────────────────────────────────
+
+/// Build a fresh `AnnounceEvent` with the current UTC timestamp.
+fn build_announce_event(
+    child_session_id: &str,
+    child_agent_id: String,
+    result_text: String,
+) -> AnnounceEvent {
+    AnnounceEvent {
+        child_session_id: child_session_id.to_string(),
+        child_agent_id,
+        result_text,
+        completed_at: Utc::now(),
+    }
+}
+
+// ── ConversationSession helper ─────────────────────────────────────────────
+
+impl ConversationSession {
+    /// Walk messages in reverse, concatenate `ContentBlock::Text`
+    /// blocks from the most recent `role="assistant"` message, and
+    /// return `None` if no assistant message exists. `Thinking` blocks
+    /// are intentionally excluded.
+    fn collect_last_assistant_text(
+        messages: &[crate::llm::session::SessionMessage],
+    ) -> Option<String> {
+        let mut text_buf = String::new();
+        for msg in messages.iter().rev() {
+            if msg.role == "assistant" {
+                for block in &msg.content_blocks {
+                    if let ContentBlock::Text(t) = block {
+                        if !text_buf.is_empty() {
+                            text_buf.push('\n');
+                        }
+                        text_buf.push_str(t);
+                    }
+                }
+                return Some(text_buf);
+            }
+        }
+        None
+    }
+}

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -1,0 +1,341 @@
+//! Tests for the announce pipeline (Step 1.6).
+//!
+//! These tests cover:
+//! - `test_push_and_drain_announce`
+//! - `test_try_push_announce_run_mode`
+//! - `test_try_push_announce_session_mode_noop`
+//! - `test_try_push_announce_non_child_noop`
+//! - `test_announce_inject_as_system_message`
+//! - `test_thinking_blocks_excluded`
+//! - `test_parallel_announce_ordering`
+//!
+//! Step 1.6 (test scaffolding) is added after Steps 1.3–1.5 land.
+//!
+//! Shared helpers (e.g. `test_resolved_config`, `setup_parent_with_conv`,
+//! `inject_events_and_return_messages`, `spawn_n_run_children`) live in
+//! `super::test_helpers` to keep this file under the 500-line limit.
+
+use super::spawn::SpawnMode;
+use super::test_helpers::{
+    append_assistant_to_child, inject_events_and_return_messages, register_child_only,
+    setup_parent_with_conv, spawn_n_run_children, test_resolved_config,
+};
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use crate::llm::session::AnnounceEvent;
+use crate::llm::types::ContentBlock;
+use chrono::Utc;
+use serial_test::serial;
+use std::collections::HashSet;
+use tempfile::TempDir;
+
+// ── 1. test_push_and_drain_announce ─────────────────────────────────────────
+
+/// `push_announce` should accept multiple events in order, and
+/// `drain_announces` should return all of them in FIFO order, leaving
+/// the queue empty.
+#[tokio::test]
+#[serial]
+async fn test_push_and_drain_announce() {
+    clear_global_prompt_state();
+
+    let mgr = make_test_mgr(None);
+    let parent_id = setup_parent_with_conv(&mgr, "parent-pd").await;
+
+    for i in 0..3 {
+        let event = AnnounceEvent {
+            child_session_id: format!("child-{}", i),
+            child_agent_id: format!("agent-{}", i),
+            result_text: format!("result-{}", i),
+            completed_at: Utc::now(),
+        };
+        mgr.push_announce(&parent_id, event)
+            .await
+            .expect("push_announce should succeed");
+    }
+
+    let drained = mgr.drain_announces(&parent_id).await;
+    assert_eq!(drained.len(), 3, "expected 3 events");
+    for (i, ev) in drained.iter().enumerate() {
+        assert_eq!(ev.child_session_id, format!("child-{}", i));
+        assert_eq!(ev.child_agent_id, format!("agent-{}", i));
+        assert_eq!(ev.result_text, format!("result-{}", i));
+    }
+
+    assert!(
+        mgr.drain_announces(&parent_id).await.is_empty(),
+        "queue should be empty after first drain"
+    );
+}
+
+// ── 2. test_try_push_announce_run_mode ──────────────────────────────────────
+
+/// A run-mode child that has completed an assistant turn should produce
+/// an `AnnounceEvent` on the parent's queue when `try_push_announce` is
+/// called.
+#[tokio::test]
+#[serial]
+async fn test_try_push_announce_run_mode() {
+    clear_global_prompt_state();
+
+    let tmp = TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let parent_id = setup_parent_with_conv(&mgr, "parent-run").await;
+
+    let child_id = mgr
+        .create_child_session(
+            &test_resolved_config("worker-run", None),
+            &parent_id,
+            1,
+            "do work",
+            true,
+            None,
+            SpawnMode::Run,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    append_assistant_to_child(
+        &mgr,
+        &child_id,
+        vec![ContentBlock::Text("task complete".to_string())],
+    )
+    .await;
+
+    mgr.try_push_announce(&child_id).await;
+
+    let drained = mgr.drain_announces(&parent_id).await;
+    assert_eq!(drained.len(), 1, "expected 1 announce event");
+    let ev = &drained[0];
+    assert_eq!(ev.child_session_id, child_id);
+    assert_eq!(ev.child_agent_id, "worker-run");
+    assert_eq!(ev.result_text, "task complete");
+}
+
+// ── 3. test_try_push_announce_session_mode_noop ─────────────────────────────
+
+/// A session-mode child must NOT produce an announce — only run-mode
+/// children trigger the push.
+#[tokio::test]
+#[serial]
+async fn test_try_push_announce_session_mode_noop() {
+    clear_global_prompt_state();
+
+    let tmp = TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let parent_id = setup_parent_with_conv(&mgr, "parent-sess").await;
+
+    let child_id = mgr
+        .create_child_session(
+            &test_resolved_config("worker-sess", None),
+            &parent_id,
+            1,
+            "stay alive",
+            true,
+            None,
+            SpawnMode::Session,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    append_assistant_to_child(
+        &mgr,
+        &child_id,
+        vec![ContentBlock::Text("still running".to_string())],
+    )
+    .await;
+
+    mgr.try_push_announce(&child_id).await;
+
+    let drained = mgr.drain_announces(&parent_id).await;
+    assert!(
+        drained.is_empty(),
+        "session-mode child should not push an announce, got: {:?}",
+        drained
+    );
+}
+
+// ── 4. test_try_push_announce_non_child_noop ────────────────────────────────
+
+/// A session id that is not registered as a child (in the `children`
+/// table) should produce no announce, no panic, and not disturb any
+/// other parent's queue.
+#[tokio::test]
+#[serial]
+async fn test_try_push_announce_non_child_noop() {
+    clear_global_prompt_state();
+
+    let mgr = make_test_mgr(None);
+    let parent_id = setup_parent_with_conv(&mgr, "parent-orphan").await;
+
+    let other_parent = setup_parent_with_conv(&mgr, "parent-other").await;
+    register_child_only(&mgr, &other_parent, "real-child", "agent-x", SpawnMode::Run).await;
+
+    mgr.try_push_announce("not-a-real-child").await;
+    assert!(mgr.drain_announces(&parent_id).await.is_empty());
+    assert!(mgr.drain_announces(&other_parent).await.is_empty());
+
+    mgr.try_push_announce("00000000-0000-0000-0000-000000000000")
+        .await;
+    assert!(mgr.drain_announces(&parent_id).await.is_empty());
+}
+
+// ── 5. test_announce_inject_as_system_message ───────────────────────────────
+
+/// After draining announce events and injecting them via
+/// `inject_system_message`, the parent's message history must contain
+/// a `role="system"` `SessionMessage` that includes the child's agent
+/// id and the result text.
+#[tokio::test]
+#[serial]
+async fn test_announce_inject_as_system_message() {
+    clear_global_prompt_state();
+
+    let mgr = make_test_mgr(None);
+    let parent_id = setup_parent_with_conv(&mgr, "parent-inj").await;
+
+    let event = AnnounceEvent {
+        child_session_id: "child-inj".to_string(),
+        child_agent_id: "sub-agent-42".to_string(),
+        result_text: "computed answer".to_string(),
+        completed_at: Utc::now(),
+    };
+    mgr.push_announce(&parent_id, event)
+        .await
+        .expect("push_announce should succeed");
+
+    let messages = inject_events_and_return_messages(&mgr, &parent_id).await;
+
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one injected system message"
+    );
+    let msg = &messages[0];
+    assert_eq!(msg.role, "system");
+    assert_eq!(msg.content_blocks.len(), 1);
+    let rendered = match &msg.content_blocks[0] {
+        ContentBlock::Text(t) => t.clone(),
+        other => panic!("expected Text block, got {:?}", other),
+    };
+    assert!(
+        rendered.contains("sub-agent-42"),
+        "rendered text should contain child agent id, got: {}",
+        rendered
+    );
+    assert!(
+        rendered.contains("computed answer"),
+        "rendered text should contain result text, got: {}",
+        rendered
+    );
+}
+
+// ── 6. test_thinking_blocks_excluded ────────────────────────────────────────
+
+/// When the child's last assistant message contains both Thinking and
+/// Text blocks, only the Text content must be included in
+/// `AnnounceEvent.result_text`.
+#[tokio::test]
+#[serial]
+async fn test_thinking_blocks_excluded() {
+    clear_global_prompt_state();
+
+    let tmp = TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let parent_id = setup_parent_with_conv(&mgr, "parent-think").await;
+
+    let child_id = mgr
+        .create_child_session(
+            &test_resolved_config("worker-think", None),
+            &parent_id,
+            1,
+            "think first",
+            true,
+            None,
+            SpawnMode::Run,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    append_assistant_to_child(
+        &mgr,
+        &child_id,
+        vec![
+            ContentBlock::Thinking("secret reasoning that should NOT leak".to_string()),
+            ContentBlock::Text("final answer that MUST be present".to_string()),
+        ],
+    )
+    .await;
+
+    mgr.try_push_announce(&child_id).await;
+
+    let drained = mgr.drain_announces(&parent_id).await;
+    assert_eq!(drained.len(), 1);
+    let ev = &drained[0];
+    assert!(
+        !ev.result_text.contains("secret reasoning"),
+        "thinking content leaked into announce: {}",
+        ev.result_text
+    );
+    assert!(
+        ev.result_text.contains("final answer that MUST be present"),
+        "result_text should contain the Text block, got: {}",
+        ev.result_text
+    );
+}
+
+// ── 7. test_parallel_announce_ordering ──────────────────────────────────────
+
+/// Multiple run-mode children completing in parallel must all produce
+/// exactly one announce each, with no deadlocks and no event loss.
+/// The events are pushed onto the parent queue under a write lock, so
+/// they end up in the order each call's `push_announce` actually
+/// acquired the parent lock — which is deterministic per scheduler run
+/// but we only assert count + presence here, not a specific order
+/// (since that depends on OS scheduling).
+#[tokio::test]
+#[serial]
+async fn test_parallel_announce_ordering() {
+    clear_global_prompt_state();
+
+    let tmp = TempDir::new().unwrap();
+    let mgr = std::sync::Arc::new(make_test_mgr(Some(tmp.path())));
+    let parent_id = setup_parent_with_conv(&mgr, "parent-par").await;
+
+    const N: usize = 5;
+    let child_ids = spawn_n_run_children(&mgr, &parent_id, N).await;
+
+    // tokio::join! polls them concurrently; if any deadlocks the test
+    // will hang and time out.
+    let mut futs = Vec::with_capacity(N);
+    for cid in &child_ids {
+        let mgr2 = mgr.clone();
+        let cid2 = cid.clone();
+        futs.push(tokio::spawn(async move {
+            mgr2.try_push_announce(&cid2).await;
+        }));
+    }
+    for f in futs {
+        f.await.expect("try_push_announce task should not panic");
+    }
+
+    let drained = mgr.drain_announces(&parent_id).await;
+    assert_eq!(
+        drained.len(),
+        N,
+        "expected {} events, got {}",
+        N,
+        drained.len()
+    );
+
+    let drained_ids: HashSet<&str> = drained
+        .iter()
+        .map(|e| e.child_session_id.as_str())
+        .collect();
+    let expected_ids: HashSet<&str> = child_ids.iter().map(|s| s.as_str()).collect();
+    assert_eq!(
+        drained_ids, expected_ids,
+        "drained child ids should match registered child ids"
+    );
+
+    assert!(mgr.drain_announces(&parent_id).await.is_empty());
+}

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone)]
 pub struct ChildSessionInfo {
     pub session_id: String,
+    pub parent_session_id: String,
     pub agent_id: String,
     pub depth: u32,
     pub mode: SpawnMode,
@@ -172,6 +173,7 @@ impl SessionManager {
             parent_session_id,
             ChildSessionInfo {
                 session_id: child_session_id.clone(),
+                parent_session_id: parent_session_id.to_string(),
                 agent_id: config.id.clone(),
                 depth,
                 mode,

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -153,6 +153,7 @@ async fn test_create_child_session_registers_child_info() {
         .expect("parent-7 should have a children entry");
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].session_id, child_id);
+    assert_eq!(list[0].parent_session_id, "parent-7");
     assert_eq!(list[0].agent_id, "worker-1");
     assert_eq!(list[0].depth, 1);
     assert_eq!(list[0].mode, SpawnMode::Session);

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -1,0 +1,192 @@
+//! Shared test helpers for `announce_tests`.
+//!
+//! Extracted to keep `announce_tests.rs` under the file-size limit.
+//! Only used by `announce_tests.rs` for now, but placed at the
+//! `session_manager` level so other test modules (e.g. future
+//! `flush_tests` extensions) can reuse it without circular imports.
+
+use super::spawn::{ChildSessionInfo, SpawnMode};
+use super::SessionManager;
+use crate::agent::config::SubagentsConfig;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::llm::session::{ChatSession, ConversationSession, SessionMessage};
+use crate::llm::types::{ContentBlock, UnifiedResponse, UnifiedUsage};
+use crate::session::bootstrap::BootstrapMode;
+use chrono::Utc;
+use std::path::PathBuf;
+
+/// Build a `ResolvedAgentConfig` for tests. Identical to the one in
+/// `spawn_tests` / `announce_tests` — kept local to avoid a
+/// cross-test-module import path.
+pub(super) fn test_resolved_config(id: &str, workspace: Option<PathBuf>) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        source: ConfigSource::Merged,
+    }
+}
+
+/// Build a `UnifiedResponse` with the given content blocks and zero usage.
+pub(super) fn make_response(blocks: Vec<ContentBlock>) -> UnifiedResponse {
+    UnifiedResponse {
+        content_blocks: blocks,
+        usage: UnifiedUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: None,
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".to_string()),
+    }
+}
+
+/// Append a single assistant message containing the given content blocks
+/// to a child session's `ConversationSession`. Used to simulate
+/// `append_response` after a child turn completes.
+pub(super) async fn append_assistant_to_child(
+    mgr: &SessionManager,
+    child_id: &str,
+    blocks: Vec<ContentBlock>,
+) {
+    let cs = mgr
+        .get_conversation_session(child_id)
+        .await
+        .expect("child ConversationSession should exist");
+    let mut cs = cs.write().await;
+    cs.append_response(make_response(blocks));
+}
+
+/// Register a parent session along with a `ConversationSession` so that
+/// `push_announce`/`drain_announces` (which look up the parent via
+/// `get_conversation_session`) succeed. Returns the parent session id.
+///
+/// This mirrors the real flow in `find_or_create` but is direct, so
+/// tests don't depend on message routing logic.
+pub(super) async fn setup_parent_with_conv(mgr: &SessionManager, parent_id: &str) -> String {
+    use crate::gateway::Session;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "feishu".to_string(),
+            created_at: Utc::now().timestamp(),
+            depth: 0,
+        },
+    );
+    let cs = Arc::new(RwLock::new(ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    )));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), cs);
+    parent_id.to_string()
+}
+
+/// Drain the parent's announce queue, inject each event as a
+/// `role="system"` `SessionMessage` using the documented
+/// `[子 agent X] 任务已完成：\n<text>` format, and return the resulting
+/// message history. Used by the system-injection test.
+pub(super) async fn inject_events_and_return_messages(
+    mgr: &SessionManager,
+    parent_id: &str,
+) -> Vec<SessionMessage> {
+    let drained = mgr.drain_announces(parent_id).await;
+    {
+        let cs = mgr
+            .get_conversation_session(parent_id)
+            .await
+            .expect("parent ConversationSession should exist");
+        let mut cs = cs.write().await;
+        for ev in &drained {
+            cs.inject_system_message(format!(
+                "[子 agent {}] 任务已完成：\n{}",
+                ev.child_agent_id, ev.result_text
+            ));
+        }
+    }
+    let cs = mgr
+        .get_conversation_session(parent_id)
+        .await
+        .expect("parent ConversationSession should exist");
+    let messages = cs.read().await.messages().to_vec();
+    messages
+}
+
+/// Register a child session under the given parent in the children
+/// tracking table only (no `ConversationSession` is created). Used by
+/// tests that don't need the child to have a real session — the
+/// `try_push_announce` code path will simply skip the lookup if the
+/// child has no `ConversationSession`.
+pub(super) async fn register_child_only(
+    mgr: &SessionManager,
+    parent_id: &str,
+    child_id: &str,
+    agent_id: &str,
+    mode: SpawnMode,
+) {
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: agent_id.to_string(),
+            depth: 1,
+            mode,
+        },
+    )
+    .await;
+}
+
+/// Create `N` run-mode children under the given parent, each with a
+/// unique `worker-{i}` agent id and a unique `answer-{i}` assistant
+/// message. Returns the list of generated child session ids.
+pub(super) async fn spawn_n_run_children(
+    mgr: &SessionManager,
+    parent_id: &str,
+    n: usize,
+) -> Vec<String> {
+    let mut child_ids: Vec<String> = Vec::with_capacity(n);
+    for i in 0..n {
+        let config = test_resolved_config(&format!("worker-{}", i), None);
+        let child_id = mgr
+            .create_child_session(
+                &config,
+                parent_id,
+                1,
+                &format!("task {}", i),
+                true,
+                None,
+                SpawnMode::Run,
+            )
+            .await
+            .expect("create_child_session should succeed");
+
+        append_assistant_to_child(
+            mgr,
+            &child_id,
+            vec![ContentBlock::Text(format!("answer-{}", i))],
+        )
+        .await;
+
+        child_ids.push(child_id);
+    }
+    child_ids
+}

--- a/src/llm/session.rs
+++ b/src/llm/session.rs
@@ -29,6 +29,27 @@ pub struct SessionMessage {
     pub timestamp: DateTime<Utc>,
 }
 
+/// Announce event pushed by a child session to its parent.
+///
+/// Produced when a run-mode child session completes its task; the parent
+/// session drains these at the start of its next turn and injects the
+/// result text as a `role="system"` SessionMessage.
+///
+/// Defined here (alongside `ConversationSession`) to avoid a `gateway -> llm`
+/// reverse-dependency for the announce pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnounceEvent {
+    /// ID of the child session that completed.
+    pub child_session_id: String,
+    /// Agent ID of the child that completed.
+    pub child_agent_id: String,
+    /// Concatenated Text content blocks from the child's final assistant
+    /// message. Thinking blocks are filtered out.
+    pub result_text: String,
+    /// When the child session finished. Used for logging / debug.
+    pub completed_at: DateTime<Utc>,
+}
+
 /// Trait for managing conversation session state.
 ///
 /// All implementations must be thread-safe (`Send + Sync`) to allow
@@ -93,6 +114,10 @@ pub struct ConversationSession {
     stats: RunningStats,
     streaming_sink: Option<Arc<dyn StreamingSink>>,
     stream_enabled: bool,
+    /// In-memory queue of announce events produced by run-mode child
+    /// sessions. Drained at the start of each parent turn. Not persisted
+    /// across process restarts.
+    announce_queue: Vec<AnnounceEvent>,
 }
 
 impl ConversationSession {
@@ -112,6 +137,7 @@ impl ConversationSession {
             stats: RunningStats::new(),
             streaming_sink: None,
             stream_enabled: false,
+            announce_queue: Vec::new(),
         }
     }
 
@@ -261,6 +287,34 @@ impl ConversationSession {
             }
         }
     }
+
+    /// Push an announce event onto the in-memory announce queue.
+    ///
+    /// Called by `SessionManager::push_announce` (typically from
+    /// `try_push_announce`) after a run-mode child session completes.
+    /// Events are drained at the start of the parent's next turn.
+    pub fn push_announce_to_queue(&mut self, event: AnnounceEvent) {
+        self.announce_queue.push(event);
+    }
+
+    /// Drain all queued announce events, returning them in FIFO order.
+    ///
+    /// Called by `SessionManager::drain_announces` at the start of
+    /// `drain_pending_loop`. After this call the queue is empty.
+    pub fn drain_announce_queue(&mut self) -> Vec<AnnounceEvent> {
+        std::mem::take(&mut self.announce_queue)
+    }
+
+    /// Inject a system message into the conversation history.
+    ///
+    /// Unlike `push_message`, this is a semantic API used for announce
+    /// injection: it only appends a `role="system"` `SessionMessage` to
+    /// the in-memory `messages` list. It does **not** trigger any
+    /// checkpoint persistence — checkpoint writes only happen on
+    /// daemon shutdown via `SessionManager::flush_all`.
+    pub fn inject_system_message(&mut self, text: String) {
+        self.push_message("system", vec![ContentBlock::Text(text)]);
+    }
 }
 
 impl std::fmt::Debug for ConversationSession {
@@ -282,6 +336,7 @@ impl std::fmt::Debug for ConversationSession {
                 &self.streaming_sink.as_ref().map(|_| "<StreamingSink>"),
             )
             .field("stream_enabled", &self.stream_enabled)
+            .field("announce_queue", &self.announce_queue)
             .finish()
     }
 }


### PR DESCRIPTION
实现 push-based announce 机制：子 session（mode="run"）完成后，将最后一条 assistant 消息的 Text 块作为 announce 推送到父 session 内部队列，父 session 在下一轮 turn 开始时消费并注入 message history。

## 变更内容

- **AnnounceEvent 类型**（llm/session.rs）：定义 announce 事件结构，announce_queue 内存队列
- **SessionManager announce 模块**（session_manager/announce.rs）：push_announce/drain_announces/try_push_announce
- **SessionMessageHandler 集成**（session_handler_announce.rs）：clear_busy_and_send 末尾触发 try_push_announce，drain_pending_loop 开头 drain announce 注入 system message
- **单元测试**（announce_tests.rs + test_helpers.rs）：7 个测试覆盖所有验收标准

## 设计决策

- AnnounceEvent 定义在 llm/session.rs（与 ConversationSession 同模块），避免 llm→gateway 反向依赖
- announce 队列为内存队列，不持久化（瞬态事件）
- inject_system_message 仅追加 SessionMessage，不触发 checkpoint 持久化
- try_push_announce 是 best-effort，错误仅 warn 不传播

Source: issue #846
Type: feat
