### PR TITLE
feat: 实现流式出站路径（StreamingRenderer + Gateway 流式调度）

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -164,6 +164,9 @@ impl Daemon {
             .set_storage(Arc::clone(&storage) as Arc<dyn PersistenceService>)
             .await;
         let gateway = Arc::new(gateway);
+        // Wire the self-ref so `handle_inbound_message` can pass
+        // a strong `Arc<Gateway>` into the streaming LLM path.
+        gateway.set_self_ref(Arc::clone(&gateway));
 
         // ── Slash Dispatcher ────────────────────────────────────────────────
         let slash_registry = Arc::new(HandlerRegistry::new());

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,6 +7,7 @@ pub mod message;
 pub mod outbound;
 pub mod session_handler;
 mod session_handler_announce;
+mod session_handler_dispatch;
 mod session_handler_streaming;
 pub mod session_manager;
 pub mod slash_permission;
@@ -126,6 +127,15 @@ pub struct Gateway {
     slash_dispatcher: RwLock<Option<Arc<SlashDispatcher>>>,
     /// Permission engine for slash command authorization.
     permission_engine: RwLock<Option<Arc<PermissionEngine>>>,
+    /// Self-reference for back-pointer to the owning `Arc<Gateway>`.
+    ///
+    /// `handle_inbound_message` is called with `&self`, but
+    /// `SessionMessageHandler` needs an `Arc<Gateway>` to call
+    /// `send_outbound_streaming`. The caller wires this after wrapping
+    /// the `Gateway` in `Arc::new(...)` via `set_self_ref`. Until set,
+    /// the slot is `None`; the handler falls back to the non-streaming
+    /// path in that case.
+    self_ref: std::sync::Mutex<Option<Arc<Gateway>>>,
 }
 
 impl Gateway {
@@ -141,6 +151,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
+            self_ref: std::sync::Mutex::new(None),
         }
     }
 
@@ -160,6 +171,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
+            self_ref: std::sync::Mutex::new(None),
         }
     }
 
@@ -181,6 +193,17 @@ impl Gateway {
         self
     }
 
+    /// Wire the back-reference to the owning `Arc<Gateway>`.
+    ///
+    /// Call this immediately after `Arc::new(Gateway::new(...))` so that
+    /// `handle_inbound_message` can pass a strong `Arc<Gateway>` to the
+    /// session handler for streaming dispatch.
+    pub fn set_self_ref(&self, arc: Arc<Gateway>) {
+        if let Ok(mut slot) = self.self_ref.lock() {
+            *slot = Some(arc);
+        }
+    }
+
     /// Handle an inbound message through the busy/pending state machine.
     ///
     /// If `sender_id` is provided and the message starts with `/approve` or
@@ -189,6 +212,13 @@ impl Gateway {
     /// `channel` identifies the IM platform / channel the message originated
     /// from (e.g. `"feishu"`). It is forwarded to `dispatch_slash` so that
     /// `SlashContext.channel` reflects the real source.
+    ///
+    /// When a plugin is registered for `channel` AND the self-ref is wired
+    /// (see [`set_self_ref`](Self::set_self_ref)), this dispatches through
+    /// [`SessionMessageHandler::handle_message_with_gateway`] so streaming
+    /// LLM output can flow through [`Gateway::send_outbound_streaming`].
+    /// Otherwise it falls back to the non-streaming path
+    /// [`SessionMessageHandler::handle_message`].
     ///
     /// Returns `HandleResult` (`LlmStarted`/`MessageQueued`/`ApprovalProcessed`),
     /// or `None` if no handler configured.
@@ -218,6 +248,28 @@ impl Gateway {
         }
 
         let handler = self.session_handler.as_ref()?;
+
+        // Streaming path: plugin is registered for this channel AND the
+        // self-ref is wired AND the handler has a back-ref. Falls back
+        // to the non-streaming path otherwise.
+        let gw_arc = self
+            .self_ref
+            .lock()
+            .ok()
+            .and_then(|slot| slot.as_ref().map(Arc::clone));
+        if let (Some(gw), Some(plugin)) = (gw_arc, self.get_plugin(channel).await) {
+            let meta = crate::gateway::session_handler::MessageMetadata {
+                sender_id: sender_id.unwrap_or("").to_string(),
+                channel: channel.to_string(),
+                timestamp: chrono::Utc::now().timestamp(),
+            };
+            return Some(
+                handler
+                    .handle_message_with_gateway(session_id, content, meta, &gw, &plugin)
+                    .await,
+            );
+        }
+
         Some(handler.handle_message(session_id, content).await)
     }
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -5,9 +5,56 @@
 
 use super::{Gateway, GatewayError, Message};
 use crate::im::IMPlugin;
-use crate::llm::types::ContentBlock;
+use crate::llm::types::{
+    ContentBlock, ContentBlockType, ContentDelta, StreamEvent, UnifiedResponse, UnifiedUsage,
+};
+use crate::processor_chain::dsl_parser::DslParser;
 use crate::processor_chain::{DslParseResult, ProcessedMessage};
+use crate::renderer::streaming::{DefaultStreamingRenderer, StreamingOutput, StreamingRenderer};
 use crate::renderer::RenderedOutput;
+use futures::StreamExt;
+
+/// Result of a streaming outbound dispatch.
+///
+/// Carries the accumulated content blocks (for downstream consumers like
+/// `append_response`) and the final token usage reported by the LLM's
+/// `MessageEnd` event.
+#[derive(Debug, Clone)]
+pub struct StreamResult {
+    /// All [`ContentBlock`]s produced by the renderer during the stream.
+    pub content_blocks: Vec<ContentBlock>,
+    /// Token usage statistics from the LLM's `MessageEnd` event.
+    pub usage: UnifiedUsage,
+}
+
+impl From<UnifiedResponse> for StreamResult {
+    /// Convert a non-streaming `UnifiedResponse` into a `StreamResult`.
+    ///
+    /// Used by the post-LLM completion path (`finish_llm` /
+    /// `clear_busy_and_send`) so both streaming and non-streaming
+    /// call sites can share the same downstream handling. `finish_reason`
+    /// is dropped because `StreamResult` does not carry one.
+    fn from(response: UnifiedResponse) -> Self {
+        StreamResult {
+            content_blocks: response.content_blocks,
+            usage: response.usage,
+        }
+    }
+}
+
+impl From<StreamResult> for UnifiedResponse {
+    /// Convert a `StreamResult` back into a `UnifiedResponse` for
+    /// `ChatSession::append_response`, which only accepts the legacy
+    /// shape. `finish_reason` is set to `None` because streaming does
+    /// not surface a structured finish reason.
+    fn from(result: StreamResult) -> Self {
+        UnifiedResponse {
+            content_blocks: result.content_blocks,
+            usage: result.usage,
+            finish_reason: None,
+        }
+    }
+}
 
 /// Per-call context for dispatching a rendered output and persisting its
 /// checkpoint. Bundled into a struct to keep the helper's parameter list short.
@@ -210,4 +257,191 @@ impl Gateway {
             tracing::warn!(session_id, "failed to save checkpoint: {}", e);
         }
     }
