### PR TITLE
feat: 实现 Agent 权限交集计算基础设施

### DIFF
--- a/src/agent/config/config_intersect_tests.rs
+++ b/src/agent/config/config_intersect_tests.rs
@@ -1,0 +1,262 @@
+use super::*;
+
+// =====================================================================
+// Step 1.5 — intersect() + is_fully_denied() tests
+// =====================================================================
+
+fn make_perms(agent_id: &str, allowed_dims: &[&str]) -> AgentPermissions {
+    let dimensions = [
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ];
+    let permissions = dimensions
+        .iter()
+        .map(|&dim| {
+            let allowed = allowed_dims.contains(&dim);
+            (
+                dim.to_string(),
+                ActionPermission {
+                    allowed,
+                    limits: if allowed {
+                        PermissionLimits {
+                            commands: vec![],
+                            paths: vec![],
+                            timeout_ms: None,
+                        }
+                    } else {
+                        PermissionLimits::default()
+                    },
+                },
+            )
+        })
+        .collect();
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions,
+        inherited_from: None,
+    }
+}
+
+#[test]
+fn test_intersect_both_allow() {
+    let child = make_perms("child", &["exec", "file_read"]);
+    let parent = make_perms("parent", &["exec", "file_read"]);
+    let result = child.intersect(&parent);
+    assert!(result.permissions.get("exec").unwrap().allowed);
+    assert!(result.permissions.get("file_read").unwrap().allowed);
+}
+
+#[test]
+fn test_intersect_child_deny() {
+    let child = make_perms("child", &["file_read"]); // exec denied in child
+    let parent = make_perms("parent", &["exec", "file_read"]);
+    let result = child.intersect(&parent);
+    assert!(!result.permissions.get("exec").unwrap().allowed);
+    assert!(result.permissions.get("file_read").unwrap().allowed);
+}
+
+#[test]
+fn test_intersect_parent_deny() {
+    let child = make_perms("child", &["exec", "file_read"]);
+    let parent = make_perms("parent", &["exec"]); // file_read denied in parent
+    let result = child.intersect(&parent);
+    assert!(result.permissions.get("exec").unwrap().allowed);
+    assert!(!result.permissions.get("file_read").unwrap().allowed);
+}
+
+#[test]
+fn test_intersect_absent_is_deny() {
+    // child has empty permissions map (no dimensions at all)
+    let child = AgentPermissions {
+        agent_id: "child".to_string(),
+        permissions: HashMap::new(),
+        inherited_from: None,
+    };
+    let parent = make_perms("parent", &["exec"]); // exec is allowed in parent
+    let result = child.intersect(&parent);
+    // absent in child → deny
+    assert!(!result.permissions.get("exec").unwrap().allowed);
+}
+
+#[test]
+fn test_intersect_result_identity() {
+    let child = make_perms("child", &["exec"]);
+    let parent = make_perms("parent", &["exec"]);
+    let result = child.intersect(&parent);
+    assert_eq!(result.agent_id, "child");
+    assert_eq!(result.inherited_from, Some("parent".to_string()));
+}
+
+#[test]
+fn test_intersect_limits_commands_intersection() {
+    let child = AgentPermissions {
+        agent_id: "child".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    commands: vec!["git".to_string(), "ls".to_string()],
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let parent = AgentPermissions {
+        agent_id: "parent".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    commands: vec!["git".to_string(), "cat".to_string()],
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let result = child.intersect(&parent);
+    let cmds = &result.permissions.get("exec").unwrap().limits.commands;
+    assert_eq!(cmds, &vec!["git".to_string()]);
+}
+
+#[test]
+fn test_intersect_limits_paths_intersection() {
+    let child = AgentPermissions {
+        agent_id: "child".to_string(),
+        permissions: HashMap::from([(
+            "file_read".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    paths: vec!["/data/**".to_string(), "/tmp/**".to_string()],
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let parent = AgentPermissions {
+        agent_id: "parent".to_string(),
+        permissions: HashMap::from([(
+            "file_read".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    paths: vec!["/data/**".to_string(), "/etc/**".to_string()],
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let result = child.intersect(&parent);
+    let paths = &result.permissions.get("file_read").unwrap().limits.paths;
+    assert_eq!(paths, &vec!["/data/**".to_string()]);
+}
+
+#[test]
+fn test_intersect_limits_timeout_min() {
+    let child = AgentPermissions {
+        agent_id: "child".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    timeout_ms: Some(60000),
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let parent = AgentPermissions {
+        agent_id: "parent".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    timeout_ms: Some(30000),
+                    ..Default::default()
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let result = child.intersect(&parent);
+    assert_eq!(
+        result.permissions.get("exec").unwrap().limits.timeout_ms,
+        Some(30000)
+    );
+}
+
+#[test]
+fn test_intersect_limits_none_no_restriction() {
+    let child = AgentPermissions {
+        agent_id: "child".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    timeout_ms: None,
+                    commands: vec![],
+                    paths: vec![],
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let parent = AgentPermissions {
+        agent_id: "parent".to_string(),
+        permissions: HashMap::from([(
+            "exec".to_string(),
+            ActionPermission {
+                allowed: true,
+                limits: PermissionLimits {
+                    timeout_ms: Some(5000),
+                    commands: vec![],
+                    paths: vec![],
+                },
+            },
+        )]),
+        inherited_from: None,
+    };
+    let result = child.intersect(&parent);
+    // None (child) vs Some(5000) (parent) → Some(5000)
+    assert_eq!(
+        result.permissions.get("exec").unwrap().limits.timeout_ms,
+        Some(5000)
+    );
+}
+
+#[test]
+fn test_is_fully_denied_true() {
+    let perms = make_perms("agent", &[]); // no dimensions allowed
+    assert!(perms.is_fully_denied());
+}
+
+#[test]
+fn test_is_fully_denied_false() {
+    let perms = make_perms("agent", &["exec"]); // one dimension allowed
+    assert!(!perms.is_fully_denied());
+}
+
+#[test]
+fn test_is_fully_denied_empty() {
+    let perms = AgentPermissions {
+        agent_id: "agent".to_string(),
+        permissions: HashMap::new(),
+        inherited_from: None,
+    };
+    assert!(perms.is_fully_denied());
+}

--- a/src/agent/config/config_tests.rs
+++ b/src/agent/config/config_tests.rs
@@ -495,3 +495,5 @@ fn test_resolved_config_merge_name_fallback() {
     assert_eq!(resolved.name, "agent-z");
     assert_eq!(resolved.source, ConfigSource::Merged);
 }
+
+// =====================================================================

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -248,7 +248,125 @@ impl AgentPermissions {
             .map(|p| p.allowed)
             .unwrap_or(false)
     }
+
+    /// Compute the intersection of this agent's permissions with a parent's.
+    ///
+    /// Seven dimensions: exec, file_read, file_write, network, spawn,
+    /// tool_call, config_write.
+    ///
+    /// - Both Allow → Allow
+    /// - Either Deny or absent → Deny
+    /// - Result `agent_id` = self.agent_id, `inherited_from` = Some(parent.agent_id)
+    /// - Limits: commands/paths → set intersection; timeout_ms → min;
+    ///   Deny dimensions get default limits.
+    /// - None means no restriction: both None → None, one None → other's Some,
+    ///   both Some → min.
+    pub fn intersect(&self, parent: &AgentPermissions) -> Self {
+        let dimensions = [
+            "exec",
+            "file_read",
+            "file_write",
+            "network",
+            "spawn",
+            "tool_call",
+            "config_write",
+        ];
+
+        let mut permissions = HashMap::with_capacity(dimensions.len());
+
+        for &dim in &dimensions {
+            let self_perm = self.permissions.get(dim);
+            let parent_perm = parent.permissions.get(dim);
+
+            let self_allowed = self_perm.map(|p| p.allowed).unwrap_or(false);
+            let parent_allowed = parent_perm.map(|p| p.allowed).unwrap_or(false);
+
+            if self_allowed && parent_allowed {
+                // Both Allow → Allow; compute limits intersection/min
+                let self_limits = self_perm.map(|p| &p.limits);
+                let parent_limits = parent_perm.map(|p| &p.limits);
+                let limits = PermissionLimits {
+                    commands: intersect_vec(
+                        self_limits.map(|l| &l.commands),
+                        parent_limits.map(|l| &l.commands),
+                    ),
+                    paths: intersect_vec(
+                        self_limits.map(|l| &l.paths),
+                        parent_limits.map(|l| &l.paths),
+                    ),
+                    timeout_ms: intersect_option_min(
+                        self_limits.and_then(|l| l.timeout_ms),
+                        parent_limits.and_then(|l| l.timeout_ms),
+                    ),
+                };
+                permissions.insert(
+                    dim.to_string(),
+                    ActionPermission {
+                        allowed: true,
+                        limits,
+                    },
+                );
+            } else {
+                // Deny (or absent) → Deny with default limits
+                permissions.insert(
+                    dim.to_string(),
+                    ActionPermission {
+                        allowed: false,
+                        limits: PermissionLimits::default(),
+                    },
+                );
+            }
+        }
+
+        Self {
+            agent_id: self.agent_id.clone(),
+            permissions,
+            inherited_from: Some(parent.agent_id.clone()),
+        }
+    }
+
+    /// Returns true if all seven permission dimensions are denied or absent.
+    pub fn is_fully_denied(&self) -> bool {
+        ![
+            "exec",
+            "file_read",
+            "file_write",
+            "network",
+            "spawn",
+            "tool_call",
+            "config_write",
+        ]
+        .iter()
+        .any(|&dim| self.permissions.get(dim).map_or(false, |p| p.allowed))
+    }
+}
+
+/// Set intersection: if both have some, return common elements;
+/// if either is None (no restriction), take the other's value;
+/// if both None → None.
+fn intersect_vec<T: Eq + std::hash::Hash + Clone>(
+    a: Option<&Vec<T>>,
+    b: Option<&Vec<T>>,
+) -> Vec<T> {
+    match (a, b) {
+        (Some(a), Some(b)) => a.iter().filter(|item| b.contains(item)).cloned().collect(),
+        (Some(a), None) | (None, Some(a)) => a.clone(),
+        (None, None) => Vec::new(),
+    }
+}
+
+/// Minimum of two optional values; if either is None (no restriction),
+/// the result is the other's value.
+fn intersect_option_min(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) | (None, Some(a)) => Some(a),
+        (None, None) => None,
+    }
 }
 
 #[cfg(test)]
 mod config_tests;
+
+#[cfg(test)]
+mod config_intersect_tests;

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -80,6 +80,26 @@ impl ConfigManager {
 
         *self.agents.write().expect("RwLock for agents was poisoned") = provider.entries().clone();
 
+        // Sync agent permissions
+        let mut perms_map = self.agent_permissions.write().expect("RwLock poisoned");
+        let provider_perms = provider.permissions();
+        for id in &agents_cfg.agents {
+            if let Some(p) = provider_perms.get(id) {
+                perms_map.insert(id.clone(), p.clone());
+            } else {
+                // Registered agent missing permissions.json → synthesize full-deny baseline
+                perms_map.insert(
+                    id.clone(),
+                    crate::agent::config::AgentPermissions {
+                        agent_id: id.clone(),
+                        permissions: std::collections::HashMap::new(),
+                        inherited_from: None,
+                    },
+                );
+            }
+        }
+        drop(perms_map);
+
         Ok(())
     }
 
@@ -98,5 +118,13 @@ impl ConfigManager {
             .expect("RwLock for agents was poisoned")
             .get(id)
             .cloned()
+    }
+
+    /// Get all agent permissions (clone).
+    pub fn agent_permissions(&self) -> HashMap<String, crate::agent::config::AgentPermissions> {
+        self.agent_permissions
+            .read()
+            .expect("RwLock for agent_permissions was poisoned")
+            .clone()
     }
 }

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -14,6 +14,7 @@ use tracing::{error, warn};
 use uuid::Uuid;
 
 use super::providers::{ConfigProvider, CredentialsProvider};
+use crate::agent::config::AgentPermissions;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -217,6 +218,8 @@ pub struct ConfigManager {
     credentials_provider: RwLock<CredentialsProvider>,
     /// Resolved agent configurations (loaded from two-level directories).
     pub(crate) agents: RwLock<HashMap<String, super::agents::ResolvedAgentConfig>>,
+    /// Per-agent raw permissions (loaded from permissions.json).
+    pub(crate) agent_permissions: RwLock<HashMap<String, AgentPermissions>>,
 }
 
 impl ConfigManager {
@@ -233,6 +236,7 @@ impl ConfigManager {
             sections: RwLock::new(HashMap::new()),
             credentials_provider: RwLock::new(CredentialsProvider::default()),
             agents: RwLock::new(HashMap::new()),
+            agent_permissions: RwLock::new(HashMap::new()),
         })
     }
 

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -399,3 +399,56 @@ fn test_config_manager_update_backup_failure() {
         ConfigWriteError::BackupFailed { .. }
     ));
 }
+
+// =====================================================================
+// Step 1.5 — agent_permissions default baseline tests
+// =====================================================================
+
+/// Test: agent registered but missing permissions.json → full seven-dim Deny default.
+#[test]
+fn test_agent_permissions_missing_file_returns_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+
+    // Create agents.json with one registered agent
+    let agents_json = r#"{ "version": "1.0", "agents": ["test-agent"] }"#;
+    fs::write(tmp.path().join("agents.json"), agents_json).unwrap();
+
+    // Create agent directory with config.json but NO permissions.json
+    let agent_dir = tmp.path().join("agents").join("test-agent");
+    fs::create_dir_all(&agent_dir).unwrap();
+    let agent_config = r#"{ "id": "test-agent", "name": "Test Agent" }"#;
+    fs::write(agent_dir.join("config.json"), agent_config).unwrap();
+    // Deliberately NOT creating permissions.json
+
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    // load_agents() doesn't require load() first
+    manager.load_agents(None).unwrap();
+
+    let perms = manager.agent_permissions();
+    let agent_perms = perms
+        .get("test-agent")
+        .expect("test-agent should be in perms");
+
+    // Should be fully denied: empty permissions map (all seven dimensions absent)
+    assert!(agent_perms.is_fully_denied());
+    assert_eq!(agent_perms.agent_id, "test-agent");
+    assert!(agent_perms.inherited_from.is_none());
+
+    // Verify each of the seven dimensions is denied
+    for dim in &[
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ] {
+        assert!(
+            !agent_perms.is_allowed(dim),
+            "dimension '{}' should be denied",
+            dim
+        );
+    }
+}

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -24,6 +24,9 @@ pub struct PermissionEngine {
     templates: HashMap<String, crate::permission::templates::Template>,
     /// Data root directory for workspace path resolution
     data_root: PathBuf,
+    /// Per-agent effective permissions cache (populated by spawn validation)
+    pub(crate) agent_permissions:
+        std::sync::RwLock<HashMap<String, crate::agent::config::AgentPermissions>>,
 }
 
 // --- Construction & index management ---
@@ -37,6 +40,7 @@ impl PermissionEngine {
             user_agent_rule_index: HashMap::new(),
             templates: HashMap::new(),
             data_root,
+            agent_permissions: std::sync::RwLock::new(HashMap::new()),
         };
         engine.rebuild_indices_with_rules(&rules);
         engine
@@ -124,6 +128,11 @@ impl PermissionEngine {
             request_type = ?request.body(),
             "permission check initiated"
         );
+
+        // Step 0.7: Agent effective permissions pre-check
+        if let Some(response) = self.check_agent_effective_permissions(&agent_id, request.body()) {
+            return response;
+        }
 
         // Step 0: Creator rule (highest priority)
         if let Some(response) = self.check_creator_rule(&caller, &agent_id) {

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -1,0 +1,95 @@
+//! Permission Engine - Agent spawn permission validation and caching.
+
+use super::engine_types::{PermissionRequestBody, PermissionResponse};
+use crate::agent::config::AgentPermissions;
+use thiserror::Error;
+
+/// Error type for spawn permission validation failures.
+#[derive(Debug, Error)]
+pub enum SpawnPermissionError {
+    #[error(
+        "spawn denied: '{child_agent_id}' denied by intersection with parent '{parent_agent_id}'"
+    )]
+    FullyDenied {
+        child_agent_id: String,
+        parent_agent_id: String,
+    },
+}
+
+impl super::engine_eval::PermissionEngine {
+    /// Validate that a child agent's permissions after intersection with parent
+    /// are not fully denied, then inject the result into the cache.
+    ///
+    /// - Computes `child_perms.intersect(parent_perms)`
+    /// - If fully denied → returns `Err(SpawnPermissionError::FullyDenied)`
+    /// - Otherwise → injects into `self.agent_permissions` cache
+    /// - Idempotent: if already cached, returns `Ok(())` immediately
+    pub fn validate_and_inject_spawn(
+        &self,
+        child_agent_id: &str,
+        child_perms: &AgentPermissions,
+        parent_perms: &AgentPermissions,
+    ) -> Result<(), SpawnPermissionError> {
+        let mut cache = self
+            .agent_permissions
+            .write()
+            .expect("agent_permissions lock poisoned");
+
+        // Idempotent: already cached
+        if cache.contains_key(child_agent_id) {
+            return Ok(());
+        }
+
+        let effective = child_perms.intersect(parent_perms);
+
+        if effective.is_fully_denied() {
+            return Err(SpawnPermissionError::FullyDenied {
+                child_agent_id: child_agent_id.to_string(),
+                parent_agent_id: parent_perms.agent_id.clone(),
+            });
+        }
+
+        cache.insert(child_agent_id.to_string(), effective);
+        Ok(())
+    }
+
+    /// Check the agent effective permissions cache for a given request body.
+    ///
+    /// Returns:
+    /// - `None` if dimension is unknown (e.g., SlashCommand) or cache miss
+    /// - `Some(Denied)` if the dimension is denied
+    /// - `None` if the dimension is allowed (continue with normal evaluate)
+    pub fn check_agent_effective_permissions(
+        &self,
+        agent_id: &str,
+        body: &PermissionRequestBody,
+    ) -> Option<PermissionResponse> {
+        let dim = body.dimension_name()?;
+
+        let cache = self
+            .agent_permissions
+            .read()
+            .expect("agent_permissions lock poisoned");
+
+        match cache.get(agent_id) {
+            None => None, // cache miss → continue with normal evaluate
+            Some(perms) => {
+                let allowed = perms
+                    .permissions
+                    .get(dim)
+                    .map(|p| p.allowed)
+                    .unwrap_or(false);
+
+                if allowed {
+                    None // allowed → continue with normal evaluate
+                } else {
+                    Some(PermissionResponse::Denied {
+                        reason: format!("agent effective permission denied for dimension '{dim}'"),
+                        rule: "<agent_effective_permissions>".to_string(),
+                        risk_level: super::engine_risk::assess_risk_level(body),
+                    })
+                }
+            }
+        }
+    }
+}

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -1,0 +1,271 @@
+use super::engine_eval::PermissionEngine;
+use super::engine_spawn::SpawnPermissionError;
+use super::engine_types::{Effect, PermissionRequest, PermissionRequestBody, PermissionResponse};
+use crate::agent::config::AgentPermissions;
+use crate::permission::rules::RuleSetBuilder;
+use std::collections::HashMap;
+
+fn make_engine() -> PermissionEngine {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Deny)
+        .default_command(Effect::Deny)
+        .default_network(Effect::Deny)
+        .default_inter_agent(Effect::Deny)
+        .default_config(Effect::Deny)
+        .build()
+        .unwrap();
+    PermissionEngine::new_with_default_data_root(ruleset)
+}
+
+fn make_allowed_perms(agent_id: &str) -> AgentPermissions {
+    let dims = [
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ];
+    let permissions = dims
+        .iter()
+        .map(|&dim| {
+            (
+                dim.to_string(),
+                crate::agent::config::ActionPermission {
+                    allowed: true,
+                    limits: crate::agent::config::PermissionLimits::default(),
+                },
+            )
+        })
+        .collect();
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions,
+        inherited_from: None,
+    }
+}
+
+fn make_fully_denied_perms(agent_id: &str) -> AgentPermissions {
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions: HashMap::new(),
+        inherited_from: None,
+    }
+}
+
+// -------------------------------------------------------------------------
+// validate_and_inject_spawn tests
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_validate_and_inject_spawn_success() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+
+    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    assert!(result.is_ok());
+
+    // Verify cache was populated
+    let cache = engine.agent_permissions.read().unwrap();
+    assert!(cache.contains_key("child"));
+}
+
+#[test]
+fn test_validate_and_inject_spawn_fully_denied() {
+    let engine = make_engine();
+    let child = make_fully_denied_perms("child");
+    let parent = make_allowed_perms("parent");
+
+    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDenied {
+            child_agent_id,
+            parent_agent_id,
+        } => {
+            assert_eq!(child_agent_id, "child");
+            assert_eq!(parent_agent_id, "parent");
+        }
+    }
+
+    // Verify cache was NOT populated
+    let cache = engine.agent_permissions.read().unwrap();
+    assert!(!cache.contains_key("child"));
+}
+
+#[test]
+fn test_validate_and_inject_spawn_idempotent() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+
+    // First call succeeds
+    engine
+        .validate_and_inject_spawn("child", &child, &parent)
+        .unwrap();
+    // Second call succeeds (idempotent)
+    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    assert!(result.is_ok());
+}
+
+// -------------------------------------------------------------------------
+// check_agent_effective_permissions tests
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_check_agent_effective_permissions_cache_miss() {
+    let engine = make_engine();
+    let body = PermissionRequestBody::CommandExec {
+        agent: "unknown-agent".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    };
+
+    let result = engine.check_agent_effective_permissions("unknown-agent", &body);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_check_agent_effective_permissions_deny() {
+    let engine = make_engine();
+    // Inject a fully denied agent into cache
+    // Force inject by directly manipulating cache
+    {
+        let mut cache = engine.agent_permissions.write().unwrap();
+        cache.insert(
+            "denied-agent".to_string(),
+            AgentPermissions {
+                agent_id: "denied-agent".to_string(),
+                permissions: HashMap::from([(
+                    "exec".to_string(),
+                    crate::agent::config::ActionPermission {
+                        allowed: false,
+                        limits: crate::agent::config::PermissionLimits::default(),
+                    },
+                )]),
+                inherited_from: Some("parent".to_string()),
+            },
+        );
+    }
+
+    let body = PermissionRequestBody::CommandExec {
+        agent: "denied-agent".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    };
+    let result = engine.check_agent_effective_permissions("denied-agent", &body);
+    assert!(result.is_some());
+    match result.unwrap() {
+        PermissionResponse::Denied { reason, .. } => {
+            assert!(reason.contains("agent effective permission denied"));
+        }
+        other => panic!("expected Denied, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_check_agent_effective_permissions_allow() {
+    let engine = make_engine();
+    // Inject an allowed agent into cache
+    {
+        let mut cache = engine.agent_permissions.write().unwrap();
+        cache.insert(
+            "allowed-agent".to_string(),
+            AgentPermissions {
+                agent_id: "allowed-agent".to_string(),
+                permissions: HashMap::from([(
+                    "exec".to_string(),
+                    crate::agent::config::ActionPermission {
+                        allowed: true,
+                        limits: crate::agent::config::PermissionLimits::default(),
+                    },
+                )]),
+                inherited_from: None,
+            },
+        );
+    }
+
+    let body = PermissionRequestBody::CommandExec {
+        agent: "allowed-agent".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    };
+    let result = engine.check_agent_effective_permissions("allowed-agent", &body);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_check_agent_effective_permissions_slash_command() {
+    let engine = make_engine();
+    // Even with agent in cache, SlashCommand → None (dimension_name returns None)
+    {
+        let mut cache = engine.agent_permissions.write().unwrap();
+        cache.insert(
+            "cached-agent".to_string(),
+            AgentPermissions {
+                agent_id: "cached-agent".to_string(),
+                permissions: HashMap::from([(
+                    "exec".to_string(),
+                    crate::agent::config::ActionPermission {
+                        allowed: false,
+                        limits: crate::agent::config::PermissionLimits::default(),
+                    },
+                )]),
+                inherited_from: None,
+            },
+        );
+    }
+
+    let body = PermissionRequestBody::SlashCommand {
+        agent: "cached-agent".to_string(),
+        command: "/status".to_string(),
+    };
+    let result = engine.check_agent_effective_permissions("cached-agent", &body);
+    assert!(result.is_none());
+}
+
+// -------------------------------------------------------------------------
+// Concurrent test (E)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_concurrent_spawn_and_evaluate() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let engine = Arc::new(make_engine());
+    let parent = Arc::new(make_allowed_perms("parent"));
+
+    let mut handles = vec![];
+
+    // Spawn multiple threads doing validate_and_inject_spawn
+    for i in 0..10 {
+        let engine = Arc::clone(&engine);
+        let parent = Arc::clone(&parent);
+        handles.push(thread::spawn(move || {
+            let child = make_allowed_perms(&format!("child-{}", i));
+            let result = engine.validate_and_inject_spawn(&format!("child-{}", i), &child, &parent);
+            assert!(result.is_ok());
+        }));
+    }
+
+    // Spawn multiple threads doing evaluate
+    for i in 0..10 {
+        let engine = Arc::clone(&engine);
+        handles.push(thread::spawn(move || {
+            let body = PermissionRequestBody::CommandExec {
+                agent: format!("eval-agent-{}", i),
+                cmd: "ls".to_string(),
+                args: vec![],
+            };
+            let req = PermissionRequest::Bare(body);
+            let _resp = engine.evaluate(req, None);
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}

--- a/src/permission/engine/engine_types.rs
+++ b/src/permission/engine/engine_types.rs
@@ -1,7 +1,6 @@
 //! Permission Engine - Core data structures
 //!
 //! Types, data structures, and Subject/Rule validation logic.
-
 use super::engine_matching::glob_match;
 use super::engine_risk::RiskLevel;
 use serde::{Deserialize, Serialize};
@@ -39,11 +38,9 @@ pub struct Defaults {
     #[serde(default = "default_deny")]
     pub tool_call: Effect,
 }
-
 fn default_deny() -> Effect {
     Effect::Deny
 }
-
 /// A single permission rule
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Rule {
@@ -135,7 +132,8 @@ pub struct TemplateRef {
 ///
 /// Supports two matching modes:
 /// - `AgentOnly` (match_mode = "agent_only" or absent): legacy mode, matches only by `agent` field
-/// - `UserAndAgent` (match_mode = "user_and_agent"): dual-key match, both `user_id` AND `agent` must match
+/// - `UserAndAgent` (match_mode = "user_and_agent"): dual-key match,
+///   both `user_id` AND `agent` must match
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "match_mode", rename_all = "snake_case", content = "fields")]
 pub enum Subject {
@@ -392,6 +390,25 @@ pub enum PermissionRequestBody {
 }
 
 impl PermissionRequestBody {
+    /// Returns the permission dimension name for this request,
+    /// or `None` if the request type does not map to a dimension
+    /// (e.g. `SlashCommand`) or the op field is unrecognized.
+    pub fn dimension_name(&self) -> Option<&str> {
+        match self {
+            PermissionRequestBody::FileOp { op, .. } => match op.as_str() {
+                "read" => Some("file_read"),
+                "write" => Some("file_write"),
+                _ => None,
+            },
+            PermissionRequestBody::CommandExec { .. } => Some("exec"),
+            PermissionRequestBody::NetOp { .. } => Some("network"),
+            PermissionRequestBody::InterAgentMsg { .. } => Some("spawn"),
+            PermissionRequestBody::ToolCall { .. } => Some("tool_call"),
+            PermissionRequestBody::ConfigWrite { .. } => Some("config_write"),
+            PermissionRequestBody::SlashCommand { .. } => None,
+        }
+    }
+
     /// Extract agent ID from the request body.
     pub fn agent_id(&self) -> &str {
         match self {

--- a/src/permission/engine/engine_types_tests.rs
+++ b/src/permission/engine/engine_types_tests.rs
@@ -1,0 +1,88 @@
+use super::PermissionRequestBody;
+
+#[test]
+fn test_dimension_name_file_op_read() {
+    let body = PermissionRequestBody::FileOp {
+        agent: "a".to_string(),
+        path: "/tmp/test".to_string(),
+        op: "read".to_string(),
+    };
+    assert_eq!(body.dimension_name(), Some("file_read"));
+}
+
+#[test]
+fn test_dimension_name_file_op_write() {
+    let body = PermissionRequestBody::FileOp {
+        agent: "a".to_string(),
+        path: "/tmp/test".to_string(),
+        op: "write".to_string(),
+    };
+    assert_eq!(body.dimension_name(), Some("file_write"));
+}
+
+#[test]
+fn test_dimension_name_file_op_unknown() {
+    let body = PermissionRequestBody::FileOp {
+        agent: "a".to_string(),
+        path: "/tmp/test".to_string(),
+        op: "delete".to_string(),
+    };
+    assert_eq!(body.dimension_name(), None);
+}
+
+#[test]
+fn test_dimension_name_command_exec() {
+    let body = PermissionRequestBody::CommandExec {
+        agent: "a".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    };
+    assert_eq!(body.dimension_name(), Some("exec"));
+}
+
+#[test]
+fn test_dimension_name_net_op() {
+    let body = PermissionRequestBody::NetOp {
+        agent: "a".to_string(),
+        host: "example.com".to_string(),
+        port: 443,
+    };
+    assert_eq!(body.dimension_name(), Some("network"));
+}
+
+#[test]
+fn test_dimension_name_inter_agent_msg() {
+    let body = PermissionRequestBody::InterAgentMsg {
+        from: "a".to_string(),
+        to: "b".to_string(),
+    };
+    assert_eq!(body.dimension_name(), Some("spawn"));
+}
+
+#[test]
+fn test_dimension_name_tool_call() {
+    let body = PermissionRequestBody::ToolCall {
+        agent: "a".to_string(),
+        skill: "web_search".to_string(),
+        method: "run".to_string(),
+    };
+    assert_eq!(body.dimension_name(), Some("tool_call"));
+}
+
+#[test]
+fn test_dimension_name_config_write() {
+    let body = PermissionRequestBody::ConfigWrite {
+        agent: "a".to_string(),
+        config_file: "models.json".to_string(),
+    };
+    assert_eq!(body.dimension_name(), Some("config_write"));
+}
+
+#[test]
+fn test_dimension_name_slash_command() {
+    let body = PermissionRequestBody::SlashCommand {
+        agent: "a".to_string(),
+        command: "/status".to_string(),
+    };
+    assert_eq!(body.dimension_name(), None);
+}

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -7,6 +7,7 @@ pub mod engine_eval;
 pub mod engine_helpers;
 pub mod engine_matching;
 pub mod engine_risk;
+pub mod engine_spawn;
 pub mod engine_types;
 pub mod engine_workspace;
 
@@ -29,3 +30,9 @@ mod engine_owner_tests;
 
 #[cfg(test)]
 mod engine_two_phase_tests;
+
+#[cfg(test)]
+mod engine_types_tests;
+
+#[cfg(test)]
+mod engine_spawn_tests;


### PR DESCRIPTION
实现 Agent 权限交集计算基础设施，包含三部分：
1. `AgentPermissions` 新增 `intersect()` 交集计算 + `is_fully_denied()` 判断
2. `PermissionEngine` 新增 per-agent 有效权限缓存 + `validate_and_inject_spawn()` + `evaluate()` 内部预筛
3. `ConfigManager` 新增内存字段存储 per-agent 原始权限

Source: issue #872
Type: feat
