### PR TITLE
feat(slash): 实现 SessionHandler (/new /stop) 和 StatusHandler (/status)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -13,11 +13,12 @@ use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
 use crate::renderer::feishu::FeishuRenderer;
 use crate::slash::dispatcher::SlashDispatcher;
-use crate::slash::handlers::{
-    ClearHandler, CompactHandler, ExecHandler, HelpHandler, ReasoningHandler, SystemHandler,
-    WorkdirHandler,
-};
+use crate::slash::handlers::{ReasoningHandler, SystemHandler, WorkdirHandler};
 use crate::slash::registry::HandlerRegistry;
+use crate::slash::{
+    ClearHandler, CompactHandler, ExecHandler, HelpHandler, NewSessionHandler, StatusHandler,
+    StopHandler,
+};
 
 use crate::permission::approval_flow::ApprovalFlow;
 use crate::permission::{Defaults, PermissionEngine, RuleSet};
@@ -181,6 +182,9 @@ impl Daemon {
             &session_manager,
         ))));
         slash_registry.register(Arc::new(SystemHandler::new(Arc::clone(&session_manager))));
+        slash_registry.register(Arc::new(NewSessionHandler));
+        slash_registry.register(Arc::new(StopHandler));
+        slash_registry.register(Arc::new(StatusHandler::new(Arc::clone(&session_manager))));
         let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
         gateway.set_slash_dispatcher(slash_dispatcher).await;
         // 高危 slash 指令（如 /exec）需要权限引擎介入；在此注入使得

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -24,6 +24,7 @@ use tokio::sync::RwLock;
 use tracing::warn;
 
 mod announce;
+mod channel;
 mod rebuild;
 mod spawn;
 pub use spawn::{ChildSessionInfo, SpawnMode};
@@ -52,6 +53,10 @@ pub struct SessionManager {
     default_reasoning_level: ReasoningLevel,
     /// Children tracking table: parent_session_id → list of child sessions.
     children: RwLock<HashMap<String, Vec<ChildSessionInfo>>>,
+    /// Channel → active session_id mapping.
+    /// Updated by `force_new_for_channel` so subsequent `find_or_create`
+    /// calls route to the latest session for a channel.
+    channel_active_sessions: RwLock<HashMap<String, String>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -84,6 +89,7 @@ impl SessionManager {
             skill_registry: RwLock::new(None),
             default_reasoning_level,
             children: RwLock::new(HashMap::new()),
+            channel_active_sessions: RwLock::new(HashMap::new()),
         }
     }
 
