### PR TITLE
feat: thread_id 端到端支持 — 入站提取 + 出站话题定向回复

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -335,12 +335,17 @@ impl Gateway {
             return Err(GatewayError::MessageTooLarge);
         }
 
+        // Resolve thread_id from the session checkpoint.
+        let thread_id = self.session_manager.get_thread_id(session_id).await;
+
         // Build a text RenderedOutput and forward to the plugin.
         let output = RenderedOutput {
             msg_type: "text".into(),
             payload: json!({"content": {"text": message.content}}),
         };
-        plugin.send(&output, &message.to, None).await?;
+        plugin
+            .send(&output, &message.to, thread_id.as_deref())
+            .await?;
 
         Ok(())
     }
@@ -386,3 +391,5 @@ mod session_handler_tests;
 mod tests;
 #[cfg(test)]
 mod tests_dmscope;
+#[cfg(test)]
+mod tests_thread;

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -67,6 +67,8 @@ struct DispatchCtx<'a> {
     session_id: &'a str,
     channel: &'a str,
     chat_id: String,
+    /// Optional thread/topic ID for directing the message into a thread.
+    thread_id: Option<String>,
 }
 
 impl Gateway {
@@ -89,8 +91,8 @@ impl Gateway {
     /// 7. Dispatch by `msg_type` (`"text"` / `"interactive"`) through
     ///    `plugin.send`. Any other type is an [`GatewayError::OutboundError`].
     /// 8. After each successful send, trigger checkpoint persistence.
-    /// 9. `thread_id` is not yet wired through — `None` is passed to
-    ///    `plugin.send`.
+    /// 9. `thread_id` is resolved via `session_manager.get_thread_id` and
+    ///    passed to `plugin.send`.
     pub async fn send_outbound(
         &self,
         session_id: &str,
@@ -135,7 +137,10 @@ impl Gateway {
             plugin.render(blocks, dsl_result.as_ref())
         };
 
-        // 5. Dispatch by msg_type and persist checkpoint on success.
+        // 5. Resolve thread_id from session checkpoint.
+        let thread_id = self.session_manager.get_thread_id(session_id).await;
+
+        // 6. Dispatch by msg_type and persist checkpoint on success.
         self.dispatch_and_persist(DispatchCtx {
             plugin: &plugin,
             rendered: &rendered,
@@ -143,6 +148,7 @@ impl Gateway {
             session_id,
             channel,
             chat_id,
+            thread_id,
         })
         .await
     }
@@ -166,14 +172,18 @@ impl Gateway {
                     .unwrap_or(ctx.fallback_text)
                     .to_string();
                 let msg = Self::make_outbound_msg(ctx.channel, ctx.chat_id.clone(), text);
-                ctx.plugin.send(ctx.rendered, &ctx.chat_id, None).await?;
+                ctx.plugin
+                    .send(ctx.rendered, &ctx.chat_id, ctx.thread_id.as_deref())
+                    .await?;
                 self.persist_outbound_checkpoint(ctx.session_id, &msg).await;
                 Ok(())
             }
             "interactive" => {
                 let payload_str = serde_json::to_string(&ctx.rendered.payload)
                     .unwrap_or_else(|_| "{}".to_string());
-                ctx.plugin.send(ctx.rendered, &ctx.chat_id, None).await?;
+                ctx.plugin
+                    .send(ctx.rendered, &ctx.chat_id, ctx.thread_id.as_deref())
+                    .await?;
                 let msg = Self::make_outbound_msg(ctx.channel, ctx.chat_id, payload_str);
                 self.persist_outbound_checkpoint(ctx.session_id, &msg).await;
                 Ok(())
@@ -268,8 +278,8 @@ impl Gateway {
     ///   `plugin.render` + `plugin.send`
     ///
     /// Accumulated `content_blocks` and the LLM-reported `usage` are returned
-    /// in a [`StreamResult`]. `thread_id` is always `None` (consistent with
-    /// [`send_outbound`](Self::send_outbound)).
+    /// in a [`StreamResult`]. `thread_id` is resolved from the session
+    /// checkpoint and forwarded to all `plugin.send` calls.
     pub async fn send_outbound_streaming<E: std::fmt::Display>(
         &self,
         session_id: &str,
@@ -283,10 +293,13 @@ impl Gateway {
             .await
             .ok_or(GatewayError::MissingSessionId)?;
 
+        // Resolve thread_id from session checkpoint for outbound thread routing.
+        let thread_id = self.session_manager.get_thread_id(session_id).await;
+
         let mut state = StreamState::new();
         while let Some(event_result) = stream.next().await {
             let event = event_result.map_err(|e| GatewayError::OutboundError(e.to_string()))?;
-            self.process_stream_event(plugin, &chat_id, event, &mut state)
+            self.process_stream_event(plugin, &chat_id, thread_id.as_deref(), event, &mut state)
                 .await?;
         }
         tracing::debug!(session_id, channel, "streaming outbound complete");
@@ -301,6 +314,7 @@ impl Gateway {
         &self,
         plugin: &std::sync::Arc<dyn IMPlugin>,
         chat_id: &str,
+        thread_id: Option<&str>,
         event: StreamEvent,
         state: &mut StreamState,
     ) -> Result<(), GatewayError> {
@@ -314,7 +328,7 @@ impl Gateway {
                 // For Text deltas, the renderer may emit completed text lines
                 // and dsl lines; non-Text deltas only update internal state.
                 if is_text_delta {
-                    dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+                    dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
                 }
             }
             StreamEvent::BlockEnd { block_type, .. } => {
@@ -322,21 +336,21 @@ impl Gateway {
                 if block_type != ContentBlockType::Text {
                     let render_blocks = std::mem::take(&mut out.render_blocks);
                     for block in render_blocks {
-                        send_render_block(plugin, chat_id, &block).await?;
+                        send_render_block(plugin, chat_id, thread_id, &block).await?;
                         state.content_blocks.push(block);
                     }
                 }
-                dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+                dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
             }
             StreamEvent::MessageEnd { usage, .. } => {
                 let mut out = state.renderer.flush();
                 let render_blocks = std::mem::take(&mut out.render_blocks);
-                dispatch_text_and_dsl(plugin, chat_id, out, state).await?;
+                dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
                 for block in render_blocks {
-                    send_render_block(plugin, chat_id, &block).await?;
+                    send_render_block(plugin, chat_id, thread_id, &block).await?;
                     state.content_blocks.push(block);
                 }
-                send_dsl_lines(plugin, chat_id, &state.dsl_lines).await?;
+                send_dsl_lines(plugin, chat_id, thread_id, &state.dsl_lines).await?;
                 if let Some(u) = usage {
                     state.usage = u;
                 }
@@ -393,11 +407,12 @@ impl StreamState {
 async fn dispatch_text_and_dsl(
     plugin: &std::sync::Arc<dyn IMPlugin>,
     chat_id: &str,
+    thread_id: Option<&str>,
     out: StreamingOutput,
     state: &mut StreamState,
 ) -> Result<(), GatewayError> {
     for text in out.text_messages {
-        send_text(plugin, chat_id, &text).await?;
+        send_text(plugin, chat_id, thread_id, &text).await?;
         state.content_blocks.push(ContentBlock::Text(text));
     }
     state.dsl_lines.extend(out.dsl_lines);
@@ -408,13 +423,14 @@ async fn dispatch_text_and_dsl(
 async fn send_text(
     plugin: &std::sync::Arc<dyn IMPlugin>,
     chat_id: &str,
+    thread_id: Option<&str>,
     text: &str,
 ) -> Result<(), GatewayError> {
     let rendered = RenderedOutput {
         msg_type: "text".to_string(),
         payload: serde_json::json!({ "content": { "text": text } }),
     };
-    plugin.send(&rendered, chat_id, None).await?;
+    plugin.send(&rendered, chat_id, thread_id).await?;
     Ok(())
 }
 
@@ -422,10 +438,11 @@ async fn send_text(
 async fn send_render_block(
     plugin: &std::sync::Arc<dyn IMPlugin>,
     chat_id: &str,
+    thread_id: Option<&str>,
     block: &ContentBlock,
 ) -> Result<(), GatewayError> {
     let rendered = plugin.render(std::slice::from_ref(block), None);
-    plugin.send(&rendered, chat_id, None).await?;
+    plugin.send(&rendered, chat_id, thread_id).await?;
     Ok(())
 }
 
@@ -433,6 +450,7 @@ async fn send_render_block(
 async fn send_dsl_lines(
     plugin: &std::sync::Arc<dyn IMPlugin>,
     chat_id: &str,
+    thread_id: Option<&str>,
     dsl_lines: &[String],
 ) -> Result<(), GatewayError> {
     if dsl_lines.is_empty() {
@@ -442,6 +460,6 @@ async fn send_dsl_lines(
     let dsl_result = DslParser.parse(&dsl_text);
     let blocks = vec![ContentBlock::Text(dsl_result.clean_content.clone())];
     let rendered = plugin.render(&blocks, Some(&dsl_result));
-    plugin.send(&rendered, chat_id, None).await?;
+    plugin.send(&rendered, chat_id, thread_id).await?;
     Ok(())
 }

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -164,7 +164,7 @@ impl SessionManager {
                 timestamp: chrono::Utc::now().timestamp(),
                 metadata: std::collections::HashMap::new(),
             };
-            if let Err(e) = adapter.send_message(&notification).await {
+            if let Err(e) = adapter.send_message(&notification, None).await {
                 warn!(session_id = %session_id, error = %e,
                     "failed to send restore notification");
             }
@@ -448,6 +448,19 @@ impl SessionManager {
         let mut cs = cs.write().await;
         cs.pop_pending()
     }
+
+    /// Get the thread_id for a session from its checkpoint.
+    /// Returns None if the session has no thread_id or the storage is not available.
+    pub async fn get_thread_id(&self, session_id: &str) -> Option<String> {
+        let storage = self.storage.read().await;
+        let Some(storage) = storage.as_ref() else {
+            return None;
+        };
+        match storage.load_checkpoint(session_id).await {
+            Ok(Some(cp)) => cp.thread_id,
+            _ => None,
+        }
+    }
 }
 
 // Unit tests
@@ -463,3 +476,5 @@ mod spawn_tests;
 mod test_helpers;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_get_thread_id;

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -190,3 +190,67 @@ pub(super) async fn spawn_n_run_children(
     }
     child_ids
 }
+
+// ── Mock persistence service ──────────────────────────────────────────────
+
+use crate::session::persistence::{
+    AgentRole, PersistenceError, PersistenceService, SessionCheckpoint,
+};
+pub struct MockPersistService {
+    pub archived_checkpoint: tokio::sync::Mutex<Option<SessionCheckpoint>>,
+    pub restore_called: tokio::sync::Mutex<bool>,
+}
+
+#[async_trait::async_trait]
+impl PersistenceService for MockPersistService {
+    async fn save_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn load_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Ok(self.archived_checkpoint.lock().await.take())
+    }
+    async fn delete_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn restore_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        *self.restore_called.lock().await = true;
+        Ok(self.archived_checkpoint.lock().await.take())
+    }
+    async fn archive_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn purge_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn invalidate_session(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_idle_sessions_for_agent(
+        &self,
+        _: &str,
+        _: AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn list_expired_archived_sessions_for_agent(
+        &self,
+        _: &str,
+        _: AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+}

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::gateway::{GatewayConfig, Message};
 use crate::session::bootstrap::BootstrapMode;
-use crate::session::persistence::{AgentRole, PersistenceError, SessionCheckpoint};
+use crate::session::persistence::SessionCheckpoint;
 use crate::system_prompt::{
     invalidate_all_sections, set_agent_prompt, set_custom_prompt, set_override_prompt,
 };
@@ -19,7 +19,7 @@ pub(super) fn clear_global_prompt_state() {
     invalidate_all_sections();
 }
 
-fn test_config() -> GatewayConfig {
+pub(crate) fn test_config() -> GatewayConfig {
     GatewayConfig {
         name: "test".to_string(),
         rate_limit_per_minute: 100,
@@ -340,65 +340,7 @@ async fn test_find_or_create_no_storage() {
     assert_eq!(result, "feishu:user-a:agent-b");
 }
 
-// Mock persistence service for tests
-struct MockPersistService {
-    archived_checkpoint: Mutex<Option<crate::session::persistence::SessionCheckpoint>>,
-    restore_called: Mutex<bool>,
-}
-
-#[async_trait::async_trait]
-impl PersistenceService for MockPersistService {
-    async fn save_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
-        Ok(())
-    }
-    async fn load_checkpoint(
-        &self,
-        _: &str,
-    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-        Ok(self.archived_checkpoint.lock().await.take())
-    }
-    async fn delete_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
-        Ok(())
-    }
-    async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
-        Ok(Vec::new())
-    }
-    async fn restore_checkpoint(
-        &self,
-        _: &str,
-    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-        *self.restore_called.lock().await = true;
-        Ok(self.archived_checkpoint.lock().await.take())
-    }
-    async fn archive_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
-        Ok(())
-    }
-    async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
-        Ok(Vec::new())
-    }
-    async fn purge_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
-        Ok(())
-    }
-    async fn invalidate_session(&self, _: &str) -> Result<(), PersistenceError> {
-        Ok(())
-    }
-    async fn list_idle_sessions_for_agent(
-        &self,
-        _: &str,
-        _: AgentRole,
-        _: i64,
-    ) -> Result<Vec<String>, PersistenceError> {
-        Ok(Vec::new())
-    }
-    async fn list_expired_archived_sessions_for_agent(
-        &self,
-        _: &str,
-        _: AgentRole,
-        _: i64,
-    ) -> Result<Vec<String>, PersistenceError> {
-        Ok(Vec::new())
-    }
-}
+use super::test_helpers::MockPersistService;
 
 // ── Workspace creation tests ─────────────────────────────────────────────────
 

--- a/src/gateway/session_manager/tests_get_thread_id.rs
+++ b/src/gateway/session_manager/tests_get_thread_id.rs
@@ -1,0 +1,60 @@
+use super::test_helpers::MockPersistService;
+use super::tests::{make_test_mgr, test_config};
+use crate::gateway::session_manager::SessionManager;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{ReasoningLevel, SessionCheckpoint};
+use std::sync::Arc;
+
+// ── get_thread_id tests ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_thread_id_no_storage() {
+    let mgr = make_test_mgr(None);
+    let result = mgr.get_thread_id("sess_no_storage").await;
+    assert!(
+        result.is_none(),
+        "should return None when no storage is configured"
+    );
+}
+
+#[tokio::test]
+async fn test_get_thread_id_returns_none_when_no_thread_id() {
+    let mock_storage = Arc::new(MockPersistService {
+        archived_checkpoint: tokio::sync::Mutex::new(Some(SessionCheckpoint::new(
+            "sess_no_tid".to_string(),
+        ))),
+        restore_called: tokio::sync::Mutex::new(false),
+    });
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(mock_storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+    let result = mgr.get_thread_id("sess_no_tid").await;
+    assert!(
+        result.is_none(),
+        "should return None when checkpoint has no thread_id"
+    );
+}
+
+#[tokio::test]
+async fn test_get_thread_id_returns_value_when_set() {
+    let mock_storage = Arc::new(MockPersistService {
+        archived_checkpoint: tokio::sync::Mutex::new(Some(
+            SessionCheckpoint::new("sess_has_tid".to_string())
+                .with_thread_id("omt_from_checkpoint".into()),
+        )),
+        restore_called: tokio::sync::Mutex::new(false),
+    });
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(mock_storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+    let result = mgr.get_thread_id("sess_has_tid").await;
+    assert_eq!(result.as_deref(), Some("omt_from_checkpoint"));
+}

--- a/src/gateway/tests_archive.rs
+++ b/src/gateway/tests_archive.rs
@@ -195,7 +195,11 @@ impl IMAdapter for MockAdapter {
         unimplemented!()
     }
 
-    async fn send_message(&self, message: &Message) -> Result<(), crate::im::AdapterError> {
+    async fn send_message(
+        &self,
+        message: &Message,
+        _root_id: Option<&str>,
+    ) -> Result<(), crate::im::AdapterError> {
         {
             let mut fail = self.fail_next.write().await;
             if *fail {

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -101,7 +101,11 @@ impl IMAdapter for MockAdapter {
         })
     }
 
-    async fn send_message(&self, _message: &Message) -> Result<(), crate::im::AdapterError> {
+    async fn send_message(
+        &self,
+        _message: &Message,
+        _root_id: Option<&str>,
+    ) -> Result<(), crate::im::AdapterError> {
         Ok(())
     }
 

--- a/src/gateway/tests_thread.rs
+++ b/src/gateway/tests_thread.rs
@@ -1,0 +1,337 @@
+// ── send_outbound / route_message / streaming thread_id tests ────────────
+
+use crate::gateway::{Gateway, SessionManager};
+use crate::im::{AdapterError, IMPlugin, NormalizedMessage};
+use crate::llm::types::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent, UnifiedUsage};
+use crate::processor_chain::DslParseResult;
+use crate::renderer::RenderedOutput;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{PersistenceService, ReasoningLevel, SessionCheckpoint};
+use async_trait::async_trait;
+use futures::stream;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use super::{GatewayConfig, Message};
+
+fn make_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 65536,
+        dm_scope: super::DmScope::PerAccountChannelPeer,
+    }
+}
+
+fn make_message(to: &str, content: &str) -> Message {
+    Message {
+        id: "test_msg".to_string(),
+        from: "user_1".to_string(),
+        to: to.to_string(),
+        content: content.to_string(),
+        channel: "feishu".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+    }
+}
+
+// ── Capturing plugin ─────────────────────────────────────────────────────
+
+/// Mock plugin that captures thread_id from each `send` call.
+struct CapturingPlugin {
+    platform: String,
+    captured_thread_id: std::sync::Mutex<Option<String>>,
+}
+
+impl CapturingPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            captured_thread_id: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn captured(&self) -> Option<String> {
+        self.captured_thread_id.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl IMPlugin for CapturingPlugin {
+    fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
+    }
+
+    fn render(
+        &self,
+        _content_blocks: &[ContentBlock],
+        _dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: json!({"content": {"text": "response"}}),
+        }
+    }
+
+    async fn send(
+        &self,
+        _output: &RenderedOutput,
+        _peer_id: &str,
+        thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        *self.captured_thread_id.lock().unwrap() = thread_id.map(|s| s.to_string());
+        Ok(())
+    }
+}
+
+// ── Mock persistence ─────────────────────────────────────────────────────
+
+struct MockPersistService {
+    checkpoint: Mutex<Option<SessionCheckpoint>>,
+}
+
+#[async_trait]
+impl PersistenceService for MockPersistService {
+    async fn save_checkpoint(
+        &self,
+        _: &SessionCheckpoint,
+    ) -> Result<(), crate::session::persistence::PersistenceError> {
+        Ok(())
+    }
+    async fn load_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, crate::session::persistence::PersistenceError> {
+        Ok(self.checkpoint.lock().await.clone())
+    }
+    async fn delete_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<(), crate::session::persistence::PersistenceError> {
+        Ok(())
+    }
+    async fn list_active_sessions(
+        &self,
+    ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn restore_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, crate::session::persistence::PersistenceError> {
+        Ok(self.checkpoint.lock().await.clone())
+    }
+    async fn archive_checkpoint(
+        &self,
+        _: &SessionCheckpoint,
+    ) -> Result<(), crate::session::persistence::PersistenceError> {
+        Ok(())
+    }
+    async fn list_archived_sessions(
+        &self,
+    ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn purge_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<(), crate::session::persistence::PersistenceError> {
+        Ok(())
+    }
+    async fn invalidate_session(
+        &self,
+        _: &str,
+    ) -> Result<(), crate::session::persistence::PersistenceError> {
+        Ok(())
+    }
+    async fn list_idle_sessions_for_agent(
+        &self,
+        _: &str,
+        _: crate::session::persistence::AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn list_expired_archived_sessions_for_agent(
+        &self,
+        _: &str,
+        _: crate::session::persistence::AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+        Ok(Vec::new())
+    }
+}
+
+// ── Setup helper ─────────────────────────────────────────────────────────
+
+async fn setup_with_thread_id(
+    thread_id: Option<&str>,
+) -> (Gateway, Arc<SessionManager>, Arc<CapturingPlugin>) {
+    let plugin = Arc::new(CapturingPlugin::new("mock"));
+    let checkpoint = {
+        let mut cp = SessionCheckpoint::new("mock:ou_sender:agent-1".to_string());
+        cp.chat_id = Some("agent-1".to_string());
+        cp.channel = Some("mock".to_string());
+        if let Some(tid) = thread_id {
+            cp.thread_id = Some(tid.to_string());
+        }
+        cp
+    };
+    let mock_storage = Arc::new(MockPersistService {
+        checkpoint: Mutex::new(Some(checkpoint)),
+    });
+    let sm = Arc::new(SessionManager::new(
+        &make_config(),
+        Some(mock_storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let gw = Gateway::new(make_config(), Arc::clone(&sm));
+    gw.register_plugin(Arc::clone(&plugin) as Arc<dyn IMPlugin>)
+        .await;
+    let msg = make_message("agent-1", "hello");
+    let _sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    (gw, sm, plugin)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_send_outbound_forwards_thread_id() {
+    let (gw, _sm, plugin) = setup_with_thread_id(Some("omt_from_ckpt")).await;
+    let msg = make_message("agent-1", "hello");
+    let sid = _sm.find_or_create("mock", &msg, None).await.unwrap();
+    gw.send_outbound(&sid, "mock", "hello world", vec![])
+        .await
+        .unwrap();
+    assert_eq!(
+        plugin.captured().as_deref(),
+        Some("omt_from_ckpt"),
+        "plugin.send should receive thread_id from checkpoint"
+    );
+}
+
+#[tokio::test]
+async fn test_send_outbound_no_thread_id() {
+    let (gw, _sm, plugin) = setup_with_thread_id(None).await;
+    let msg = make_message("agent-1", "hello");
+    let sid = _sm.find_or_create("mock", &msg, None).await.unwrap();
+    gw.send_outbound(&sid, "mock", "hello world", vec![])
+        .await
+        .unwrap();
+    assert!(
+        plugin.captured().is_none(),
+        "plugin.send should receive None when checkpoint \
+         has no thread_id"
+    );
+}
+
+#[tokio::test]
+async fn test_route_message_forwards_thread_id() {
+    let plugin = Arc::new(CapturingPlugin::new("mock"));
+    let checkpoint = {
+        let mut cp = SessionCheckpoint::new("mock:ou_sender:agent-1".to_string());
+        cp.chat_id = Some("agent-1".to_string());
+        cp.channel = Some("mock".to_string());
+        cp.thread_id = Some("omt_route_tid".to_string());
+        cp
+    };
+    let mock_storage = Arc::new(MockPersistService {
+        checkpoint: Mutex::new(Some(checkpoint)),
+    });
+    let sm = Arc::new(SessionManager::new(
+        &make_config(),
+        Some(mock_storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let gw = Gateway::new(make_config(), Arc::clone(&sm));
+    gw.register_plugin(Arc::clone(&plugin) as Arc<dyn IMPlugin>)
+        .await;
+    let setup_msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &setup_msg, None).await.unwrap();
+    let mut msg = make_message("agent-1", "hello");
+    msg.metadata.insert("session_id".into(), sid);
+    gw.route_message("mock", msg, None).await.unwrap();
+    assert_eq!(
+        plugin.captured().as_deref(),
+        Some("omt_route_tid"),
+        "route_message should forward thread_id from checkpoint \
+         to plugin.send"
+    );
+}
+
+#[tokio::test]
+async fn test_send_outbound_streaming_forwards_thread_id() {
+    let plugin_for_stream: Arc<CapturingPlugin> = Arc::new(CapturingPlugin::new("mock"));
+    let checkpoint = {
+        let mut cp = SessionCheckpoint::new("mock:ou_sender:agent-1".to_string());
+        cp.chat_id = Some("agent-1".to_string());
+        cp.channel = Some("mock".to_string());
+        cp.thread_id = Some("omt_stream_tid".to_string());
+        cp
+    };
+    let mock_storage = Arc::new(MockPersistService {
+        checkpoint: Mutex::new(Some(checkpoint)),
+    });
+    let sm = Arc::new(SessionManager::new(
+        &make_config(),
+        Some(mock_storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let gw = Gateway::new(make_config(), Arc::clone(&sm));
+    gw.register_plugin(Arc::clone(&plugin_for_stream) as Arc<dyn IMPlugin>)
+        .await;
+    let msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    let events = vec![
+        Ok::<_, String>(StreamEvent::BlockStart {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }),
+        Ok(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "hello".to_string(),
+            },
+        }),
+        Ok(StreamEvent::BlockEnd {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }),
+        Ok(StreamEvent::MessageEnd {
+            usage: Some(UnifiedUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: Some(0),
+                reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            }),
+            finish_reason: Some("stop".to_string()),
+        }),
+    ];
+    let stream = stream::iter(events);
+    let plugin_arc: Arc<dyn IMPlugin> = plugin_for_stream.clone();
+    gw.send_outbound_streaming(&sid, "mock", stream, &plugin_arc)
+        .await
+        .unwrap();
+    assert_eq!(
+        plugin_for_stream.captured().as_deref(),
+        Some("omt_stream_tid"),
+        "send_outbound_streaming should forward thread_id to \
+         plugin.send"
+    );
+}

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -43,6 +43,15 @@ struct FeishuMessageEvent {
     content: String,
     chat_id: String,
     message_type: String,
+    /// Thread ID — direct thread identifier from Feishu.
+    #[serde(default)]
+    thread_id: Option<String>,
+    /// Root message ID of the thread — used as fallback for thread_id.
+    #[serde(default)]
+    root_id: Option<String>,
+    /// Parent message ID — second fallback for thread_id.
+    #[serde(default)]
+    parent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -234,6 +243,18 @@ impl IMAdapter for FeishuAdapter {
             .unwrap_or("")
             .to_string();
 
+        // Extract thread_id with priority: thread_id > root_id > parent_id
+        let thread_id = event
+            .event
+            .thread_id
+            .or(event.event.root_id)
+            .or(event.event.parent_id);
+
+        let mut metadata = HashMap::from([("account_id".to_string(), event.header.app_id.clone())]);
+        if let Some(tid) = thread_id {
+            metadata.insert("thread_id".to_string(), tid);
+        }
+
         Ok(Message {
             id: event.header.event_id,
             from: event.event.sender.sender_id.open_id,
@@ -241,11 +262,15 @@ impl IMAdapter for FeishuAdapter {
             content: text,
             channel: "feishu".to_string(),
             timestamp: chrono::Utc::now().timestamp(),
-            metadata: HashMap::from([("account_id".to_string(), event.header.app_id.clone())]),
+            metadata,
         })
     }
 
-    async fn send_message(&self, message: &Message) -> Result<(), AdapterError> {
+    async fn send_message(
+        &self,
+        message: &Message,
+        root_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
         let token = self.get_tenant_token().await?;
 
         #[derive(Serialize)]
@@ -267,12 +292,14 @@ impl IMAdapter for FeishuAdapter {
             content: &serde_json::json!({ "text": &message.content }).to_string(),
         };
 
+        let mut url = format!("{}/im/v1/messages?receive_id_type=open_id", FEISHU_API_BASE);
+        if let Some(rid) = root_id {
+            url = format!("{}&root_id={}", url, rid);
+        }
+
         let resp: SendResponse = self
             .http_client
-            .post(format!(
-                "{}/im/v1/messages?receive_id_type=open_id",
-                FEISHU_API_BASE
-            ))
+            .post(&url)
             .header("Authorization", format!("Bearer {}", token))
             .json(&payload)
             .send()
@@ -285,6 +312,60 @@ impl IMAdapter for FeishuAdapter {
         if resp.code != 0 {
             return Err(AdapterError::SendFailed(format!(
                 "Feishu send error {}: {}",
+                resp.code, resp.msg
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn send_card_json(
+        &self,
+        chat_id: &str,
+        card_json: &str,
+        root_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        let token = self.get_tenant_token().await?;
+
+        #[derive(Serialize)]
+        struct CardRequest<'a> {
+            receive_id: &'a str,
+            msg_type: &'a str,
+            content: &'a str,
+        }
+
+        #[derive(Deserialize)]
+        struct CardResponse {
+            code: i32,
+            msg: String,
+        }
+
+        let payload = CardRequest {
+            receive_id: chat_id,
+            msg_type: "interactive",
+            content: card_json,
+        };
+
+        let mut url = format!("{}/im/v1/messages?receive_id_type=chat_id", FEISHU_API_BASE);
+        if let Some(rid) = root_id {
+            url = format!("{}&root_id={}", url, rid);
+        }
+
+        let resp: CardResponse = self
+            .http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| AdapterError::SendFailed(e.to_string()))?
+            .json()
+            .await
+            .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+
+        if resp.code != 0 {
+            return Err(AdapterError::SendFailed(format!(
+                "Feishu card send error {}: {}",
                 resp.code, resp.msg
             )));
         }
@@ -340,7 +421,7 @@ impl IMPlugin for FeishuPlugin {
             peer_id: message.to,
             content: message.content,
             timestamp: message.timestamp,
-            thread_id: None,
+            thread_id: message.metadata.get("thread_id").cloned(),
             account_id: message.metadata.get("account_id").cloned(),
         }))
     }
@@ -380,12 +461,14 @@ impl IMPlugin for FeishuPlugin {
                     timestamp: chrono::Utc::now().timestamp(),
                     metadata: HashMap::new(),
                 };
-                self.adapter.send_message(&message).await
+                self.adapter.send_message(&message, _thread_id).await
             }
             "interactive" => {
                 let card_json = serde_json::to_string(&output.payload)
                     .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
-                self.adapter.send_card_json(peer_id, &card_json).await
+                self.adapter
+                    .send_card_json(peer_id, &card_json, _thread_id)
+                    .await
             }
             _ => Err(AdapterError::UnsupportedOperation),
         }

--- a/src/im/feishu_tests.rs
+++ b/src/im/feishu_tests.rs
@@ -1,6 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::gateway::Message;
+    use crate::im::feishu::{CachedToken, FeishuAdapter, FeishuPlugin};
+    use crate::im::{IMAdapter, IMPlugin};
+    use crate::renderer::feishu::FeishuRenderer;
+    use sha2::{Digest, Sha256};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn test_feishu_adapter_name() {
@@ -52,8 +59,22 @@ mod tests {
         let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
         let payload = serde_json::json!({
             "schema": "2.0",
-            "header": {"event_id":"evt_1","event_type":"im.message.receive_v1","create_time":"0","token":"t","app_id":"a"},
-            "event": {"sender":{"sender_id":{"open_id":"ou_abc"},"sender_type":"user"},"content":"{\"text\":\"hello\"}","chat_id":"oc_x","message_type":"text"}
+            "header": {
+                "event_id":"evt_1",
+                "event_type":"im.message.receive_v1",
+                "create_time":"0",
+                "token":"t",
+                "app_id":"a"
+            },
+            "event": {
+                "sender": {
+                    "sender_id":{"open_id":"ou_abc"},
+                    "sender_type":"user"
+                },
+                "content":"{\"text\":\"hello\"}",
+                "chat_id":"oc_x",
+                "message_type":"text"
+            }
         });
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
@@ -75,8 +96,23 @@ mod tests {
     async fn test_handle_webhook_empty_text() {
         let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
         let payload = serde_json::json!({
-            "schema":"2.0","header":{"event_id":"e2","event_type":"x","create_time":"0","token":"t","app_id":"a"},
-            "event":{"sender":{"sender_id":{"open_id":"ou_x"},"sender_type":"user"},"content":"{\"other\":\"data\"}","chat_id":"oc_y","message_type":"text"}
+            "schema":"2.0",
+            "header":{
+                "event_id":"e2",
+                "event_type":"x",
+                "create_time":"0",
+                "token":"t",
+                "app_id":"a"
+            },
+            "event":{
+                "sender":{
+                    "sender_id":{"open_id":"ou_x"},
+                    "sender_type":"user"
+                },
+                "content":"{\"other\":\"data\"}",
+                "chat_id":"oc_y",
+                "message_type":"text"
+            }
         });
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
@@ -86,28 +122,10 @@ mod tests {
         assert_eq!(msg.metadata.get("account_id"), Some(&"a".to_string()));
     }
 
-    #[test]
-    fn test_build_card_body() {
-        let card = RichCard {
-            card_id: None,
-            title: "T".into(),
-            elements: vec![],
-            header: None,
-        };
-        assert!(FeishuAdapter::build_card_body(&card).is_ok());
-    }
-
     #[tokio::test]
     async fn test_error_cases() {
         let a = FeishuAdapter::new("bad".into(), "bad".into(), "t".into());
         assert!(a.fetch_tenant_token().await.is_err());
-        let card = RichCard {
-            card_id: None,
-            title: "T".into(),
-            elements: vec![],
-            header: None,
-        };
-        assert!(a.send_card("ou", &card).await.is_err());
         let msg = Message {
             id: "1".into(),
             from: "a".into(),
@@ -117,7 +135,7 @@ mod tests {
             timestamp: 0,
             metadata: HashMap::new(),
         };
-        assert!(a.send_message(&msg).await.is_err());
+        assert!(a.send_message(&msg, None).await.is_err());
     }
 
     #[tokio::test]
@@ -127,5 +145,201 @@ mod tests {
             .update_message("om_1", &serde_json::json!({}))
             .await
             .is_err());
+    }
+
+    // ── thread_id tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_handle_webhook_with_thread_id() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e1", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_1"}, "sender_type": "user"},
+                "content": "{\"text\":\"hi\"}",
+                "chat_id": "oc_x", "message_type": "text",
+                "thread_id": "omt_thread_abc"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            msg.metadata.get("thread_id"),
+            Some(&"omt_thread_abc".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_with_root_id() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e2", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_2"}, "sender_type": "user"},
+                "content": "{\"text\":\"hello\"}",
+                "chat_id": "oc_y", "message_type": "text",
+                "root_id": "omt_root_123"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            msg.metadata.get("thread_id"),
+            Some(&"omt_root_123".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_with_parent_id() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e3", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_3"}, "sender_type": "user"},
+                "content": "{\"text\":\"hey\"}",
+                "chat_id": "oc_z", "message_type": "text",
+                "parent_id": "omt_parent_456"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            msg.metadata.get("thread_id"),
+            Some(&"omt_parent_456".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_no_thread_fields() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e4", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_4"}, "sender_type": "user"},
+                "content": "{\"text\":\"yo\"}",
+                "chat_id": "oc_w", "message_type": "text"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert!(!msg.metadata.contains_key("thread_id"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_thread_id_priority() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        // All three present — thread_id should win
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e5", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_5"}, "sender_type": "user"},
+                "content": "{\"text\":\"test\"}",
+                "chat_id": "oc_v", "message_type": "text",
+                "thread_id": "omt_direct",
+                "root_id": "omt_root",
+                "parent_id": "omt_parent"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            msg.metadata.get("thread_id"),
+            Some(&"omt_direct".to_string())
+        );
+
+        // thread_id absent, root_id should win
+        let payload2 = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e6", "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_6"}, "sender_type": "user"},
+                "content": "{\"text\":\"test2\"}",
+                "chat_id": "oc_u", "message_type": "text",
+                "root_id": "omt_root2",
+                "parent_id": "omt_parent2"
+            }
+        });
+        let msg2 = adapter
+            .handle_webhook(&serde_json::to_vec(&payload2).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            msg2.metadata.get("thread_id"),
+            Some(&"omt_root2".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_inbound_thread_id() {
+        let adapter = Arc::new(FeishuAdapter::new("a".into(), "s".into(), "t".into()));
+        let renderer = Arc::new(FeishuRenderer::new());
+        let plugin = FeishuPlugin::new(adapter, renderer);
+
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e7",
+                        "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_7"}, "sender_type": "user"},
+                "content": "{\"text\":\"hi thread\"}",
+                "chat_id": "oc_t", "message_type": "text",
+                "thread_id": "omt_from_webhook"
+            }
+        });
+        let msg = plugin
+            .parse_inbound(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.thread_id, Some("omt_from_webhook".to_string()));
+        assert_eq!(msg.platform, "feishu");
+        assert_eq!(msg.content, "hi thread");
+    }
+
+    #[tokio::test]
+    async fn test_parse_inbound_no_thread_id() {
+        let adapter = Arc::new(FeishuAdapter::new("a".into(), "s".into(), "t".into()));
+        let renderer = Arc::new(FeishuRenderer::new());
+        let plugin = FeishuPlugin::new(adapter, renderer);
+
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": {"event_id": "e8",
+                        "event_type": "im.message.receive_v1",
+                        "create_time": "0", "token": "t", "app_id": "a"},
+            "event": {
+                "sender": {"sender_id": {"open_id": "ou_8"}, "sender_type": "user"},
+                "content": "{\"text\":\"hi\"}",
+                "chat_id": "oc_s", "message_type": "text"
+            }
+        });
+        let msg = plugin
+            .parse_inbound(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(msg.thread_id, None);
     }
 }

--- a/src/im/mod.rs
+++ b/src/im/mod.rs
@@ -3,6 +3,8 @@
 //! Each adapter implements the IMAdapter trait for a specific IM platform.
 
 pub mod feishu;
+#[cfg(test)]
+pub mod feishu_tests;
 pub mod normalized;
 #[cfg(test)]
 pub mod normalized_tests;
@@ -23,15 +25,29 @@ pub trait IMAdapter: Send + Sync {
     /// Handle incoming message from IM platform
     async fn handle_webhook(&self, payload: &[u8]) -> Result<Message, AdapterError>;
 
-    /// Send message to IM platform
-    async fn send_message(&self, message: &Message) -> Result<(), AdapterError>;
+    /// Send message to IM platform.
+    ///
+    /// `root_id` optionally directs the message into a specific thread/topic
+    /// (e.g. Feishu `root_id` query parameter).
+    async fn send_message(
+        &self,
+        message: &Message,
+        root_id: Option<&str>,
+    ) -> Result<(), AdapterError>;
 
     /// Validate webhook signature
     async fn validate_signature(&self, signature: &str, payload: &[u8]) -> bool;
 
     /// Send an interactive card message using pre-serialized JSON.
+    ///
+    /// `root_id` optionally directs the message into a specific thread/topic.
     /// Returns `AdapterError::UnsupportedOperation` by default.
-    async fn send_card_json(&self, _chat_id: &str, _card_json: &str) -> Result<(), AdapterError> {
+    async fn send_card_json(
+        &self,
+        _chat_id: &str,
+        _card_json: &str,
+        _root_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
         Err(AdapterError::UnsupportedOperation)
     }
 }

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -46,6 +46,11 @@ pub struct SessionCheckpoint {
     /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为空 Vec）。
     #[serde(default)]
     pub system_appends: Vec<String>,
+    /// 话题 ID（IM 渠道话题消息的线程标识）
+    ///
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为 None）。
+    #[serde(default)]
+    pub thread_id: Option<String>,
 }
 
 impl SessionCheckpoint {
@@ -70,6 +75,7 @@ impl SessionCheckpoint {
             role: None,
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         }
     }
 
@@ -154,6 +160,12 @@ impl SessionCheckpoint {
     /// Update the reasoning level
     pub fn with_reasoning_level(mut self, level: ReasoningLevel) -> Self {
         self.reasoning_level = level;
+        self
+    }
+
+    /// Update the thread ID
+    pub fn with_thread_id(mut self, thread_id: String) -> Self {
+        self.thread_id = Some(thread_id);
         self
     }
 

--- a/src/session/persistence_tests.rs
+++ b/src/session/persistence_tests.rs
@@ -365,4 +365,41 @@ mod tests {
         state.complete();
         assert!(state.is_complete);
     }
+
+    // ── thread_id tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_checkpoint_thread_id_roundtrip() {
+        let cp = SessionCheckpoint::new("s1".into()).with_thread_id("omt_abc123".into());
+        let json = serde_json::to_string(&cp).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.thread_id.as_deref(), Some("omt_abc123"));
+    }
+
+    #[test]
+    fn test_checkpoint_thread_id_default_none() {
+        let cp = SessionCheckpoint::new("s2".into());
+        let mut json_value: serde_json::Value = serde_json::to_value(&cp).unwrap();
+        json_value.as_object_mut().unwrap().remove("thread_id");
+        let json_str = serde_json::to_string(&json_value).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json_str).unwrap();
+        assert!(
+            parsed.thread_id.is_none(),
+            "old data without thread_id should default to None"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_with_thread_id_builder() {
+        let cp = SessionCheckpoint::new("s3".into()).with_thread_id("omt_xyz".into());
+        assert_eq!(cp.thread_id.as_deref(), Some("omt_xyz"));
+    }
+
+    #[test]
+    fn test_checkpoint_thread_id_none_roundtrip() {
+        let cp = SessionCheckpoint::new("s4".into());
+        let json = serde_json::to_string(&cp).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+        assert!(parsed.thread_id.is_none());
+    }
 }

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -139,6 +139,7 @@ mod tests {
             role: None,
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         }
     }
 

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -146,6 +146,7 @@ mod tests {
             role: None,
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         }
     }
 

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -99,6 +99,8 @@ impl SqliteStorage {
 
             CREATE INDEX IF NOT EXISTS idx_sessions_agent_role
                 ON sessions(agent_id, role);
+
+            ALTER TABLE sessions ADD COLUMN thread_id TEXT;
             "#,
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
@@ -295,8 +297,8 @@ impl PersistenceService for SqliteStorage {
             conn.execute(
                 "INSERT OR REPLACE INTO sessions
                  (id, agent_id, role, channel, chat_id, status, title,
-                  last_message_at, created_at, archived_at, message_count, metadata)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                  last_message_at, created_at, archived_at, message_count, metadata, thread_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     checkpoint.session_id,
                     checkpoint.agent_id.as_deref().unwrap_or("unknown"),
@@ -316,6 +318,7 @@ impl PersistenceService for SqliteStorage {
                     Option::<i64>::None, // archived_at
                     checkpoint.message_count as i64,
                     metadata_json,
+                    checkpoint.thread_id.as_deref(),
                 ],
             )
             .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -149,7 +149,7 @@ pub fn load_checkpoint_inner(
     let mut stmt = conn
         .prepare(
             "SELECT agent_id, role, channel, chat_id, status, title,
-             last_message_at, created_at, archived_at, message_count, metadata
+             last_message_at, created_at, archived_at, message_count, metadata, thread_id
              FROM sessions WHERE id = ?1",
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
@@ -167,6 +167,7 @@ pub fn load_checkpoint_inner(
             row.get::<_, Option<i64>>(8)?,
             row.get::<_, i64>(9)?,
             row.get::<_, Option<String>>(10)?,
+            row.get::<_, Option<String>>(11)?,
         ))
     }) {
         Ok(r) => r,
@@ -186,6 +187,7 @@ pub fn load_checkpoint_inner(
         _archived_ts,
         msg_count,
         metadata,
+        thread_id,
     ) = row;
 
     let status = match status_db.as_str() {
@@ -278,6 +280,7 @@ pub fn load_checkpoint_inner(
         },
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         system_appends,
+        thread_id,
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -28,6 +28,7 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         role: None,
         reasoning_level: ReasoningLevel::default(),
         system_appends: Vec::new(),
+        thread_id: None,
     }
 }
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -30,6 +30,7 @@ mod tests {
             role: None,
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         }
     }
 
@@ -385,6 +386,7 @@ mod tests {
             role: Some(AgentRole::SubAgent),
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -422,6 +424,7 @@ mod tests {
             role: Some(AgentRole::SubAgent),
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -459,6 +462,7 @@ mod tests {
             role: Some(AgentRole::MainAgent),
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
+            thread_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 

--- a/tests/feishu_adapter_tests.rs
+++ b/tests/feishu_adapter_tests.rs
@@ -106,7 +106,7 @@ async fn test_error_cases() {
         timestamp: 0,
         metadata: HashMap::new(),
     };
-    assert!(a.send_message(&msg).await.is_err());
+    assert!(a.send_message(&msg, None).await.is_err());
 }
 
 #[tokio::test]

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -346,13 +346,13 @@ async fn test_feishu_adapter_send_card_json_default() {
         async fn handle_webhook(&self, _: &[u8]) -> Result<Message, AdapterError> {
             Err(AdapterError::InvalidPayload("x".into()))
         }
-        async fn send_message(&self, _: &Message) -> Result<(), AdapterError> {
+        async fn send_message(&self, _: &Message, _: Option<&str>) -> Result<(), AdapterError> {
             Err(AdapterError::InvalidPayload("x".into()))
         }
         async fn validate_signature(&self, _: &str, _: &[u8]) -> bool {
             true
         }
     }
-    let result = DummyAdapter.send_card_json("chat_1", "{}").await;
+    let result = DummyAdapter.send_card_json("chat_1", "{}", None).await;
     assert!(matches!(result, Err(AdapterError::UnsupportedOperation)));
 }


### PR DESCRIPTION
实现飞书群聊话题消息的端到端 thread_id 支持：

**入站链路**：
- FeishuAdapter::handle_webhook 提取 thread_id/root_id/parent_id，存入 Message.metadata
- FeishuPlugin::parse_inbound 从 metadata 读取 thread_id 填入 NormalizedMessage

**出站链路**：
- Gateway send_outbound/send_outbound_streaming/route_message 从 SessionManager 获取 thread_id 传给 plugin.send
- FeishuPlugin::send 传递 thread_id 给 adapter
- FeishuAdapter::send_message/send_card_json 在请求中加入 root_id

**Session 持久化**：
- SessionCheckpoint 新增 thread_id 字段
- SQLite sessions 表新增 thread_id 列
- SessionManager::get_thread_id 从 checkpoint 读取

Source: issue #882
Type: feat
