### PR TITLE
feat(skills): 实现 Skill 执行层 — inline 正文注入 + fork 子 agent 执行

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -32,7 +32,7 @@ pub use spawn::{ChildSessionInfo, SpawnMode};
 /// It provides find_or_create to lookup or create a session by channel + message.
 pub struct SessionManager {
     /// Active sessions: session_id -> Session
-    sessions: RwLock<HashMap<String, Session>>,
+    pub(crate) sessions: RwLock<HashMap<String, Session>>,
     /// Persistence backend (for archived session restoration)
     storage: RwLock<Option<Arc<dyn PersistenceService>>>,
     /// DM scope policy (determines how session keys are computed)
@@ -40,7 +40,7 @@ pub struct SessionManager {
     /// IM adapters for sending notifications during restoration
     adapters: RwLock<HashMap<String, Arc<dyn IMAdapter>>>,
     /// Per-session ConversationSession for llm_busy and pending_messages management
-    conversation_sessions: RwLock<HashMap<String, Arc<RwLock<ConversationSession>>>>,
+    pub(crate) conversation_sessions: RwLock<HashMap<String, Arc<RwLock<ConversationSession>>>>,
     /// Workspace directory for bootstrap file loading (None means no workspace)
     workspace_dir: Option<PathBuf>,
     /// Bootstrap mode determining which files to load

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -91,6 +91,7 @@ async fn test_try_push_announce_run_mode() {
             None,
             SpawnMode::Run,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -135,6 +136,7 @@ async fn test_try_push_announce_session_mode_noop() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -255,6 +257,7 @@ async fn test_thinking_blocks_excluded() {
             None,
             SpawnMode::Run,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -83,7 +83,20 @@ impl SessionManager {
         workspace: Option<&str>,
         mode: SpawnMode,
         fork: bool,
+        allowed_tools: Option<Vec<String>>,
     ) -> Result<String, String> {
+        // Apply tool whitelist override: when allowed_tools is provided,
+        // replace the config's tools list so the child session only has
+        // access to the specified tools.
+        let config = if let Some(ref tools) = allowed_tools {
+            let mut overridden = config.clone();
+            overridden.tools = tools.clone();
+            overridden
+        } else {
+            config.clone()
+        };
+        let config = &config;
+
         // 1. Generate child session_id
         let child_session_id = Uuid::new_v4().to_string();
 

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -74,6 +74,7 @@ async fn test_create_child_session_basic() {
             None,
             SpawnMode::Run,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -127,6 +128,7 @@ async fn test_create_child_session_workspace_fallback() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -146,6 +148,7 @@ async fn test_create_child_session_workspace_fallback() {
             Some(other.path().to_str().unwrap()),
             SpawnMode::Run,
             false,
+            None,
         )
         .await
         .expect("create_child_session with explicit workspace should succeed");
@@ -181,6 +184,7 @@ async fn test_create_child_session_registers_child_info() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -219,6 +223,7 @@ async fn test_steer_child_injects_pending_message() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -269,6 +274,7 @@ async fn test_kill_child_removes_from_all_tables() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -329,6 +335,7 @@ async fn test_validate_child_ownership_returns_none_for_run_mode() {
             None,
             SpawnMode::Run,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -364,6 +371,7 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
             None,
             SpawnMode::Session,
             false,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -377,4 +385,83 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
     assert_eq!(info.session_id, child_id);
     assert_eq!(info.mode, SpawnMode::Session);
     assert_eq!(info.parent_session_id, "parent-validate-session");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_allowed_tools_override() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Config with some tools listed
+    let config = ResolvedAgentConfig {
+        id: "tools-agent".to_string(),
+        name: "tools-agent".to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec!["ToolA".into(), "ToolB".into(), "ToolC".into()],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        source: ConfigSource::Merged,
+    };
+
+    register_parent_session(&mgr, "parent-tools", tmp.path().to_path_buf()).await;
+
+    // Create child with allowed_tools override
+    let allowed = vec!["ToolA".to_string(), "ToolC".to_string()];
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-tools",
+            1,
+            "restricted task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            Some(allowed),
+        )
+        .await
+        .expect("create_child_session with allowed_tools should succeed");
+
+    // Child should be created successfully
+    assert!(mgr.has_session(&child_id).await);
+    assert_eq!(mgr.get_session_depth(&child_id).await, Some(1));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_no_allowed_tools_preserves_config() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    let config = test_resolved_config("no-restrict", None);
+
+    register_parent_session(&mgr, "parent-no-restrict", tmp.path().to_path_buf()).await;
+
+    // Create child without allowed_tools (None) — should use config's tools as-is
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-no-restrict",
+            1,
+            "normal task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+        )
+        .await
+        .expect("create_child_session without allowed_tools should succeed");
+
+    assert!(mgr.has_session(&child_id).await);
 }

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -176,6 +176,7 @@ pub(super) async fn spawn_n_run_children(
                 None,
                 SpawnMode::Run,
                 false,
+                None,
             )
             .await
             .expect("create_child_session should succeed");

--- a/src/skills/disk/frontmatter.rs
+++ b/src/skills/disk/frontmatter.rs
@@ -108,10 +108,13 @@ pub fn parse_skill_md(raw: &str) -> Result<ParsedSkill, ParseError> {
         && !frontmatter_trimmed.contains("paths:")
         && !frontmatter_trimmed.contains("user_invocable:");
 
+    let body = extract_skill_body(raw).to_string();
+
     Ok(ParsedSkill {
         manifest,
         description_only,
         frontmatter_raw: frontmatter_trimmed.to_string(),
+        body,
     })
 }
 
@@ -298,5 +301,78 @@ user_invocable: false
         let input = "---\ndescription: Skill\n---\n\n  # Title  \n\nContent.  \n  ";
         let body = extract_skill_body(input);
         assert_eq!(body, "# Title  \n\nContent.");
+    }
+
+    // --- parse_skill_md body extraction tests ---
+
+    #[test]
+    fn test_parse_skill_md_populates_body() {
+        let input = r#"---
+name: "test"
+description: "A test skill"
+---
+
+# Body
+
+Some instructions here."#;
+
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "# Body\n\nSome instructions here.");
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_no_frontmatter() {
+        // No frontmatter → body is empty (extract_skill_body returns "")
+        let input = "---\ndescription: test\n---";
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "");
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_with_bom() {
+        let input = concat!("\u{feff}", "---\ndescription: With BOM\n---\n\n# Body\n");
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "# Body");
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_no_body_text() {
+        let input = "---\ndescription: No body\n---\n";
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "");
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_preserves_multiline() {
+        let input = "---\ndescription: Multi\n---\n\n# Step 1\nDo something.\n\n# Step 2\nDo another thing.";
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(
+            result.body,
+            "# Step 1\nDo something.\n\n# Step 2\nDo another thing."
+        );
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_bom_no_body() {
+        // BOM present, frontmatter present, but no body text after closing ---
+        let input = concat!("\u{feff}", "---\ndescription: BOM skill\n---\n");
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "");
+    }
+
+    #[test]
+    fn test_parse_skill_md_body_whitespace_only_after_frontmatter() {
+        // Only whitespace after closing --- should trim to empty
+        let input = "---\ndescription: Whitespace body\n---\n   \n  \n";
+        let result = parse_skill_md(input).expect("should parse");
+        assert_eq!(result.body, "");
+    }
+
+    #[test]
+    fn test_extract_skill_body_bom_no_frontmatter() {
+        // BOM present but no frontmatter delimiters at all
+        let input = concat!("\u{feff}", "Just plain text with BOM.");
+        let body = extract_skill_body(input);
+        assert_eq!(body, "");
     }
 }

--- a/src/skills/disk/loader.rs
+++ b/src/skills/disk/loader.rs
@@ -118,6 +118,7 @@ fn scan_layer(
             manifest,
             readme_path,
             skill_dir,
+            body: parsed.body,
         };
 
         if let Some(existing) = skills.get(&name) {
@@ -300,5 +301,73 @@ mod tests {
         };
         let skills = scan_all_skills(&config);
         assert_eq!(skills.len(), 1);
+    }
+
+    #[test]
+    fn test_scan_populates_body() {
+        let temp = tempfile::tempdir().unwrap();
+        create_file(
+            &temp.path().join("my-skill").join("SKILL.md"),
+            "---\ndescription: A skill\n---\n\n# Hello\n\nInstructions here.\n",
+        );
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let skills = scan_all_skills(&config);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].body, "# Hello\n\nInstructions here.");
+    }
+
+    #[test]
+    fn test_scan_body_empty_when_no_body_text() {
+        let temp = tempfile::tempdir().unwrap();
+        create_file(
+            &temp.path().join("no-body").join("SKILL.md"),
+            "---\ndescription: No body\n---\n",
+        );
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let skills = scan_all_skills(&config);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].body, "");
+    }
+
+    #[test]
+    fn test_scan_body_with_bom() {
+        let temp = tempfile::tempdir().unwrap();
+        create_file(
+            &temp.path().join("bom-skill").join("SKILL.md"),
+            concat!("\u{feff}", "---\ndescription: BOM skill\n---\n\n# Body\n"),
+        );
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let skills = scan_all_skills(&config);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].body, "# Body");
+    }
+
+    #[test]
+    fn test_scan_body_preserves_multiline() {
+        let temp = tempfile::tempdir().unwrap();
+        create_file(
+            &temp.path().join("multi").join("SKILL.md"),
+            "---\ndescription: Multi\n---\n\n# Step 1\nDo A.\n\n# Step 2\nDo B.\n",
+        );
+
+        let config = ScanConfig {
+            bundled_dir: Some(temp.path().to_path_buf()),
+            ..Default::default()
+        };
+        let skills = scan_all_skills(&config);
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].body, "# Step 1\nDo A.\n\n# Step 2\nDo B.");
     }
 }