@@ -193,6 +199,18 @@ impl SessionManager {
         message: &Message,
         account_id: Option<&str>,
     ) -> Result<String, ProcessError> {
+        // Channel-level override: if a channel has an active session
+        // (e.g. from /new), route directly to it.
+        {
+            let channel_map = self.channel_active_sessions.read().await;
+            if let Some(active_id) = channel_map.get(channel) {
+                let sessions = self.sessions.read().await;
+                if sessions.contains_key(active_id) {
+                    return Ok(active_id.clone());
+                }
+            }
+        }
+
         let session_id = self.compute_session_key(channel, message, account_id);
         // Fast path: session already exists
         {

--- a/src/gateway/session_manager/channel.rs
+++ b/src/gateway/session_manager/channel.rs
@@ -1,0 +1,75 @@
+//! Channel-level session routing helpers.
+//!
+//! These methods extend `SessionManager` with channel→session mapping
+//! so that `/new` can force a fresh session per channel while the old
+//! session is preserved for recovery.
+
+use super::SessionManager;
+use crate::gateway::Session;
+use crate::llm::session::ConversationSession;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+impl SessionManager {
+    /// Returns the active session_id for a channel, if any.
+    #[allow(dead_code)]
+    pub async fn active_session_for_channel(&self, channel: &str) -> Option<String> {
+        let channel_map = self.channel_active_sessions.read().await;
+        channel_map.get(channel).cloned()
+    }
+
+    /// Force-create a new session for the given channel, replacing the
+    /// channel→session mapping. The old session is preserved in the
+    /// sessions map for recovery but is no longer routed to by default.
+    ///
+    /// Returns the new session_id.
+    pub async fn force_new_for_channel(&self, channel: &str, agent_id: &str) -> String {
+        // Generate a unique session id using timestamp + channel
+        let session_id = format!(
+            "{}-{}-{}",
+            channel,
+            agent_id,
+            chrono::Utc::now().timestamp_millis()
+        );
+
+        // Compute workdir
+        let workdir_path = if let Some(ref workspace_dir) = self.workspace_dir {
+            crate::session::workspace::ensure_workspace_dir(workspace_dir, agent_id, agent_id)
+                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"))
+        } else {
+            std::path::PathBuf::from("/tmp")
+        };
+
+        // Create ConversationSession
+        let conv_session =
+            ConversationSession::new(session_id.clone(), "default".to_string(), workdir_path)
+                .with_reasoning_level(self.default_reasoning_level);
+        {
+            let mut conv_sessions = self.conversation_sessions.write().await;
+            conv_sessions.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));
+        }
+
+        // Create Session entry
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.insert(
+                session_id.clone(),
+                Session {
+                    id: session_id.clone(),
+                    agent_id: agent_id.to_string(),
+                    channel: channel.to_string(),
+                    created_at: chrono::Utc::now().timestamp(),
+                    depth: 0,
+                },
+            );
+        }
+
+        // Update channel → session mapping
+        {
+            let mut channel_map = self.channel_active_sessions.write().await;
+            channel_map.insert(channel.to_string(), session_id.clone());
+        }
+
+        session_id
+    }
+}

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -401,3 +401,74 @@ async fn test_find_or_create_workspace_invalid_ids() {
     msg.from = r#"..\foo"#.to_string();
     assert!(mgr.find_or_create("feishu", &msg, None).await.is_err());
 }
