### PR TITLE
feat(sessions): implement sessions_steer and sessions_kill tools

### DIFF
--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -260,4 +260,78 @@ impl SessionManager {
         }
         Ok(PathBuf::from("/tmp"))
     }
+
+    /// Validate that a child session is owned by the given parent and
+    /// was spawned in `Session` mode (persistent). Returns the child
+    /// info on success, `None` otherwise.
+    ///
+    /// Pure read operation — does not hold the children lock across
+    /// any await point.
+    pub(crate) async fn validate_child_ownership(
+        &self,
+        parent_id: &str,
+        child_id: &str,
+    ) -> Option<ChildSessionInfo> {
+        let children = self.children.read().await;
+        children
+            .get(parent_id)
+            .and_then(|list| {
+                list.iter()
+                    .find(|info| info.session_id == child_id && info.mode == SpawnMode::Session)
+            })
+            .cloned()
+    }
+
+    /// Inject a new task into a persistent child session's pending
+    /// message queue. The task is enqueued (FIFO) and will be
+    /// consumed after the child's current turn completes.
+    pub(crate) async fn steer_child(&self, child_id: &str, task: &str) -> Result<(), String> {
+        let cs = self
+            .get_conversation_session(child_id)
+            .await
+            .ok_or_else(|| format!("child session not found: {}", child_id))?;
+        let pending_msg = PendingMessage::new(format!("{}-steer", child_id), task.to_string());
+        cs.write().await.push_pending(pending_msg);
+        Ok(())
+    }
+
+    /// Force-terminate a child session: cancel its token tree,
+    /// remove it from `conversation_sessions`, `sessions`, and
+    /// the parent's `children` tracking table. The archive is
+    /// preserved (no purge).
+    pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
+        let cs = self
+            .get_conversation_session(child_id)
+            .await
+            .ok_or_else(|| format!("child session not found: {}", child_id))?;
+
+        // Cascade-stop: cancels the token tree and cleans up tool
+        // handles / child handles.
+        cs.read().await.stop(true).await;
+
+        // Remove from conversation_sessions.
+        {
+            let mut conv_sessions = self.conversation_sessions.write().await;
+            conv_sessions.remove(child_id);
+        }
+
+        // Remove from sessions.
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.remove(child_id);
+        }
+
+        // Remove from children tracking table.
+        {
+            let mut children = self.children.write().await;
+            if let Some(list) = children.get_mut(parent_id) {
+                list.retain(|info| info.session_id != child_id);
+                if list.is_empty() {
+                    children.remove(parent_id);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -193,3 +193,180 @@ async fn test_create_child_session_registers_child_info() {
     assert_eq!(list[0].depth, 1);
     assert_eq!(list[0].mode, SpawnMode::Session);
 }
+
+#[tokio::test]
+#[serial]
+async fn test_steer_child_injects_pending_message() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("steer-child", None);
+
+    register_parent_session(&mgr, "parent-steer", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-steer",
+            1,
+            "initial task",
+            false,
+            None,
+            SpawnMode::Session,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Steer the child with a new task
+    mgr.steer_child(&child_id, "new task")
+        .await
+        .expect("steer_child should succeed");
+
+    // Verify the pending message was injected
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("conversation session should exist");
+    let cs_guard = cs.read().await;
+    let pending = cs_guard.get_pending_messages();
+    // There should be 2 pending messages: the original task + the steer message
+    assert!(
+        pending.len() >= 2,
+        "expected at least 2 pending messages, got {}",
+        pending.len()
+    );
+    let steer_msg = pending
+        .iter()
+        .find(|m| m.content == "new task")
+        .expect("pending messages should contain 'new task'");
+    assert_eq!(steer_msg.content, "new task");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_kill_child_removes_from_all_tables() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("kill-child", None);
+
+    register_parent_session(&mgr, "parent-kill", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-kill",
+            1,
+            "doomed task",
+            false,
+            None,
+            SpawnMode::Session,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Confirm child exists before kill
+    assert!(mgr.has_session(&child_id).await);
+    assert!(mgr.get_conversation_session(&child_id).await.is_some());
+    assert_eq!(mgr.count_active_children("parent-kill").await, 1);
+
+    // Kill the child
+    mgr.kill_child("parent-kill", &child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    // Verify child is removed from sessions
+    assert!(
+        !mgr.has_session(&child_id).await,
+        "has_session should return false after kill"
+    );
+
+    // Verify child is removed from conversation_sessions
+    assert!(
+        mgr.get_conversation_session(&child_id).await.is_none(),
+        "get_conversation_session should return None after kill"
+    );
+
+    // Verify child is removed from children tracking table
+    assert_eq!(
+        mgr.count_active_children("parent-kill").await,
+        0,
+        "children table should be empty after kill"
+    );
+    let children = mgr.children.read().await;
+    assert!(
+        children.get("parent-kill").is_none(),
+        "parent entry should be removed from children table when list is empty"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_validate_child_ownership_returns_none_for_run_mode() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("run-child", None);
+
+    register_parent_session(&mgr, "parent-validate-run", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-validate-run",
+            1,
+            "run task",
+            false,
+            None,
+            SpawnMode::Run,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // validate_child_ownership should return None for Run mode children
+    let result = mgr
+        .validate_child_ownership("parent-validate-run", &child_id)
+        .await;
+    assert!(
+        result.is_none(),
+        "validate_child_ownership should return None for Run mode children"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_validate_child_ownership_returns_info_for_session_mode() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("session-child", None);
+
+    register_parent_session(&mgr, "parent-validate-session", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-validate-session",
+            1,
+            "session task",
+            false,
+            None,
+            SpawnMode::Session,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // validate_child_ownership should return Some for Session mode children
+    let result = mgr
+        .validate_child_ownership("parent-validate-session", &child_id)
+        .await;
+    let info =
+        result.expect("validate_child_ownership should return Some for Session mode children");
+    assert_eq!(info.session_id, child_id);
+    assert_eq!(info.mode, SpawnMode::Session);
+    assert_eq!(info.parent_session_id, "parent-validate-session");
+}

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -11,7 +11,9 @@ pub mod file_ops;
 pub mod git_ops;
 pub mod permission;
 pub mod search;
+pub mod sessions_kill;
 pub mod sessions_spawn;
+pub mod sessions_steer;
 pub mod skill_creator;
 pub mod skill_tool;
 
@@ -21,7 +23,9 @@ pub use file_ops::{EditTool, GrepTool, LsTool, ReadTool, WriteTool};
 pub use git_ops::{GitCommitTool, GitLogTool, GitPullTool, GitPushTool, GitStatusTool};
 pub use permission::PermissionQueryTool;
 pub use search::ToolSearchTool;
+pub use sessions_kill::SessionsKillTool;
 pub use sessions_spawn::SessionsSpawnTool;
+pub use sessions_steer::SessionsSteerTool;
 pub use skill_creator::SkillCreatorTool;
 pub use skill_tool::SkillTool;
 
@@ -34,7 +38,7 @@ use crate::skills::DiskSkillRegistry;
 
 /// Registers all built-in tools with the given registry.
 ///
-/// Currently registers 17 tools:
+/// Currently registers 19 tools:
 ///
 /// 5 file_ops tools:
 /// - [`ReadTool`]
@@ -57,8 +61,10 @@ use crate::skills::DiskSkillRegistry;
 /// 1 bash tool:
 /// - [`BashTool`]
 ///
-/// 1 sessions tool:
+/// 3 sessions tools:
 /// - [`SessionsSpawnTool`]
+/// - [`SessionsSteerTool`]
+/// - [`SessionsKillTool`]
 ///
 /// 3 stub tools:
 /// - [`CodingAgentTool`]
@@ -99,7 +105,18 @@ pub async fn register_builtin_tools(
     registry.register(SkillTool::new(disk_registry)).await.ok();
     // sessions
     registry
-        .register(SessionsSpawnTool::new(spawn_controller, session_manager))
+        .register(SessionsSpawnTool::new(
+            spawn_controller,
+            session_manager.clone(),
+        ))
+        .await
+        .ok();
+    registry
+        .register(SessionsSteerTool::new(session_manager.clone()))
+        .await
+        .ok();
+    registry
+        .register(SessionsKillTool::new(session_manager))
         .await
         .ok();
 }
@@ -107,3 +124,7 @@ pub async fn register_builtin_tools(
 #[cfg(test)]
 #[path = "sessions_spawn_tests.rs"]
 mod sessions_spawn_tests;
+
+#[cfg(test)]
+#[path = "sessions_steer_kill_tests.rs"]
+mod sessions_steer_kill_tests;

--- a/src/tools/builtin/sessions_kill.rs
+++ b/src/tools/builtin/sessions_kill.rs
@@ -1,0 +1,105 @@
+//! Built-in sessions_kill tool — terminates a persistent child session and releases resources.
+
+use crate::gateway::SessionManager;
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// Tool that kills a persistent child session by stopping it (cascade)
+/// and removing it from all tracking tables.
+///
+/// Only works on `mode=session` children owned by the calling parent.
+pub struct SessionsKillTool {
+    session_manager: Arc<SessionManager>,
+}
+
+impl SessionsKillTool {
+    /// Create a new `SessionsKillTool` with the given dependencies.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+}
+
+#[async_trait]
+impl Tool for SessionsKillTool {
+    fn name(&self) -> &str {
+        "sessions_kill"
+    }
+
+    fn group(&self) -> &str {
+        "sessions"
+    }
+
+    fn summary(&self) -> String {
+        "Terminate a persistent child session and release resources".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Kill a persistent (mode=session) child session by triggering a cascading \
+         stop (cancels in-flight LLM requests and tool processes), then removing \
+         it from all tracking tables. The archive is preserved. \
+         Requires the child to be owned by the calling parent session."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "childId": {
+                    "type": "string",
+                    "description": "The session ID of the child session to kill"
+                }
+            },
+            "required": ["childId"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            ..Default::default()
+        }
+    }
+
+    async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        // 1. Extract parameters
+        let child_id = args
+            .get("childId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolCallError::InvalidArgs("missing required field 'childId'".into()))?;
+
+        // 2. Get parent session_id from context
+        let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {
+            ToolCallError::ExecutionFailed("no session_id in tool context".into())
+        })?;
+
+        // 3. Validate ownership
+        self.session_manager
+            .validate_child_ownership(parent_session_id, child_id)
+            .await
+            .ok_or_else(|| {
+                ToolCallError::ExecutionFailed(
+                    "child session not found or not owned by parent".into(),
+                )
+            })?;
+
+        // 4. Kill the child session
+        self.session_manager
+            .kill_child(parent_session_id, child_id)
+            .await
+            .map_err(ToolCallError::ExecutionFailed)?;
+
+        // 5. Return result
+        Ok(ToolResult {
+            data: json!({
+                "child_id": child_id,
+                "status": "killed",
+            }),
+            new_messages: vec![],
+            context_modifier: None,
+        })
+    }
+}

--- a/src/tools/builtin/sessions_steer.rs
+++ b/src/tools/builtin/sessions_steer.rs
@@ -1,0 +1,113 @@
+//! Built-in sessions_steer tool — injects a new task into a persistent child session.
+
+use crate::gateway::SessionManager;
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// Tool that steers a persistent child session by injecting a new task
+/// into its pending message queue.
+///
+/// Only works on `mode=session` children owned by the calling parent.
+pub struct SessionsSteerTool {
+    session_manager: Arc<SessionManager>,
+}
+
+impl SessionsSteerTool {
+    /// Create a new `SessionsSteerTool` with the given dependencies.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+}
+
+#[async_trait]
+impl Tool for SessionsSteerTool {
+    fn name(&self) -> &str {
+        "sessions_steer"
+    }
+
+    fn group(&self) -> &str {
+        "sessions"
+    }
+
+    fn summary(&self) -> String {
+        "Inject a new task into a persistent child session".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Steer a persistent (mode=session) child session by injecting a new task \
+         into its pending message queue. The task is enqueued (FIFO) and will be \
+         consumed after the child's current turn completes. \
+         Requires the child to be owned by the calling parent session."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "childId": {
+                    "type": "string",
+                    "description": "The session ID of the child session to steer"
+                },
+                "task": {
+                    "type": "string",
+                    "description": "The new task to inject into the child session"
+                }
+            },
+            "required": ["childId", "task"]
+        })
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_concurrency_safe: true,
+            ..Default::default()
+        }
+    }
+
+    async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        // 1. Extract parameters
+        let child_id = args
+            .get("childId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolCallError::InvalidArgs("missing required field 'childId'".into()))?;
+        let task = args
+            .get("task")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolCallError::InvalidArgs("missing required field 'task'".into()))?;
+
+        // 2. Get parent session_id from context
+        let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {
+            ToolCallError::ExecutionFailed("no session_id in tool context".into())
+        })?;
+
+        // 3. Validate ownership
+        self.session_manager
+            .validate_child_ownership(parent_session_id, child_id)
+            .await
+            .ok_or_else(|| {
+                ToolCallError::ExecutionFailed(
+                    "child session not found or not owned by parent".into(),
+                )
+            })?;
+
+        // 4. Steer the child session
+        self.session_manager
+            .steer_child(child_id, task)
+            .await
+            .map_err(ToolCallError::ExecutionFailed)?;
+
+        // 5. Return result
+        Ok(ToolResult {
+            data: json!({
+                "child_id": child_id,
+                "task": task,
+            }),
+            new_messages: vec![],
+            context_modifier: None,
+        })
+    }
+}

--- a/src/tools/builtin/sessions_steer_kill_tests.rs
+++ b/src/tools/builtin/sessions_steer_kill_tests.rs
@@ -1,0 +1,187 @@
+//! Unit tests for `SessionsSteerTool` and `SessionsKillTool`.
+//!
+//! Covers early-error (validation) tests only.
+//! Tests requiring real parent/child sessions (which access private fields
+//! on `SessionManager`) have been removed; those belong in integration tests.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::{DmScope, GatewayConfig};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use crate::tools::builtin::sessions_kill::SessionsKillTool;
+use crate::tools::builtin::sessions_steer::SessionsSteerTool;
+use crate::tools::{Tool, ToolCallError, ToolContext};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn test_gateway_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+    }
+}
+
+fn make_session_manager() -> Arc<SessionManager> {
+    Arc::new(SessionManager::new(
+        &test_gateway_config(),
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
+fn ctx_with_session(session_id: &str) -> ToolContext {
+    ToolContext {
+        agent_id: "test-agent".to_string(),
+        workdir: None,
+        session_id: Some(session_id.to_string()),
+        call_id: None,
+        session: None,
+    }
+}
+
+fn ctx_without_session() -> ToolContext {
+    ToolContext {
+        agent_id: "test-agent".to_string(),
+        workdir: None,
+        session_id: None,
+        call_id: None,
+        session: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer: missing childId
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_missing_child_id() {
+    let mgr = make_session_manager();
+    let tool = SessionsSteerTool::new(mgr);
+    let ctx = ctx_with_session("parent-x");
+
+    let result = tool.call(json!({"task": "something"}), &ctx).await;
+
+    let err = result.expect_err("steer should fail when childId is missing");
+    match err {
+        ToolCallError::InvalidArgs(msg) => {
+            assert!(
+                msg.contains("childId"),
+                "error should mention childId, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected InvalidArgs, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer: missing task
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_missing_task() {
+    let mgr = make_session_manager();
+    let tool = SessionsSteerTool::new(mgr);
+    let ctx = ctx_with_session("parent-x");
+
+    let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
+
+    let err = result.expect_err("steer should fail when task is missing");
+    match err {
+        ToolCallError::InvalidArgs(msg) => {
+            assert!(
+                msg.contains("task"),
+                "error should mention task, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected InvalidArgs, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kill: missing childId
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_missing_child_id() {
+    let mgr = make_session_manager();
+    let tool = SessionsKillTool::new(mgr);
+    let ctx = ctx_with_session("parent-x");
+
+    let result = tool.call(json!({}), &ctx).await;
+
+    let err = result.expect_err("kill should fail when childId is missing");
+    match err {
+        ToolCallError::InvalidArgs(msg) => {
+            assert!(
+                msg.contains("childId"),
+                "error should mention childId, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected InvalidArgs, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer: no session_id in context
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_no_session_id_in_context() {
+    let mgr = make_session_manager();
+    let tool = SessionsSteerTool::new(mgr);
+    let ctx = ctx_without_session();
+
+    let result = tool
+        .call(json!({"childId": "some-id", "task": "something"}), &ctx)
+        .await;
+
+    let err = result.expect_err("steer should fail when session_id is None");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("session_id"),
+                "error should mention session_id, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kill: no session_id in context
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_no_session_id_in_context() {
+    let mgr = make_session_manager();
+    let tool = SessionsKillTool::new(mgr);
+    let ctx = ctx_without_session();
+
+    let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
+
+    let err = result.expect_err("kill should fail when session_id is None");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("session_id"),
+                "error should mention session_id, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Implement `sessions_steer` and `sessions_kill` tools for controlling persistent (mode=session) child sessions.

Closes #865

## Changes

- **SessionManager** (spawn.rs): add `validate_child_ownership`, `steer_child`, `kill_child` methods
- **SessionsSteerTool**: inject new task into child's pending message queue
- **SessionsKillTool**: cascade-stop child, remove from all tracking tables, preserve archive
- **mod.rs**: register both tools in the sessions group (tool count 17→19)

## Tests

- 4 integration tests in spawn_tests.rs (steer pending msg, kill cleanup, validate ownership for Run/Session modes)
- 5 unit tests in sessions_steer_kill_tests.rs (missing args, no session_id)

## Notes

- 3 pre-existing test failures (unrelated): test_busy_message_returns_queued, test_find_or_create_with_tool_registry, test_build_append_section_appended

Source: issue #865
Type: feat