### PR TITLE
feat(slash): 实现 /reasoning 斜杠指令 — 运行时动态修改推理深度

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -14,7 +14,7 @@ use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
 use crate::renderer::feishu::FeishuRenderer;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{
-    ClearHandler, CompactHandler, ExecHandler, HelpHandler, WorkdirHandler,
+    ClearHandler, CompactHandler, ExecHandler, HelpHandler, ReasoningHandler, WorkdirHandler,
 };
 use crate::slash::registry::HandlerRegistry;
 
@@ -176,6 +176,9 @@ impl Daemon {
         slash_registry.register(Arc::new(WorkdirHandler::new(Arc::clone(&session_manager))));
         let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
         slash_registry.register(Arc::new(help_handler));
+        slash_registry.register(Arc::new(ReasoningHandler::new(Arc::clone(
+            &session_manager,
+        ))));
         let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
         gateway.set_slash_dispatcher(slash_dispatcher).await;
         // 高危 slash 指令（如 /exec）需要权限引擎介入；在此注入使得

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -23,6 +23,7 @@ use crate::llm::session_state::LlmState;
 use crate::llm::streaming::{StreamDone, StreamingSink};
 use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent};
 use crate::llm::{LLMError, Message as ChatMessage};
+use crate::session::persistence::ReasoningLevel;
 
 impl SessionMessageHandler {
     /// Make a streaming LLM call and dispatch it through Gateway's
@@ -52,7 +53,7 @@ impl SessionMessageHandler {
         gateway: &Arc<Gateway>,
         plugin: &Arc<dyn IMPlugin>,
     ) -> Result<StreamResult, LLMError> {
-        let (static_prompt_opt, turn_count, workdir_path, system_appends) =
+        let (static_prompt_opt, turn_count, workdir_path, system_appends, reasoning_level) =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                 let cs_read = cs.read().await;
                 (
@@ -60,9 +61,16 @@ impl SessionMessageHandler {
                     cs_read.turn_count(),
                     cs_read.workdir().to_string_lossy().into_owned(),
                     cs_read.system_appends().to_vec(),
+                    cs_read.reasoning_level().clone(),
                 )
             } else {
-                (None, 0, String::new(), Vec::new())
+                (
+                    None,
+                    0,
+                    String::new(),
+                    Vec::new(),
+                    ReasoningLevel::default(),
+                )
             };
 
         let dynamic_sections = build_dynamic_sections(
@@ -102,7 +110,7 @@ impl SessionMessageHandler {
             system_dynamic: None,
             system_blocks: None,
             session_id: None,
-            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            reasoning_level,
         };
 
         // Get streaming sink from session (CLI/websocket consumers).

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -187,6 +187,23 @@ impl Gateway {
                     sh.send_reply(format!("命令已提交审批：/{cmd_name}")).await;
                 }
             }
+            SlashResult::SetReasoning { level } => {
+                if let Some(cs) = self
+                    .session_manager
+                    .get_conversation_session(session_id)
+                    .await
+                {
+                    cs.write().await.set_reasoning_level(level.clone());
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply(format!("推理深度已设置为 {:?}", level)).await;
+                    }
+                } else {
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply("当前会话未激活，无法设置推理深度".to_owned())
+                            .await;
+                    }
+                }
+            }
             SlashResult::SetMode(_)
             | SlashResult::NewSession
             | SlashResult::Stop

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -180,6 +180,16 @@ impl ConversationSession {
         self
     }
 
