### PR TITLE
fix: SQLite 存储层持久化 system_appends 字段

### DIFF
--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -5,6 +5,9 @@
 
 mod archive_support;
 
+#[cfg(test)]
+mod tests;
+
 use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -274,10 +277,13 @@ impl PersistenceService for SqliteStorage {
                 .map_err(PersistenceError::Serialization)?;
             let pending_json = serde_json::to_string(&checkpoint.pending_messages)
                 .map_err(PersistenceError::Serialization)?;
+            let system_appends_json = serde_json::to_string(&checkpoint.system_appends)
+                .map_err(PersistenceError::Serialization)?;
             let metadata_json = json!({
                 "mode": mode_to_db(&checkpoint.mode),
                 "mode_state": mode_state_json,
                 "pending_messages": pending_json,
+                "system_appends": system_appends_json,
             })
             .to_string();
 

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -212,6 +212,7 @@ pub fn load_checkpoint_inner(
     #[allow(unused_mut)]
     let mut mode_state_val: crate::session::persistence::ReasoningModeState;
     let mode_val: String;
+    let mut system_appends: Vec<String> = Vec::new();
     if let Some(ref meta) = metadata {
         let v: serde_json::Value =
             serde_json::from_str(meta).map_err(PersistenceError::Serialization)?;
@@ -223,6 +224,10 @@ pub fn load_checkpoint_inner(
             .get("mode")
             .and_then(|x| x.as_str().map(|s| s.to_string()))
             .unwrap_or_else(|| "direct".to_string());
+        system_appends = v
+            .get("system_appends")
+            .and_then(|x| serde_json::from_str(x.as_str().unwrap_or("[]")).ok())
+            .unwrap_or_default();
     } else {
         mode_state_val = crate::session::persistence::ReasoningModeState::default();
         mode_val = "direct".to_string();
@@ -272,7 +277,7 @@ pub fn load_checkpoint_inner(
             _ => None,
         },
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
-        system_appends: Vec::new(),
+        system_appends,
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+use crate::session::persistence::{
+    PersistenceService, ReasoningLevel, ReasoningMode, ReasoningModeState, SessionStatus,
+};
+use chrono::Utc;
+
+fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
+    SessionCheckpoint {
+        session_id: session_id.to_string(),
+        last_message_id: Some("msg123".to_string()),
+        mode_state: ReasoningModeState {
+            current_step: 1,
+            total_steps: 3,
+            step_messages: vec!["Step 1".to_string()],
+            is_complete: false,
+        },
+        pending_messages: Vec::new(),
+        mode: ReasoningMode::Plan,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        ttl_seconds: 604800,
+        status: SessionStatus::Active,
+        last_message_at: None,
+        message_count: 0,
+        channel: None,
+        chat_id: None,
+        agent_id: None,
+        role: None,
+        reasoning_level: ReasoningLevel::default(),
+        system_appends: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn test_save_load_system_appends_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    let mut checkpoint = create_test_checkpoint("roundtrip-sa");
+    checkpoint.system_appends = vec!["append-A".to_string(), "append-B".to_string()];
+
+    // Save
+    storage.save_checkpoint(&checkpoint).await.unwrap();
+
+    // Load
+    let loaded = storage.load_checkpoint("roundtrip-sa").await.unwrap();
+    assert!(loaded.is_some(), "loaded checkpoint should exist");
+    let loaded = loaded.unwrap();
+    assert_eq!(loaded.system_appends, checkpoint.system_appends);
+}
+
+#[tokio::test]
+async fn test_load_system_appends_backward_compat() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    // 1. Save a checkpoint so the transcript file is created
+    let mut checkpoint = create_test_checkpoint("compat-sa");
+    checkpoint.system_appends = vec!["should-be-cleared".to_string()];
+    storage.save_checkpoint(&checkpoint).await.unwrap();
+
+    // 2. Manually rewrite metadata to remove system_appends key
+    //    (simulates an old DB written before the feature existed)
+    {
+        let db_path = tmp.path().join("sessions.sqlite");
+        let conn = Connection::open(&db_path).unwrap();
+        let metadata_without_appends = json!({
+            "mode": mode_to_db(&checkpoint.mode),
+            "mode_state":
+                serde_json::to_string(&checkpoint.mode_state).unwrap(),
+            "pending_messages":
+                serde_json::to_string(&checkpoint.pending_messages).unwrap(),
+            // intentionally omit "system_appends"
+        })
+        .to_string();
+        conn.execute(
+            "UPDATE sessions SET metadata = ?1 WHERE id = ?2",
+            params![metadata_without_appends, "compat-sa"],
+        )
+        .unwrap();
+    }
+
+    // 3. Load — system_appends should default to empty Vec
+    let loaded = storage.load_checkpoint("compat-sa").await.unwrap();
+    assert!(loaded.is_some(), "loaded checkpoint should exist");
+    let loaded = loaded.unwrap();
+    assert!(
+        loaded.system_appends.is_empty(),
+        "missing system_appends key in metadata should yield empty Vec"
+    );
+}


### PR DESCRIPTION
## 概述

SQLite 存储层未持久化 `system_appends` 字段，导致 daemon 重启后追加区内容丢失。

## 问题

PR #868 将追加区从全局静态迁移到 `ConversationSession` 持久化字段，但 SQLite 后端：
- `save_checkpoint` 构造 metadata JSON 时未包含 `system_appends` 键
- `load_checkpoint_inner` 硬编码 `system_appends: Vec::new()`

## 修复

将 `system_appends` 嵌入现有 `metadata` JSON 字段（与 `mode_state`/`pending_messages` 模式一致）：
- `save_checkpoint`：序列化 `system_appends` 写入 metadata JSON
- `load_checkpoint_inner`：从 metadata JSON 解析 `system_appends`，旧 DB 无该键时反序列化为空 Vec

无需数据库迁移。

## 测试

- `test_save_load_system_appends_roundtrip`：往返一致性验证
- `test_load_system_appends_backward_compat`：旧 DB 向后兼容验证

Source: issue #880
Type: fix
