### PR TITLE
feat(skills): daemon 热重载接入 global_dir

### DIFF
--- a/src/daemon/skill_reload.rs
+++ b/src/daemon/skill_reload.rs
@@ -6,7 +6,7 @@ use crate::skills::{
     init_disk_skills, start_skill_watcher, DiskSkillRegistry, ScanConfig, SkillWatcherHandle,
 };
 use crate::system_prompt::sections::invalidate_skill_listing;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use tracing::info;
 
@@ -21,13 +21,10 @@ use tracing::info;
 pub(crate) async fn init_skill_hot_reload(
     config_dir: &str,
 ) -> anyhow::Result<(Arc<RwLock<Option<DiskSkillRegistry>>>, SkillWatcherHandle)> {
-    let skill_dir = std::path::Path::new(config_dir).join("skills");
-    let skill_dirs: Vec<PathBuf> = vec![skill_dir.clone()];
-
-    let scan_config = ScanConfig {
-        bundled_dir: Some(skill_dir),
-        ..Default::default()
-    };
+    let bundled_dir = Path::new(config_dir).join("skills");
+    let global_dir = derive_global_dir(config_dir);
+    let scan_config = build_scan_config(bundled_dir.clone(), global_dir.clone());
+    let skill_dirs = build_skill_dirs(bundled_dir, global_dir);
 
     // Initialize shared registry state
     let registry = init_disk_skills(&scan_config);
@@ -58,4 +55,96 @@ pub(crate) async fn init_skill_hot_reload(
 
     info!("skill hot reload initialized");
     Ok((registry_arc, watcher))
+}
+
+/// Derive the global skills directory from the config directory.
+///
+/// `config_dir` is typically `~/.closeclaw/<agent>`; the global
+/// skills directory is `<parent>/skills` (i.e. `~/.closeclaw/skills`).
+/// Returns `None` when `config_dir` has no parent (e.g. root `/`).
+fn derive_global_dir(config_dir: &str) -> Option<PathBuf> {
+    Path::new(config_dir).parent().map(|p| p.join("skills"))
+}
+
+/// Build the list of directories to watch for skill changes.
+///
+/// Always includes `bundled_dir`. Includes `global_dir` only when
+/// it exists on disk.
+fn build_skill_dirs(bundled_dir: PathBuf, global_dir: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut dirs = vec![bundled_dir];
+    if let Some(gd) = global_dir {
+        if gd.exists() {
+            dirs.push(gd);
+        }
+    }
+    dirs
+}
+
+/// Build a [`ScanConfig`] for the given bundled and global directories.
+fn build_scan_config(bundled_dir: PathBuf, global_dir: Option<PathBuf>) -> ScanConfig {
+    ScanConfig {
+        bundled_dir: Some(bundled_dir),
+        global_dir,
+        extra_dirs: vec![],
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_global_dir_derived_from_config_dir_parent() {
+        // Create a temp dir structure: <tmp>/home/user/.closeclaw/eda
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("home/user/.closeclaw/eda");
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let result = derive_global_dir(config_dir.to_str().unwrap());
+        let expected = tmp.path().join("home/user/.closeclaw/skills");
+        assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn test_scan_config_contains_global_dir() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("home/user/.closeclaw/eda");
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let bundled_dir = config_dir.join("skills");
+        let global_dir = derive_global_dir(config_dir.to_str().unwrap());
+
+        let scan_config = build_scan_config(bundled_dir.clone(), global_dir.clone());
+
+        assert_eq!(scan_config.bundled_dir, Some(bundled_dir));
+        assert_eq!(scan_config.global_dir, global_dir);
+        assert!(scan_config.extra_dirs.is_empty());
+    }
+
+    #[test]
+    fn test_skill_dirs_contains_both_directories() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("home/user/.closeclaw/eda");
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let bundled_dir = config_dir.join("skills");
+        std::fs::create_dir_all(&bundled_dir).unwrap();
+
+        let global_dir = derive_global_dir(config_dir.to_str().unwrap()).unwrap();
+        std::fs::create_dir_all(&global_dir).unwrap();
+
+        let skill_dirs = build_skill_dirs(bundled_dir.clone(), Some(global_dir.clone()));
+
+        assert_eq!(skill_dirs.len(), 2);
+        assert!(skill_dirs.contains(&bundled_dir));
+        assert!(skill_dirs.contains(&global_dir));
+    }
+
+    #[test]
+    fn test_global_dir_none_when_no_parent() {
+        let result = derive_global_dir("/");
+        assert_eq!(result, None);
+    }
 }


### PR DESCRIPTION
## 变更内容

接入 `global_dir`（`~/.closeclaw/skills/`）到 `ScanConfig` 和文件监听器，使全局 skill 目录下的 SKILL.md 能被发现且文件变更能触发热重载。

### 具体改动

- `src/daemon/skill_reload.rs`：
  - 提取 `derive_global_dir`、`build_skill_dirs`、`build_scan_config` 辅助函数
  - `ScanConfig` 新增 `global_dir` 字段填充
  - `skill_dirs` 向量加入 `global_dir`（目录存在时）
  - 新增 4 个单元测试

### 范围说明

- ✅ `global_dir`：本次接入
- ❌ `extra_dirs`：暂留空（配置项未定义），后续可扩展
- ❌ `project_root`、`agent_id`：daemon 启动时无法推导，不在本次范围

### 测试

- 4 个新增单元测试全部通过
- `cargo fmt --check` 通过
- Clippy 和全量测试中的失败均为 pre-existing，非本次引入

Closes #881

Source: issue #881
Type: feat