### PR TITLE
refactor: 移除 APPEND_SECTION 全局 API — 清理 #860 后死代码

### DIFF
--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -21,6 +21,15 @@ use crate::llm::turn::TurnCounter;
 use crate::llm::types::{ContentBlock, UnifiedUsage};
 use crate::session::persistence::ReasoningLevel;
 
+/// Maximum length of an individual append-section item (in characters).
+///
+/// Used by [`ConversationSession::add_system_append`] to truncate
+/// user-supplied content. Previously lived in `crate::system_prompt`
+/// alongside the now-removed global `APPEND_SECTION` static;
+/// migrated here as part of issue #862 since the per-session
+/// `system_appends` list is the only remaining production consumer.
+pub const APPEND_SECTION_MAX_LEN: usize = 500;
+
 // Re-export `KillHandle` so call sites that `use crate::llm::session::KillHandle`
 // keep working after the trait moved to `session_handles` in Step 1.8.
 pub(crate) use crate::llm::session_handles::KillHandle;
@@ -280,14 +289,13 @@ impl ConversationSession {
 ///
 /// Replaces the previous global static `APPEND_SECTION` in
 /// [`crate::system_prompt::sections`] so archived sessions can
-/// restore their append list intact. The legacy global is kept alive
-/// in #862 and is no longer touched on the production path.
+/// restore their append list intact. The legacy global was removed
+/// in #862 and is no longer present.
 impl ConversationSession {
     /// Append `content` to the per-session append-section list.
     /// Truncates to `APPEND_SECTION_MAX_LEN` (500) chars if needed.
     /// Returns the index of the newly added item (0-based, sequential).
     pub fn add_system_append(&mut self, content: String) -> usize {
-        use crate::system_prompt::APPEND_SECTION_MAX_LEN;
         let truncated: String = if content.chars().count() > APPEND_SECTION_MAX_LEN {
             content
                 .chars()

--- a/src/llm/session/tests/system_appends_tests.rs
+++ b/src/llm/session/tests/system_appends_tests.rs
@@ -101,7 +101,7 @@ fn test_system_appends_restore() {
 
 #[test]
 fn test_system_appends_max_len_truncation() {
-    use crate::system_prompt::APPEND_SECTION_MAX_LEN;
+    use super::super::APPEND_SECTION_MAX_LEN;
 
     let mut session = new_session();
 

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -17,12 +17,6 @@ pub use builder::{
     build_from_workspace, build_system_prompt, set_agent_prompt, set_custom_prompt,
     set_override_prompt, WorkspaceBuildConfig,
 };
-pub use sections::{
-    clear_append_section, get_append_section, get_cached_section, invalidate_all_sections,
-    invalidate_section, set_append_section, Section,
-};
+pub use sections::{get_cached_section, invalidate_all_sections, invalidate_section, Section};
 pub use tools_section::build_tools_section;
 pub use workdir::{build_git_status_for, build_workdir_context, WorkdirContext};
-
-/// Maximum character length for append_section content
-pub const APPEND_SECTION_MAX_LEN: usize = sections::APPEND_SECTION_MAX_LEN;

--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -10,9 +10,6 @@ use std::sync::LazyLock;
 use std::sync::RwLock;
 use std::time::SystemTime;
 
-/// Maximum length of append_section content (in characters)
-pub const APPEND_SECTION_MAX_LEN: usize = 500;
-
 /// Represents a system prompt section
 #[derive(Debug, Clone)]
 pub enum Section {
@@ -236,46 +233,6 @@ pub fn load_cached_file_section(name: &str, path: &Path) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Append Section (request-scoped)
-// ---------------------------------------------------------------------------
-
-/// Append section state — NOT persisted, cleared after each request
-static APPEND_SECTION: RwLock<Option<String>> = RwLock::new(None);
-
-/// Set the append section content, truncating if over MAX_LEN and returning
-/// a notification message.
-pub fn set_append_section(text: String) -> Option<String> {
-    let is_truncated = text.chars().count() > APPEND_SECTION_MAX_LEN;
-    let warning;
-    let content = if is_truncated {
-        let chars: Vec<char> = text.chars().take(APPEND_SECTION_MAX_LEN).collect();
-        warning = Some("⚠️ 内容已截断至 500 字限制".to_string());
-        chars.iter().collect::<String>()
-    } else {
-        warning = None;
-        text.clone()
-    };
-
-    if let Ok(mut guard) = APPEND_SECTION.write() {
-        *guard = Some(content);
-    }
-
-    warning
-}
-
-/// Get the current append section content
-pub fn get_append_section() -> Option<String> {
-    APPEND_SECTION.write().ok()?.clone()
-}
-
-/// Clear the append section (called after request completes)
-pub fn clear_append_section() {
-    if let Ok(mut guard) = APPEND_SECTION.write() {
-        *guard = None;
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Working Directory sanitization
 // ---------------------------------------------------------------------------
 
@@ -331,38 +288,6 @@ mod tests {
         assert!(rendered.contains("turn_count: 5"));
         assert!(rendered.contains("task1"));
         assert!(!s.is_cacheable());
-    }
-
-    #[test]
-
-    fn test_append_section_truncation() {
-        let long_text = "a".repeat(600);
-        let warning = set_append_section(long_text);
-        assert!(warning.is_some());
-        assert!(warning.unwrap().contains("500"));
-
-        let content = get_append_section().unwrap();
-        assert_eq!(content.chars().count(), APPEND_SECTION_MAX_LEN);
-        clear_append_section();
-    }
-
-    #[test]
-
-    fn test_append_section_no_truncation() {
-        let text = "short text".to_string();
-        let warning = set_append_section(text.clone());
-        assert!(warning.is_none());
-        assert_eq!(get_append_section(), Some(text));
-        clear_append_section();
-    }
-
-    #[test]
-
-    fn test_append_section_cleared_after_request() {
-        set_append_section("test".to_string());
-        assert!(get_append_section().is_some());
-        clear_append_section();
-        assert!(get_append_section().is_none());
     }
 
     #[test]


### PR DESCRIPTION
移除 sections.rs 中的全局静态 APPEND_SECTION 及三个关联函数（set_append_section / get_append_section / clear_append_section），将 APPEND_SECTION_MAX_LEN 常量迁移至 session 模块。

#860 将 build_dynamic_sections 的 get_append_section() 调用替换为 system_appends 参数后，这些全局 API 成为死代码。

变更：
- sections.rs：移除 APPEND_SECTION 静态、3 个函数、APPEND_SECTION_MAX_LEN 常量、3 个关联测试
- mod.rs：移除 4 个 re-export
- session/mod.rs：新增 APPEND_SECTION_MAX_LEN 常量定义
- session/tests：更新导入路径

Source: issue #862
Type: refactor
