### PR TITLE
fix: 修复 test_busy_message_returns_queued 在新执行状态模型下的 busy 设置遗漏

### DIFF
--- a/src/gateway/session_handler_tests.rs
+++ b/src/gateway/session_handler_tests.rs
@@ -3,6 +3,7 @@ use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
 use crate::llm::protocol::{ChatProtocol, IncomingSseStream, OutgoingEventStream};
 use crate::llm::provider::{Provider, ProviderError};
+use crate::llm::session_state::LlmState;
 use crate::llm::types::ProtocolId;
 use crate::llm::types::{
     InternalRequest, InternalResponse, RawContentBlock, RawUsage, SseStateMachine,
@@ -196,6 +197,7 @@ async fn test_busy_message_returns_queued() {
     // Manually set busy
     if let Some(cs) = sm.get_conversation_session(&sid).await {
         cs.write().await.set_llm_busy(true);
+        cs.write().await.set_llm_state(LlmState::Requesting);
     }
 
     let handler = handler_with_sm(Arc::clone(&sm));


### PR DESCRIPTION
修复 test_busy_message_returns_queued 测试在三维执行状态模型下的 busy 设置遗漏。#857 将 is_llm_busy() 改为委托 exec_status()，但测试仅调用 set_llm_busy(true) 而未设置 llm_state，导致断言失败。

Source: issue #877
Type: fix