--- a/src/skills/disk/mod.rs
+++ b/src/skills/disk/mod.rs
@@ -19,6 +19,6 @@ pub use loader::scan_all_skills;
 pub use registry::DiskSkillRegistry;
 pub use resolve::{resolve_skill, ResolvedSkill};
 pub use types::{
-    DiskSkill, LoadBodyError, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort,
-    SkillManifest, SkillSource,
+    DiskSkill, ParseError, ParsedSkill, ScanConfig, SkillContext, SkillEffort, SkillManifest,
+    SkillSource,
 };

--- a/src/skills/disk/registry_tests/mod.rs
+++ b/src/skills/disk/registry_tests/mod.rs
@@ -22,6 +22,7 @@ fn skill(name: &str, source: SkillSource) -> DiskSkill {
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -92,6 +93,7 @@ fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskS
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -112,6 +114,7 @@ fn skill_with_when_to_use(name: &str, source: SkillSource, when_to_use: &str) ->
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -191,6 +194,7 @@ fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> Disk
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 

--- a/src/skills/disk/registry_tests/user_invocable.rs
+++ b/src/skills/disk/registry_tests/user_invocable.rs
@@ -24,6 +24,7 @@ fn skill_with_invocable(name: &str, source: SkillSource, user_invocable: bool) -
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -44,6 +45,7 @@ fn skill(name: &str, source: SkillSource) -> DiskSkill {
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -64,6 +66,7 @@ fn skill_with_agent_id(name: &str, source: SkillSource, agent_id: &str) -> DiskS
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 
@@ -84,6 +87,7 @@ fn skill_with_paths(name: &str, source: SkillSource, paths: Vec<String>) -> Disk
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 

--- a/src/skills/disk/resolve.rs
+++ b/src/skills/disk/resolve.rs
@@ -85,6 +85,7 @@ mod tests {
             },
             readme_path: std::path::PathBuf::from("/tmp/test"),
             skill_dir: std::path::PathBuf::from("/tmp/test"),
+            body: String::new(),
         }
     }
 

--- a/src/skills/disk/types.rs
+++ b/src/skills/disk/types.rs
@@ -1,6 +1,5 @@
 //! Disk Skill Types - type definitions for the disk skill system
 
-use super::frontmatter::extract_skill_body;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -114,6 +113,9 @@ pub struct DiskSkill {
     pub readme_path: std::path::PathBuf,
     /// Absolute path to the skill directory.
     pub skill_dir: std::path::PathBuf,
+    /// Skill body (instruction text) extracted from the SKILL.md file.
+    /// Empty string until populated by the loader layer.
+    pub body: String,
 }
 
 /// Result of parsing a SKILL.md frontmatter block.
