### PR TITLE
feat(config): ConfigReloadManager 接入 daemon，推送配置变更到已有会话

### DIFF
--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -7,6 +7,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
+use tracing::info;
+
 use super::agents::{AgentDirectoryProvider, AgentsConfig, ResolvedAgentConfig};
 use super::manager::{ConfigLoadError, ConfigManager};
 
@@ -100,6 +102,14 @@ impl ConfigManager {
         }
         drop(perms_map);
 
+        Ok(())
+    }
+
+    /// Hot-reload: re-scan agents/ directory and update agents + agent_permissions caches.
+    /// Called when agents.json or any agents/<id>/*.json file changes on disk.
+    pub fn reload_agents(&self) -> Result<(), ConfigLoadError> {
+        self.load_agents(None)?;
+        info!("Agent configs reloaded");
         Ok(())
     }
 

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -163,7 +163,7 @@ impl ConfigSection {
     }
 
     /// Returns the absolute path to this section's file relative to config_dir.
-    fn path(&self, config_dir: &Path) -> PathBuf {
+    pub(crate) fn path(&self, config_dir: &Path) -> PathBuf {
         config_dir.join(self.filename())
     }
 }
@@ -213,7 +213,7 @@ pub struct ConfigManager {
     /// Thread-safe backup manager.
     backup_manager: SafeBackupManager,
     /// In-memory cache of all loaded config sections.
-    sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
+    pub(crate) sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
     /// Loaded credentials provider (from config/credentials/ directory).
     credentials_provider: RwLock<CredentialsProvider>,
     /// Resolved agent configurations (loaded from two-level directories).

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -1,0 +1,33 @@
+//! Hot-reload extension for ConfigManager.
+//!
+//! Provides `reload_section()` for updating a single config section's
+//! in-memory cache from validated file content without backup or disk write.
+
+use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
+use tracing::info;
+
+impl ConfigManager {
+    /// Hot-reload a single section from file content (no backup/write).
+    pub fn reload_section(
+        &self,
+        section: ConfigSection,
+        content: &str,
+    ) -> Result<(), ConfigLoadError> {
+        let value: serde_json::Value =
+            serde_json::from_str(content).map_err(|e| ConfigLoadError::ParseError {
+                path: section.path(&self.config_dir),
+                error: e.to_string(),
+            })?;
+        let mut sections = self
+            .sections
+            .write()
+            .expect("RwLock for config sections was poisoned");
+        sections.insert(section, value);
+        info!("reloaded config section: {}", section);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "manager_reload_tests.rs"]
+mod tests;

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -1,0 +1,87 @@
+//! Tests for ConfigManager hot-reload methods (reload_section / reload_agents).
+
+use crate::config::manager::*;
+use std::fs;
+
+/// Helper: set up a valid config directory with all mandatory JSON files.
+fn setup_config_dir_at(dir: &std::path::Path) {
+    fs::write(dir.join("models.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("system.json"), r#"{"version": "1.0"}"#).unwrap();
+}
+
+/// Test: reload_section with valid JSON updates the in-memory cache.
+#[test]
+fn test_reload_section_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let before = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(before["version"], "1.0");
+
+    let new_json = r#"{"version": "9.9", "updated": true}"#;
+    manager
+        .reload_section(ConfigSection::System, new_json)
+        .unwrap();
+
+    let after = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(after["version"], "9.9");
+    assert_eq!(after["updated"], true);
+}
+
+/// Test: reload_section with invalid JSON returns an error and leaves the cache unchanged.
+#[test]
+fn test_reload_section_invalid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let before = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(before["version"], "1.0");
+
+    let result = manager.reload_section(ConfigSection::System, "not json");
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigLoadError::ParseError { .. }
+    ));
+
+    let after = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(after["version"], "1.0");
+}
+
+/// Test: reload_agents succeeds when agents/ directory has valid agent configs.
+///
+/// Note: `load_agents` resolves the user agents directory as
+/// `config_dir.parent().join("agents")`, so the agent directory must
+/// be a sibling of the config directory, not inside it.
+#[test]
+fn test_reload_agents_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    setup_config_dir_at(&config_dir);
+
+    let agents_json = r#"{ "version": "1.0", "agents": ["alpha"] }"#;
+    fs::write(config_dir.join("agents.json"), agents_json).unwrap();
+
+    let agent_dir = tmp.path().join("agents").join("alpha");
+    fs::create_dir_all(&agent_dir).unwrap();
+    fs::write(
+        agent_dir.join("config.json"),
+        r#"{ "id": "alpha", "name": "Alpha Agent" }"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(config_dir).unwrap();
+    manager.reload_agents().unwrap();
+
+    let agents = manager.agents();
+    assert!(agents.contains_key("alpha"));
+    assert_eq!(agents["alpha"].id, "alpha");
+}

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -254,11 +254,15 @@ fn test_config_manager_load_credentials_corrupted_file() {
 // ---------------------------------------------------------------------------
 
 fn setup_config_dir(tmp: &tempfile::TempDir) {
-    fs::write(tmp.path().join("models.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(tmp.path().join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(tmp.path().join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(tmp.path().join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(tmp.path().join("system.json"), r#"{"version": "1.0"}"#).unwrap();
+    setup_config_dir_at(tmp.path());
+}
+
+fn setup_config_dir_at(dir: &std::path::Path) {
+    fs::write(dir.join("models.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
+    fs::write(dir.join("system.json"), r#"{"version": "1.0"}"#).unwrap();
 }
 
 #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ pub mod agent_loader;
 pub mod agents;
 pub mod backup;
 pub mod manager;
+pub mod manager_reload;
 pub mod migration;
 pub mod providers;
 pub mod reload;

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -1,0 +1,214 @@
+//! Config Hot Reload Initialization
+//!
+//! Initializes file watching for configuration changes at daemon startup.
+//! Watches individual config JSON files and the agents/ directory, triggering
+//! incremental or full reloads on the ConfigManager.
+
+use crate::config::manager::{ConfigManager, ConfigSection};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tracing::info;
+
+/// RAII handle for the config file watcher.
+///
+/// Dropping this stops the underlying filesystem watcher.
+pub(crate) struct ConfigWatcherHandle {
+    _watcher: RecommendedWatcher,
+}
+
+/// Map a config filename to its corresponding ConfigSection.
+///
+/// `agents.json` is NOT mapped here — it is handled separately via
+/// `ConfigManager::reload_agents()` in the event consumer.
+fn filename_to_section(filename: &str) -> Option<ConfigSection> {
+    match filename {
+        "models.json" => Some(ConfigSection::Models),
+        "channels.json" => Some(ConfigSection::Channels),
+        "gateway.json" => Some(ConfigSection::Gateway),
+        "plugins.json" => Some(ConfigSection::Plugins),
+        "system.json" => Some(ConfigSection::System),
+        _ => None,
+    }
+}
+
+/// Create a filesystem watcher and return it with the event receiver.
+///
+/// Watches individual config JSON files and the `agents/` directory.
+fn setup_watcher(
+    config_dir: &str,
+) -> anyhow::Result<(RecommendedWatcher, mpsc::Receiver<notify::Result<Event>>)> {
+    let config_path = Path::new(config_dir);
+    let agents_dir = config_path.join("agents");
+
+    let config_files: Vec<PathBuf> = [
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+        "agents.json",
+    ]
+    .iter()
+    .map(|f| config_path.join(f))
+    .collect();
+
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>(64);
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            if let Ok(event) = res {
+                let _ = tx.try_send(Ok(event));
+            }
+        },
+        notify::Config::default(),
+    )?;
+
+    for path in &config_files {
+        if path.exists() {
+            watcher.watch(path.as_ref(), RecursiveMode::NonRecursive)?;
+        }
+    }
+
+    if agents_dir.exists() {
+        watcher.watch(agents_dir.as_ref(), RecursiveMode::Recursive)?;
+    }
+
+    Ok((watcher, rx))
+}
+
+/// Reload all agent configs and log the result.
+fn reload_agents_with_log(path: &std::path::Path, cm: &ConfigManager) {
+    info!(
+        path = %path.display(),
+        "agent config change detected, reloading agents"
+    );
+    if let Err(e) = cm.reload_agents() {
+        tracing::warn!(error = %e, "failed to reload agent configs");
+    }
+}
+
+/// Handle a single changed file path: reload agents or the matching section.
+async fn handle_changed_path(path: &std::path::Path, cm: &ConfigManager) {
+    let path_str = path.to_string_lossy();
+
+    if path_str.contains("/agents/") || path_str.contains("\\agents\\") {
+        reload_agents_with_log(path, cm);
+        return;
+    }
+
+    let filename = match path.file_name().and_then(|n| n.to_str()) {
+        Some(f) => f,
+        None => return,
+    };
+
+    if filename == "agents.json" {
+        reload_agents_with_log(path, cm);
+        return;
+    }
+
+    if let Some(section) = filename_to_section(filename) {
+        match tokio::fs::read_to_string(path).await {
+            Ok(content) => {
+                info!(
+                    path = %path.display(),
+                    section = %section,
+                    "config file changed, reloading section"
+                );
+                if let Err(e) = cm.reload_section(section, &content) {
+                    tracing::warn!(
+                        error = %e, section = %section,
+                        "failed to reload config section"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e, path = %path.display(),
+                    "failed to read changed config file"
+                );
+            }
+        }
+    }
+}
+
+/// Spawn the background event consumer that processes file change events.
+///
+/// Applies a simple time-window debounce and dispatches reloads to the
+/// appropriate `ConfigManager` method based on the changed path.
+fn spawn_event_consumer(
+    mut rx: mpsc::Receiver<notify::Result<Event>>,
+    config_manager: Arc<ConfigManager>,
+) {
+    tokio::spawn(async move {
+        let debounce = Duration::from_millis(500);
+        let mut last_reload = Instant::now() - debounce * 2;
+
+        while let Some(event_result) = rx.recv().await {
+            let event = match event_result {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(error = %e, "config watcher event error");
+                    continue;
+                }
+            };
+
+            match event.kind {
+                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {}
+                _ => continue,
+            }
+
+            let now = Instant::now();
+            if now.duration_since(last_reload) < debounce {
+                continue;
+            }
+            last_reload = now;
+
+            for path in &event.paths {
+                handle_changed_path(path, &config_manager).await;
+            }
+        }
+    });
+}
+
+/// Initialize config hot-reload: create a file watcher and spawn the event consumer.
+///
+/// Returns the watcher handle (RAII: stops on drop). The spawned tokio task
+/// continues running in the background for the lifetime of the daemon.
+pub(crate) fn init_config_hot_reload(
+    config_dir: &str,
+    config_manager: Arc<ConfigManager>,
+) -> anyhow::Result<ConfigWatcherHandle> {
+    let (watcher, rx) = setup_watcher(config_dir)?;
+    spawn_event_consumer(rx, Arc::clone(&config_manager));
+
+    let config_path = Path::new(config_dir);
+    let agents_dir = config_path.join("agents");
+    let watch_count = [
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+        "agents.json",
+    ]
+    .iter()
+    .filter(|f| config_path.join(f).exists())
+    .count()
+        + if agents_dir.exists() { 1 } else { 0 };
+
+    info!(
+        watch_count,
+        "config hot-reload initialized, watching {} \
+         files + agents/ directory",
+        watch_count,
+    );
+
+    Ok(ConfigWatcherHandle { _watcher: watcher })
+}
+
+#[cfg(test)]
+#[path = "config_reload_tests.rs"]
+mod tests;

--- a/src/daemon/config_reload_tests.rs
+++ b/src/daemon/config_reload_tests.rs
@@ -1,0 +1,30 @@
+//! Tests for daemon config hot-reload module.
+
+use super::*;
+
+#[test]
+fn test_filename_to_section() {
+    assert_eq!(
+        filename_to_section("models.json"),
+        Some(ConfigSection::Models)
+    );
+    assert_eq!(
+        filename_to_section("channels.json"),
+        Some(ConfigSection::Channels)
+    );
+    assert_eq!(
+        filename_to_section("gateway.json"),
+        Some(ConfigSection::Gateway)
+    );
+    assert_eq!(
+        filename_to_section("plugins.json"),
+        Some(ConfigSection::Plugins)
+    );
+    assert_eq!(
+        filename_to_section("system.json"),
+        Some(ConfigSection::System)
+    );
+    // agents.json is NOT mapped — handled via reload_agents() separately
+    assert_eq!(filename_to_section("agents.json"), None);
+    assert_eq!(filename_to_section("unknown.json"), None);
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Orchestrates all components: Gateway, AgentRegistry, PermissionEngine.
 //! Handles graceful shutdown via ShutdownCoordinator.
+pub mod config_reload;
 pub mod shutdown;
 pub mod skill_reload;
 use crate::agent::spawn::SpawnController;
@@ -70,6 +71,8 @@ pub struct Daemon {
     pub skill_registry: Arc<RwLock<Option<DiskSkillRegistry>>>,
     /// Skill file watcher handle (RAII: stops on drop)
     _skill_watcher: Option<SkillWatcherHandle>,
+    /// Config file watcher handle (RAII: stops on drop)
+    _config_watcher: Option<config_reload::ConfigWatcherHandle>,
     /// Daemon-level approval orchestrator
     pub approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
 }
@@ -99,7 +102,10 @@ impl Daemon {
             }
             Err(e) => {
                 // Migration errors are non-fatal; log and continue
-                tracing::warn!(error = %e, "openclaw.json migration failed — continuing with existing config");
+                tracing::warn!(
+                    error = %e,
+                    "openclaw.json migration failed — continuing with existing config"
+                );
             }
         }
         // Initialize SQLite storage — fail hard if this fails (no MemoryStorage fallback)
@@ -126,7 +132,8 @@ impl Daemon {
                         path = %session_config_path.display(),
                         "failed to load session config, using hardcoded defaults"
                     );
-                    // Use a non-existent path so new() returns Ok with config=None (hardcoded defaults)
+                    // Use a non-existent path so new() returns Ok with
+                    // config=None (hardcoded defaults)
                     Arc::new(
                         JsonSessionConfigProvider::new(
                             "/dev/null/closeclaw_session_config_nonexistent",
@@ -204,6 +211,7 @@ impl Daemon {
 
         // Create ToolRegistry and register builtin tools
         let tool_registry = Arc::new(ToolRegistry::new());
+        let mut config_watcher = None;
         {
             let disk_reg_opt = {
                 let guard = skill_registry.read().unwrap();
@@ -216,8 +224,28 @@ impl Daemon {
                         .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
                 );
                 if let Err(e) = config_manager.load_agents(None) {
-                    tracing::warn!(error = %e, "failed to load agent configs from ConfigManager — spawn validation will use defaults");
+                    tracing::warn!(
+                        error = %e,
+                        "failed to load agent configs from ConfigManager — \
+                         spawn validation will use defaults"
+                    );
                 }
+
+                // Initialize config hot-reload: watch JSON files + agents/ dir
+                config_watcher = match config_reload::init_config_hot_reload(
+                    config_dir,
+                    Arc::clone(&config_manager),
+                ) {
+                    Ok(handle) => Some(handle),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to initialize config hot-reload — \
+                             config changes will require restart"
+                        );
+                        None
+                    }
+                };
                 // Create SpawnController for session-based spawn validation.
                 let spawn_controller = Arc::new(SpawnController::new(
                     Arc::clone(&config_manager),
@@ -269,6 +297,7 @@ impl Daemon {
             sweeper_shutdown_tx: sweeper_tx,
             skill_registry,
             _skill_watcher: Some(skill_watcher),
+            _config_watcher: config_watcher,
             approval_flow,
         })
     }


### PR DESCRIPTION
feat(config): ConfigReloadManager 接入 daemon，推送配置变更到已有会话

## 变更内容
- ConfigManager 新增 `reload_section()` 方法：从已校验的文件内容更新单个 section 内存缓存
- ConfigManager 新增 `reload_agents()` 方法：重新扫描 agents/ 目录更新 agent 配置
- Daemon 启动时创建 `notify` watcher 监听 config/ 下 6 个 JSON 文件 + agents/ 目录
- Spawn tokio 事件消费任务，500ms 去抖，匹配路径调用对应 reload 方法
- 错误降级：热重载初始化失败不阻塞 daemon 启动

## 文件变更
- `src/config/manager_reload.rs` — reload_section() 实现
- `src/config/manager_reload_tests.rs` — reload 单元测试
- `src/config/agent_loader.rs` — reload_agents() 实现
- `src/config/mod.rs` — 新模块声明
- `src/daemon/config_reload.rs` — watcher 初始化 + 事件消费任务
- `src/daemon/config_reload_tests.rs` — filename_to_section 测试
- `src/daemon/mod.rs` — 集成热重载到 daemon 启动流程

Source: issue #895
Type: feat
