### PR TITLE
fix(tests): 清除全局状态污染修复 CI flaky tests

### DIFF
--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -240,6 +240,7 @@ mod tests {
         set_override_prompt(None);
         set_agent_prompt(None);
         set_custom_prompt(None);
+        invalidate_all_sections();
     }
 
     #[test]
@@ -258,6 +259,7 @@ mod tests {
         let sections = vec![];
         let result = build_system_prompt(sections, None);
         assert!(result.contains("agent prompt"));
+        clear_all_prompts();
     }
 
     #[test]
@@ -267,6 +269,7 @@ mod tests {
         let sections = vec![];
         let result = build_system_prompt(sections, None);
         assert!(result.contains("custom prompt"));
+        clear_all_prompts();
     }
 
     #[test]
@@ -302,6 +305,7 @@ mod tests {
         assert!(result.contains("agent prompt"));
         assert!(result.contains("append content"));
         assert!(result.contains("## Append"));
+        clear_all_prompts();
     }
 
     #[test]
@@ -313,6 +317,7 @@ mod tests {
         assert!(result.contains("custom prompt"));
         assert!(result.contains("append notes"));
         assert!(result.contains("## Append"));
+        clear_all_prompts();
     }
 
     #[test]


### PR DESCRIPTION
修复 builder.rs 测试模块的全局可变状态清理不完整导致的 CI flaky tests。

问题：
- clear_all_prompts() 缺少 invalidate_all_sections() 调用，section cache 污染跨测试
- 4 个 priority prompt 测试未自清理，并行运行时污染其他测试

修复：
- clear_all_prompts() 增加 invalidate_all_sections()
- 4 个测试末尾增加 clear_all_prompts() 自清理

Source: CI
Type: fix
