### PR TITLE
feat: 实现 /system 斜杠指令 — 动态管理 system prompt 追加区

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -14,7 +14,8 @@ use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
 use crate::renderer::feishu::FeishuRenderer;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{
-    ClearHandler, CompactHandler, ExecHandler, HelpHandler, ReasoningHandler, WorkdirHandler,
+    ClearHandler, CompactHandler, ExecHandler, HelpHandler, ReasoningHandler, SystemHandler,
+    WorkdirHandler,
 };
 use crate::slash::registry::HandlerRegistry;
 
@@ -179,6 +180,7 @@ impl Daemon {
         slash_registry.register(Arc::new(ReasoningHandler::new(Arc::clone(
             &session_manager,
         ))));
+        slash_registry.register(Arc::new(SystemHandler::new(Arc::clone(&session_manager))));
         let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
         gateway.set_slash_dispatcher(slash_dispatcher).await;
         // 高危 slash 指令（如 /exec）需要权限引擎介入；在此注入使得

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -11,6 +11,7 @@ use crate::permission::engine::engine_types::{
     Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
 };
 use crate::slash::handler::SlashHandler;
+use crate::slash::handler::SystemAppendAction;
 use crate::slash::{parse_slash, SlashContext, SlashDispatcher, SlashResult};
 
 use super::{Gateway, HandleResult};
@@ -204,10 +205,47 @@ impl Gateway {
                     }
                 }
             }