+
+#[tokio::test]
+async fn test_force_new_for_channel_creates_valid_session() {
+    let mgr = make_test_mgr(None);
+    let new_id = mgr.force_new_for_channel("feishu", "agent-test").await;
+    // Should be non-empty and contain the channel
+    assert!(!new_id.is_empty());
+    assert!(new_id.starts_with("feishu"));
+    // Session should exist in the sessions map
+    assert!(mgr.has_session(&new_id).await);
+    // Channel mapping should be correct
+    assert_eq!(
+        mgr.active_session_for_channel("feishu").await.as_deref(),
+        Some(new_id.as_str())
+    );
+    // ConversationSession should also exist
+    assert!(mgr.get_conversation_session(&new_id).await.is_some());
+}
+
+#[tokio::test]
+async fn test_clear_pending_with_messages() {
+    let mgr = make_test_mgr(None);
+    let msg = test_message();
+    let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    // Push some pending messages
+    use crate::session::persistence::PendingMessage;
+    mgr.push_pending_message(&session_id, PendingMessage::new("p1".into(), "msg1".into()))
+        .await
+        .unwrap();
+    mgr.push_pending_message(&session_id, PendingMessage::new("p2".into(), "msg2".into()))
+        .await
+        .unwrap();
+    assert_eq!(
+        mgr.get_conversation_session(&session_id)
+            .await
+            .unwrap()
+            .read()
+            .await
+            .pending_count(),
+        2
+    );
+    // Clear pending
+    let count = {
+        let cs = mgr.get_conversation_session(&session_id).await.unwrap();
+        let mut cs = cs.write().await;
+        cs.clear_pending()
+    };
+    assert_eq!(count, 2);
+    assert_eq!(
+        mgr.get_conversation_session(&session_id)
+            .await
+            .unwrap()
+            .read()
+            .await
+            .pending_count(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_clear_pending_empty() {
+    let mgr = make_test_mgr(None);
+    let msg = test_message();
+    let session_id = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    let count = {
+        let cs = mgr.get_conversation_session(&session_id).await.unwrap();
+        let mut cs = cs.write().await;
+        cs.clear_pending()
+    };
+    assert_eq!(count, 0);
+}

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use crate::llm::session::ChatSession;
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_types::{
     Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
@@ -245,10 +246,66 @@ impl Gateway {
                     }
                 }
             }
-            SlashResult::SetMode(_) | SlashResult::NewSession | SlashResult::Stop => {
+            SlashResult::NewSession => {
+                let agent_id = self
+                    .session_manager
+                    .get_chat_id(session_id)
+                    .await
+                    .unwrap_or_default();
+                let new_session_id = self
+                    .session_manager
+                    .force_new_for_channel(channel, &agent_id)
+                    .await;
+                if let Some(sh) = self.session_handler.as_ref() {
+                    sh.send_reply(format!("已创建新 session：{new_session_id}"))
+                        .await;
+                }
+            }
+            SlashResult::Stop => {
+                match self
+                    .session_manager
+                    .get_conversation_session(session_id)
+                    .await
+                {
+                    None => {
+                        if let Some(sh) = self.session_handler.as_ref() {
+                            sh.send_reply("当前会话未激活".to_owned()).await;
+                        }
+                    }
+                    Some(conv) => {
+                        let busy = {
+                            let cs = conv.read().await;
+                            cs.is_llm_busy()
+                        };
+                        if busy {
+                            let mut cs = conv.write().await;
+                            cs.cancel_token.cancel();
+                            // Cascade stop to child handles.
+                            {
+                                let child_handles = cs
+                                    .child_handles
+                                    .read()
+                                    .expect("child_handles lock poisoned");
+                                let handles_to_stop: Vec<_> =
+                                    child_handles.values().filter_map(|w| w.upgrade()).collect();
+                                drop(child_handles);
+                                for child in handles_to_stop {
+                                    let child_cs = child.read().await;
+                                    child_cs.cancel_token.cancel();
+                                }
+                            }
+                            cs.clear_pending();
+                        }
+                        if let Some(sh) = self.session_handler.as_ref() {
+                            sh.send_reply("已停止当前任务".to_owned()).await;
+                        }
+                    }
+                }
+            }
+            SlashResult::SetMode(_) => {
                 tracing::warn!(
                     cmd = cmd_name,
-                    "SlashResult variant not yet routed through dispatch_slash"
+                    "SlashResult::SetMode not yet routed through dispatch_slash"
                 );
             }
             SlashResult::Unknown(_) => {

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -257,6 +257,14 @@ impl ConversationSession {
         self.pending_messages.pop_front()
     }
 
+    /// Clears all pending messages from the queue.
+    /// Returns the number of messages that were cleared.
+    pub fn clear_pending(&mut self) -> usize {
+        let n = self.pending_messages.len();
+        self.pending_messages.clear();
+        n
+    }
+
     /// Returns whether there are any pending messages.
     pub fn has_pending(&self) -> bool {
         !self.pending_messages.is_empty()

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -447,3 +447,30 @@ fn test_build_api_request_reasoning_level_medium() {
     let req = session.build_api_request();
     assert_eq!(req.reasoning_level, ReasoningLevel::Medium);
 }
+
+// ── clear_pending tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_clear_pending_returns_count_and_empties() {
+    let mut session =
+        ConversationSession::new("sess_clear".into(), "gpt-4o".into(), PathBuf::from("/tmp"));
+    session.push_pending(PendingMessage::new("a".into(), "msg_a".into()));
+    session.push_pending(PendingMessage::new("b".into(), "msg_b".into()));
+    assert_eq!(session.pending_count(), 2);
+
+    let cleared = session.clear_pending();
+    assert_eq!(cleared, 2);
+    assert_eq!(session.pending_count(), 0);
+    assert!(session.get_pending_messages().is_empty());
+}
+
+#[test]
+fn test_clear_pending_empty_returns_zero() {
+    let mut session = ConversationSession::new(
+        "sess_clear_empty".into(),
+        "gpt-4o".into(),
+        PathBuf::from("/tmp"),
+    );
+    let cleared = session.clear_pending();
+    assert_eq!(cleared, 0);
+}

--- a/src/slash/dispatcher.rs
+++ b/src/slash/dispatcher.rs
@@ -73,7 +73,7 @@ impl SlashDispatcher {
     pub fn is_immediate(&self, command: &str) -> bool {
         self.registry
             .get(command)
-            .map(|h| h.immediate())
+            .map(|h| h.immediate(command))
             .unwrap_or(false)
     }
 

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -46,7 +46,7 @@ pub trait SlashHandler: Send + Sync {
     fn description(&self) -> &str;
 
     /// Whether this is an immediate command (responds even when LLM is busy).
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         false
     }
 

--- a/src/slash/handlers.rs
+++ b/src/slash/handlers.rs
@@ -25,7 +25,7 @@ impl SlashHandler for CompactHandler {
         "手动压缩对话历史"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         false
     }
 
@@ -65,7 +65,7 @@ impl SlashHandler for ClearHandler {
         "清除 system prompt 静态层缓存并触发重建"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         true
     }
 
@@ -101,7 +101,7 @@ impl SlashHandler for HelpHandler {
         "显示所有可用指令"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         true
     }
 
@@ -162,7 +162,7 @@ impl SlashHandler for ReasoningHandler {
         "查询或设置推理深度"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         true
     }
 
@@ -213,7 +213,7 @@ impl SlashHandler for ExecHandler {
         "以 owner 身份执行 shell 命令（需权限审批）"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         false
     }
 
@@ -256,7 +256,7 @@ impl SlashHandler for SystemHandler {
         "管理 system prompt 追加区"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         false
     }
 
@@ -401,7 +401,7 @@ impl SlashHandler for WorkdirHandler {
         "工作目录操作"
     }
 
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         false
     }
 

--- a/src/slash/handlers_session.rs
+++ b/src/slash/handlers_session.rs
@@ -1,0 +1,152 @@
+//! Session-related slash command handlers.
+//!
+//! Extracted from `handlers.rs` to keep individual files under 500 lines.
+
+use std::sync::Arc;
+
+use crate::gateway::SessionManager;
+use crate::llm::session::{ChatSession, ConversationSession};
+use crate::slash::context::SlashContext;
+use crate::slash::handler::{SlashHandler, SlashResult};
+
+// ── NewSessionHandler ────────────────────────────────────────────────────
+
+/// `/new` — create a new session for the current channel.
+///
+/// The Gateway routes `SlashResult::NewSession` by calling
+/// `SessionManager::force_new_for_channel`, which creates a fresh
+/// `ConversationSession` and updates the channel→session mapping.
+/// The old session is preserved in the sessions map for recovery.
+pub struct NewSessionHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for NewSessionHandler {
+    fn commands(&self) -> &[&str] {
+        &["new"]
+    }
+
+    fn description(&self) -> &str {
+        "创建新会话"
+    }
+
+    fn immediate(&self, _cmd: &str) -> bool {
+        false
+    }
+
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::NewSession
+    }
+}
+
+// ── StopHandler ───────────────────────────────────────────────────────────
+
+/// `/stop` — terminate the current running task.
+///
+/// The Gateway routes `SlashResult::Stop` by cancelling the active LLM turn,
+/// cascading to child handles, and clearing the pending message queue.
+pub struct StopHandler;
+
+#[async_trait::async_trait]
+impl SlashHandler for StopHandler {
+    fn commands(&self) -> &[&str] {
+        &["stop"]
+    }
+
+    fn description(&self) -> &str {
+        "终止当前运行的任务"
+    }
+
+    fn immediate(&self, _cmd: &str) -> bool {
+        true
+    }
+
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        SlashResult::Stop
+    }
+}
+
+// ── StatusHandler ──────────────────────────────────────────────────────
+
+/// `/status` — display the current session status.
+///
+/// Reads various fields from the [`ConversationSession`] and formats them
+/// into a human-readable status report.
+pub struct StatusHandler {
+    session_manager: Arc<SessionManager>,
+}
+
+impl StatusHandler {
+    /// Create a new StatusHandler operating on the given session manager.
+    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+        Self { session_manager }
+    }
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for StatusHandler {
+    fn commands(&self) -> &[&str] {
+        &["status"]
+    }
+
+    fn description(&self) -> &str {
+        "查看当前会话状态"
+    }
+
+    fn immediate(&self, _cmd: &str) -> bool {
+        true
+    }
+
+    async fn handle(&self, _args: &str, ctx: &SlashContext) -> SlashResult {
+        let Some(conv) = self
+            .session_manager
+            .get_conversation_session(&ctx.session_id)
+            .await
+        else {
+            return SlashResult::Reply("当前会话未激活".to_owned());
+        };
+        let cs = conv.read().await;
+
+        let busy = cs.is_llm_busy();
+        let llm_status = if busy { "运行中" } else { "空闲" };
+
+        let model = cs.model();
+        let reasoning = cs.reasoning_level();
+        let total_tokens = cs.stats().total_tokens;
+
+        // Count active child handles (Weak references that are still alive).
+        let child_handles = cs.child_handles.read().unwrap_or_else(|e| e.into_inner());
+        let active_children: usize = child_handles
+            .values()
+            .filter(
+                |w: &&std::sync::Weak<tokio::sync::RwLock<ConversationSession>>| {
+                    w.upgrade().is_some()
+                },
+            )
+            .count();
+
+        let workdir = cs.workdir().display();
+        let appends = cs.system_appends();
+
+        // TODO: 「当前模式」字段暂不可用（需 mode 基础设施）
+
+        let mut lines = vec![
+            format!("LLM 状态：{llm_status}"),
+            format!("模型：{model}"),
+            format!("推理深度：{reasoning}"),
+            format!("上下文用量：{total_tokens} tokens"),
+            format!("活跃子 agent：{active_children}"),
+            format!("工作目录：{workdir}"),
+        ];
+
+        if appends.is_empty() {
+            lines.push("追加指令：无".to_owned());
+        } else {
+            lines.push("追加指令：".to_owned());
+            for (i, s) in appends.iter().enumerate() {
+                lines.push(format!("  [{i}] {s}"));
+            }
+        }
+
+        SlashResult::Reply(lines.join("\n"))
+    }
+}

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -29,7 +29,7 @@ impl SlashHandler for MockHandler {
     fn description(&self) -> &str {
         self.desc
     }
-    fn immediate(&self) -> bool {
+    fn immediate(&self, _cmd: &str) -> bool {
         self.imm
     }
     async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
@@ -75,7 +75,7 @@ fn test_compact_handler_commands_and_description() {
     let h = CompactHandler;
     assert_eq!(h.commands(), &["compact"]);
     assert_eq!(h.description(), "手动压缩对话历史");
-    assert!(!h.immediate());
+    assert!(!h.immediate("compact"));
 }
 
 // ── ClearHandler tests ────────────────────────────────────────────────────────
@@ -149,7 +149,7 @@ fn test_help_handler_commands_and_description() {
     let help = HelpHandler::new(Arc::new(registry));
     assert_eq!(help.commands(), &["help"]);
     assert_eq!(help.description(), "显示所有可用指令");
-    assert!(help.immediate());
+    assert!(help.immediate("help"));
 }
 
 // ── HandlerRegistry iter / all_commands tests ───────────────────────────────
@@ -292,7 +292,7 @@ fn test_workdir_handler_commands_and_description() {
     let h = WorkdirHandler::new(sm);
     assert_eq!(h.commands(), &["cd", "pwd", "git"]);
     assert_eq!(h.description(), "工作目录操作");
-    assert!(!h.immediate());
+    assert!(!h.immediate("cd"));
 }
 
 #[tokio::test]
@@ -364,7 +364,7 @@ fn test_reasoning_handler_commands_and_description() {
     let h = ReasoningHandler::new(sm);
     assert_eq!(h.commands(), &["reasoning"]);
     assert_eq!(h.description(), "查询或设置推理深度");
-    assert!(h.immediate());
+    assert!(h.immediate("reasoning"));
 }
 
 #[tokio::test]
@@ -422,7 +422,7 @@ fn test_system_handler_commands_and_description() {
     let h = SystemHandler::new(make_workdir_session_manager());
     assert_eq!(h.commands(), &["system"]);
     assert_eq!(h.description(), "管理 system prompt 追加区");
-    assert!(!h.immediate());
+    assert!(!h.immediate("system"));
 }
 
 #[tokio::test]

--- a/src/slash/handlers_tests_legacy.rs
+++ b/src/slash/handlers_tests_legacy.rs
@@ -20,7 +20,7 @@ fn test_clear_handler_commands_and_description() {
     };
     assert_eq!(h.commands(), &["clear"]);
     assert_eq!(h.description(), "清除 system prompt 静态层缓存并触发重建");
-    assert!(h.immediate());
+    assert!(h.immediate("clear"));
 }
 
 #[test]

--- a/src/slash/handlers_tests_new.rs
+++ b/src/slash/handlers_tests_new.rs
@@ -1,0 +1,164 @@
+//! Tests for NewSessionHandler, StopHandler, StatusHandler, and /help inclusion.
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::slash::context::SlashContext;
+use crate::slash::handler::{SlashHandler, SlashResult};
+use crate::slash::registry::HandlerRegistry;
+use crate::slash::{HelpHandler, NewSessionHandler, StatusHandler, StopHandler};
+
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+pub(crate) fn dummy_ctx() -> SlashContext {
+    SlashContext {
+        command: String::new(),
+        sender_id: "test_sender".to_owned(),
+        session_id: "test_session".to_owned(),
+        channel: "test_channel".to_owned(),
+    }
+}
+
+fn make_workdir_session_manager() -> std::sync::Arc<SessionManager> {
+    use crate::gateway::DmScope;
+    use crate::session::bootstrap::loader::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
+
+    let gc = crate::gateway::GatewayConfig {
+        name: String::new(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: DmScope::default(),
+    };
+    Arc::new(SessionManager::new(
+        &gc,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
+async fn create_test_session(sm: &SessionManager) -> String {
+    use crate::gateway::Message;
+
+    let msg = Message {
+        id: "workdir-test-msg-1".to_string(),
+        from: "user-a".to_string(),
+        to: "agent-b".to_string(),
+        content: "hello".to_string(),
+        channel: "feishu".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+    };
+    sm.find_or_create("feishu", &msg, None)
+        .await
+        .expect("session")
+}
+
+// ── NewSessionHandler tests ────────────────────────────────────────────────
+
+#[test]
+fn test_new_session_handler_commands() {
+    let h = NewSessionHandler;
+    assert_eq!(h.commands(), &["new"]);
+}
+
+#[test]
+fn test_new_session_handler_immediate() {
+    assert!(!NewSessionHandler.immediate("new"));
+}
+
+#[tokio::test]
+async fn test_new_session_handler_handle() {
+    let result = NewSessionHandler.handle("", &dummy_ctx()).await;
+    assert!(matches!(result, SlashResult::NewSession));
+}
+
+// ── StopHandler tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_stop_handler_commands() {
+    let h = StopHandler;
+    assert_eq!(h.commands(), &["stop"]);
+}
+
+#[test]
+fn test_stop_handler_immediate() {
+    assert!(StopHandler.immediate("stop"));
+}
+
+#[tokio::test]
+async fn test_stop_handler_handle() {
+    let result = StopHandler.handle("", &dummy_ctx()).await;
+    assert!(matches!(result, SlashResult::Stop));
+}
+
+// ── StatusHandler tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_status_handler_commands() {
+    let h = StatusHandler::new(make_workdir_session_manager());
+    assert_eq!(h.commands(), &["status"]);
+}
+
+#[test]
+fn test_status_handler_immediate() {
+    assert!(StatusHandler::new(make_workdir_session_manager()).immediate("status"));
+}
+
+#[tokio::test]
+async fn test_status_handler_no_session() {
+    let h = StatusHandler::new(make_workdir_session_manager());
+    let ctx = SlashContext {
+        command: "status".to_owned(),
+        sender_id: "test_sender".to_owned(),
+        session_id: "nonexistent_session".to_owned(),
+        channel: "test_channel".to_owned(),
+    };
+    match h.handle("", &ctx).await {
+        SlashResult::Reply(t) => assert_eq!(t, "当前会话未激活", "got: {t}"),
+        _ => panic!("expected Reply with no-session message"),
+    }
+}
+
+#[tokio::test]
+async fn test_status_handler_with_session() {
+    let sm = make_workdir_session_manager();
+    let sid = create_test_session(&sm).await;
+    let h = StatusHandler::new(Arc::clone(&sm));
+    let mut ctx = dummy_ctx();
+    ctx.session_id = sid;
+    match h.handle("", &ctx).await {
+        SlashResult::Reply(t) => {
+            assert!(t.contains("LLM 状态"), "missing LLM status, got: {t}");
+            assert!(t.contains("模型"), "missing model, got: {t}");
+            assert!(t.contains("推理深度"), "missing reasoning, got: {t}");
+            assert!(t.contains("上下文用量"), "missing tokens, got: {t}");
+            assert!(t.contains("活跃子 agent"), "missing children, got: {t}");
+            assert!(t.contains("工作目录"), "missing workdir, got: {t}");
+            assert!(t.contains("追加指令"), "missing appends, got: {t}");
+        }
+        _ => panic!("expected Reply with status fields"),
+    }
+}
+
+// ── /help includes new, stop, status ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_help_includes_new_stop_status() {
+    let registry = Arc::new(HandlerRegistry::new());
+    registry.register(Arc::new(NewSessionHandler));
+    registry.register(Arc::new(StopHandler));
+    registry.register(Arc::new(StatusHandler::new(make_workdir_session_manager())));
+    let help = HelpHandler::new(Arc::clone(&registry));
+    let ctx = dummy_ctx();
+    match help.handle("", &ctx).await {
+        SlashResult::Reply(t) => {
+            assert!(t.contains("/new"), "missing /new, got: {t}");
+            assert!(t.contains("/stop"), "missing /stop, got: {t}");
+            assert!(t.contains("/status"), "missing /status, got: {t}");
+        }
+        _ => panic!("expected Reply"),
+    }
+}

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -2,15 +2,20 @@ pub mod context;
 pub mod dispatcher;
 pub mod handler;
 pub mod handlers;
+pub mod handlers_session;
 pub mod registry;
 
 pub use context::SlashContext;
 pub use dispatcher::{parse_slash, SlashDispatcher};
 pub use handler::{SlashHandler, SlashResult};
 pub use handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
+pub use handlers_session::{NewSessionHandler, StatusHandler, StopHandler};
 
 #[cfg(test)]
 mod handlers_tests;
+
+#[cfg(test)]
+mod handlers_tests_new;
 
 #[cfg(test)]
 mod handlers_tests_legacy;

--- a/src/slash/tests.rs
+++ b/src/slash/tests.rs
@@ -106,8 +106,8 @@ async fn test_handler_registry() {
 async fn test_slash_handler_immediate_default() {
     // Default is false
     let safe = EchoHandler;
-    assert!(!safe.immediate());
+    assert!(!safe.immediate("echo"));
 
     let risky = RiskyHandler;
-    assert!(!risky.immediate());
+    assert!(!risky.immediate("exec"));
 }


### PR DESCRIPTION
feat(slash): 实现 SessionHandler (/new /stop) 和 StatusHandler (/status)

- 修改 SlashHandler::immediate() 签名为 fn immediate(&self, _cmd: &str) -> bool
- 新增 NewSessionHandler（/new，非 Immediate）
- 新增 StopHandler（/stop，Immediate）
- 新增 StatusHandler（/status，Immediate）
- SessionManager 新增 force_new_for_channel + active_session_for_channel
- ConversationSession 新增 clear_pending
- Gateway 路由实现 NewSession 和 Stop 分支
- 拆分 handlers_session.rs 和 handlers_tests_new.rs 保持文件 ≤ 500 行

Source: issue #892
Type: feat
