### PR TITLE
fix: unregister child handle on child completion to prevent memory leak

### DIFF
--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -150,6 +150,16 @@ impl SessionManager {
                 "try_push_announce: push_announce failed"
             );
         }
+
+        // Unregister child handle from parent's ConversationSession.
+        // This cleans up the Weak reference so the parent's child_handles
+        // map does not accumulate stale entries for completed children.
+        if let Some(parent_cs) = self.get_conversation_session(&parent_session_id).await {
+            parent_cs
+                .read()
+                .await
+                .unregister_child_handle(child_session_id);
+        }
     }
 
     /// Find the (parent_session_id, child_agent_id) of a child whose

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -315,6 +315,14 @@ impl SessionManager {
             conv_sessions.remove(child_id);
         }
 
+        // Unregister child handle from parent's ConversationSession.
+        {
+            let conv_sessions = self.conversation_sessions.read().await;
+            if let Some(parent_cs) = conv_sessions.get(parent_id) {
+                parent_cs.read().await.unregister_child_handle(child_id);
+            }
+        }
+
         // Remove from sessions.
         {
             let mut sessions = self.sessions.write().await;


### PR DESCRIPTION
补全 `SessionManager` 中两条生产路径缺失的 `unregister_child_handle` 调用，防止父 session 的 `child_handles` map 积累陈旧 `Weak` 引用导致内存泄漏。

## 变更内容

1. **`kill_child`（spawn.rs）**：从 `conv_sessions` 移除子项后，调用 `unregister_child_handle(child_id)`
2. **`try_push_announce`（announce.rs）**：`push_announce` 成功后，调用 `unregister_child_handle(child_session_id)`

不新增接口，不修改 design doc，纯增量补漏。

## 测试

`cargo test -p closeclaw` 全部通过（1825 passed / 4 pre-existing failures）。

Source: issue #878
Type: fix