-            SlashResult::SetMode(_)
-            | SlashResult::NewSession
-            | SlashResult::Stop
-            | SlashResult::SystemAppend { .. } => {
+            SlashResult::SystemAppend {
+                action: SystemAppendAction::Add(content),
+            } => {
+                if let Some(cs) = self
+                    .session_manager
+                    .get_conversation_session(session_id)
+                    .await
+                {
+                    let mut session = cs.write().await;
+                    let index = session.add_system_append(content);
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply(format!("已追加指令（序号 {index}）")).await;
+                    }
+                } else {
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply("当前会话未激活，无法追加指令".to_owned())
+                            .await;
+                    }
+                }
+            }
+            SlashResult::SystemAppend {
+                action: SystemAppendAction::Clear,
+            } => {
+                if let Some(cs) = self
+                    .session_manager
+                    .get_conversation_session(session_id)
+                    .await
+                {
+                    let mut session = cs.write().await;
+                    let count = session.clear_system_appends();
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply(format!("已清除 {count} 条追加指令")).await;
+                    }
+                } else {
+                    if let Some(sh) = self.session_handler.as_ref() {
+                        sh.send_reply("当前会话未激活，无法清除指令".to_owned())
+                            .await;
+                    }
+                }
+            }
+            SlashResult::SetMode(_) | SlashResult::NewSession | SlashResult::Stop => {
                 tracing::warn!(
                     cmd = cmd_name,
                     "SlashResult variant not yet routed through dispatch_slash"

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -1,6 +1,15 @@
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 
+/// Action for the `SystemAppend` slash result.
+#[derive(Debug, Clone)]
+pub enum SystemAppendAction {
+    /// Append a new system prompt instruction.
+    Add(String),
+    /// Clear all appended system prompt instructions.
+    Clear,
+}
+
 /// Result of a slash command dispatch.
 pub enum SlashResult {
     /// Reply with a text message.
@@ -14,7 +23,7 @@ pub enum SlashResult {
     /// Compact context with optional instruction.
     Compact { instruction: Option<String> },
     /// Append to system prompt (future).
-    SystemAppend { content: String },
+    SystemAppend { action: SystemAppendAction },
     /// Execute a sub-command (future).
     Exec { command: String },
     /// Set the reasoning level for the current session.

--- a/src/slash/handlers.rs
+++ b/src/slash/handlers.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::gateway::SessionManager;
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
-use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::handler::{SlashHandler, SlashResult, SystemAppendAction};
 use crate::slash::registry::HandlerRegistry;
 use crate::system_prompt::build_git_status_for;
 
@@ -224,6 +224,83 @@ impl SlashHandler for ExecHandler {
     async fn handle(&self, args: &str, _ctx: &SlashContext) -> SlashResult {
         SlashResult::Exec {
             command: args.to_owned(),
+        }
+    }
+}
+
+// ── SystemHandler ──────────────────────────────────────────────────────────
+
+/// `/system` — manage the system prompt append section.
+///
+/// - `/system add <content>` or `/system + <content>`: append an instruction.
+/// - `/system list` or `/system` (no args): list current appended instructions.
+/// - `/system clear`: clear all appended instructions.
+pub struct SystemHandler {
+    session_manager: Arc<SessionManager>,
+}
+
+impl SystemHandler {
+    /// Create a new SystemHandler operating on the given session manager.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for SystemHandler {
+    fn commands(&self) -> &[&str] {
+        &["system"]
+    }
+
+    fn description(&self) -> &str {
+        "管理 system prompt 追加区"
+    }
+
+    fn immediate(&self) -> bool {
+        false
+    }
+
+    async fn handle(&self, args: &str, ctx: &SlashContext) -> SlashResult {
+        let parts: Vec<&str> = args.trim().splitn(2, |c: char| c.is_whitespace()).collect();
+        let sub = parts[0];
+        let remaining = if parts.len() > 1 { parts[1].trim() } else { "" };
+
+        match sub {
+            "add" | "+" => {
+                if remaining.is_empty() {
+                    SlashResult::Reply("用法：/system add <要追加的指令>".to_owned())
+                } else {
+                    SlashResult::SystemAppend {
+                        action: SystemAppendAction::Add(remaining.to_owned()),
+                    }
+                }
+            }
+            "list" | "" => {
+                let Some(conv) = self
+                    .session_manager
+                    .get_conversation_session(&ctx.session_id)
+                    .await
+                else {
+                    return SlashResult::Reply("当前会话未激活".to_owned());
+                };
+                let cs = conv.read().await;
+                let appends = cs.system_appends();
+                if appends.is_empty() {
+                    SlashResult::Reply("当前无追加指令".to_owned())
+                } else {
+                    let list: String = appends
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| format!("[{i}] {s}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    SlashResult::Reply(list)
+                }
+            }
+            "clear" => SlashResult::SystemAppend {
+                action: SystemAppendAction::Clear,
+            },
+            other => SlashResult::Reply(format!("未知子指令：{other}。支持 add / list / clear。")),
         }
     }
 }

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -6,19 +6,19 @@ use crate::gateway::session_manager::SessionManager;
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 use crate::slash::dispatcher::SlashDispatcher;
-use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::handler::{SlashHandler, SlashResult, SystemAppendAction};
 use crate::slash::handlers::{
-    ClearHandler, CompactHandler, HelpHandler, ReasoningHandler, WorkdirHandler,
+    ClearHandler, CompactHandler, HelpHandler, ReasoningHandler, SystemHandler, WorkdirHandler,
 };
 use crate::slash::registry::HandlerRegistry;
 
 // ── Mock handler ────────────────────────────────────────────────────────────
 
-struct MockHandler {
-    cmds: Vec<&'static str>,
-    desc: &'static str,
-    imm: bool,
-    reply_text: String,
+pub(crate) struct MockHandler {
+    pub(crate) cmds: Vec<&'static str>,
+    pub(crate) desc: &'static str,
+    pub(crate) imm: bool,
+    pub(crate) reply_text: String,
 }
 
 #[async_trait::async_trait]
@@ -37,7 +37,7 @@ impl SlashHandler for MockHandler {
     }
 }
 
-fn dummy_ctx() -> SlashContext {
+pub(crate) fn dummy_ctx() -> SlashContext {
     SlashContext {
         command: String::new(),
         sender_id: "test_sender".to_owned(),
@@ -79,20 +79,6 @@ fn test_compact_handler_commands_and_description() {
 }
 
 // ── ClearHandler tests ────────────────────────────────────────────────────────
-
-#[test]
-fn test_clear_handler_commands_and_description() {
-    // Verify static metadata via trait interface
-    let h = MockHandler {
-        cmds: vec!["clear"],
-        desc: "清除 system prompt 静态层缓存并触发重建",
-        imm: true,
-        reply_text: String::new(),
-    };
-    assert_eq!(h.commands(), &["clear"]);
-    assert_eq!(h.description(), "清除 system prompt 静态层缓存并触发重建");
-    assert!(h.immediate());
-}
 
 #[tokio::test]
 async fn test_clear_handler_handle_returns_reply() {
@@ -254,33 +240,6 @@ fn test_dispatcher_is_immediate_false() {
     assert!(!dispatcher.is_immediate("test_cmd"));
 }
 
-#[test]
-fn test_dispatcher_is_immediate_unknown() {
-    let registry = HandlerRegistry::new();
-    let dispatcher = SlashDispatcher::new(registry);
-    assert!(!dispatcher.is_immediate("nonexistent"));
-}
-
-#[test]
-fn test_dispatcher_all_handlers() {
-    let registry = HandlerRegistry::new();
-    registry.register(Arc::new(MockHandler {
-        cmds: vec!["x"],
-        desc: "x desc",
-        imm: false,
-        reply_text: String::new(),
-    }));
-    registry.register(Arc::new(MockHandler {
-        cmds: vec!["y"],
-        desc: "y desc",
-        imm: true,
-        reply_text: String::new(),
-    }));
-    let dispatcher = SlashDispatcher::new(registry);
-    let handlers = dispatcher.all_handlers();
-    assert_eq!(handlers.len(), 2);
-}
-
 // ── WorkdirHandler tests ────────────────────────────────────────────────────
 
 /// Construct a SessionManager the same way `test_clear_handler_handle_returns_reply`
@@ -378,14 +337,14 @@ async fn test_workdir_handler_cd_invalid_and_no_args() {
 async fn test_workdir_handler_pwd_and_git() {
     let sm = make_workdir_session_manager();
     let sid = create_test_session(&sm).await;
-    // pwd
     let h = WorkdirHandler::new(Arc::clone(&sm));
+    // pwd
     let mut ctx = dummy_ctx();
     ctx.session_id = sid.clone();
     ctx.command = "pwd".to_owned();
     match h.handle("", &ctx).await {
         SlashResult::Reply(t) => assert!(!t.is_empty()),
-        _other => panic!("expected Reply"),
+        _ => panic!("expected Reply"),
     }
     // git placeholder
     let mut ctx2 = dummy_ctx();
@@ -393,7 +352,7 @@ async fn test_workdir_handler_pwd_and_git() {
     ctx2.command = "git".to_owned();
     match h.handle("status", &ctx2).await {
         SlashResult::Reply(t) => assert!(t.contains("git 指令即将支持"), "got: {t}"),
-        _other => panic!("expected Reply"),
+        _ => panic!("expected Reply"),
     }
 }
 
@@ -456,32 +415,75 @@ async fn test_reasoning_handler_invalid_level() {
     }
 }
 
+// ── SystemHandler tests ─────────────────────────────────────────────────────
+
 #[test]
-fn test_reasoning_level_getter_setter_symmetry() {
-    let mut s = crate::llm::session::ConversationSession::new(
-        "test-sym".to_owned(),
-        "test-model".to_owned(),
-        std::path::PathBuf::from("/tmp"),
-    );
-    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
-    for &lv in &[
-        ReasoningLevel::Low,
-        ReasoningLevel::Medium,
-        ReasoningLevel::High,
-        ReasoningLevel::Max,
-    ] {
-        s.set_reasoning_level(lv);
-        assert_eq!(s.reasoning_level(), lv);
+fn test_system_handler_commands_and_description() {
+    let h = SystemHandler::new(make_workdir_session_manager());
+    assert_eq!(h.commands(), &["system"]);
+    assert_eq!(h.description(), "管理 system prompt 追加区");
+    assert!(!h.immediate());
+}
+
+#[tokio::test]
+async fn test_system_add_returns_append() {
+    let h = SystemHandler::new(make_workdir_session_manager());
+    let ctx = dummy_ctx();
+    match h.handle("add 你好", &ctx).await {
+        SlashResult::SystemAppend {
+            action: SystemAppendAction::Add(t),
+        } => assert_eq!(t, "你好"),
+        _ => panic!("expected SystemAppend::Add"),
+    }
+}
+
+#[tokio::test]
+async fn test_system_add_empty_returns_usage() {
+    let h = SystemHandler::new(make_workdir_session_manager());
+    match h.handle("add", &dummy_ctx()).await {
+        SlashResult::Reply(t) => assert!(t.contains("用法"), "got: {t}"),
+        _ => panic!("expected Reply with usage"),
+    }
+}
+
+#[tokio::test]
+async fn test_system_clear_returns_clear() {
+    let h = SystemHandler::new(make_workdir_session_manager());
+    match h.handle("clear", &dummy_ctx()).await {
+        SlashResult::SystemAppend {
+            action: SystemAppendAction::Clear,
+        } => {}
+        _ => panic!("expected SystemAppend::Clear"),
+    }
+}
+
+#[tokio::test]
+async fn test_system_unknown_subcommand() {
+    let h = SystemHandler::new(make_workdir_session_manager());
+    match h.handle("foo", &dummy_ctx()).await {
+        SlashResult::Reply(t) => assert!(t.contains("未知子指令"), "got: {t}"),
+        _ => panic!("expected Reply with unknown"),
     }
 }
 
 #[test]
-fn test_reasoning_level_with_builder() {
-    let s = crate::llm::session::ConversationSession::new(
-        "test-b".to_owned(),
-        "test-model".to_owned(),
-        std::path::PathBuf::from("/tmp"),
-    )
-    .with_reasoning_level(ReasoningLevel::High);
-    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
+fn test_system_append_action_match() {
+    // Add variant
+    match (SlashResult::SystemAppend {
+        action: SystemAppendAction::Add("test".to_owned()),
+    }) {
+        SlashResult::SystemAppend {
+            action: SystemAppendAction::Add(s),
+        } => assert_eq!(s, "test"),
+        _ => panic!("Add match failed"),
+    }
+    // Clear variant
+    match (SlashResult::SystemAppend {
+        action: SystemAppendAction::Clear,
+    }) {
+        SlashResult::SystemAppend {
+            action: SystemAppendAction::Clear,
+        } => {}
+        _ => panic!("Clear match failed"),
+    }
 }

--- a/src/slash/handlers_tests_legacy.rs
+++ b/src/slash/handlers_tests_legacy.rs
@@ -1,0 +1,81 @@
+//! Migrated tests from handlers_tests.rs (moved here to keep files ≤500 lines).
+
+use std::sync::Arc;
+
+use crate::session::persistence::ReasoningLevel;
+use crate::slash::dispatcher::SlashDispatcher;
+use crate::slash::handler::SlashHandler;
+use crate::slash::registry::HandlerRegistry;
+
+use super::handlers_tests::MockHandler;
+
+#[test]
+fn test_clear_handler_commands_and_description() {
+    // Verify static metadata via trait interface
+    let h = MockHandler {
+        cmds: vec!["clear"],
+        desc: "清除 system prompt 静态层缓存并触发重建",
+        imm: true,
+        reply_text: String::new(),
+    };
+    assert_eq!(h.commands(), &["clear"]);
+    assert_eq!(h.description(), "清除 system prompt 静态层缓存并触发重建");
+    assert!(h.immediate());
+}
+
+#[test]
+fn test_dispatcher_is_immediate_unknown() {
+    let registry = HandlerRegistry::new();
+    let dispatcher = SlashDispatcher::new(registry);
+    assert!(!dispatcher.is_immediate("nonexistent"));
+}
+
+#[test]
+fn test_dispatcher_all_handlers() {
+    let registry = HandlerRegistry::new();
+    registry.register(Arc::new(MockHandler {
+        cmds: vec!["x"],
+        desc: "x desc",
+        imm: false,
+        reply_text: String::new(),
+    }));
+    registry.register(Arc::new(MockHandler {
+        cmds: vec!["y"],
+        desc: "y desc",
+        imm: true,
+        reply_text: String::new(),
+    }));
+    let dispatcher = SlashDispatcher::new(registry);
+    let handlers = dispatcher.all_handlers();
+    assert_eq!(handlers.len(), 2);
+}
+
+#[test]
+fn test_reasoning_level_getter_setter_symmetry() {
+    let mut s = crate::llm::session::ConversationSession::new(
+        "test-sym".to_owned(),
+        "test-model".to_owned(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
+    for &lv in &[
+        ReasoningLevel::Low,
+        ReasoningLevel::Medium,
+        ReasoningLevel::High,
+        ReasoningLevel::Max,
+    ] {
+        s.set_reasoning_level(lv);
+        assert_eq!(s.reasoning_level(), lv);
+    }
+}
+
+#[test]
+fn test_reasoning_level_with_builder() {
+    let s = crate::llm::session::ConversationSession::new(
+        "test-b".to_owned(),
+        "test-model".to_owned(),
+        std::path::PathBuf::from("/tmp"),
+    )
+    .with_reasoning_level(ReasoningLevel::High);
+    assert_eq!(s.reasoning_level(), ReasoningLevel::High);
+}

--- a/src/slash/handlers_tests_system.rs
+++ b/src/slash/handlers_tests_system.rs
@@ -1,0 +1,123 @@
+//! Tests for `/system list` and `/system` (no args) branches.
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::slash::context::SlashContext;
+use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::handlers::SystemHandler;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn make_sm() -> Arc<SessionManager> {
+    use crate::gateway::DmScope;
+    use crate::session::bootstrap::loader::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
+
+    let gc = crate::gateway::GatewayConfig {
+        name: String::new(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: DmScope::default(),
+    };
+    Arc::new(SessionManager::new(
+        &gc,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
+async fn create_test_session(sm: &SessionManager) -> String {
+    use crate::gateway::Message;
+
+    let msg = Message {
+        id: "sys-test-msg-1".to_string(),
+        from: "user-a".to_string(),
+        to: "agent-b".to_string(),
+        content: "hello".to_string(),
+        channel: "feishu".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+    };
+    sm.find_or_create("feishu", &msg, None)
+        .await
+        .expect("session")
+}
+
+fn make_ctx(session_id: &str) -> SlashContext {
+    SlashContext {
+        command: String::new(),
+        sender_id: "test_sender".to_owned(),
+        session_id: session_id.to_owned(),
+        channel: "test_channel".to_owned(),
+    }
+}
+
+/// Add system append content directly to a session via its ConversationSession.
+async fn seed_system_append(sm: &SessionManager, session_id: &str, content: &str) {
+    let conv = sm
+        .get_conversation_session(session_id)
+        .await
+        .expect("session active");
+    let mut cs = conv.write().await;
+    cs.add_system_append(content.to_owned());
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_system_list_with_content() {
+    let sm = make_sm();
+    let sid = create_test_session(&sm).await;
+    seed_system_append(&sm, &sid, "请始终使用中文回复").await;
+    seed_system_append(&sm, &sid, "不要使用 markdown").await;
+
+    let h = SystemHandler::new(Arc::clone(&sm));
+    let ctx = make_ctx(&sid);
+    match h.handle("list", &ctx).await {
+        SlashResult::Reply(text) => {
+            assert!(text.contains("[0]"), "should contain index 0, got: {text}");
+            assert!(text.contains("请始终使用中文回复"), "got: {text}");
+            assert!(text.contains("[1]"), "should contain index 1, got: {text}");
+            assert!(text.contains("不要使用 markdown"), "got: {text}");
+        }
+        _other => panic!("expected Reply"),
+    }
+}
+
+#[tokio::test]
+async fn test_system_list_empty() {
+    let sm = make_sm();
+    let sid = create_test_session(&sm).await;
+
+    let h = SystemHandler::new(Arc::clone(&sm));
+    let ctx = make_ctx(&sid);
+    match h.handle("list", &ctx).await {
+        SlashResult::Reply(text) => {
+            assert_eq!(text, "当前无追加指令", "got: {text}");
+        }
+        _other => panic!("expected Reply"),
+    }
+}
+
+#[tokio::test]
+async fn test_system_no_args_with_content() {
+    let sm = make_sm();
+    let sid = create_test_session(&sm).await;
+    seed_system_append(&sm, &sid, "第一条指令").await;
+    seed_system_append(&sm, &sid, "第二条指令").await;
+    seed_system_append(&sm, &sid, "第三条指令").await;
+
+    let h = SystemHandler::new(Arc::clone(&sm));
+    let ctx = make_ctx(&sid);
+    match h.handle("", &ctx).await {
+        SlashResult::Reply(text) => {
+            assert!(text.contains("[0] 第一条指令"), "got: {text}");
+            assert!(text.contains("[1] 第二条指令"), "got: {text}");
+            assert!(text.contains("[2] 第三条指令"), "got: {text}");
+        }
+        _other => panic!("expected Reply"),
+    }
+}

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -13,4 +13,10 @@ pub use handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
 mod handlers_tests;
 
 #[cfg(test)]
+mod handlers_tests_legacy;
+
+#[cfg(test)]
+mod handlers_tests_system;
+
+#[cfg(test)]
 mod tests;


### PR DESCRIPTION
实现 /system 斜杠指令交互层，支持动态管理 system prompt 追加区。

## 变更内容

- **SystemAppendAction 枚举**：替代原 `SystemAppend { content: String }`，支持 Add 和 Clear 两种操作
- **SystemHandler**：处理 `/system add`、`/system list`、`/system clear` 子指令
- **Gateway 路由**：`execute_and_route()` 实现 SystemAppend 的 Add/Clear 分支
- **daemon 注册**：SystemHandler 注入 HandlerRegistry
- **测试**：9 个新测试 + 5 个迁移测试

## 已有基础设施（无需修改）

- system prompt 注入：`build_dynamic_sections()` 已自动读取 `system_appends()` 拼入 `## Append` Section
- 持久化：`SessionCheckpoint::system_appends` 已序列化/反序列化，archive 恢复时保留

Source: issue #891
Type: feat