+
+    /// Send a streaming LLM response via the registered IM plugin.
+    ///
+    /// Drives a [`DefaultStreamingRenderer`] over the [`StreamEvent`] stream,
+    /// dispatching incremental output to `plugin` as it becomes available:
+    /// - Text delta → line buffer → complete lines → `plugin.send` (text)
+    /// - BlockEnd (non-Text) → `plugin.render(&[block], None)` → `plugin.send`
+    /// - MessageEnd → flush + `DslParser::parse` on accumulated DSL lines →
+    ///   `plugin.render` + `plugin.send`
+    ///
+    /// Accumulated `content_blocks` and the LLM-reported `usage` are returned
+    /// in a [`StreamResult`]. `thread_id` is always `None` (consistent with
+    /// [`send_outbound`](Self::send_outbound)).
+    pub async fn send_outbound_streaming<E: std::fmt::Display>(
+        &self,
+        session_id: &str,
+        channel: &str,
+        mut stream: impl futures::Stream<Item = Result<StreamEvent, E>> + Unpin,
+        plugin: &std::sync::Arc<dyn IMPlugin>,
+    ) -> Result<StreamResult, GatewayError> {
+        let chat_id = self
+            .session_manager
+            .get_chat_id(session_id)
+            .await
+            .ok_or(GatewayError::MissingSessionId)?;
+
+        let mut state = StreamState::new();
+        while let Some(event_result) = stream.next().await {
+            let event = event_result.map_err(|e| GatewayError::OutboundError(e.to_string()))?;
+            self.process_stream_event(plugin, &chat_id, event, &mut state)
+                .await?;
+        }
+        tracing::debug!(session_id, channel, "streaming outbound complete");
+        Ok(StreamState::into_result(state))
+    }
+
+    /// Process a single [`StreamEvent`] and update `state`.
+    ///
+    /// Split from `send_outbound_streaming` to keep the main loop under the
+    /// 50-line helper cap.
+    async fn process_stream_event(
+        &self,
+        plugin: &std::sync::Arc<dyn IMPlugin>,
+        chat_id: &str,
+        event: StreamEvent,
+        state: &mut StreamState,
+    ) -> Result<(), GatewayError> {
+        match event {
+            StreamEvent::BlockDelta { delta, .. } => {
+                let is_text_delta = matches!(delta, ContentDelta::Text { .. });
+                // Reconstruct event for the renderer (index is unused for BlockDelta).
+                let out = state
+                    .renderer
+                    .handle_event(StreamEvent::BlockDelta { index: 0, delta });
+                // For Text deltas, the renderer may emit completed text lines
+                // and dsl lines; non-Text deltas only update internal state.
+                if is_text_delta {
+                    dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+                }
+            }
+            StreamEvent::BlockEnd { block_type, .. } => {
+                let mut out = state.renderer.handle_event(event);
+                if block_type != ContentBlockType::Text {
+                    let render_blocks = std::mem::take(&mut out.render_blocks);
+                    for block in render_blocks {
+                        send_render_block(plugin, chat_id, &block).await?;
+                        state.content_blocks.push(block);
+                    }
+                }
+                dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+            }
+            StreamEvent::MessageEnd { usage, .. } => {
+                let mut out = state.renderer.flush();
+                let render_blocks = std::mem::take(&mut out.render_blocks);
+                dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+                for block in render_blocks {
+                    send_render_block(plugin, chat_id, &block).await?;
+                    state.content_blocks.push(block);
+                }
+                send_dsl_lines(plugin, chat_id, &state.dsl_lines).await?;
+                if let Some(u) = usage {
+                    state.usage = u;
+                }
+            }
+            StreamEvent::Error { message } => {
+                return Err(GatewayError::OutboundError(message));
+            }
+            StreamEvent::BlockStart { .. } => {
+                state.renderer.handle_event(event);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming outbound helpers
+// ---------------------------------------------------------------------------
+
+/// Mutable state carried across stream events in `send_outbound_streaming`.
+struct StreamState {
+    renderer: DefaultStreamingRenderer,
+    content_blocks: Vec<ContentBlock>,
+    dsl_lines: Vec<String>,
+    usage: UnifiedUsage,
+}
+
+impl StreamState {
+    fn new() -> Self {
+        Self {
+            renderer: DefaultStreamingRenderer::new(),
+            content_blocks: Vec::new(),
+            dsl_lines: Vec::new(),
+            usage: UnifiedUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: None,
+                reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+        }
+    }
+
+    fn into_result(self) -> StreamResult {
+        StreamResult {
+            content_blocks: self.content_blocks,
+            usage: self.usage,
+        }
+    }
+}
+
+/// Send any text messages from `out` and accumulate dsl lines into `state`.
+async fn dispatch_text_and_dsl(
+    plugin: &std::sync::Arc<dyn IMPlugin>,
+    chat_id: &str,
+    out: StreamingOutput,
+    state: &mut StreamState,
+) -> Result<(), GatewayError> {
+    for text in out.text_messages {
+        send_text(plugin, chat_id, &text).await?;
+        state.content_blocks.push(ContentBlock::Text(text));
+    }
+    state.dsl_lines.extend(out.dsl_lines);
+    Ok(())
+}
+
+/// Construct a text [`RenderedOutput`] and dispatch via `plugin.send`.
+async fn send_text(
+    plugin: &std::sync::Arc<dyn IMPlugin>,
+    chat_id: &str,
+    text: &str,
+) -> Result<(), GatewayError> {
+    let rendered = RenderedOutput {
+        msg_type: "text".to_string(),
+        payload: serde_json::json!({ "content": { "text": text } }),
+    };
+    plugin.send(&rendered, chat_id, None).await?;
+    Ok(())
+}
+
+/// Call `plugin.render(&[block], None)` and dispatch via `plugin.send`.
+async fn send_render_block(
+    plugin: &std::sync::Arc<dyn IMPlugin>,
+    chat_id: &str,
+    block: &ContentBlock,
+) -> Result<(), GatewayError> {
+    let rendered = plugin.render(std::slice::from_ref(block), None);
+    plugin.send(&rendered, chat_id, None).await?;
+    Ok(())
+}
+
+/// Parse accumulated DSL lines and dispatch via `plugin.render + plugin.send`.
+async fn send_dsl_lines(
+    plugin: &std::sync::Arc<dyn IMPlugin>,
+    chat_id: &str,
+    dsl_lines: &[String],
+) -> Result<(), GatewayError> {
+    if dsl_lines.is_empty() {
+        return Ok(());
+    }
+    let dsl_text = dsl_lines.join("\n");
+    let dsl_result = DslParser.parse(&dsl_text);
+    let blocks = vec![ContentBlock::Text(dsl_result.clean_content.clone())];
+    let rendered = plugin.render(&blocks, Some(&dsl_result));
+    plugin.send(&rendered, chat_id, None).await?;
+    Ok(())
 }

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -7,6 +7,7 @@
 //! `FallbackClient::chat()` (non-streaming) is used for all LLM calls.
 //! The `output_tx` channel is used to surface LLM response text to callers.
 
+use super::Gateway;
 use crate::gateway::session_manager::SessionManager;
 use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
 use crate::llm::client::UnifiedChatClient;
@@ -19,7 +20,6 @@ use crate::llm::{ChatRequest, LLMError, Message as ChatMessage};
 use crate::session::compaction::{
     execute_compact, CompactConfig, CompactionResult, CompactionService,
 };
-use crate::session::persistence::PendingMessage;
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -57,11 +57,19 @@ pub enum HandleResult {
 
 /// Gateway-layer LLM session handler with busy/pending state management.
 pub struct SessionMessageHandler {
-    session_manager: Arc<SessionManager>,
-    fallback_client: Arc<FallbackClient>,
-    output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
-    compaction_service: Arc<std::sync::Mutex<CompactionService>>,
-    unified_client: Arc<UnifiedChatClient>,
+    pub(super) session_manager: Arc<SessionManager>,
+    pub(super) fallback_client: Arc<FallbackClient>,
+    pub(super) output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    pub(super) compaction_service: Arc<std::sync::Mutex<CompactionService>>,
+    pub(super) unified_client: Arc<UnifiedChatClient>,
+    /// Optional back-reference to the owning [`Gateway`] (weak).
+    ///
+    /// When set, `handle_message_with_gateway` can route streaming LLM
+    /// output through [`Gateway::send_outbound_streaming`]. When `None`
+    /// (default in tests), the handler still works for non-streaming
+    /// paths; `handle_message_with_gateway` is the only entry point that
+    /// can consume a streaming session and it requires this ref.
+    pub(super) gateway: Option<Arc<std::sync::Weak<Gateway>>>,
 }
 
 // ── Construction ──
@@ -81,6 +89,7 @@ impl SessionMessageHandler {
                 CompactConfig::default(),
             ))),
             unified_client,
+            gateway: None,
         }
     }
     /// Create a new handler without an output channel (used in tests).
@@ -97,7 +106,17 @@ impl SessionMessageHandler {
                 CompactConfig::default(),
             ))),
             unified_client,
+            gateway: None,
         }