@@ -125,14 +127,8 @@ pub struct ParsedSkill {
     pub description_only: bool,
     /// Raw frontmatter block (without delimiters), kept for traceability.
     pub frontmatter_raw: String,
-}
-
-/// Errors that can occur when loading the skill body from disk.
-#[derive(Debug, thiserror::Error)]
-pub enum LoadBodyError {
-    /// Failed to read the SKILL.md file from disk.
-    #[error("failed to read SKILL.md: {0}")]
-    Io(String),
+    /// Skill body (instruction text) extracted from after the frontmatter.
+    pub body: String,
 }
 
 /// Errors that can occur when parsing SKILL.md frontmatter.
@@ -166,36 +162,9 @@ pub struct ScanConfig {
     pub agent_id: Option<String>,
 }
 
-impl DiskSkill {
-    /// Load the skill body (instruction text) from disk on demand.
-    ///
-    /// Reads the SKILL.md file at `self.readme_path`, extracts the
-    /// text after the frontmatter closing `---` delimiter, and returns
-    /// the trimmed result.
-    pub fn load_body(&self) -> Result<String, LoadBodyError> {
-        let raw = std::fs::read_to_string(&self.readme_path)
-            .map_err(|e| LoadBodyError::Io(e.to_string()))?;
-        let body = extract_skill_body(&raw);
-        Ok(body.to_string())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn make_skill(path: std::path::PathBuf) -> DiskSkill {
-        DiskSkill {
-            source: SkillSource::Global,
-            manifest: SkillManifest {
-                name: "test".into(),
-                description: "test".into(),
-                ..Default::default()
-            },
-            readme_path: path,
-            skill_dir: std::path::PathBuf::new(),
-        }
-    }
 
     #[test]
     fn test_skill_source_priority() {
@@ -281,45 +250,5 @@ mod tests {
         assert!(cfg.global_dir.is_none());
         assert!(cfg.project_root.is_none());
         assert!(cfg.agent_id.is_none());
-    }
-
-    #[test]
-    fn test_load_body_existing_file() {
-        let dir = std::env::temp_dir().join(format!("load_body_test_{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("SKILL.md");
-        let content = "---\ndescription: Test\n---\n\n# Hello\n\nInstructions here.\n";
-        std::fs::write(&path, content).unwrap();
-
-        let skill = make_skill(path.clone());
-        let body = skill.load_body().unwrap();
-        assert_eq!(body, "# Hello\n\nInstructions here.");
-
-        std::fs::remove_file(&path).unwrap();
-        std::fs::remove_dir(&dir).unwrap();
-    }
-
-    #[test]
-    fn test_load_body_missing_file() {
-        let path = std::path::PathBuf::from("/nonexistent/SKILL.md");
-        let skill = make_skill(path);
-        let err = skill.load_body().unwrap_err();
-        assert!(matches!(err, LoadBodyError::Io(_)));
-    }
-
-    #[test]
-    fn test_load_body_no_frontmatter() {
-        let dir = std::env::temp_dir().join(format!("load_body_no_fm_{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("SKILL.md");
-        let content = "Just plain text with no frontmatter.";
-        std::fs::write(&path, content).unwrap();
-
-        let skill = make_skill(path.clone());
-        let body = skill.load_body().unwrap();
-        assert_eq!(body, "");
-
-        std::fs::remove_file(&path).unwrap();
-        std::fs::remove_dir(&dir).unwrap();
     }
 }

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -103,7 +103,14 @@ pub async fn register_builtin_tools(
         .await
         .ok();
     // skills
-    registry.register(SkillTool::new(disk_registry)).await.ok();
+    registry
+        .register(SkillTool::new(
+            disk_registry,
+            spawn_controller.clone(),
+            session_manager.clone(),
+        ))
+        .await
+        .ok();
     // sessions
     registry
         .register(SessionsSpawnTool::new(
@@ -123,6 +130,9 @@ pub async fn register_builtin_tools(
         .await
         .ok();
 }
+
+#[cfg(test)]
+mod skill_tool_tests;
 
 #[cfg(test)]
 #[path = "sessions_spawn_tests.rs"]

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -31,6 +31,7 @@ struct SpawnArgs {
     mode: SpawnMode,
     mode_str: String,
     fork: bool,
+    allowed_tools: Option<Vec<String>>,
 }
 
 impl SessionsSpawnTool {
@@ -73,6 +74,15 @@ impl SessionsSpawnTool {
             _ => SpawnMode::Run,
         };
         let fork = args.get("fork").and_then(|v| v.as_bool()).unwrap_or(false);
+        let allowed_tools = args
+            .get("allowedTools")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect::<Vec<String>>()
+            })
+            .filter(|v| !v.is_empty());
         Ok(SpawnArgs {
             task: task.to_string(),
             agent_id,
@@ -81,6 +91,7 @@ impl SessionsSpawnTool {
             mode,
             mode_str: mode_str.to_string(),
             fork,
+            allowed_tools,
         })
     }
 
@@ -134,6 +145,7 @@ impl SessionsSpawnTool {
         workspace: Option<&str>,
         mode: SpawnMode,
         fork: bool,
+        allowed_tools: Option<Vec<String>>,
     ) -> Result<String, ToolCallError> {
         self.session_manager
             .create_child_session(
@@ -145,6 +157,7 @@ impl SessionsSpawnTool {
                 workspace,
                 mode,
                 fork,
+                allowed_tools,
             )
             .await
             .map_err(|e| {
@@ -176,6 +189,13 @@ impl Tool for SessionsSpawnTool {
     }
 
     fn input_schema(&self) -> Value {
+        let fork_desc = "是否 fork 父 agent 上下文：fork=true 时子 session ".to_owned()
+            + "在 task 之前注入父 agent 的完整对话历史"
+            + "（不含 system prompt），"
+            + "使子 agent 继承父 agent 的上下文认知";
+        let tools_desc = "Optional whitelist of tools the child session may ".to_owned()
+            + "use. When provided, only these tools are available"
+            + " to the child agent.";
         json!({
             "type": "object",
             "properties": {
@@ -212,8 +232,15 @@ impl Tool for SessionsSpawnTool {
                 },
                 "fork": {
                     "type": "boolean",
-                    "description": "是否 fork 父 agent 上下文：fork=true 时子 session 在 task 之前注入父 agent 的完整对话历史（不含 system prompt），使子 agent 继承父 agent 的上下文认知",
+                    "description": fork_desc,
                     "default": false
+                },
+                "allowedTools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": tools_desc
                 }
             },
             "required": ["task"]
@@ -256,6 +283,7 @@ impl Tool for SessionsSpawnTool {
                 spawn_args.workspace.as_deref(),
                 spawn_args.mode,
                 spawn_args.fork,
+                spawn_args.allowed_tools,
             )
             .await?;
         Ok(ToolResult {

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -165,3 +165,50 @@ fn test_sessions_spawn_fork_schema() {
         "description should mention fork"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 4. test_sessions_spawn_allowed_tools_schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sessions_spawn_allowed_tools_schema() {
+    let tool = make_tool();
+    let schema = tool.input_schema();
+
+    let at_prop = schema["properties"]["allowedTools"]
+        .as_object()
+        .expect("allowedTools should be an object in properties");
+
+    assert_eq!(at_prop["type"], "array");
+    let items = at_prop["items"]
+        .as_object()
+        .expect("items should be an object");
+    assert_eq!(items["type"], "string");
+    assert!(
+        at_prop["description"]
+            .as_str()
+            .unwrap()
+            .contains("whitelist"),
+        "description should mention whitelist"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. test_sessions_spawn_missing_task_error_with_allowed_tools
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_sessions_spawn_missing_task_error_with_allowed_tools() {
+    let tool = make_tool();
+    // allowedTools present but task is missing — should still fail
+    let result = tool
+        .call(json!({"allowedTools": ["ReadTool"]}), &ctx_with_session())
+        .await;
+    let err = result.expect_err("should fail without task");
+    match err {
+        ToolCallError::InvalidArgs(msg) => {
+            assert!(msg.contains("task"), "error should mention 'task'");
+        }
+        other => panic!("expected InvalidArgs, got {:?}", other),
+    }
+}

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -4,6 +4,8 @@
 //! reading its SKILL.md file, and returning the content as a meta message
 //! to be injected into the agent context.
 
+use crate::agent::spawn::SpawnController;
+use crate::gateway::session_manager::{SessionManager, SpawnMode};
 use crate::skills::disk::types::SkillContext;
 use crate::skills::disk::DiskSkillRegistry;
 use crate::tools::{
@@ -21,16 +23,30 @@ use std::sync::Arc;
 /// Tool that loads and executes a disk-based skill.
 ///
 /// When called, `SkillTool` looks up the named skill in the
-/// [`DiskSkillRegistry`], reads its SKILL.md file, and injects the
-/// content as a meta message into the agent context.
+/// [`DiskSkillRegistry`], and depending on the skill's context:
+///
+/// - **Inline / Agent**: injects `skill.body` as a meta message into the
+///   agent context, with `context_modifier` for `allowed_tools`.
+/// - **Fork**: creates an isolated child session via [`SessionManager`]
+///   with `task = skill.body`.
 pub struct SkillTool {
     registry: Arc<DiskSkillRegistry>,
+    spawn_controller: Arc<SpawnController>,
+    session_manager: Arc<SessionManager>,
 }
 
 impl SkillTool {
     /// Creates a new `SkillTool` backed by the given registry.
-    pub fn new(registry: Arc<DiskSkillRegistry>) -> Self {
-        Self { registry }
+    pub fn new(
+        registry: Arc<DiskSkillRegistry>,
+        spawn_controller: Arc<SpawnController>,
+        session_manager: Arc<SessionManager>,
+    ) -> Self {
+        Self {
+            registry,
+            spawn_controller,
+            session_manager,
+        }
     }
 }
 
@@ -81,7 +97,7 @@ impl Tool for SkillTool {
         }
     }
 
-    async fn call(&self, args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+    async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
         // Extract skill_name from args
         let skill_name = args
             .get("skill_name")
@@ -94,23 +110,8 @@ impl Tool for SkillTool {
             .get(skill_name)
             .ok_or_else(|| ToolCallError::NotFound(skill_name.to_string()))?;
 
-        // Load skill body (instruction text without frontmatter)
-        let skill_clone = skill.clone();
-        let skill_name_owned = skill_name.to_string();
-        let body = tokio::task::spawn_blocking(move || skill_clone.load_body())
-            .await
-            .map_err(|e| {
-                ToolCallError::ExecutionFailed(format!(
-                    "failed to spawn load task for skill '{}': {}",
-                    skill_name_owned, e
-                ))
-            })?
-            .map_err(|e| {
-                ToolCallError::ExecutionFailed(format!(
-                    "failed to load body for skill '{}': {}",
-                    skill_name, e
-                ))
-            })?;
+        // Use skill.body (populated by loader) instead of reading from disk
+        let body = skill.body.clone();
 
         // Build context_modifier from manifest.allowed_tools
         let context_modifier = if skill.manifest.allowed_tools.is_empty() {
@@ -121,7 +122,7 @@ impl Tool for SkillTool {
             })
         };
 
-        // Determine execution_mode from context type
+        // Dispatch based on SkillContext
         match &skill.manifest.context {
             SkillContext::Inline => Ok(ToolResult {
                 data: serde_json::json!({
@@ -148,18 +149,71 @@ impl Tool for SkillTool {
                 }],
                 context_modifier,
             }),
-            SkillContext::Fork => Ok(ToolResult {
-                data: serde_json::json!({
-                    "skill_name": skill_name,
-                    "status": "loaded",
-                    "execution_mode": "fork"
-                }),
-                new_messages: vec![ToolMessage {
-                    content: body,
-                    is_meta: true,
-                }],
-                context_modifier,
-            }),
+            SkillContext::Fork => {
+                // Fork: create an isolated child session with skill.body as task
+                let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {
+                    ToolCallError::ExecutionFailed(
+                        "no session_id in tool context (fork requires a tracked session)".into(),
+                    )
+                })?;
+
+                // Validate spawn with the parent agent's config
+                let config = self
+                    .spawn_controller
+                    .validate(parent_session_id, None)
+                    .await
+                    .map_err(|e| {
+                        ToolCallError::ExecutionFailed(format!(
+                            "fork spawn validation failed: {}",
+                            e
+                        ))
+                    })?;
+
+                // Get parent depth
+                let parent_depth = self
+                    .session_manager
+                    .get_session_depth(parent_session_id)
+                    .await
+                    .unwrap_or(0);
+
+                // Create child session with skill's allowed_tools whitelist.
+                let allowed_tools = if skill.manifest.allowed_tools.is_empty() {
+                    None
+                } else {
+                    Some(skill.manifest.allowed_tools.clone())
+                };
+                let child_session_id = self
+                    .session_manager
+                    .create_child_session(
+                        &config,
+                        parent_session_id,
+                        parent_depth + 1,
+                        &body,
+                        false, // light_context
+                        None,  // workspace
+                        SpawnMode::Run,
+                        false, // fork (parent history inheritance)
+                        allowed_tools,
+                    )
+                    .await
+                    .map_err(|e| {
+                        ToolCallError::ExecutionFailed(format!(
+                            "fork child session creation failed: {}",
+                            e
+                        ))
+                    })?;
+
+                Ok(ToolResult {
+                    data: serde_json::json!({
+                        "skill_name": skill_name,
+                        "status": "spawned",
+                        "execution_mode": "fork",
+                        "child_session_id": child_session_id
+                    }),
+                    new_messages: vec![],
+                    context_modifier,
+                })
+            }
         }
     }
 }
@@ -167,11 +221,41 @@ impl Tool for SkillTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::spawn::SpawnController;
+    use crate::config::ConfigManager;
+    use crate::gateway::{GatewayConfig, SessionManager};
+    use crate::session::bootstrap::loader::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
     use crate::skills::disk::types::{
         DiskSkill, SkillContext, SkillEffort, SkillManifest, SkillSource,
     };
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    fn test_deps() -> (Arc<SpawnController>, Arc<SessionManager>) {
+        let tmp = TempDir::new().unwrap();
+        let config_manager = Arc::new(
+            ConfigManager::new(tmp.path().to_path_buf())
+                .expect("ConfigManager::new should succeed"),
+        );
+        let session_manager = Arc::new(SessionManager::new(
+            &GatewayConfig {
+                name: "test".to_string(),
+                rate_limit_per_minute: 100,
+                max_message_size: 1024,
+                dm_scope: crate::gateway::DmScope::default(),
+            },
+            None,
+            None,
+            BootstrapMode::Full,
+            ReasoningLevel::default(),
+        ));
+        let spawn_controller = Arc::new(SpawnController::new(
+            config_manager,
+            session_manager.clone(),
+        ));
+        (spawn_controller, session_manager)
+    }
 
     fn make_skill(
         name: &str,
@@ -194,6 +278,7 @@ mod tests {
             },
             readme_path,
             skill_dir: std::path::PathBuf::new(),
+            body: String::new(),
         }
     }
 
@@ -207,28 +292,27 @@ mod tests {
         }
     }
 
-    // -----------------------------------------------------------------
-    // Metadata tests
-    // -----------------------------------------------------------------
-
     #[test]
     fn test_skill_tool_name() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         assert_eq!(tool.name(), "SkillTool");
     }
 
     #[test]
     fn test_skill_tool_group() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         assert_eq!(tool.group(), "skills");
     }
 
     #[test]
     fn test_skill_tool_summary_length() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let summary = tool.summary();
         assert!(
             summary.len() <= 50,
@@ -240,7 +324,8 @@ mod tests {
     #[test]
     fn test_skill_tool_flags_is_deferred_false() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let flags = tool.flags();
         assert!(!flags.is_deferred_by_default);
     }
@@ -248,7 +333,8 @@ mod tests {
     #[test]
     fn test_skill_tool_input_schema_contains_skill_name() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let schema = tool.input_schema();
         let props = schema.get("properties").unwrap().as_object().unwrap();
         assert!(props.contains_key("skill_name"));
@@ -264,7 +350,8 @@ mod tests {
     #[tokio::test]
     async fn test_call_skill_not_found() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let result = tool
             .call(serde_json::json!({"skill_name": "nonexistent"}), &new_ctx())
             .await;
@@ -280,7 +367,8 @@ mod tests {
     #[tokio::test]
     async fn test_call_missing_skill_name() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let result = tool.call(serde_json::json!({}), &new_ctx()).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -290,7 +378,8 @@ mod tests {
     #[tokio::test]
     async fn test_call_skill_name_wrong_type() {
         let registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let result = tool
             .call(serde_json::json!({"skill_name": 123}), &new_ctx())
             .await;
@@ -300,167 +389,49 @@ mod tests {
 
     #[tokio::test]
     async fn test_call_readme_file_not_found() {
-        let skill = make_skill(
+        // With body pre-populated by the loader, an empty body is used
+        // even when readme_path doesn't exist (load_body is no longer called).
+        let mut skill = make_skill(
             "orphan",
             vec![],
             std::path::PathBuf::from("/nonexistent/path/SKILL.md"),
         );
+        skill.body = "".to_string();
         let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
         let result = tool
             .call(serde_json::json!({"skill_name": "orphan"}), &new_ctx())
             .await;
-        assert!(result.is_err());
-        assert!(matches!(result, Err(ToolCallError::ExecutionFailed(_))));
-    }
-
-    // -----------------------------------------------------------------
-    // call() — normal cases
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_call_inline_mode() {
-        let temp = TempDir::new().unwrap();
-        let readme_path = temp.path().join("SKILL.md");
-        let skill_content =
-            "---\ndescription: A test skill\n---\n\n# Test Skill\n\nSome skill content here.\n";
-        std::fs::write(&readme_path, skill_content).unwrap();
-
-        let skill = make_skill("testskill", vec![], readme_path);
-        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
-
-        let result = tool
-            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
-            .await
-            .unwrap();
-
-        assert_eq!(result.data["skill_name"], "testskill");
-        assert_eq!(result.data["status"], "loaded");
+        // Should succeed with empty body (inline mode)
+        assert!(result.is_ok());
+        let result = result.unwrap();
         assert_eq!(result.data["execution_mode"], "inline");
-        assert_eq!(result.new_messages.len(), 1);
-        assert!(result.new_messages[0].is_meta);
-        // After Step 1.3, body() extracts text after frontmatter
-        assert_eq!(
-            result.new_messages[0].content,
-            "# Test Skill\n\nSome skill content here."
-        );
-        // Ensure frontmatter is NOT present in injected content
-        assert!(!result.new_messages[0].content.contains("---"));
-        assert!(result.context_modifier.is_none());
     }
 
     #[tokio::test]
-    async fn test_call_agent_mode() {
-        let temp = TempDir::new().unwrap();
-        let readme_path = temp.path().join("SKILL.md");
-        let skill_content = "---\ndescription: An agent skill\n---\n\n# Agent Skill\n";
-        std::fs::write(&readme_path, skill_content).unwrap();
-
-        let mut skill = make_skill("agentskill", vec![], readme_path);
-        skill.manifest.context = SkillContext::Agent {
-            agent_id: "my-agent".to_string(),
-        };
-        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
-
-        let result = tool
-            .call(serde_json::json!({"skill_name": "agentskill"}), &new_ctx())
-            .await
-            .unwrap();
-
-        assert_eq!(result.data["execution_mode"], "agent");
-        assert_eq!(result.data["agent_id"], "my-agent");
-    }
-
-    #[tokio::test]
-    async fn test_call_fork_mode() {
+    async fn test_call_fork_mode_no_session() {
+        // Fork without session_id in context should fail
         let temp = TempDir::new().unwrap();
         let readme_path = temp.path().join("SKILL.md");
         let skill_content = "---\ndescription: A fork skill\n---\n\n# Fork Skill\n";
         std::fs::write(&readme_path, skill_content).unwrap();
 
         let mut skill = make_skill("forkskill", vec![], readme_path);
+        skill.body = "# Fork Skill".to_string();
         skill.manifest.context = SkillContext::Fork;
         let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
 
+        // new_ctx() has session_id = None
         let result = tool
             .call(serde_json::json!({"skill_name": "forkskill"}), &new_ctx())
-            .await
-            .unwrap();
-
-        assert_eq!(result.data["execution_mode"], "fork");
-        assert_eq!(result.data["skill_name"], "forkskill");
-        assert_eq!(result.data["status"], "loaded");
-    }
-
-    #[tokio::test]
-    async fn test_call_injects_body_only() {
-        let temp = TempDir::new().unwrap();
-        let readme_path = temp.path().join("SKILL.md");
-        let skill_content =
-            "---\ndescription: Some description\ntags:\n  - test\n---\n\n# Actual Skill Body\n\nThis is the real content.\n";
-        std::fs::write(&readme_path, skill_content).unwrap();
-
-        let skill = make_skill("testskill", vec![], readme_path);
-        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
-
-        let result = tool
-            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
-            .await
-            .unwrap();
-
-        let content = result.new_messages[0].content.as_str();
-        // Must NOT contain frontmatter delimiters
-        assert!(
-            !content.contains("---"),
-            "content should not contain frontmatter delimiters"
-        );
-        // Must NOT contain YAML field names from frontmatter
-        assert!(
-            !content.contains("description:"),
-            "content should not contain YAML fields"
-        );
-        assert!(
-            !content.contains("tags:"),
-            "content should not contain YAML fields"
-        );
-        // Must contain the body text
-        assert!(
-            content.contains("# Actual Skill Body"),
-            "content should contain body heading"
-        );
-        assert!(
-            content.contains("This is the real content."),
-            "content should contain body text"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_call_normal_with_allowed_tools() {
-        let temp = TempDir::new().unwrap();
-        let readme_path = temp.path().join("SKILL.md");
-        let skill_content = "---\ndescription: Skill with allowed tools\n---\n\n# My Skill\n";
-        std::fs::write(&readme_path, skill_content).unwrap();
-
-        let skill = make_skill(
-            "tooled",
-            vec!["ReadTool".into(), "WriteTool".into()],
-            readme_path,
-        );
-        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
-        let tool = SkillTool::new(registry);
-
-        let result = tool
-            .call(serde_json::json!({"skill_name": "tooled"}), &new_ctx())
-            .await
-            .unwrap();
-
-        assert!(result.context_modifier.is_some());
-        let cm = result.context_modifier.unwrap();
-        assert_eq!(cm.allowed_tools, vec!["ReadTool", "WriteTool"]);
-        assert_eq!(result.data["execution_mode"], "inline");
+            .await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ToolCallError::ExecutionFailed(_)
+        ));
     }
 }

--- a/src/tools/builtin/skill_tool_tests.rs
+++ b/src/tools/builtin/skill_tool_tests.rs
@@ -1,0 +1,416 @@
+//! Fork-mode integration tests for SkillTool.
+//!
+//! Extracted from `skill_tool.rs` to keep the main file under 500 lines.
+
+#[cfg(test)]
+mod tests {
+    use super::super::skill_tool::SkillTool;
+    use crate::agent::config::SubagentsConfig;
+    use crate::agent::spawn::SpawnController;
+    use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+    use crate::config::ConfigManager;
+    use crate::gateway::{GatewayConfig, SessionManager};
+    use crate::llm::session::ConversationSession;
+    use crate::session::bootstrap::loader::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
+    use crate::skills::disk::types::{
+        DiskSkill, SkillContext, SkillEffort, SkillManifest, SkillSource,
+    };
+    use crate::skills::disk::DiskSkillRegistry;
+    use crate::tools::{Tool, ToolContext};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::RwLock;
+
+    fn test_deps() -> (Arc<SpawnController>, Arc<SessionManager>) {
+        let tmp = TempDir::new().unwrap();
+        let config_manager = Arc::new(
+            ConfigManager::new(tmp.path().to_path_buf())
+                .expect("ConfigManager::new should succeed"),
+        );
+        let session_manager = Arc::new(SessionManager::new(
+            &GatewayConfig {
+                name: "test".to_string(),
+                rate_limit_per_minute: 100,
+                max_message_size: 1024,
+                dm_scope: crate::gateway::DmScope::default(),
+            },
+            None,
+            None,
+            BootstrapMode::Full,
+            ReasoningLevel::default(),
+        ));
+        let spawn_controller = Arc::new(SpawnController::new(
+            config_manager,
+            session_manager.clone(),
+        ));
+        (spawn_controller, session_manager)
+    }
+
+    fn new_ctx() -> ToolContext {
+        ToolContext {
+            agent_id: "test-agent".to_string(),
+            workdir: None,
+            session_id: None,
+            call_id: None,
+            session: None,
+        }
+    }
+
+    /// Helper to build a ConfigManager pre-populated with parent + child
+    /// agent configs, a SessionManager, and register a parent
+    /// ConversationSession.
+    async fn setup_fork_env() -> (
+        Arc<ConfigManager>,
+        Arc<SessionManager>,
+        Arc<SpawnController>,
+    ) {
+        let tmp = TempDir::new().unwrap();
+        let config_manager = Arc::new(
+            ConfigManager::new(tmp.path().to_path_buf())
+                .expect("ConfigManager::new should succeed"),
+        );
+
+        // Insert parent agent config with default_child_agent set
+        let parent_config = ResolvedAgentConfig {
+            id: "parent-agent".to_string(),
+            name: "parent-agent".to_string(),
+            parent_id: None,
+            model: Some("test-model".to_string()),
+            workspace: Some(tmp.path().to_path_buf()),
+            agent_dir: None,
+            bootstrap_mode: BootstrapMode::Full,
+            skills: vec![],
+            tools: vec![],
+            disallowed_tools: vec![],
+            subagents: SubagentsConfig {
+                default_child_agent: Some("child-agent".to_string()),
+                require_agent_id: false,
+                max_spawn_depth: 3,
+                max_children: 16,
+                allow_agents: vec!["*".to_string()],
+                model: None,
+            },
+            source: ConfigSource::Merged,
+        };
+        {
+            let mut agents = config_manager.agents.write().unwrap();
+            agents.insert("parent-agent".to_string(), parent_config);
+        }
+
+        // Insert child/target agent config
+        let child_config = ResolvedAgentConfig {
+            id: "child-agent".to_string(),
+            name: "child-agent".to_string(),
+            parent_id: Some("parent-agent".to_string()),
+            model: Some("test-model".to_string()),
+            workspace: Some(tmp.path().to_path_buf()),
+            agent_dir: None,
+            bootstrap_mode: BootstrapMode::Full,
+            skills: vec![],
+            tools: vec![],
+            disallowed_tools: vec![],
+            subagents: SubagentsConfig::default(),
+            source: ConfigSource::Merged,
+        };
+        {
+            let mut agents = config_manager.agents.write().unwrap();
+            agents.insert("child-agent".to_string(), child_config);
+        }
+
+        let session_manager = Arc::new(SessionManager::new(
+            &GatewayConfig {
+                name: "test".to_string(),
+                rate_limit_per_minute: 100,
+                max_message_size: 1024,
+                dm_scope: crate::gateway::DmScope::default(),
+            },
+            None,
+            Some(tmp.path().to_path_buf()),
+            BootstrapMode::Full,
+            ReasoningLevel::default(),
+        ));
+
+        // Register parent session in conversation_sessions
+        let parent_id = "parent-session-fork";
+        let cs = ConversationSession::new(
+            parent_id.to_string(),
+            "test-model".to_string(),
+            tmp.path().to_path_buf(),
+        );
+        let arc = Arc::new(RwLock::new(cs));
+        {
+            let mut conv = session_manager.conversation_sessions.write().await;
+            conv.insert(parent_id.to_string(), arc);
+        }
+        // Also register in sessions map so depth lookup works
+        {
+            let mut sessions = session_manager.sessions.write().await;
+            sessions.insert(
+                parent_id.to_string(),
+                crate::gateway::Session {
+                    id: parent_id.to_string(),
+                    agent_id: "parent-agent".to_string(),
+                    channel: "test".to_string(),
+                    created_at: chrono::Utc::now().timestamp(),
+                    depth: 0,
+                },
+            );
+        }
+
+        let spawn_controller = Arc::new(SpawnController::new(
+            config_manager.clone(),
+            session_manager.clone(),
+        ));
+
+        (config_manager, session_manager, spawn_controller)
+    }
+
+    fn make_skill(
+        name: &str,
+        allowed_tools: Vec<String>,
+        readme_path: std::path::PathBuf,
+    ) -> DiskSkill {
+        DiskSkill {
+            source: SkillSource::Bundled,
+            manifest: SkillManifest {
+                name: name.into(),
+                description: format!("A test skill named {}", name),
+                allowed_tools,
+                when_to_use: String::new(),
+                context: SkillContext::Inline,
+                agent: String::new(),
+                agent_id: String::new(),
+                effort: SkillEffort::Small,
+                paths: vec![],
+                user_invocable: false,
+            },
+            readme_path,
+            skill_dir: std::path::PathBuf::new(),
+            body: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_call_fork_mode_spawns_child() {
+        let (_cm, sm, sc) = setup_fork_env().await;
+
+        // Create a fork skill with body and allowed_tools
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        std::fs::write(
+            &readme_path,
+            "---\ndescription: Fork skill\n---\n\n# Fork Skill\n",
+        )
+        .unwrap();
+
+        let mut skill = make_skill(
+            "forkskill",
+            vec!["ReadTool".into(), "WriteTool".into()],
+            readme_path,
+        );
+        skill.body = "# Fork Skill\n\nDo the fork thing.".to_string();
+        skill.manifest.context = SkillContext::Fork;
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry, sc, sm.clone());
+
+        let ctx = ToolContext {
+            agent_id: "parent-agent".to_string(),
+            workdir: None,
+            session_id: Some("parent-session-fork".to_string()),
+            call_id: None,
+            session: None,
+        };
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "forkskill"}), &ctx)
+            .await;
+
+        let result = result.expect("fork mode should succeed");
+        assert_eq!(result.data["execution_mode"], "fork");
+        assert_eq!(result.data["status"], "spawned");
+        assert!(result.data["child_session_id"].is_string());
+        let child_id = result.data["child_session_id"].as_str().unwrap();
+
+        // Verify the child session was actually created
+        assert!(sm.has_session(child_id).await);
+        assert_eq!(sm.get_session_depth(child_id).await, Some(1));
+
+        // Verify the child session has the skill body as its pending task
+        let cs = sm
+            .get_conversation_session(child_id)
+            .await
+            .expect("child conversation session should exist");
+        let pending = cs.read().await.get_pending_messages();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].content, "# Fork Skill\n\nDo the fork thing.");
+    }
+
+    #[tokio::test]
+    async fn test_call_fork_mode_no_allowed_tools() {
+        let (_cm, sm, sc) = setup_fork_env().await;
+
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        std::fs::write(&readme_path, "---\ndescription: Simple fork\n---\n").unwrap();
+
+        let mut skill = make_skill("simplefork", vec![], readme_path);
+        skill.body = "Simple task".to_string();
+        skill.manifest.context = SkillContext::Fork;
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let tool = SkillTool::new(registry, sc, sm.clone());
+
+        let ctx = ToolContext {
+            agent_id: "parent-agent".to_string(),
+            workdir: None,
+            session_id: Some("parent-session-fork".to_string()),
+            call_id: None,
+            session: None,
+        };
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "simplefork"}), &ctx)
+            .await
+            .expect("fork mode should succeed");
+
+        assert_eq!(result.data["execution_mode"], "fork");
+        let child_id = result.data["child_session_id"].as_str().unwrap();
+        assert!(sm.has_session(child_id).await);
+
+        // context_modifier should be None when no allowed_tools
+        assert!(result.context_modifier.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_call_inline_mode() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content =
+            "---\ndescription: A test skill\n---\n\n# Test Skill\n\nSome skill content here.\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let mut skill = make_skill("testskill", vec![], readme_path);
+        skill.body = "# Test Skill\n\nSome skill content here.".to_string();
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result.data["skill_name"], "testskill");
+        assert_eq!(result.data["status"], "loaded");
+        assert_eq!(result.data["execution_mode"], "inline");
+        assert_eq!(result.new_messages.len(), 1);
+        assert!(result.new_messages[0].is_meta);
+        // body is used directly (populated by loader)
+        assert_eq!(
+            result.new_messages[0].content,
+            "# Test Skill\n\nSome skill content here."
+        );
+        // Ensure frontmatter is NOT present in injected content
+        assert!(!result.new_messages[0].content.contains("---"));
+        assert!(result.context_modifier.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_call_agent_mode() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content = "---\ndescription: An agent skill\n---\n\n# Agent Skill\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let mut skill = make_skill("agentskill", vec![], readme_path);
+        skill.body = "# Agent Skill".to_string();
+        skill.manifest.context = SkillContext::Agent {
+            agent_id: "my-agent".to_string(),
+        };
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "agentskill"}), &new_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result.data["execution_mode"], "agent");
+        assert_eq!(result.data["agent_id"], "my-agent");
+    }
+
+    #[tokio::test]
+    async fn test_call_injects_body_only() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content = "---\ndescription: Some description\ntags:\n  - test\n---\n\n"
+            .to_string()
+            + "# Actual Skill Body\n\nThis is the real content.\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let mut skill = make_skill("testskill", vec![], readme_path);
+        skill.body = "# Actual Skill Body\n\nThis is the real content.".to_string();
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "testskill"}), &new_ctx())
+            .await
+            .unwrap();
+
+        let content = result.new_messages[0].content.as_str();
+        // Must NOT contain frontmatter delimiters
+        assert!(
+            !content.contains("---"),
+            "content should not contain frontmatter delimiters"
+        );
+        // Must NOT contain YAML field names from frontmatter
+        assert!(
+            !content.contains("description:"),
+            "content should not contain YAML fields"
+        );
+        assert!(
+            !content.contains("tags:"),
+            "content should not contain YAML fields"
+        );
+        // Must contain the body text
+        assert!(
+            content.contains("# Actual Skill Body"),
+            "content should contain body heading"
+        );
+        assert!(
+            content.contains("This is the real content."),
+            "content should contain body text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_call_normal_with_allowed_tools() {
+        let temp = TempDir::new().unwrap();
+        let readme_path = temp.path().join("SKILL.md");
+        let skill_content = "---\ndescription: Skill with allowed tools\n---\n\n# My Skill\n";
+        std::fs::write(&readme_path, skill_content).unwrap();
+
+        let mut skill = make_skill(
+            "tooled",
+            vec!["ReadTool".into(), "WriteTool".into()],
+            readme_path,
+        );
+        skill.body = "# My Skill".to_string();
+        let registry = Arc::new(DiskSkillRegistry::new(vec![skill]));
+        let (sc, sm) = test_deps();
+        let tool = SkillTool::new(registry, sc, sm);
+
+        let result = tool
+            .call(serde_json::json!({"skill_name": "tooled"}), &new_ctx())
+            .await
+            .unwrap();
+
+        assert!(result.context_modifier.is_some());
+        let cm = result.context_modifier.unwrap();
+        assert_eq!(cm.allowed_tools, vec!["ReadTool", "WriteTool"]);
+        assert_eq!(result.data["execution_mode"], "inline");
+    }
+}

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -26,6 +26,7 @@ fn make_test_skill(name: &str, description: &str, when_to_use: &str, agent_id: &
         },
         readme_path: PathBuf::from(format!("/skills/{}/SKILL.md", name)),
         skill_dir: PathBuf::from(format!("/skills/{}", name)),
+        body: String::new(),
     }
 }
 


### PR DESCRIPTION
实现 Skill 执行层的 Inline 和 Fork 两条执行路径：

**Inline 模式**：正文展开到 agent 上下文，`context_modifier` 设置 `allowed_tools` 白名单
**Fork 模式**：调用 `sessions_spawn` 创建隔离子 agent，通过 `allowed_tools` 参数限制子 agent 工具集

### 改动
- 数据层：`ParsedSkill`/`DiskSkill` 新增 `body` 字段
- 加载层：`parse_skill_md` + `scan_layer` 透传 body
- 执行层：`SkillTool.call()` 按 `SkillContext` 分流
- spawn 层：`sessions_spawn` 新增 `allowedTools`，`create_child_session` 接收 `allowed_tools`
- 测试：11 个新 UT 全覆盖

Source: issue #889
Type: feat