+    /// Returns the current reasoning level.
+    pub fn reasoning_level(&self) -> ReasoningLevel {
+        self.reasoning_level
+    }
+
+    /// Overrides the reasoning level at runtime.
+    pub fn set_reasoning_level(&mut self, level: ReasoningLevel) {
+        self.reasoning_level = level;
+    }
+
     /// Replace the system prompt on an existing session.
     /// Used by `SessionManager::rebuild_system_prompt` after compaction.
     pub fn replace_system_prompt(&mut self, prompt: impl Into<String>) {

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -1,3 +1,4 @@
+use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 
 /// Result of a slash command dispatch.
@@ -16,6 +17,8 @@ pub enum SlashResult {
     SystemAppend { content: String },
     /// Execute a sub-command (future).
     Exec { command: String },
+    /// Set the reasoning level for the current session.
+    SetReasoning { level: ReasoningLevel },
     /// Unknown command — no handler matched.
     Unknown(String),
 }

--- a/src/slash/handlers.rs
+++ b/src/slash/handlers.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::gateway::SessionManager;
+use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 use crate::slash::handler::{SlashHandler, SlashResult};
 use crate::slash::registry::HandlerRegistry;
@@ -117,6 +118,78 @@ impl SlashHandler for HelpHandler {
             lines.push(format!("  /{cmd}  - {desc}"));
         }
         SlashResult::Reply(lines.join("\n"))
+    }
+}
+
+// ── ReasoningHandler ───────────────────────────────────────────────────────
+
+/// `/reasoning` — query or set the reasoning depth for the current session.
+///
+/// - No arguments: reply with the current reasoning level.
+/// - With an argument (`low`, `medium`, `high`, `max`, `off`): update the
+///   session's reasoning level via `SlashResult::SetReasoning`.
+///
+/// The `off` alias maps to `Low` (the minimum reasoning depth).
+pub struct ReasoningHandler {
+    session_manager: Arc<SessionManager>,
+}
+
+impl ReasoningHandler {
+    /// Create a new ReasoningHandler operating on the given session manager.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+
+    /// Parse a reasoning level string. Returns `None` for invalid values.
+    fn parse_level(s: &str) -> Option<ReasoningLevel> {
+        match s.to_lowercase().as_str() {
+            "low" | "off" => Some(ReasoningLevel::Low),
+            "medium" => Some(ReasoningLevel::Medium),
+            "high" => Some(ReasoningLevel::High),
+            "max" => Some(ReasoningLevel::Max),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for ReasoningHandler {
+    fn commands(&self) -> &[&str] {
+        &["reasoning"]
+    }
+
+    fn description(&self) -> &str {
+        "查询或设置推理深度"
+    }
+
+    fn immediate(&self) -> bool {
+        true
+    }
+
+    async fn handle(&self, args: &str, ctx: &SlashContext) -> SlashResult {
+        let arg = args.trim();
+
+        // No arguments — return the current reasoning level.
+        if arg.is_empty() {
+            let Some(conv) = self
+                .session_manager
+                .get_conversation_session(&ctx.session_id)
+                .await
+            else {
+                return SlashResult::Reply("当前会话未激活".to_owned());
+            };
+            let cs = conv.read().await;
+            let level = cs.reasoning_level();
+            return SlashResult::Reply(format!("当前推理深度：{level}"));
+        }
+
+        // With argument — parse and return SetReasoning.
+        match Self::parse_level(arg) {
+            Some(level) => SlashResult::SetReasoning { level },
+            None => SlashResult::Reply(format!(
+                "无效的推理深度：{arg}。可选值：low, medium, high, max, off"
+            )),
+        }
     }
 }
 

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -3,10 +3,13 @@
 use std::sync::Arc;
 
 use crate::gateway::session_manager::SessionManager;
+use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handler::{SlashHandler, SlashResult};
-use crate::slash::handlers::{ClearHandler, CompactHandler, HelpHandler, WorkdirHandler};
+use crate::slash::handlers::{
+    ClearHandler, CompactHandler, HelpHandler, ReasoningHandler, WorkdirHandler,
+};
 use crate::slash::registry::HandlerRegistry;
 
 // ── Mock handler ────────────────────────────────────────────────────────────
@@ -336,105 +339,149 @@ fn test_workdir_handler_commands_and_description() {
 #[tokio::test]
 async fn test_workdir_handler_cd_valid_path() {
     let sm = make_workdir_session_manager();
-    let session_id = create_test_session(&sm).await;
-    let handler = WorkdirHandler::new(Arc::clone(&sm));
-
+    let sid = create_test_session(&sm).await;
+    let h = WorkdirHandler::new(Arc::clone(&sm));
     let mut ctx = dummy_ctx();
-    ctx.session_id = session_id;
+    ctx.session_id = sid;
     ctx.command = "cd".to_owned();
-
-    // Use a portable temp-dir path instead of hardcoding "/tmp" so the test
-    // passes on every platform (e.g. Windows uses %TEMP%).
-    let target_path = std::env::temp_dir();
-    let result = handler.handle(&target_path.to_string_lossy(), &ctx).await;
-    match result {
-        SlashResult::Reply(text) => {
-            assert!(
-                text.contains("工作目录已变更为"),
-                "expected '工作目录已变更为' in reply, got: {text}"
-            );
-        }
-        _other => panic!("expected Reply, got non-Reply variant"),
+    let target = std::env::temp_dir();
+    match h.handle(&target.to_string_lossy(), &ctx).await {
+        SlashResult::Reply(t) => assert!(t.contains("工作目录已变更为"), "got: {t}"),
+        _other => panic!("expected Reply"),
     }
 }
 
 #[tokio::test]
-async fn test_workdir_handler_cd_invalid_path() {
+async fn test_workdir_handler_cd_invalid_and_no_args() {
     let sm = make_workdir_session_manager();
-    let session_id = create_test_session(&sm).await;
-    let handler = WorkdirHandler::new(Arc::clone(&sm));
-
+    let sid = create_test_session(&sm).await;
+    let h = WorkdirHandler::new(Arc::clone(&sm));
+    // invalid path
     let mut ctx = dummy_ctx();
-    ctx.session_id = session_id;
+    ctx.session_id = sid.clone();
     ctx.command = "cd".to_owned();
-
-    let result = handler.handle("/nonexistent_xyz_path", &ctx).await;
-    match result {
-        SlashResult::Reply(text) => {
-            assert!(
-                text.contains("目录不存在"),
-                "expected '目录不存在' in reply, got: {text}"
-            );
-        }
-        _other => panic!("expected Reply, got non-Reply variant"),
+    match h.handle("/nonexistent_xyz_path", &ctx).await {
+        SlashResult::Reply(t) => assert!(t.contains("目录不存在"), "got: {t}"),
+        _other => panic!("expected Reply"),
+    }
+    // no args
+    let mut ctx2 = dummy_ctx();
+    ctx2.session_id = sid;
+    ctx2.command = "cd".to_owned();
+    match h.handle("", &ctx2).await {
+        SlashResult::Reply(t) => assert!(t.contains("用法"), "got: {t}"),
+        _other => panic!("expected Reply"),
     }
 }
 
 #[tokio::test]
-async fn test_workdir_handler_pwd() {
+async fn test_workdir_handler_pwd_and_git() {
     let sm = make_workdir_session_manager();
-    let session_id = create_test_session(&sm).await;
-    let handler = WorkdirHandler::new(Arc::clone(&sm));
-
+    let sid = create_test_session(&sm).await;
+    // pwd
+    let h = WorkdirHandler::new(Arc::clone(&sm));
     let mut ctx = dummy_ctx();
-    ctx.session_id = session_id;
+    ctx.session_id = sid.clone();
     ctx.command = "pwd".to_owned();
+    match h.handle("", &ctx).await {
+        SlashResult::Reply(t) => assert!(!t.is_empty()),
+        _other => panic!("expected Reply"),
+    }
+    // git placeholder
+    let mut ctx2 = dummy_ctx();
+    ctx2.session_id = sid;
+    ctx2.command = "git".to_owned();
+    match h.handle("status", &ctx2).await {
+        SlashResult::Reply(t) => assert!(t.contains("git 指令即将支持"), "got: {t}"),
+        _other => panic!("expected Reply"),
+    }
+}
 
-    let result = handler.handle("", &ctx).await;
-    match result {
-        SlashResult::Reply(text) => {
-            assert!(!text.is_empty(), "expected non-empty pwd reply");
-        }
-        _other => panic!("expected Reply, got non-Reply variant"),
+// ── ReasoningHandler tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_reasoning_handler_commands_and_description() {
+    let sm = make_workdir_session_manager();
+    let h = ReasoningHandler::new(sm);
+    assert_eq!(h.commands(), &["reasoning"]);
+    assert_eq!(h.description(), "查询或设置推理深度");
+    assert!(h.immediate());
+}
+
+#[tokio::test]
+async fn test_reasoning_handler_no_args_returns_current_level() {
+    let sm = make_workdir_session_manager();
+    let sid = create_test_session(&sm).await;
+    let h = ReasoningHandler::new(Arc::clone(&sm));
+    let mut ctx = dummy_ctx();
+    ctx.session_id = sid;
+    match h.handle("", &ctx).await {
+        SlashResult::Reply(t) => assert!(t.contains("high"), "got: {t}"),
+        _other => panic!("expected Reply"),
     }
 }
 
 #[tokio::test]
-async fn test_workdir_handler_git_placeholder() {
+async fn test_reasoning_handler_valid_levels() {
     let sm = make_workdir_session_manager();
-    let handler = WorkdirHandler::new(Arc::clone(&sm));
-
-    let mut ctx = dummy_ctx();
-    ctx.command = "git".to_owned();
-
-    let result = handler.handle("status", &ctx).await;
-    match result {
-        SlashResult::Reply(text) => {
-            assert!(
-                text.contains("git 指令即将支持"),
-                "expected 'git 指令即将支持' in reply, got: {text}"
-            );
+    let sid = create_test_session(&sm).await;
+    let h = ReasoningHandler::new(Arc::clone(&sm));
+    let cases = &[
+        ("low", ReasoningLevel::Low),
+        ("medium", ReasoningLevel::Medium),
+        ("high", ReasoningLevel::High),
+        ("max", ReasoningLevel::Max),
+        ("off", ReasoningLevel::Low),
+    ];
+    for (arg, expected) in cases {
+        let mut ctx = dummy_ctx();
+        ctx.session_id = sid.clone();
+        match h.handle(arg, &ctx).await {
+            SlashResult::SetReasoning { level } => assert_eq!(level, *expected),
+            _other => panic!("expected SetReasoning"),
         }
-        _other => panic!("expected Reply, got non-Reply variant"),
     }
 }
 
 #[tokio::test]
-async fn test_workdir_handler_cd_no_args() {
+async fn test_reasoning_handler_invalid_level() {
     let sm = make_workdir_session_manager();
-    let handler = WorkdirHandler::new(Arc::clone(&sm));
-
+    let sid = create_test_session(&sm).await;
+    let h = ReasoningHandler::new(Arc::clone(&sm));
     let mut ctx = dummy_ctx();
-    ctx.command = "cd".to_owned();
-
-    let result = handler.handle("", &ctx).await;
-    match result {
-        SlashResult::Reply(text) => {
-            assert!(
-                text.contains("用法"),
-                "expected '用法' in reply, got: {text}"
-            );
-        }
-        _other => panic!("expected Reply, got non-Reply variant"),
+    ctx.session_id = sid;
+    match h.handle("banana", &ctx).await {
+        SlashResult::Reply(t) => assert!(t.contains("无效的推理深度"), "got: {t}"),
+        _other => panic!("expected Reply error"),
     }
+}
+
+#[test]
+fn test_reasoning_level_getter_setter_symmetry() {
+    let mut s = crate::llm::session::ConversationSession::new(
+        "test-sym".to_owned(),
+        "test-model".to_owned(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
+    for &lv in &[
+        ReasoningLevel::Low,
+        ReasoningLevel::Medium,
+        ReasoningLevel::High,
+        ReasoningLevel::Max,
+    ] {
+        s.set_reasoning_level(lv);
+        assert_eq!(s.reasoning_level(), lv);
+    }
+}
+
+#[test]
+fn test_reasoning_level_with_builder() {
+    let s = crate::llm::session::ConversationSession::new(
+        "test-b".to_owned(),
+        "test-model".to_owned(),
+        std::path::PathBuf::from("/tmp"),
+    )
+    .with_reasoning_level(ReasoningLevel::High);
+    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
 }


### PR DESCRIPTION
实现 `/reasoning` 斜杠指令，允许用户在会话运行时动态查询和修改推理深度（ReasoningLevel）。

## 变更内容

- `ConversationSession` 新增 `reasoning_level()` getter 和 `set_reasoning_level()` setter
- `SlashResult` 新增 `SetReasoning { level }` 变体
- 新增 `ReasoningHandler`，支持 `/reasoning` 查询当前等级和设置新等级
- `execute_and_route` 新增 `SetReasoning` 路由分支，调用 session setter 并回复确认
- `session_handler_streaming` 从 session 读取 `reasoning_level()` 替代硬编码 `ReasoningLevel::default()`
- `/reasoning` 无参返回当前等级，`/reasoning off` 映射到 `Low`
- 新增完整单元测试覆盖

## 使用方式

- `/reasoning` — 查询当前推理深度
- `/reasoning low` — 设置为 low
- `/reasoning off` — 关闭推理（映射为 low）

Source: issue #876
Type: feat
