### PR TITLE
fix: rename sessions.db to sessions.sqlite per design doc

### DIFF
--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -45,8 +45,15 @@ impl SqliteStorage {
         std::fs::create_dir_all(&archived_dir)
             .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
+        // Migrate legacy `sessions.db` to `sessions.sqlite` (per design doc)
+        let legacy_db_path = data_dir.join("sessions.db");
+        let db_path = data_dir.join("sessions.sqlite");
+        if legacy_db_path.exists() {
+            std::fs::rename(&legacy_db_path, &db_path)
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+        }
+
         // Open or create SQLite database
-        let db_path = data_dir.join("sessions.db");
         let conn =
             Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
@@ -258,7 +265,7 @@ impl PersistenceService for SqliteStorage {
         let checkpoint = checkpoint.clone();
 
         spawn_blocking(move || {
-            let conn = Connection::open(data_dir.join("sessions.db"))
+            let conn = Connection::open(data_dir.join("sessions.sqlite"))
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
             let status = status_to_db(&checkpoint.status);
@@ -329,7 +336,7 @@ impl PersistenceService for SqliteStorage {
         let session_id = session_id.to_string();
 
         spawn_blocking(move || {
-            let conn = Connection::open(data_dir.join("sessions.db"))
+            let conn = Connection::open(data_dir.join("sessions.sqlite"))
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
             Self::load_checkpoint_inner(&conn, &data_dir, &session_id)
         })
@@ -344,7 +351,7 @@ impl PersistenceService for SqliteStorage {
         let session_id = session_id.to_string();
 
         spawn_blocking(move || {
-            let conn = Connection::open(data_dir.join("sessions.db"))
+            let conn = Connection::open(data_dir.join("sessions.sqlite"))
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
             conn.execute(
@@ -375,7 +382,7 @@ impl PersistenceService for SqliteStorage {
         let data_dir = self.data_dir.clone();
 
         spawn_blocking(move || {
-            let conn = Connection::open(data_dir.join("sessions.db"))
+            let conn = Connection::open(data_dir.join("sessions.sqlite"))
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
             let mut stmt = conn

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -42,7 +42,7 @@ pub fn delete_transcript(path: &Path) {
 /// Archive a checkpoint: move its active transcript to archived_sessions/
 /// and mark the DB record as archived.
 pub fn do_archive(data_dir: &Path, checkpoint: &SessionCheckpoint) -> Result<(), PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
     begin_immediate(&conn)?;
@@ -92,7 +92,7 @@ pub fn do_restore(
     data_dir: &Path,
     session_id: &str,
 ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
     begin_immediate(&conn)?;
@@ -305,7 +305,7 @@ fn read_transcript(
 /// Purge an archived checkpoint: delete its archived transcript and remove
 /// the DB record.
 pub fn do_purge(data_dir: &Path, session_id: &str) -> Result<(), PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
     begin_immediate(&conn)?;
@@ -326,7 +326,7 @@ pub fn do_purge(data_dir: &Path, session_id: &str) -> Result<(), PersistenceErro
 
 /// List all archived session IDs.
 pub fn do_list_archived(data_dir: &Path) -> Result<Vec<String>, PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
 
     let mut stmt = conn
@@ -347,7 +347,7 @@ pub fn list_idle_sessions_inner(
     data_dir: &Path,
     idle_minutes: i64,
 ) -> Result<Vec<String>, PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
     let cutoff = Utc::now().timestamp_millis() - idle_minutes * 60 * 1000;
     let mut stmt = conn
@@ -369,7 +369,7 @@ pub fn list_expired_archived_sessions_inner(
     if purge_after_minutes == 0 {
         return Ok(Vec::new());
     }
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
     let cutoff = Utc::now().timestamp_millis() - purge_after_minutes * 60 * 1000;
     let mut stmt = conn
@@ -391,7 +391,7 @@ pub fn list_idle_sessions_for_agent_inner(
     role: &str,
     idle_minutes: i64,
 ) -> Result<Vec<String>, PersistenceError> {
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
     let cutoff = Utc::now().timestamp_millis() - idle_minutes * 60 * 1000;
     let mut stmt = conn
@@ -420,7 +420,7 @@ pub fn list_expired_archived_sessions_for_agent_inner(
     if purge_after_minutes == 0 {
         return Ok(Vec::new());
     }
-    let db_path = data_dir.join("sessions.db");
+    let db_path = data_dir.join("sessions.sqlite");
     let conn = Connection::open(&db_path).map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
     let cutoff = Utc::now().timestamp_millis() - purge_after_minutes * 60 * 1000;
     let mut stmt = conn

--- a/tests/integration_shutdown_checkpoint.rs
+++ b/tests/integration_shutdown_checkpoint.rs
@@ -215,7 +215,7 @@ async fn test_restore_after_checkpoint_skips_all_messages() {
 //           graceful shutdown triggered by SIGTERM.
 //
 // This is an E2E test that starts a real daemon process, sends SIGTERM,
-// and verifies that `sessions.db` was created in the config directory.
+// and verifies that `sessions.sqlite` was created in the config directory.
 // The in-process tests (1.2/1.3/1.5) cover checkpoint content correctness;
 // this test verifies the SIGTERM → graceful shutdown → SqliteStorage init link.
 // ---------------------------------------------------------------------------
@@ -284,11 +284,11 @@ async fn test_sigterm_triggers_graceful_shutdown_with_storage() {
         status
     );
 
-    // Verify SqliteStorage was initialized — `sessions.db` must exist
-    let sessions_db = config_dir.join("sessions.db");
+    // Verify SqliteStorage was initialized — `sessions.sqlite` must exist
+    let sessions_sqlite = config_dir.join("sessions.sqlite");
     assert!(
-        sessions_db.exists(),
-        "sessions.db should exist after SIGTERM graceful shutdown, proving \
+        sessions_sqlite.exists(),
+        "sessions.sqlite should exist after SIGTERM graceful shutdown, proving \
          SqliteStorage was initialized via the flush_all → graceful shutdown path"
     );
 }


### PR DESCRIPTION
fix: rename sessions.db to sessions.sqlite per design doc

Align SQLite database filename with design doc (session-lifecycle.md).
Add migration logic to auto-rename legacy sessions.db on startup.

Source: issue #859
Type: fix
