### PR TITLE
feat(skills): 实现两阶段加载 — 调用时按需加载正文

### DIFF
--- a/src/skills/disk/frontmatter.rs
+++ b/src/skills/disk/frontmatter.rs
@@ -20,6 +20,47 @@
 
 use super::{ParseError, ParsedSkill, SkillManifest};
 
+/// Extract the skill body (instruction text) from a SKILL.md raw string.
+///
+/// Returns the text after the closing `---` delimiter of the frontmatter,
+/// trimmed of leading/trailing whitespace. Returns an empty string when
+/// no frontmatter is present or when the frontmatter block has no body.
+pub fn extract_skill_body(raw: &str) -> &str {
+    let raw = raw.trim();
+
+    // Strip UTF-8 BOM if present
+    let raw = raw.strip_prefix('\u{feff}').unwrap_or(raw);
+
+    // Find opening `---`
+    let start = match raw.find("---\n").or_else(|| raw.find("---\r\n")) {
+        Some(s) => s,
+        None => return "",
+    };
+
+    let after_open = &raw[start + 3..];
+
+    // Find closing `---`
+    let after_skip = after_open.trim_start_matches('\n').trim_start_matches('\r');
+
+    let close_pos = match after_skip
+        .find("\n---")
+        .or_else(|| after_skip.find("\r\n---"))
+        .or_else(|| after_skip.find("---"))
+    {
+        Some(p) => p,
+        None => return "",
+    };
+
+    // Advance past the closing delimiter
+    let after_close = &after_skip[close_pos..];
+    let after_close = after_close
+        .trim_start_matches('\n')
+        .trim_start_matches('\r')
+        .trim_start_matches("---");
+
+    after_close.trim()
+}
+
 /// Parse a SKILL.md file, extracting YAML frontmatter.
 pub fn parse_skill_md(raw: &str) -> Result<ParsedSkill, ParseError> {
     let raw = raw.trim();
@@ -212,5 +253,50 @@ user_invocable: false
         let parsed = parse_skill_md(input).expect("parse ok");
         let yaml = serde_yaml::to_string(&parsed.manifest).expect("serialize ok");
         assert!(yaml.contains("serde-skill"));
+    }
+
+    #[test]
+    fn test_extract_skill_body_standard() {
+        let input = concat!(
+            "---\n",
+            "name: \"test\"\n",
+            "description: \"A test skill\"\n",
+            "---\n",
+            "\n",
+            "# Title\n",
+            "\n",
+            "Some instructions here.\n",
+        );
+
+        let body = extract_skill_body(input);
+        assert_eq!(body, "# Title\n\nSome instructions here.");
+    }
+
+    #[test]
+    fn test_extract_skill_body_no_frontmatter() {
+        let input = "Just some text with no frontmatter.";
+        let body = extract_skill_body(input);
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn test_extract_skill_body_no_body() {
+        let input = "---\ndescription: A skill\n---\n";
+        let body = extract_skill_body(input);
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn test_extract_skill_body_with_bom() {
+        let input = concat!("\u{feff}", "---\ndescription: With BOM\n---\n# Body\n");
+        let body = extract_skill_body(input);
+        assert_eq!(body, "# Body");
+    }
+
+    #[test]
+    fn test_extract_skill_body_whitespace_trim() {
+        let input = "---\ndescription: Skill\n---\n\n  # Title  \n\nContent.  \n  ";
+        let body = extract_skill_body(input);
+        assert_eq!(body, "# Title  \n\nContent.");
     }
 }

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -12,13 +12,13 @@ pub mod registry;
 pub mod resolve;
 pub mod types;
 
-pub use frontmatter::parse_skill_md;
+pub use frontmatter::{extract_skill_body, parse_skill_md};
 pub use hot_reload::{start_skill_watcher, SkillWatcherHandle};
 pub use init::init_disk_skills;
 pub use loader::scan_all_skills;
 pub use registry::DiskSkillRegistry;
 pub use resolve::{resolve_skill, ResolvedSkill};
 pub use types::{
-    DiskSkill, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort, SkillManifest,
-    SkillSource,
+    DiskSkill, LoadBodyError, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort,
+    SkillManifest, SkillSource,
 };

--- a/src/skills/disk/types.rs
+++ b/src/skills/disk/types.rs
@@ -1,5 +1,6 @@
 //! Disk Skill Types - type definitions for the disk skill system
 
+use super::frontmatter::extract_skill_body;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -68,7 +69,7 @@ impl Default for SkillEffort {
 ///
 /// Differs from [`crate::skills::SkillManifest`] which is the runtime
 /// registry entry; this one is persisted in skill definition files.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SkillManifest {
     /// Skill name. Used as the directory name on disk.
     #[serde(default)]
@@ -126,6 +127,14 @@ pub struct ParsedSkill {
     pub frontmatter_raw: String,
 }
 
+/// Errors that can occur when loading the skill body from disk.
+#[derive(Debug, thiserror::Error)]
+pub enum LoadBodyError {
+    /// Failed to read the SKILL.md file from disk.
+    #[error("failed to read SKILL.md: {0}")]
+    Io(String),
+}
+
 /// Errors that can occur when parsing SKILL.md frontmatter.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum ParseError {
@@ -157,9 +166,36 @@ pub struct ScanConfig {
     pub agent_id: Option<String>,
 }
 
+impl DiskSkill {
+    /// Load the skill body (instruction text) from disk on demand.
+    ///
+    /// Reads the SKILL.md file at `self.readme_path`, extracts the
+    /// text after the frontmatter closing `---` delimiter, and returns
+    /// the trimmed result.
+    pub fn load_body(&self) -> Result<String, LoadBodyError> {
+        let raw = std::fs::read_to_string(&self.readme_path)
+            .map_err(|e| LoadBodyError::Io(e.to_string()))?;
+        let body = extract_skill_body(&raw);
+        Ok(body.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_skill(path: std::path::PathBuf) -> DiskSkill {
+        DiskSkill {
+            source: SkillSource::Global,
+            manifest: SkillManifest {
+                name: "test".into(),
+                description: "test".into(),
+                ..Default::default()
+            },
+            readme_path: path,
+            skill_dir: std::path::PathBuf::new(),
+        }
+    }
 
     #[test]
     fn test_skill_source_priority() {
@@ -245,5 +281,45 @@ mod tests {
         assert!(cfg.global_dir.is_none());
         assert!(cfg.project_root.is_none());
         assert!(cfg.agent_id.is_none());
+    }
+
+    #[test]
+    fn test_load_body_existing_file() {
+        let dir = std::env::temp_dir().join(format!("load_body_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("SKILL.md");
+        let content = "---\ndescription: Test\n---\n\n# Hello\n\nInstructions here.\n";
+        std::fs::write(&path, content).unwrap();
+
+        let skill = make_skill(path.clone());
+        let body = skill.load_body().unwrap();
+        assert_eq!(body, "# Hello\n\nInstructions here.");
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::remove_dir(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_load_body_missing_file() {
+        let path = std::path::PathBuf::from("/nonexistent/SKILL.md");
+        let skill = make_skill(path);
+        let err = skill.load_body().unwrap_err();
+        assert!(matches!(err, LoadBodyError::Io(_)));
+    }
+
+    #[test]
+    fn test_load_body_no_frontmatter() {
+        let dir = std::env::temp_dir().join(format!("load_body_no_fm_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("SKILL.md");
+        let content = "Just plain text with no frontmatter.";
+        std::fs::write(&path, content).unwrap();
+
+        let skill = make_skill(path.clone());
+        let body = skill.load_body().unwrap();
+        assert_eq!(body, "");
+
+        std::fs::remove_file(&path).unwrap();
+        std::fs::remove_dir(&dir).unwrap();
     }
 }

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -94,14 +94,21 @@ impl Tool for SkillTool {
             .get(skill_name)
             .ok_or_else(|| ToolCallError::NotFound(skill_name.to_string()))?;
 
-        // Read the SKILL.md file
-        let readme_content = tokio::fs::read_to_string(&skill.readme_path)
+        // Load skill body (instruction text without frontmatter)
+        let skill_clone = skill.clone();
+        let skill_name_owned = skill_name.to_string();
+        let body = tokio::task::spawn_blocking(move || skill_clone.load_body())
             .await
             .map_err(|e| {
                 ToolCallError::ExecutionFailed(format!(
-                    "failed to read {}: {}",
-                    skill.readme_path.display(),
-                    e
+                    "failed to spawn load task for skill '{}': {}",
+                    skill_name_owned, e
+                ))
+            })?
+            .map_err(|e| {
+                ToolCallError::ExecutionFailed(format!(
+                    "failed to load body for skill '{}': {}",
+                    skill_name, e
                 ))
             })?;
 
@@ -123,7 +130,7 @@ impl Tool for SkillTool {
                     "execution_mode": "inline"
                 }),
                 new_messages: vec![ToolMessage {
-                    content: readme_content,
+                    content: body,
                     is_meta: true,
                 }],
                 context_modifier,
@@ -136,7 +143,7 @@ impl Tool for SkillTool {
                     "agent_id": agent_id
                 }),
                 new_messages: vec![ToolMessage {
-                    content: readme_content,
+                    content: body,
                     is_meta: true,
                 }],
                 context_modifier,
@@ -148,7 +155,7 @@ impl Tool for SkillTool {
                     "execution_mode": "fork"
                 }),
                 new_messages: vec![ToolMessage {
-                    content: readme_content,
+                    content: body,
                     is_meta: true,
                 }],
                 context_modifier,
@@ -333,7 +340,13 @@ mod tests {
         assert_eq!(result.data["execution_mode"], "inline");
         assert_eq!(result.new_messages.len(), 1);
         assert!(result.new_messages[0].is_meta);
-        assert_eq!(result.new_messages[0].content, skill_content);
+        // After Step 1.3, body() extracts text after frontmatter
+        assert_eq!(
+            result.new_messages[0].content,
+            "# Test Skill\n\nSome skill content here."
+        );
+        // Ensure frontmatter is NOT present in injected content
+        assert!(!result.new_messages[0].content.contains("---"));
         assert!(result.context_modifier.is_none());
     }
 
@@ -380,6 +393,49 @@ mod tests {
         assert_eq!(result.data["execution_mode"], "fork");
         assert_eq!(result.data["skill_name"], "forkskill");
         assert_eq!(result.data["status"], "loaded");
+    }
+
+    #[tokio::test]
+    async fn test_call_injects_body_only() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content =
+            "---\ndescription: Some description\ntags:\n  - test\n---\n\n# Actual Skill Body\n\nThis is the real content.\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let skill = make_skill("testskill", vec![], readme_path);
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
+            .await
+            .unwrap();
+
+        let content = result.new_messages[0].content.as_str();
+        // Must NOT contain frontmatter delimiters
+        assert!(
+            !content.contains("---"),
+            "content should not contain frontmatter delimiters"
+        );
+        // Must NOT contain YAML field names from frontmatter
+        assert!(
+            !content.contains("description:"),
+            "content should not contain YAML fields"
+        );
+        assert!(
+            !content.contains("tags:"),
+            "content should not contain YAML fields"
+        );
+        // Must contain the body text
+        assert!(
+            content.contains("# Actual Skill Body"),
+            "content should contain body heading"
+        );
+        assert!(
+            content.contains("This is the real content."),
+            "content should contain body text"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
实现两阶段加载 Stage 2：SkillTool::call() 调用时按需加载 SKILL.md 正文（去除 YAML frontmatter），替换全文注入。

变更：
- 新增 extract_skill_body() 从 SKILL.md 提取 frontmatter 后正文
- 新增 DiskSkill::load_body() 按需读取并提取正文
- SkillTool::call() 改用 load_body() + spawn_blocking 注入正文
- 新增 10 个单元测试覆盖各场景

Source: issue #888
Type: feat