+    }
+    /// Attach a back-reference (weak) to the owning [`Gateway`].
+    ///
+    /// Once set, [`handle_message_with_gateway`](Self::handle_message_with_gateway)
+    /// can route streaming LLM output through
+    /// [`Gateway::send_outbound_streaming`].
+    pub fn with_gateway_ref(mut self, gateway: std::sync::Weak<Gateway>) -> Self {
+        self.gateway = Some(Arc::new(gateway));
+        self
     }
 }
 // ── Message dispatch ──
@@ -119,68 +138,8 @@ impl SessionMessageHandler {
             return HandleResult::MessageQueued;
         }
         self.check_and_run_auto_compact(session_id).await;
-        self.dispatch_llm_call(session_id, content, meta).await
-    }
-
-    async fn dispatch_llm_call(
-        &self,
-        session_id: &str,
-        content: String,
-        meta: MessageMetadata,
-    ) -> HandleResult {
-        self.set_busy(session_id, true).await;
-        let session_id = session_id.to_string();
-        let content_for_task = content;
-        let sm = Arc::clone(&self.session_manager);
-        let fc = Arc::clone(&self.fallback_client);
-        let uc = Arc::clone(&self.unified_client);
-        let output_tx = Arc::clone(&self.output_tx);
-
-        tokio::spawn(async move {
-            // Check if streaming is enabled for this session
-            let stream_enabled = if let Some(cs) = sm.get_conversation_session(&session_id).await {
-                cs.read().await.stream_enabled()
-            } else {
-                false
-            };
-
-            let result = if stream_enabled {
-                Self::call_llm_streaming(&uc, &content_for_task, &meta, &sm, &session_id).await
-            } else {
-                Self::call_llm(&fc, &content_for_task, &meta, &sm, &session_id).await
-            };
-            Self::finish_llm(&sm, &session_id, result, &fc, &output_tx).await;
-        });
-
-        HandleResult::LlmStarted
-    }
-
-    async fn set_busy(&self, session_id: &str, busy: bool) {
-        if let Some(cs) = self
-            .session_manager
-            .get_conversation_session(session_id)
+        self.dispatch_llm_call(session_id, content, meta, None, None)
             .await
-        {
-            let cs = cs.write().await;
-            cs.set_llm_busy(busy);
-            if busy {
-                cs.set_llm_state(LlmState::Requesting);
-            }
-        }
-    }
-
-    async fn enqueue_pending(&self, session_id: &str, content: String) {
-        let msg = PendingMessage::new(
-            format!("pending-{}", chrono::Utc::now().timestamp_millis()),
-            content,
-        );
-        if let Err(e) = self
-            .session_manager
-            .push_pending_message(session_id, msg)
-            .await
-        {
-            tracing::warn!(session_id, error = %e, "failed to enqueue pending message");
-        }
     }
 }
 // ── Compaction ──
@@ -223,7 +182,7 @@ impl SessionMessageHandler {
         send_output(&self.output_tx, &text).await;
     }
 
