### PR TITLE
feat: 实现 sessions_spawn Fork 模式 — 子 agent 继承父对话历史

### DIFF
--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -90,6 +90,7 @@ async fn test_try_push_announce_run_mode() {
             true,
             None,
             SpawnMode::Run,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -133,6 +134,7 @@ async fn test_try_push_announce_session_mode_noop() {
             true,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -252,6 +254,7 @@ async fn test_thinking_blocks_excluded() {
             true,
             None,
             SpawnMode::Run,
+            false,
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -8,6 +8,7 @@
 use super::SessionManager;
 use crate::config::agents::ResolvedAgentConfig;
 use crate::gateway::Session;
+use crate::llm::session::ChatSession;
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
 use crate::session::persistence::PendingMessage;
@@ -81,6 +82,7 @@ impl SessionManager {
         light_context: bool,
         workspace: Option<&str>,
         mode: SpawnMode,
+        fork: bool,
     ) -> Result<String, String> {
         // 1. Generate child session_id
         let child_session_id = Uuid::new_v4().to_string();
@@ -173,6 +175,15 @@ impl SessionManager {
         )
         .with_system_prompt(prompt)
         .with_reasoning_level(self.default_reasoning_level);
+
+        // 6a. Fork mode: inject parent session's conversation history
+        //     before the task so the child inherits the parent's context.
+        if fork {
+            if let Some(parent_cs) = self.get_conversation_session(parent_session_id).await {
+                let parent_msgs = parent_cs.read().await.messages().to_vec();
+                cs.clone_messages_from(&parent_msgs);
+            }
+        }
 
         // 6. Inject task as pending message
         let pending_msg =

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -73,6 +73,7 @@ async fn test_create_child_session_basic() {
             false,
             None,
             SpawnMode::Run,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -125,6 +126,7 @@ async fn test_create_child_session_workspace_fallback() {
             true,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -143,6 +145,7 @@ async fn test_create_child_session_workspace_fallback() {
             false,
             Some(other.path().to_str().unwrap()),
             SpawnMode::Run,
+            false,
         )
         .await
         .expect("create_child_session with explicit workspace should succeed");
@@ -177,6 +180,7 @@ async fn test_create_child_session_registers_child_info() {
             false,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -214,6 +218,7 @@ async fn test_steer_child_injects_pending_message() {
             false,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -263,6 +268,7 @@ async fn test_kill_child_removes_from_all_tables() {
             false,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -322,6 +328,7 @@ async fn test_validate_child_ownership_returns_none_for_run_mode() {
             false,
             None,
             SpawnMode::Run,
+            false,
         )
         .await
         .expect("create_child_session should succeed");
@@ -356,6 +363,7 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
             false,
             None,
             SpawnMode::Session,
+            false,
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -175,6 +175,7 @@ pub(super) async fn spawn_n_run_children(
                 true,
                 None,
                 SpawnMode::Run,
+                false,
             )
             .await
             .expect("create_child_session should succeed");

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -214,6 +214,12 @@ impl ConversationSession {
     pub fn model(&self) -> &str {
         &self.model
     }
+
+    /// 将来源消息克隆后注入到自身 messages 列表，
+    /// 保留原始时间戳。用于 Fork 模式注入父 session 的对话历史。
+    pub fn clone_messages_from(&mut self, source: &[SessionMessage]) {
+        self.messages.extend(source.iter().cloned());
+    }
 }
 
 /// Message replacement, stats, and streaming-sink accessors.

--- a/src/llm/session/tests/clone_messages_tests.rs
+++ b/src/llm/session/tests/clone_messages_tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+use crate::llm::types::UnifiedResponse;
+
+#[test]
+fn test_clone_messages_from() {
+    let mut source_session =
+        ConversationSession::new("src_1".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    source_session.append_response(UnifiedResponse {
+        content_blocks: vec![ContentBlock::Text("hello from parent".into())],
+        usage: UnifiedUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: Some(2),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    });
+    source_session.append_response(UnifiedResponse {
+        content_blocks: vec![ContentBlock::Text("second response".into())],
+        usage: UnifiedUsage {
+            prompt_tokens: 2,
+            completion_tokens: 1,
+            total_tokens: Some(3),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    });
+
+    let mut child_session =
+        ConversationSession::new("child_1".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    assert_eq!(child_session.messages().len(), 0);
+
+    child_session.clone_messages_from(&source_session.messages());
+
+    assert_eq!(child_session.messages().len(), 2);
+    assert_eq!(child_session.messages()[0].role, "assistant");
+    assert_eq!(child_session.messages()[1].role, "assistant");
+}
+
+#[test]
+fn test_clone_messages_from_empty() {
+    let mut child_session =
+        ConversationSession::new("child_empty".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    assert_eq!(child_session.messages().len(), 0);
+
+    child_session.clone_messages_from(&[]);
+
+    // No side effects: still empty.
+    assert_eq!(child_session.messages().len(), 0);
+}
+
+#[test]
+fn test_clone_messages_from_preserves_timestamp() {
+    let ts1 = Utc::now();
+    let ts2 = Utc::now();
+    let source_msgs = vec![
+        SessionMessage {
+            role: "user".into(),
+            content_blocks: vec![ContentBlock::Text("msg1".into())],
+            timestamp: ts1,
+        },
+        SessionMessage {
+            role: "assistant".into(),
+            content_blocks: vec![ContentBlock::Text("msg2".into())],
+            timestamp: ts2,
+        },
+    ];
+
+    let mut child_session =
+        ConversationSession::new("child_ts".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    child_session.clone_messages_from(&source_msgs);
+
+    assert_eq!(child_session.messages().len(), 2);
+    assert_eq!(child_session.messages()[0].timestamp, ts1);
+    assert_eq!(child_session.messages()[1].timestamp, ts2);
+}

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::llm::types::{UnifiedResponse, UnifiedUsage};
 use crate::session::persistence::PendingMessage;
 use std::path::PathBuf;
 
+mod clone_messages_tests;
 mod exec_state_tests;
 mod stop_tests;
 mod streaming_tests;

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -87,6 +87,11 @@ impl Tool for SessionsSpawnTool {
                 "model": {
                     "type": "string",
                     "description": "Override the target agent's default model"
+                },
+                "fork": {
+                    "type": "boolean",
+                    "description": "是否 fork 父 agent 上下文：fork=true 时子 session 在 task 之前注入父 agent 的完整对话历史（不含 system prompt），使子 agent 继承父 agent 的上下文认知",
+                    "default": false
                 }
             },
             "required": ["task"]
@@ -117,6 +122,7 @@ impl Tool for SessionsSpawnTool {
             "session" => SpawnMode::Session,
             _ => SpawnMode::Run,
         };
+        let fork = args.get("fork").and_then(|v| v.as_bool()).unwrap_or(false);
 
         // 2. Get parent session_id from context
         let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {
@@ -150,6 +156,7 @@ impl Tool for SessionsSpawnTool {
                 light_context,
                 workspace,
                 mode,
+                fork,
             )
             .await
             .map_err(|e| {

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -135,3 +135,24 @@ async fn test_sessions_spawn_no_session_id() {
         other => panic!("expected ExecutionFailed, got {:?}", other),
     }
 }
+
+// ---------------------------------------------------------------------------
+// 3. test_sessions_spawn_fork_schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sessions_spawn_fork_schema() {
+    let tool = make_tool();
+    let schema = tool.input_schema();
+
+    let fork_prop = schema["properties"]["fork"]
+        .as_object()
+        .expect("fork should be an object in properties");
+
+    assert_eq!(fork_prop["type"], "boolean");
+    assert_eq!(fork_prop["default"], false);
+    assert!(
+        fork_prop["description"].as_str().unwrap().contains("fork"),
+        "description should mention fork"
+    );
+}


### PR DESCRIPTION
实现 sessions_spawn 工具的 Fork 模式：当 fork=true 时，子 session 在 task 之前注入父 session 的完整对话历史（不含 system prompt），使子 agent 继承父 agent 的上下文认知。

变更内容：
- ConversationSession 新增 clone_messages_from() 方法
- SessionManager::create_child_session 新增 fork 参数，fork=true 时读取父 session 消息注入子 session
- SessionsSpawnTool input_schema 新增 fork 字段并透传

Source: issue #875
Type: feat