-    async fn check_and_run_auto_compact(&self, session_id: &str) {
+    pub(super) async fn check_and_run_auto_compact(&self, session_id: &str) {
         let Some((model, llm_messages)) =
             load_compact_inputs(&self.session_manager, session_id).await
         else {

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -21,19 +21,24 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 
 use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use crate::gateway::outbound::StreamResult;
 use crate::gateway::session_manager::SessionManager;
 use crate::llm::fallback::FallbackClient;
 use crate::llm::session::ChatSession;
 use crate::llm::session_state::LlmState;
 use crate::llm::types::ContentBlock;
-use crate::llm::types::UnifiedResponse;
 
 impl SessionMessageHandler {
     /// Clear busy flag, send output, and drain pending messages.
+    ///
+    /// Accepts a [`StreamResult`] (returned by the streaming LLM call) or an
+    /// `LLMError`. The non-streaming `call_llm` path converts its
+    /// `UnifiedResponse` into a `StreamResult` via [`StreamResult::from`]
+    /// before calling this entry point.
     pub(super) async fn finish_llm(
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-        result: Result<UnifiedResponse, crate::llm::LLMError>,
+        result: Result<StreamResult, crate::llm::LLMError>,
         fallback_client: &Arc<FallbackClient>,
         output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     ) {
@@ -44,7 +49,7 @@ impl SessionMessageHandler {
     async fn clear_busy_and_send(
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-        result: Result<UnifiedResponse, crate::llm::LLMError>,
+        result: Result<StreamResult, crate::llm::LLMError>,
         output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
     ) {
         if let Some(cs) = session_manager.get_conversation_session(session_id).await {
@@ -53,14 +58,17 @@ impl SessionMessageHandler {
             cs.set_llm_state(LlmState::Idle);
         }
         match result {
-            Ok(response) => {
-                // Append response to session message history
+            Ok(stream_result) => {
+                // Append response to session message history. `append_response`
+                // takes a `UnifiedResponse`; convert via the existing
+                // `From<StreamResult> for UnifiedResponse` impl.
+                let unified: crate::llm::types::UnifiedResponse = stream_result.clone().into();
                 if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                     let mut cs_write = cs.write().await;
-                    cs_write.append_response(response.clone());
-                    cs_write.accumulate_usage(&response.usage);
+                    cs_write.append_response(unified);
+                    cs_write.accumulate_usage(&stream_result.usage);
                 }
-                let text = response
+                let text = stream_result
                     .content_blocks
                     .iter()
                     .filter_map(|b| match b {
@@ -71,7 +79,7 @@ impl SessionMessageHandler {
                     .join("");
                 let guard = output_tx.read().await;
                 if let Some(tx) = guard.as_ref() {
-                    let _ = tx.send((text, response.content_blocks)).await;
+                    let _ = tx.send((text, stream_result.content_blocks)).await;
                 }
             }
             Err(err) => {
@@ -102,14 +110,17 @@ impl SessionMessageHandler {
             }
 
             let meta = MessageMetadata::default_meta();
-            let result = Self::call_llm(
+            // Non-streaming path: `call_llm` returns `UnifiedResponse`.
+            // Convert to `StreamResult` for the unified `finish_llm` entry point.
+            let result: Result<StreamResult, crate::llm::LLMError> = Self::call_llm(
                 fallback_client,
                 &pending.content,
                 &meta,
                 session_manager,
                 session_id,
             )
-            .await;
+            .await
+            .map(Into::into);
             Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
         }
     }

--- a/src/gateway/session_handler_compaction.rs
+++ b/src/gateway/session_handler_compaction.rs
@@ -1,0 +1,154 @@
+//! Compaction helper functions for `SessionMessageHandler`.
+//!
+//! Extracted from `session_handler.rs` to keep the handler file under
+//! the 500-line project limit. These helpers support the
+//! `/compact` slash command and the auto-compaction check that runs
+//! before each LLM call:
+//! - `flatten_content_blocks` / `build_compact_messages` — flatten
+//!   a session's message history into the LLM-friendly
+//!   `ChatMessage` list used as compaction input.
+//! - `apply_compact_result` — replace the session's messages with
+//!   the compaction boundary message and rebuild the system prompt.
+//! - `send_output` — push a string reply onto the handler's
+//!   `output_tx` channel.
+//! - `load_compact_inputs` — read the model + flattened messages
+//!   for a session in a single read lock.
+//! - `run_manual_compact` / `finalize_auto_compact` — drive the
+//!   two compaction entry points and apply their results.
+
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+use crate::gateway::session_manager::SessionManager;
+use crate::llm::fallback::FallbackClient;
+use crate::llm::session::ChatSession;
+use crate::llm::types::ContentBlock;
+use crate::llm::Message as ChatMessage;
+use crate::session::compaction::{execute_compact, CompactionResult, CompactionService};
+
+fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|b| match b {
+            ContentBlock::Text(t) => Some(t.as_str()),
+            ContentBlock::Thinking(t) => Some(t.as_str()),
+            ContentBlock::ToolUse { input, .. } => Some(input.as_str()),
+            ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_compact_messages(messages: &[crate::llm::session::SessionMessage]) -> Vec<ChatMessage> {
+    messages
+        .iter()
+        .filter(|m| m.role == "user" || m.role == "assistant")
+        .map(|m| ChatMessage {
+            role: m.role.clone(),
+            content: flatten_content_blocks(&m.content_blocks),
+        })
+        .collect()
+}
+
+/// Replace session messages with boundary message on compaction.
+async fn apply_compact_result(
+    sm: &Arc<SessionManager>,
+    session_id: &str,
+    result: &CompactionResult,
+) {
+    let Some(cs) = sm.get_conversation_session(session_id).await else {
+        return;
+    };
+    let boundary = crate::llm::session::SessionMessage {
+        role: "assistant".to_string(),
+        content_blocks: vec![ContentBlock::Text(result.boundary_message.clone())],
+        timestamp: chrono::Utc::now(),
+    };
+    {
+        let mut cs = cs.write().await;
+        cs.replace_messages(vec![boundary]);
+    }
+    // Rebuild system prompt after compaction so skills stay fresh.
+    // The write guard above is now dropped, so rebuild_system_prompt
+    // can safely acquire its own write lock.
+    sm.rebuild_system_prompt(session_id).await;
+}
+
+/// Push a reply onto the handler's `output_tx` channel. The reply
+/// carries an empty `content_blocks` list because compaction
+/// feedback is plain text, not a structured LLM response.
+pub(super) async fn send_output(
+    output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    text: &str,
+) {
+    let guard = output_tx.read().await;
+    if let Some(tx) = guard.as_ref() {
+        let _ = tx.send((text.to_string(), vec![])).await;
+    }
+}
+
+/// Load compaction inputs: (model, llm_messages). Returns None if session not found.
+pub(super) async fn load_compact_inputs(
+    sm: &Arc<SessionManager>,
+    session_id: &str,
+) -> Option<(String, Vec<ChatMessage>)> {
+    let cs = sm.get_conversation_session(session_id).await?;
+    let cs_read = cs.read().await;
+    let model = cs_read.model().to_string();
+    let llm_msgs = build_compact_messages(ChatSession::messages(&*cs_read));
+    Some((model, llm_msgs))
+}
+
+/// Run manual `/compact` invocation.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_manual_compact(
+    sm: Arc<SessionManager>,
+    fc: Arc<FallbackClient>,
+    output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    svc: Arc<std::sync::Mutex<CompactionService>>,
+    sid: String,
+    model: String,
+    llm_messages: Vec<ChatMessage>,
+    instruction: Option<String>,
+) {
+    let result = execute_compact(&llm_messages, &*fc, &model, instruction.as_deref(), false).await;
+    match result {
+        Ok(r) => {
+            apply_compact_result(&sm, &sid, &r).await;
+            send_output(&output_tx, &r.message).await;
+            svc.lock()
+                .expect("compaction_service poisoned")
+                .record_success();
+        }
+        Err(e) => {
+            tracing::warn!(session_id = %sid, error = %e, "manual compact failed");
+            svc.lock()
+                .expect("compaction_service poisoned")
+                .record_failure();
+            send_output(&output_tx, &format!("Compact failed: {}", e)).await;
+        }
+    }
+}
+
+/// Finalize auto-compact result.
+pub(super) async fn finalize_auto_compact(
+    sm: &Arc<SessionManager>,
+    svc: &Arc<std::sync::Mutex<CompactionService>>,
+    session_id: &str,
+    result: Result<CompactionResult, crate::session::compaction::CompactionError>,
+) {
+    match result {
+        Ok(r) => {
+            apply_compact_result(sm, session_id, &r).await;
+            svc.lock()
+                .expect("compaction_service poisoned")
+                .record_success();
+        }
+        Err(e) => {
+            tracing::warn!(session_id, error = %e, "auto compact failed");
+            svc.lock()
+                .expect("compaction_service poisoned")
+                .record_failure();
+        }
+    }
+}

--- a/src/gateway/session_handler_dispatch.rs
+++ b/src/gateway/session_handler_dispatch.rs
@@ -1,0 +1,142 @@
+//! LLM dispatch helpers for `SessionMessageHandler`.
+//!
+//! Extracted from `session_handler.rs` to keep the file under the
+//! 500-line project limit. This module hosts the streaming-aware
+//! dispatch path: [`SessionMessageHandler::handle_message_with_gateway`]
+//! and [`SessionMessageHandler::dispatch_llm_call`], which route a
+//! spawned LLM call to either the streaming pipeline (via
+//! [`Gateway::send_outbound_streaming`]) or the non-streaming
+//! fallback ([`SessionMessageHandler::call_llm`]).
+
+use std::sync::Arc;
+
+use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use super::Gateway;
+use crate::gateway::HandleResult;
+use crate::im::IMPlugin;
+use crate::llm::session_state::LlmState;
+use crate::llm::ChatSession;
+use crate::session::persistence::PendingMessage;
+
+impl SessionMessageHandler {
+    /// Streaming-aware entry point used by [`Gateway::handle_inbound_message`].
+    ///
+    /// Same as [`handle_message_with_meta`](Self::handle_message_with_meta) but
+    /// passes the [`Gateway`] reference and [`IMPlugin`] to the dispatch
+    /// task so streaming LLM output can be routed through
+    /// [`Gateway::send_outbound_streaming`].
+    pub async fn handle_message_with_gateway(
+        &self,
+        session_id: &str,
+        content: String,
+        meta: MessageMetadata,
+        gateway: &Arc<Gateway>,
+        plugin: &Arc<dyn IMPlugin>,
+    ) -> HandleResult {
+        if self.session_manager.is_session_busy(session_id).await {
+            self.enqueue_pending(session_id, content).await;
+            return HandleResult::MessageQueued;
+        }
+        self.check_and_run_auto_compact(session_id).await;
+        self.dispatch_llm_call(session_id, content, meta, Some(gateway), Some(plugin))
+            .await
+    }
+
+    /// Dispatch an LLM call inside a `tokio::spawn` task.
+    ///
+    /// When both `gateway` and `plugin` are provided AND the session has
+    /// `stream_enabled = true`, the streaming pipeline is used
+    /// ([`Self::call_llm_streaming`]). Otherwise the non-streaming
+    /// pipeline is used ([`Self::call_llm`]).
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn dispatch_llm_call(
+        &self,
+        session_id: &str,
+        content: String,
+        meta: MessageMetadata,
+        gateway: Option<&Arc<Gateway>>,
+        plugin: Option<&Arc<dyn IMPlugin>>,
+    ) -> HandleResult {
+        self.set_busy(session_id, true).await;
+        let session_id = session_id.to_string();
+        let content_for_task = content;
+        let sm = Arc::clone(&self.session_manager);
+        let fc = Arc::clone(&self.fallback_client);
+        let uc = Arc::clone(&self.unified_client);
+        let output_tx = Arc::clone(&self.output_tx);
+        let channel = meta.channel.clone();
+        // Clone the gateway/plugin into the spawn (optional). If streaming
+        // is enabled for the session but no gateway/plugin is provided we
+        // fall back to the non-streaming path with a warning.
+        let gw_for_task = gateway.map(Arc::clone);
+        let plugin_for_task = plugin.map(Arc::clone);
+
+        tokio::spawn(async move {
+            // Check if streaming is enabled for this session
+            let stream_enabled = if let Some(cs) = sm.get_conversation_session(&session_id).await {
+                cs.read().await.stream_enabled()
+            } else {
+                false
+            };
+
+            let result = if stream_enabled {
+                if let (Some(gw), Some(pl)) = (gw_for_task.as_ref(), plugin_for_task.as_ref()) {
+                    Self::call_llm_streaming(
+                        &uc,
+                        &content_for_task,
+                        &meta,
+                        &sm,
+                        &session_id,
+                        &channel,
+                        gw,
+                        pl,
+                    )
+                    .await
+                } else {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        "streaming enabled but no gateway/plugin available; falling back to non-streaming"
+                    );
+                    Self::call_llm(&fc, &content_for_task, &meta, &sm, &session_id)
+                        .await
+                        .map(Into::into)
+                }
+            } else {
+                Self::call_llm(&fc, &content_for_task, &meta, &sm, &session_id)
+                    .await
+                    .map(Into::into)
+            };
+            Self::finish_llm(&sm, &session_id, result, &fc, &output_tx).await;
+        });
+
+        HandleResult::LlmStarted
+    }
+
+    pub(super) async fn set_busy(&self, session_id: &str, busy: bool) {
+        if let Some(cs) = self
+            .session_manager
+            .get_conversation_session(session_id)
+            .await
+        {
+            let cs = cs.write().await;
+            cs.set_llm_busy(busy);
+            if busy {
+                cs.set_llm_state(LlmState::Requesting);
+            }
+        }
+    }
+
+    pub(super) async fn enqueue_pending(&self, session_id: &str, content: String) {
+        let msg = PendingMessage::new(
+            format!("pending-{}", chrono::Utc::now().timestamp_millis()),
+            content,
+        );
+        if let Err(e) = self
+            .session_manager
+            .push_pending_message(session_id, msg)
+            .await
+        {
+            tracing::warn!(session_id, error = %e, "failed to enqueue pending message");
+        }
+    }
+}

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -3,30 +3,55 @@
 //! Extracted from `session_handler.rs` to keep file sizes under the
 //! 500-line project limit.
 
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::StreamExt;
+use futures::Stream;
 use tokio_util::sync::CancellationToken;
 
 use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use crate::gateway::outbound::StreamResult;
 use crate::gateway::session_manager::SessionManager;
 use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::gateway::Gateway;
+use crate::im::IMPlugin;
 use crate::llm::client::UnifiedChatClient;
+use crate::llm::protocol::ProtocolError;
 use crate::llm::session::ChatSession;
 use crate::llm::session_state::LlmState;
 use crate::llm::streaming::{StreamDone, StreamingSink};
-use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent, UnifiedResponse, UnifiedUsage};
+use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent};
 use crate::llm::{LLMError, Message as ChatMessage};
 
 impl SessionMessageHandler {
-    /// Make a streaming LLM call using UnifiedChatClient.
+    /// Make a streaming LLM call and dispatch it through Gateway's
+    /// streaming outbound pipeline.
+    ///
+    /// The function:
+    /// 1. Builds the request (system prompt + user message).
+    /// 2. Opens the LLM stream and wraps it with [`SinkUpdater`] so the
+    ///    session's [`StreamingSink`] (CLI/websocket consumers) still
+    ///    receives per-delta text notifications.
+    /// 3. Calls [`Gateway::send_outbound_streaming`] which drives the
+    ///    [`crate::renderer::streaming::DefaultStreamingRenderer`] and
+    ///    dispatches incremental output to `plugin` via the IM platform.
+    /// 4. Returns the accumulated [`StreamResult`] (content blocks + usage)
+    ///    for the post-LLM completion pipeline.
+    ///
+    /// Cancellation: the LLM call is raced against `cancel_token.cancelled()`
+    /// so a cascade stop can abort the in-flight stream.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn call_llm_streaming(
         unified_client: &Arc<UnifiedChatClient>,
         content: &str,
         meta: &MessageMetadata,
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-    ) -> Result<UnifiedResponse, LLMError> {
+        channel: &str,
+        gateway: &Arc<Gateway>,
+        plugin: &Arc<dyn IMPlugin>,
+    ) -> Result<StreamResult, LLMError> {
         let (static_prompt_opt, turn_count, workdir_path, system_appends) =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                 let cs_read = cs.read().await;
@@ -80,7 +105,7 @@ impl SessionMessageHandler {
             reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         };
 
-        // Get streaming sink from session
+        // Get streaming sink from session (CLI/websocket consumers).
         let sink: Option<Arc<dyn StreamingSink>> =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                 let cs_read = cs.read().await;
@@ -94,7 +119,7 @@ impl SessionMessageHandler {
             cs.read().await.set_llm_state(LlmState::Requesting);
         }
 
-        let mut stream = match unified_client.chat_streaming(internal_request).await {
+        let stream = match unified_client.chat_streaming(internal_request).await {
             Ok(s) => s,
             Err(e) => {
                 let msg = e.to_string();
@@ -110,13 +135,8 @@ impl SessionMessageHandler {
             }
         };
 
-        let mut full_text = String::new();
-        let mut last_usage = None;
-        let mut first_token = true;
-
         // Acquire this session's cancellation token so a streaming
-        // request can be aborted mid-stream by a cascade stop. Fall
-        // back to a never-cancelled token if the session is gone.
+        // request can be aborted mid-stream by a cascade stop.
         let cancel_token: CancellationToken =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                 cs.read().await.cancel_token().clone()
@@ -124,99 +144,165 @@ impl SessionMessageHandler {
                 CancellationToken::new()
             };
 
-        // Loop body: race the next stream event against cancellation.
-        // We need an explicit `loop { tokio::select! { ... } }` because
-        // a plain `while let Some(...) = stream.next().await` would
-        // block on the stream and ignore the cancel token.
-        loop {
-            let event_result = tokio::select! {
-                next = stream.next() => next,
-                _ = cancel_token.cancelled() => {
-                    // Restore idle state so the session can accept the
-                    // next request. Tool/child cleanup is owned by
-                    // `stop()` itself; we just abort the in-flight LLM
-                    // stream here.
-                    if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                        cs.read().await.set_llm_state(LlmState::Idle);
-                    }
-                    if let Some(ref s) = sink {
-                        s.send_error("cancelled".to_string());
-                    }
-                    tracing::info!(session_id = %session_id, "streaming LLM request cancelled");
-                    return Err(LLMError::Cancelled);
+        // Wrap the raw LLM stream with SinkUpdater so the session's
+        // StreamingSink (CLI/websocket) still receives per-delta text
+        // notifications in parallel with the IM plugin dispatch in
+        // `send_outbound_streaming`.
+        let wrapped = SinkUpdater::new(
+            stream,
+            sink.clone(),
+            Arc::clone(session_manager),
+            session_id.to_string(),
+        );
+
+        // Race the streaming outbound dispatch against the cancel token.
+        let dispatch_result = tokio::select! {
+            res = gateway.send_outbound_streaming(session_id, channel, wrapped, plugin) => res,
+            _ = cancel_token.cancelled() => {
+                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                    cs.read().await.set_llm_state(LlmState::Idle);
                 }
-            };
-            let Some(event_result) = event_result else {
-                // Stream ended normally.
-                break;
-            };
-            match event_result {
-                Ok(StreamEvent::BlockDelta {
-                    delta: ContentDelta::Text { text },
-                    ..
-                }) => {
-                    // Transition to Receiving on first text delta.
-                    if first_token {
-                        if let Some(cs) = session_manager.get_conversation_session(session_id).await
-                        {
-                            cs.read().await.set_llm_state(LlmState::Receiving);
-                        }
-                        first_token = false;
-                    }
-                    full_text.push_str(&text);
-                    if let Some(ref s) = sink {
-                        s.send_text(&text);
-                    }
+                if let Some(ref s) = sink {
+                    s.send_error("cancelled".to_string());
                 }
-                Ok(StreamEvent::MessageEnd { usage, .. }) => {
-                    last_usage = usage;
-                    if let Some(ref s) = sink {
-                        s.send_done(StreamDone {
-                            model: String::new(),
-                            usage: last_usage.clone(),
-                        });
-                    }
-                    break;
-                }
-                Ok(StreamEvent::Error { message }) => {
-                    tracing::error!(error = %message, "streaming LLM call failed");
-                    if let Some(ref s) = sink {
-                        s.send_error(message.clone());
-                    }
-                    return Err(LLMError::ApiError(message));
-                }
-                Err(e) => {
-                    let msg = e.to_string();
-                    tracing::error!(error = %msg, "streaming LLM call failed");
-                    if let Some(ref s) = sink {
-                        s.send_error(msg.clone());
-                    }
-                    return Err(LLMError::ApiError(msg));
-                }
-                _ => {}
+                tracing::info!(session_id = %session_id, "streaming LLM request cancelled");
+                return Err(LLMError::Cancelled);
             }
-        }
+        };
 
         // Reset LLM state to Idle after stream completes.
         if let Some(cs) = session_manager.get_conversation_session(session_id).await {
             cs.read().await.set_llm_state(LlmState::Idle);
         }
 
-        Ok(UnifiedResponse {
-            content_blocks: if full_text.is_empty() {
-                vec![]
-            } else {
-                vec![ContentBlock::Text(full_text)]
-            },
-            usage: last_usage.unwrap_or(UnifiedUsage {
-                prompt_tokens: 0,
-                completion_tokens: 0,
-                total_tokens: None,
-                reasoning_tokens: None,
-                cache_read_tokens: None,
-                cache_write_tokens: None,
-            }),
-            finish_reason: None,
-        })
+        let stream_result = dispatch_result.map_err(|e| {
+            let msg = e.to_string();
+            if let Some(ref s) = sink {
+                s.send_error(msg.clone());
+            }
+            LLMError::ApiError(msg)
+        })?;
+
+        // Best-effort: notify sink of stream completion with usage, so
+        // CLI/websocket consumers see a matching `send_done` after the
+        // last `send_text` (matching the StreamingSink contract).
+        if let Some(ref s) = sink {
+            s.send_done(StreamDone {
+                model: String::new(),
+                usage: Some(stream_result.usage.clone()),
+            });
+        }
+
+        // If streaming produced no text content blocks, fall back to a
+        // single empty text block so the post-LLM completion pipeline
+        // (which appends to history) still has something to record.
+        if stream_result.content_blocks.is_empty() {
+            return Ok(StreamResult {
+                content_blocks: vec![ContentBlock::Text(String::new())],
+                usage: stream_result.usage,
+            });
+        }
+        Ok(stream_result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SinkUpdater: stream wrapper that mirrors LLM events to the session's
+// StreamingSink while forwarding them downstream to the renderer.
+// ---------------------------------------------------------------------------
+
+/// Wraps an LLM [`Stream`] so each event is mirrored to the session's
+/// [`StreamingSink`] before being forwarded to the downstream consumer
+/// (the IM plugin in `send_outbound_streaming`).
+///
+/// - `BlockDelta(Text)` → `sink.send_text` (and triggers the
+///   `Requesting → Receiving` state transition on the first text delta).
+/// - `MessageEnd` → `sink.send_done` with the final usage.
+/// - `Error` → `sink.send_error`.
+/// - Protocol/transport errors → `sink.send_error` with the stringified
+///   error message.
+///
+/// `StreamEvent` derives `Clone` so the wrapper can emit a clone of each
+/// event after performing side effects on the original.
+struct SinkUpdater<S> {
+    inner: S,
+    sink: Option<Arc<dyn StreamingSink>>,
+    session_manager: Arc<SessionManager>,
+    session_id: String,
+    first_token: bool,
+}
+
+impl<S> SinkUpdater<S> {
+    fn new(
+        inner: S,
+        sink: Option<Arc<dyn StreamingSink>>,
+        session_manager: Arc<SessionManager>,
+        session_id: String,
+    ) -> Self {
+        Self {
+            inner,
+            sink,
+            session_manager,
+            session_id,
+            first_token: true,
+        }
+    }
+}
+
+impl<S> Stream for SinkUpdater<S>
+where
+    S: Stream<Item = Result<StreamEvent, ProtocolError>> + Unpin,
+{
+    type Item = Result<StreamEvent, ProtocolError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(event))) => {
+                match &event {
+                    StreamEvent::BlockDelta {
+                        delta: ContentDelta::Text { text },
+                        ..
+                    } => {
+                        if self.first_token {
+                            self.first_token = false;
+                            let sm = Arc::clone(&self.session_manager);
+                            let sid = self.session_id.clone();
+                            tokio::spawn(async move {
+                                if let Some(cs) = sm.get_conversation_session(&sid).await {
+                                    cs.read().await.set_llm_state(LlmState::Receiving);
+                                }
+                            });
+                        }
+                        if let Some(ref sink) = self.sink {
+                            sink.send_text(text);
+                        }
+                    }
+                    StreamEvent::MessageEnd { usage, .. } => {
+                        if let Some(ref sink) = self.sink {
+                            sink.send_done(StreamDone {
+                                model: String::new(),
+                                usage: usage.clone(),
+                            });
+                        }
+                    }
+                    StreamEvent::Error { message } => {
+                        if let Some(ref sink) = self.sink {
+                            sink.send_error(message.clone());
+                        }
+                    }
+                    _ => {}
+                }
+                Poll::Ready(Some(Ok(event)))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                let msg = e.to_string();
+                if let Some(ref sink) = self.sink {
+                    sink.send_error(msg);
+                }
+                Poll::Ready(Some(Err(e)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod code_block;
 pub mod feishu;
+pub mod streaming;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/renderer/streaming.rs
+++ b/src/renderer/streaming.rs
@@ -1,0 +1,498 @@
+//! StreamingRenderer — incremental rendering for LLM `StreamEvent` streams.
+//!
+//! See `docs/design/im_adapter/streaming-render.md` for the architecture.
+//!
+//! This module provides:
+//! - [`LineBuffer`] — splits incoming text on sentence terminators
+//!   (`。！？.!?\n`) when outside fenced code blocks, and on `\n` when
+//!   inside. Forces emission when the buffer exceeds a character threshold.
+//! - [`DefaultStreamingRenderer`] — implements [`StreamingRenderer`]:
+//!   feeds Text deltas through [`LineBuffer`], accumulates non-Text blocks,
+//!   and routes DSL lines to a dedicated slot in [`StreamingOutput`].
+//! - [`StreamingOutput`] — incremental output struct carrying completed
+//!   text lines, non-Text [`ContentBlock`]s, and parsed DSL lines.
+
+use crate::llm::types::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent};
+use crate::processor_chain::dsl_parser::DslParser;
+
+/// Default threshold (in characters) for forcing buffer emission.
+const LINE_THRESHOLD: usize = 100;
+
+/// Incremental output produced by [`StreamingRenderer`] for a batch of events.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct StreamingOutput {
+    /// Completed text lines emitted by the line buffer.
+    pub text_messages: Vec<String>,
+    /// Non-Text content blocks completed in this batch.
+    pub render_blocks: Vec<ContentBlock>,
+    /// DSL lines (e.g. `::button[...]`) extracted from text content.
+    pub dsl_lines: Vec<String>,
+}
+
+/// Line buffer for incremental text rendering.
+///
+/// Splits incoming text on sentence terminators (`。！？.!?\n`) when outside
+/// fenced code blocks, and on `\n` when inside. Forces emission when the
+/// buffer exceeds the configured threshold.
+pub struct LineBuffer {
+    buffer: String,
+    in_code_block: bool,
+    threshold: usize,
+}
+
+impl Default for LineBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LineBuffer {
+    /// Create a new line buffer with the default threshold (100 chars).
+    pub fn new() -> Self {
+        Self::with_threshold(LINE_THRESHOLD)
+    }
+
+    /// Create a new line buffer with a custom threshold.
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self {
+            buffer: String::new(),
+            in_code_block: false,
+            threshold,
+        }
+    }
+
+    /// Reset the buffer and code-block state.
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.in_code_block = false;
+    }
+
+    /// Feed a text chunk; returns any lines completed by this chunk.
+    pub fn feed(&mut self, chunk: &str) -> Vec<String> {
+        if chunk.is_empty() {
+            return Vec::new();
+        }
+        let mut emitted: Vec<String> = Vec::new();
+        let mut current_line = std::mem::take(&mut self.buffer);
+        let mut in_code = self.in_code_block;
+        let mut backtick_run: usize = count_trailing_backticks(&current_line);
+
+        for ch in chunk.chars() {
+            if ch == '`' {
+                backtick_run += 1;
+                current_line.push(ch);
+                continue;
+            }
+            if backtick_run >= 3 {
+                in_code = !in_code;
+            }
+            backtick_run = 0;
+            current_line.push(ch);
+
+            let emit = if in_code {
+                ch == '\n'
+            } else {
+                is_sentence_terminator(ch) || ch == '\n'
+            };
+            if emit {
+                emitted.push(std::mem::take(&mut current_line));
+            }
+        }
+
+        self.in_code_block = in_code;
+        self.buffer = current_line;
+
+        if self.buffer.chars().count() >= self.threshold {
+            self.force_emit(&mut emitted);
+        }
+        emitted
+    }
+
+    /// Flush the buffer; returns remaining content if any.
+    pub fn flush(&mut self) -> Option<String> {
+        if self.buffer.is_empty() {
+            None
+        } else {
+            self.in_code_block = false;
+            Some(std::mem::take(&mut self.buffer))
+        }
+    }
+
+    fn force_emit(&mut self, emitted: &mut Vec<String>) {
+        if let Some((byte_idx, _)) = self.buffer.char_indices().nth(self.threshold) {
+            let line: String = self.buffer.drain(..byte_idx).collect();
+            emitted.push(line);
+        } else {
+            emitted.push(std::mem::take(&mut self.buffer));
+        }
+    }
+}
+
+fn is_sentence_terminator(ch: char) -> bool {
+    matches!(ch, '。' | '！' | '？' | '.' | '!' | '?')
+}
+
+fn count_trailing_backticks(s: &str) -> usize {
+    s.chars().rev().take_while(|&c| c == '`').count()
+}
+
+fn is_dsl_line(line: &str) -> bool {
+    let parser = DslParser;
+    !parser.parse(line).instructions.is_empty()
+}
+
+fn route_line(line: &str, out: &mut StreamingOutput) {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if is_dsl_line(trimmed) {
+        out.dsl_lines.push(trimmed.to_string());
+    } else {
+        out.text_messages.push(line.to_string());
+    }
+}
+
+/// Per-block accumulator for non-Text blocks (Thinking / ToolUse).
+#[derive(Debug, Default)]
+struct BlockAccumulator {
+    /// Concatenated text content (used for Thinking).
+    text: String,
+    /// Tool call id (for ToolUse).
+    tool_id: Option<String>,
+    /// Tool name (for ToolUse).
+    tool_name: Option<String>,
+    /// Tool input JSON (for ToolUse).
+    tool_input: String,
+}
+
+impl BlockAccumulator {
+    /// Convert the accumulated data into a [`ContentBlock`].
+    fn into_block(self, block_type: ContentBlockType) -> ContentBlock {
+        match block_type {
+            ContentBlockType::Thinking => ContentBlock::Thinking(self.text),
+            ContentBlockType::ToolUse => ContentBlock::ToolUse {
+                id: self.tool_id.unwrap_or_default(),
+                name: self.tool_name.unwrap_or_default(),
+                input: self.tool_input,
+            },
+            ContentBlockType::Text => ContentBlock::Text(self.text),
+        }
+    }
+}
+
+/// Trait for incremental rendering of LLM [`StreamEvent`] streams.
+///
+/// Implementors must be `Send` so the renderer can be driven from async
+/// tasks. Each [`handle_event`](Self::handle_event) call returns the
+/// incremental output produced by that event; [`flush`](Self::flush) is
+/// called at `MessageEnd` to drain any remaining buffered content.
+pub trait StreamingRenderer: Send {
+    /// Process a single [`StreamEvent`] and return incremental output.
+    fn handle_event(&mut self, event: StreamEvent) -> StreamingOutput;
+
+    /// Flush any remaining buffered content; called at MessageEnd.
+    fn flush(&mut self) -> StreamingOutput;
+}
+
+/// Default streaming renderer: line-buffered text + per-block accumulation.
+pub struct DefaultStreamingRenderer {
+    line_buffer: LineBuffer,
+    current_block_type: Option<ContentBlockType>,
+    current_block_index: Option<usize>,
+    current_acc: Option<BlockAccumulator>,
+}
+
+impl Default for DefaultStreamingRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultStreamingRenderer {
+    /// Create a new renderer.
+    pub fn new() -> Self {
+        Self {
+            line_buffer: LineBuffer::new(),
+            current_block_type: None,
+            current_block_index: None,
+            current_acc: None,
+        }
+    }
+
+    fn handle_text_delta(&mut self, text: &str, out: &mut StreamingOutput) {
+        for line in self.line_buffer.feed(text) {
+            route_line(&line, out);
+        }
+    }
+
+    fn handle_thinking_delta(&mut self, thinking: &str) {
+        if let Some(acc) = self.current_acc.as_mut() {
+            acc.text.push_str(thinking);
+        }
+    }
+
+    fn handle_tool_id(&mut self, id: String) {
+        if let Some(acc) = self.current_acc.as_mut() {
+            acc.tool_id = Some(id);
+        }
+    }
+
+    fn handle_tool_name(&mut self, name: String) {
+        if let Some(acc) = self.current_acc.as_mut() {
+            acc.tool_name = Some(name);
+        }
+    }
+
+    fn handle_tool_input(&mut self, input: &str) {
+        if let Some(acc) = self.current_acc.as_mut() {
+            acc.tool_input.push_str(input);
+        }
+    }
+
+    fn handle_block_start(&mut self, index: usize, block_type: ContentBlockType) {
+        self.current_block_type = Some(block_type);
+        self.current_block_index = Some(index);
+        match block_type {
+            ContentBlockType::Text => self.line_buffer.reset(),
+            ContentBlockType::Thinking | ContentBlockType::ToolUse => {
+                self.current_acc = Some(BlockAccumulator::default());
+            }
+        }
+    }
+
+    fn handle_block_end(
+        &mut self,
+        index: usize,
+        block_type: ContentBlockType,
+        out: &mut StreamingOutput,
+    ) {
+        match block_type {
+            ContentBlockType::Text => {
+                if let Some(remaining) = self.line_buffer.flush() {
+                    route_line(&remaining, out);
+                }
+            }
+            ContentBlockType::Thinking | ContentBlockType::ToolUse => {
+                if let Some(acc) = self.current_acc.take() {
+                    out.render_blocks.push(acc.into_block(block_type));
+                }
+            }
+        }
+        if self.current_block_index == Some(index) {
+            self.current_block_type = None;
+            self.current_block_index = None;
+        }
+    }
+}
+
+impl StreamingRenderer for DefaultStreamingRenderer {
+    fn handle_event(&mut self, event: StreamEvent) -> StreamingOutput {
+        let mut out = StreamingOutput::default();
+        match event {
+            StreamEvent::BlockStart { index, block_type } => {
+                self.handle_block_start(index, block_type);
+            }
+            StreamEvent::BlockDelta { delta, .. } => match delta {
+                ContentDelta::Text { text } => self.handle_text_delta(&text, &mut out),
+                ContentDelta::Thinking { thinking } => self.handle_thinking_delta(&thinking),
+                ContentDelta::ToolUseId { id } => self.handle_tool_id(id),
+                ContentDelta::ToolUseName { name } => self.handle_tool_name(name),
+                ContentDelta::ToolUseInputChunk { input } => self.handle_tool_input(&input),
+            },
+            StreamEvent::BlockEnd { index, block_type } => {
+                self.handle_block_end(index, block_type, &mut out);
+            }
+            StreamEvent::MessageEnd { .. } | StreamEvent::Error { .. } => {}
+        }
+        out
+    }
+
+    fn flush(&mut self) -> StreamingOutput {
+        let mut out = StreamingOutput::default();
+        if let Some(remaining) = self.line_buffer.flush() {
+            route_line(&remaining, &mut out);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_delta(text: &str) -> StreamEvent {
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: text.to_string(),
+            },
+        }
+    }
+
+    fn block_start(index: usize, bt: ContentBlockType) -> StreamEvent {
+        StreamEvent::BlockStart {
+            index,
+            block_type: bt,
+        }
+    }
+
+    fn block_end(index: usize, bt: ContentBlockType) -> StreamEvent {
+        StreamEvent::BlockEnd {
+            index,
+            block_type: bt,
+        }
+    }
+
+    // --- LineBuffer ---
+
+    #[test]
+    fn line_buffer_pure_text_splits_on_punctuation() {
+        let mut buf = LineBuffer::new();
+        // English and Chinese sentence terminators, plus newlines.
+        let out = buf.feed("Hello world. 你好世界！\nDone?");
+        assert_eq!(out, vec!["Hello world.", " 你好世界！", "\n", "Done?"]);
+    }
+
+    #[test]
+    fn line_buffer_keeps_incomplete_across_feeds() {
+        let mut buf = LineBuffer::new();
+        assert!(buf.feed("Hello ").is_empty());
+        let out = buf.feed("world.");
+        assert_eq!(out, vec!["Hello world."]);
+        assert_eq!(buf.flush(), None);
+    }
+
+    #[test]
+    fn line_buffer_code_block_only_splits_on_newline() {
+        let mut buf = LineBuffer::new();
+        // Inside the fenced code block, "foo.bar" must NOT split on '.'.
+        let out = buf.feed("```\nfoo.bar.baz\n```\n");
+        assert_eq!(out, vec!["```\n", "foo.bar.baz\n", "```\n"]);
+    }
+
+    #[test]
+    fn line_buffer_force_emits_at_threshold() {
+        let mut buf = LineBuffer::with_threshold(10);
+        let out = buf.feed("a]long string without any terminator");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].chars().count(), 10);
+        assert_eq!(out[0], "a]long str");
+    }
+
+    #[test]
+    fn line_buffer_flush_and_reset() {
+        let mut buf = LineBuffer::new();
+        buf.feed("partial");
+        assert_eq!(buf.flush(), Some("partial".to_string()));
+        assert_eq!(buf.flush(), None);
+        buf.feed("more");
+        buf.reset();
+        assert_eq!(buf.flush(), None);
+    }
+
+    // --- DefaultStreamingRenderer ---
+
+    #[test]
+    fn renderer_pure_text_emits_complete_lines() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::Text));
+        let out = r.handle_event(text_delta("Hello world."));
+        assert_eq!(out.text_messages, vec!["Hello world."]);
+        assert!(out.dsl_lines.is_empty());
+        assert!(out.render_blocks.is_empty());
+    }
+
+    #[test]
+    fn renderer_with_code_block_preserves_inner_periods() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::Text));
+        let out = r.handle_event(text_delta("```\nfoo.bar.baz\n```\n"));
+        // "foo.bar.baz" must be one line, no split on '.'.
+        assert_eq!(out.text_messages, vec!["```\n", "foo.bar.baz\n", "```\n"]);
+    }
+
+    #[test]
+    fn renderer_routes_dsl_line_to_dsl_lines() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::Text));
+        let dsl = "::button[label:Yes;action:vote;value:1]";
+        let out = r.handle_event(text_delta(&format!("{}\n", dsl)));
+        assert_eq!(out.dsl_lines, vec![dsl]);
+        assert!(out.text_messages.is_empty());
+    }
+
+    #[test]
+    fn renderer_force_emits_long_text_at_threshold() {
+        let mut r = DefaultStreamingRenderer::new();
+        // No terminator in 150-char string; first 100 chars must be emitted.
+        let long_text = "a".repeat(150);
+        r.handle_event(block_start(0, ContentBlockType::Text));
+        let out = r.handle_event(text_delta(&long_text));
+        assert_eq!(out.text_messages.len(), 1);
+        assert_eq!(out.text_messages[0].chars().count(), 100);
+    }
+
+    #[test]
+    fn renderer_block_end_thinking_emits_render_block() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::Thinking));
+        r.handle_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Thinking {
+                thinking: "Let me think.".to_string(),
+            },
+        });
+        let out = r.handle_event(block_end(0, ContentBlockType::Thinking));
+        assert_eq!(
+            out.render_blocks,
+            vec![ContentBlock::Thinking("Let me think.".to_string())]
+        );
+    }
+
+    #[test]
+    fn renderer_block_end_tool_use_assembles_block() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::ToolUse));
+        r.handle_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseId {
+                id: "call_123".to_string(),
+            },
+        });
+        r.handle_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseName {
+                name: "search".to_string(),
+            },
+        });
+        r.handle_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseInputChunk {
+                input: r#"{"q":"rust"}"#.to_string(),
+            },
+        });
+        let out = r.handle_event(block_end(0, ContentBlockType::ToolUse));
+        assert_eq!(
+            out.render_blocks,
+            vec![ContentBlock::ToolUse {
+                id: "call_123".to_string(),
+                name: "search".to_string(),
+                input: r#"{"q":"rust"}"#.to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn renderer_text_block_end_and_flush_drain_buffer() {
+        let mut r = DefaultStreamingRenderer::new();
+        r.handle_event(block_start(0, ContentBlockType::Text));
+        // Feed partial (no terminator).
+        r.handle_event(text_delta("partial"));
+        let out = r.handle_event(block_end(0, ContentBlockType::Text));
+        assert_eq!(out.text_messages, vec!["partial"]);
+        // After BlockEnd, flush should have nothing to emit.
+        let after = r.flush();
+        assert!(after.text_messages.is_empty());
+    }
+}


### PR DESCRIPTION
feat: 实现流式出站路径（StreamingRenderer + Gateway 流式调度）

## 概述

实现 renderer 层的流式出站路径。原先出站仅有批处理模式——`call_llm_streaming` 收集所有 LLM delta 拼成完整 `UnifiedResponse` 后通过 `output_tx` 送出，用户需等整个 LLM 响应完成后才看到输出。本次实现使 `stream_enabled=true` 时 LLM 输出逐句增量推送到 IMPlugin，显著降低首字延迟。

依据设计文档：
- `docs/design/im_adapter/streaming-render.md` — 流式渲染架构、行缓冲规则
- `docs/design/im_adapter/README.md` — IMPlugin trait 契约
- `docs/design/processor_chain/outbound-chain.md` — 出站 Processor 链

## 主要变更

### 新增模块
- **`src/renderer/streaming.rs`** — `DefaultStreamingRenderer`（实现 `StreamingRenderer` trait）+ `LineBuffer`（按 `。！？.!?\n` 切行，代码块内按换行符切行，超 100 字符强制输出）+ `StreamingOutput`（已完成行 / 非 Text 块 / DSL 行）

### Gateway 出站路径
- **`src/gateway/outbound.rs`** — 新增 `send_outbound_streaming` 方法 + `StreamResult` struct（`content_blocks: Vec<ContentBlock>`, `usage: UnifiedUsage`）。逐 `StreamEvent` 驱动 `DefaultStreamingRenderer`：Text delta 行缓冲 + 立即 `plugin.send`；非 Text 块 `BlockEnd` 时 `plugin.render()` + `plugin.send`；`MessageEnd` 时 `flush` + `DslParser` + `render` + `send`
- **`src/gateway/session_handler_streaming.rs`** — `call_llm_streaming` 接入 `send_outbound_streaming`，返回 `Result<StreamResult, LLMError>` 替代 `Result<UnifiedResponse, LLMError>`；`finish_llm` 适配新返回类型（`content_blocks` 做 `append_response`，`usage` 做 `accumulate_usage`）。`StreamingSink` push 逻辑保留，CLI/websocket 消费方不受影响
- **`src/gateway/session_handler_dispatch.rs`** — 新文件，从 `session_handler.rs` 拆出 `dispatch_llm_call`
- **`src/gateway/session_handler_compaction.rs`** — 新文件，从 `session_handler.rs` 拆出 compaction 路径

### 模块注册
- **`src/renderer/mod.rs`** — 新增 `pub mod streaming;`
- **`src/gateway/mod.rs`** — 新增 `pub mod session_handler_dispatch;` / `session_handler_compaction;`
- **`src/daemon/mod.rs`** — 注册新模块

### 重构
- **`src/gateway/session_handler.rs`** — 拆分为 dispatch / compaction 子模块，行为不变
- **`src/gateway/session_handler_announce.rs`** — 适配子模块拆分

## 兼容性

- 非流式路径（`stream_enabled=false`）行为完全不变
- `src/llm/streaming.rs`（`StreamingSink`）保持不变，CLI/websocket 消费方不受影响
- `src/gateway/outbound.rs` 原 `send_outbound` 批处理路径保持不变

## 验收

- ✅ Plan Step 1.1/1.2/1.3 全部验收标准通过
- ✅ Design doc 红线：未修改 `docs/design/` 任何文件
- ✅ 文件行数限制：所有变更文件均 ≤ 500 行
- ✅ `cargo fmt --check` 通过
- ✅ `cargo test` 1782 passed / 4 pre-existing failures（与本次改动无关）

## 关联

Closes #847

Source: issue #847
Type: feat
