### PR TITLE
fix(im): thread_id 端到端入站写入修复 + SQLite schema 迁移修复

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-bash",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 # SQLite for session persistence (bundled to avoid system SQLite dependency)
 rusqlite = { version = "0.31", features = ["bundled"] }
 
+# URL encoding
+url = "2"
+
 # Hashing (for signature validation)
 sha2 = "0.10"
 hex = "0.4"

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -84,6 +84,7 @@ async fn setup_parent_session(mgr: &SessionManager, agent_id: &str) -> String {
         channel: "test-channel".to_string(),
         timestamp: 0,
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     };
     mgr.find_or_create("test-channel", &msg, None)
         .await

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -88,6 +88,8 @@ pub struct Message {
     pub timestamp: i64,
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub thread_id: Option<String>,
 }
 
 /// Gateway configuration

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -232,6 +232,7 @@ impl Gateway {
             channel: channel.to_string(),
             timestamp: chrono::Utc::now().timestamp(),
             metadata: std::collections::HashMap::new(),
+            thread_id: None,
         }
     }
 

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -155,6 +155,7 @@ fn make_msg() -> crate::gateway::Message {
         channel: "ch".into(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/src/gateway/session_handler_tests.rs
+++ b/src/gateway/session_handler_tests.rs
@@ -153,6 +153,7 @@ fn make_msg() -> crate::gateway::Message {
         channel: "ch".into(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -7,16 +7,14 @@ use crate::gateway::{DmScope, GatewayConfig, Message, Session};
 use crate::im::processor::ProcessError;
 use crate::im::IMAdapter;
 use crate::llm::session::{ChatSession, ConversationSession};
-use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
+use crate::session::bootstrap::loader::BootstrapMode;
 use crate::session::persistence::{
     PendingMessage, PersistenceError, PersistenceService, ReasoningLevel, SessionCheckpoint,
     SessionStatus,
 };
 use crate::session::workspace;
 use crate::skills::DiskSkillRegistry;
-use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
-use crate::system_prompt::workdir::build_workdir_context;
-use crate::tools::{ToolContext, ToolRegistry};
+use crate::tools::ToolRegistry;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -26,6 +24,7 @@ use tracing::warn;
 mod announce;
 mod channel;
 mod rebuild;
+mod session_helpers;
 mod spawn;
 pub use spawn::{ChildSessionInfo, SpawnMode};
 /// SessionManager holds all session state previously belonging to Gateway.
@@ -169,6 +168,7 @@ impl SessionManager {
                 channel: channel.to_string(),
                 timestamp: chrono::Utc::now().timestamp(),
                 metadata: std::collections::HashMap::new(),
+                thread_id: None,
             };
             if let Err(e) = adapter.send_message(&notification, None).await {
                 warn!(session_id = %session_id, error = %e,
@@ -227,72 +227,41 @@ impl SessionManager {
         if sessions.contains_key(&session_id) {
             return Ok(session_id);
         }
-        // Build system prompt
-        let bootstrap_files = if let Some(ref workspace) = self.workspace_dir {
-            load_bootstrap_files(workspace, self.bootstrap_mode)
-                .unwrap_or_default()
-                .into_iter()
-                .collect()
-        } else {
-            vec![]
-        };
-        let tool_registry_guard = self.tool_registry.read().await;
-        let tool_registry_ref = tool_registry_guard.as_ref().map(|r| r.as_ref());
+        let tool_registry = self.tool_registry.read().await;
         let skill_registry = self.skill_registry.read().await.clone();
         let agent_id = message.to.clone();
-        let workdir_ctx = self
-            .workspace_dir
-            .as_ref()
-            .map(|p| build_workdir_context(&p.to_string_lossy()));
-        let tool_ctx = ToolContext {
-            agent_id: agent_id.clone(),
-            workdir: workdir_ctx,
-            session_id: None,
-            call_id: None,
-            session: None,
-        };
-        let workspace_root = self.workspace_dir.clone().unwrap_or_default();
-        let prompt = build_from_workspace(
-            &workspace_root,
-            WorkspaceBuildConfig {
-                bootstrap_files,
-                tool_registry: tool_registry_ref,
-                tool_ctx: &tool_ctx,
-                skill_registry,
-                agent_id: Some(&agent_id),
-                dynamic_sections: vec![],
-                append_section: None,
-            },
+        let prompt = session_helpers::build_session_system_prompt(
+            &self.workspace_dir,
+            self.bootstrap_mode,
+            &tool_registry,
+            skill_registry,
+            &agent_id,
         )
         .await;
 
         // Compute per-session workdir path
-        let workdir_path = if restored {
-            let checkpoint_agent_id = {
-                let storage_guard = self.storage.read().await;
-                match storage_guard.as_ref() {
-                    Some(storage) => storage
-                        .load_checkpoint(&session_id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .and_then(|cp| cp.agent_id),
-                    None => None,
+        let workdir_path = {
+            if restored {
+                let storage = self.storage.read().await;
+                if let Some(storage) = storage.as_ref() {
+                    session_helpers::compute_session_workdir(
+                        true,
+                        &session_id,
+                        message,
+                        &self.workspace_dir,
+                        storage,
+                    )
+                    .await?
+                } else {
+                    PathBuf::from("/tmp")
                 }
-            };
-            let aid = checkpoint_agent_id.as_deref().unwrap_or(&message.to);
-            if let Some(ref wd) = self.workspace_dir {
-                workspace::ensure_workspace_dir(wd, aid, aid)
-                    .unwrap_or_else(|_| PathBuf::from("/tmp"))
+            } else if let Some(ref workspace_dir) = self.workspace_dir {
+                workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from).map_err(
+                    |e| ProcessError::ProcessingFailed(format!("workspace creation failed: {}", e)),
+                )?
             } else {
                 PathBuf::from("/tmp")
             }
-        } else if let Some(ref workspace_dir) = self.workspace_dir {
-            workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from).map_err(
-                |e| ProcessError::ProcessingFailed(format!("workspace creation failed: {}", e)),
-            )?
-        } else {
-            PathBuf::from("/tmp")
         };
 
         let conv_session =
@@ -305,45 +274,41 @@ impl SessionManager {
         }
 
         if restored {
-            // Reload checkpoint to obtain chat_id / agent_id and pending_messages
             let storage = self.storage.read().await;
             if let Some(storage) = storage.as_ref() {
-                if let Ok(Some(cp)) = storage.load_checkpoint(&session_id).await {
-                    // Restore pending_messages into ConversationSession
-                    let conv_sessions = self.conversation_sessions.read().await;
-                    if let Some(cs) = conv_sessions.get(&session_id) {
-                        let mut cs = cs.write().await;
-                        cs.restore_pending_messages(cp.pending_messages);
-                        // Restore per-session append-section list from checkpoint
-                        // (issue #860: archived session restore preserves append content).
-                        cs.restore_system_appends(cp.system_appends);
-                    }
-                    drop(conv_sessions);
-
-                    sessions.insert(
-                        session_id.clone(),
-                        Session {
-                            id: session_id.clone(),
-                            agent_id: cp.chat_id.unwrap_or_else(|| message.to.clone()),
-                            channel: channel.to_string(),
-                            created_at: chrono::Utc::now().timestamp(),
-                            depth: 0,
-                        },
-                    );
+                if let Some(session) = session_helpers::restore_checkpoint_session(
+                    storage,
+                    &session_id,
+                    channel,
+                    message,
+                    &self.conversation_sessions,
+                )
+                .await
+                {
+                    sessions.insert(session_id.clone(), session);
                 }
             }
         } else {
             // No archived session — create a brand-new Session
             sessions.insert(
                 session_id.clone(),
-                Session {
-                    id: session_id.clone(),
-                    agent_id: message.to.clone(),
-                    channel: channel.to_string(),
-                    created_at: chrono::Utc::now().timestamp(),
-                    depth: 0,
-                },
+                session_helpers::create_new_session(&session_id, message, channel),
             );
+            // Persist checkpoint with thread_id so outbound can find it
+            let mut cp = SessionCheckpoint::new(session_id.clone())
+                .with_status(SessionStatus::Active)
+                .with_channel(channel.to_string())
+                .with_chat_id(message.to.clone())
+                .with_agent_id(message.to.clone());
+            if let Some(ref thread_id) = message.thread_id {
+                cp = cp.with_thread_id(thread_id.clone());
+            }
+            if let Some(storage) = self.storage.read().await.as_ref() {
+                if let Err(e) = storage.save_checkpoint(&cp).await {
+                    warn!(session_id = %session_id, error = %e,
+                        "failed to save new session checkpoint");
+                }
+            }
         }
 
         Ok(session_id)
@@ -398,12 +363,27 @@ impl SessionManager {
         let mut saved = 0;
         for (session_id, session) in sessions.iter() {
             let pending = pending_map.get(session_id).cloned().unwrap_or_default();
-            let mut cp = SessionCheckpoint::new(session_id.clone())
-                .with_status(SessionStatus::Active)
-                .with_channel(session.channel.clone())
-                .with_chat_id(session.agent_id.clone())
-                .with_agent_id(session.agent_id.clone())
-                .with_pending_messages(pending);
+            // Load existing checkpoint to preserve fields like thread_id (Bug #904).
+            let mut cp = match storage.load_checkpoint(session_id).await {
+                Ok(Some(mut cp)) => {
+                    // Update fields from active session state
+                    cp.status = SessionStatus::Active;
+                    cp.channel = Some(session.channel.clone());
+                    cp.chat_id = Some(session.agent_id.clone());
+                    cp.agent_id = Some(session.agent_id.clone());
+                    cp.pending_messages = pending;
+                    cp
+                }
+                _ => {
+                    // No existing checkpoint — create a fresh one
+                    SessionCheckpoint::new(session_id.clone())
+                        .with_status(SessionStatus::Active)
+                        .with_channel(session.channel.clone())
+                        .with_chat_id(session.agent_id.clone())
+                        .with_agent_id(session.agent_id.clone())
+                        .with_pending_messages(pending)
+                }
+            };
             // Sync per-session append-section list from ConversationSession
             // (issue #860: archived session restore preserves append content).
             if let Some(cs) = conv_sessions.get(session_id) {
@@ -484,6 +464,8 @@ impl SessionManager {
 // Unit tests
 #[cfg(test)]
 mod announce_tests;
+#[cfg(test)]
+mod bug904_tests;
 #[cfg(test)]
 mod flush_tests;
 #[cfg(test)]

--- a/src/gateway/session_manager/bug904_tests.rs
+++ b/src/gateway/session_manager/bug904_tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+use crate::gateway::GatewayConfig;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{AgentRole, PersistenceError, SessionCheckpoint};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Mock persistence that records saved checkpoints and also supports
+/// loading them (needed for the Bug 2 / Bug 3 round-trip tests).
+struct Bug904MockStorage {
+    saved_checkpoints: Mutex<Vec<SessionCheckpoint>>,
+    loaded_checkpoints: std::sync::Mutex<std::collections::HashMap<String, SessionCheckpoint>>,
+}
+
+impl Bug904MockStorage {
+    fn new() -> Self {
+        Self {
+            saved_checkpoints: Mutex::new(Vec::new()),
+            loaded_checkpoints: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Seed a checkpoint that will be returned by `load_checkpoint`.
+    fn with_loaded_checkpoint(self, cp: SessionCheckpoint) -> Self {
+        self.loaded_checkpoints
+            .lock()
+            .unwrap()
+            .insert(cp.session_id.clone(), cp);
+        self
+    }
+}
+
+#[async_trait]
+impl crate::session::persistence::PersistenceService for Bug904MockStorage {
+    async fn save_checkpoint(
+        &self,
+        checkpoint: &SessionCheckpoint,
+    ) -> Result<(), PersistenceError> {
+        self.saved_checkpoints.lock().await.push(checkpoint.clone());
+        Ok(())
+    }
+
+    async fn load_checkpoint(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Ok(self.loaded_checkpoints.lock().unwrap().remove(session_id))
+    }
+
+    async fn delete_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn archive_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn restore_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Ok(None)
+    }
+    async fn list_idle_sessions_for_agent(
+        &self,
+        _: &str,
+        _: AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+    async fn list_expired_archived_sessions_for_agent(
+        &self,
+        _: &str,
+        _: AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
+}
+
+pub(super) fn test_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 65536,
+        dm_scope: DmScope::PerChannelPeer,
+    }
+}
+
+pub(super) fn test_message() -> crate::gateway::Message {
+    crate::gateway::Message {
+        id: "msg-1".to_string(),
+        from: "user-a".to_string(),
+        to: "agent-b".to_string(),
+        content: "hello".to_string(),
+        channel: "feishu".to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+        metadata: std::collections::HashMap::new(),
+        thread_id: None,
+    }
+}
+
+pub(super) fn make_test_session(id: &str) -> Session {
+    Session {
+        id: id.to_string(),
+        agent_id: "agent-b".to_string(),
+        channel: "feishu".to_string(),
+        created_at: chrono::Utc::now().timestamp(),
+        depth: 0,
+    }
+}
+
+// ===================================================================
+// Bug #904: find_or_create writes thread_id to checkpoint (Bug 2)
+// ===================================================================
+
+#[tokio::test]
+async fn test_find_or_create_writes_thread_id_to_checkpoint() {
+    // Bug #904: find_or_create should write message.thread_id to the new checkpoint.
+    let storage = Arc::new(Bug904MockStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let mut msg = test_message();
+    msg.thread_id = Some("omt_from_inbound".to_string());
+
+    let session_id = mgr
+        .find_or_create("feishu", &msg, None)
+        .await
+        .expect("find_or_create should succeed");
+
+    // The checkpoint saved by find_or_create should carry the thread_id.
+    let saved = storage.saved_checkpoints.lock().await;
+    let cp = saved
+        .iter()
+        .find(|c| c.session_id == session_id)
+        .expect("should have saved a checkpoint for this session");
+    assert_eq!(
+        cp.thread_id.as_deref(),
+        Some("omt_from_inbound"),
+        "checkpoint thread_id should match message.thread_id"
+    );
+}
+
+// ===================================================================
+// Bug #904: flush_all preserves thread_id (Bug 3)
+// ===================================================================
+
+#[tokio::test]
+async fn test_flush_all_preserves_existing_thread_id() {
+    // Bug #904: flush_all should not discard an existing thread_id.
+    let existing_cp = SessionCheckpoint::new("sess-flush-tid".to_string())
+        .with_status(SessionStatus::Active)
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-b".to_string())
+        .with_agent_id("agent-b".to_string())
+        .with_thread_id("omt_existing_thread".to_string());
+
+    let storage = Arc::new(Bug904MockStorage::new().with_loaded_checkpoint(existing_cp));
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    // Insert a session so flush_all has something to iterate over.
+    {
+        let mut sessions = mgr.sessions.write().await;
+        sessions.insert(
+            "sess-flush-tid".to_string(),
+            make_test_session("sess-flush-tid"),
+        );
+    }
+
+    let result = mgr.flush_all().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 1);
+
+    let saved = storage.saved_checkpoints.lock().await;
+    assert_eq!(saved.len(), 1);
+    assert_eq!(
+        saved[0].thread_id.as_deref(),
+        Some("omt_existing_thread"),
+        "flush_all must preserve the existing thread_id"
+    );
+}

--- a/src/gateway/session_manager/flush_tests.rs
+++ b/src/gateway/session_manager/flush_tests.rs
@@ -26,6 +26,7 @@ pub(super) fn test_message() -> Message {
         channel: "feishu".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     }
 }
 
@@ -387,3 +388,4 @@ async fn test_with_pending_messages_bulk_set() {
 }
 
 // rebuild tests moved to rebuild_tests.rs (file kept under 500 lines)
+// Bug #904 tests moved to bug904_tests.rs

--- a/src/gateway/session_manager/session_helpers.rs
+++ b/src/gateway/session_manager/session_helpers.rs
@@ -1,0 +1,151 @@
+//! Helper functions extracted from SessionManager::find_or_create
+//! to keep the main file under the 500-line limit.
+
+use crate::gateway::Message;
+use crate::llm::session::ConversationSession;
+use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
+use crate::session::workspace;
+use crate::skills::DiskSkillRegistry;
+use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
+use crate::system_prompt::workdir::build_workdir_context;
+use crate::tools::{ToolContext, ToolRegistry};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::warn;
+
+/// Build the system prompt for a new session.
+pub(super) async fn build_session_system_prompt(
+    workspace_dir: &Option<PathBuf>,
+    bootstrap_mode: BootstrapMode,
+    tool_registry: &Option<Arc<ToolRegistry>>,
+    skill_registry: Option<Arc<std::sync::RwLock<Option<DiskSkillRegistry>>>>,
+    agent_id: &str,
+) -> String {
+    let bootstrap_files = if let Some(ref workspace) = workspace_dir {
+        load_bootstrap_files(workspace, bootstrap_mode)
+            .unwrap_or_default()
+            .into_iter()
+            .collect()
+    } else {
+        vec![]
+    };
+    let tool_registry_ref = tool_registry.as_ref().map(|r| r.as_ref());
+    let workdir_ctx = workspace_dir
+        .as_ref()
+        .map(|p| build_workdir_context(&p.to_string_lossy()));
+    let tool_ctx = ToolContext {
+        agent_id: agent_id.to_string(),
+        workdir: workdir_ctx,
+        session_id: None,
+        call_id: None,
+        session: None,
+    };
+    let workspace_root = workspace_dir.clone().unwrap_or_default();
+    build_from_workspace(
+        &workspace_root,
+        WorkspaceBuildConfig {
+            bootstrap_files,
+            tool_registry: tool_registry_ref,
+            tool_ctx: &tool_ctx,
+            skill_registry,
+            agent_id: Some(agent_id),
+            dynamic_sections: vec![],
+            append_section: None,
+        },
+    )
+    .await
+}
+
+/// Compute the workdir path for a new session.
+pub(super) async fn compute_session_workdir(
+    restored: bool,
+    session_id: &str,
+    message: &Message,
+    workspace_dir: &Option<PathBuf>,
+    storage: &Arc<dyn crate::session::persistence::PersistenceService>,
+) -> Result<PathBuf, crate::im::processor::ProcessError> {
+    if restored {
+        let checkpoint_agent_id = {
+            match storage
+                .load_checkpoint(session_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|cp| cp.agent_id)
+            {
+                Some(aid) => aid,
+                None => message.to.clone(),
+            }
+        };
+        let aid = &checkpoint_agent_id;
+        if let Some(ref wd) = workspace_dir {
+            Ok(workspace::ensure_workspace_dir(wd, aid, aid)
+                .unwrap_or_else(|_| PathBuf::from("/tmp")))
+        } else {
+            Ok(PathBuf::from("/tmp"))
+        }
+    } else if let Some(ref workspace_dir) = workspace_dir {
+        workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from).map_err(|e| {
+            crate::im::processor::ProcessError::ProcessingFailed(format!(
+                "workspace creation failed: {}",
+                e
+            ))
+        })
+    } else {
+        Ok(PathBuf::from("/tmp"))
+    }
+}
+
+/// Restore a session from an archived checkpoint.
+pub(super) async fn restore_checkpoint_session(
+    storage: &Arc<dyn crate::session::persistence::PersistenceService>,
+    session_id: &str,
+    channel: &str,
+    message: &Message,
+    conv_sessions: &RwLock<std::collections::HashMap<String, Arc<RwLock<ConversationSession>>>>,
+) -> Option<crate::gateway::Session> {
+    let mut cp = storage.load_checkpoint(session_id).await.ok().flatten()?;
+
+    // Restore pending_messages and system_appends into ConversationSession
+    {
+        let sessions = conv_sessions.read().await;
+        if let Some(cs) = sessions.get(session_id) {
+            let mut cs = cs.write().await;
+            cs.restore_pending_messages(cp.pending_messages.clone());
+            cs.restore_system_appends(cp.system_appends.clone());
+        }
+    }
+
+    let session = crate::gateway::Session {
+        id: session_id.to_string(),
+        agent_id: cp.chat_id.clone().unwrap_or_else(|| message.to.clone()),
+        channel: channel.to_string(),
+        created_at: chrono::Utc::now().timestamp(),
+        depth: 0,
+    };
+
+    // 覆盖式写入: 每次入站都用 message.thread_id 覆盖 checkpoint.thread_id
+    cp.thread_id = message.thread_id.clone();
+    if let Err(e) = storage.save_checkpoint(&cp).await {
+        warn!(session_id = %session_id, error = %e,
+            "failed to save checkpoint with updated thread_id");
+    }
+
+    Some(session)
+}
+
+/// Create and persist a brand-new session.
+pub(super) fn create_new_session(
+    session_id: &str,
+    message: &Message,
+    channel: &str,
+) -> crate::gateway::Session {
+    crate::gateway::Session {
+        id: session_id.to_string(),
+        agent_id: message.to.clone(),
+        channel: channel.to_string(),
+        created_at: chrono::Utc::now().timestamp(),
+        depth: 0,
+    }
+}

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -37,6 +37,7 @@ fn test_message() -> Message {
         channel: "feishu".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -97,6 +97,7 @@ fn make_message(to: &str, content: &str) -> Message {
         channel: "mock".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 
@@ -173,6 +174,7 @@ fn msg(from: &str, to: &str) -> Message {
         channel: "ch".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 
@@ -362,6 +364,7 @@ async fn test_per_channel_peer_different_senders() {
         channel: "ch".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     };
     let mut m2 = Message {
         id: "2".into(),
@@ -371,6 +374,7 @@ async fn test_per_channel_peer_different_senders() {
         channel: "ch".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     };
     add_session(&sm, "ch", &mut m1, None).await;
     add_session(&sm, "ch", &mut m2, None).await;

--- a/src/gateway/tests_dmscope.rs
+++ b/src/gateway/tests_dmscope.rs
@@ -118,6 +118,7 @@ fn feishu_msg(from: &str, to: &str) -> crate::gateway::Message {
         channel: "feishu".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/src/gateway/tests_thread.rs
+++ b/src/gateway/tests_thread.rs
@@ -33,6 +33,7 @@ fn make_message(to: &str, content: &str) -> Message {
         channel: "feishu".to_string(),
         timestamp: 0,
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -263,6 +263,7 @@ impl IMAdapter for FeishuAdapter {
             channel: "feishu".to_string(),
             timestamp: chrono::Utc::now().timestamp(),
             metadata,
+            thread_id: None,
         })
     }
 
@@ -294,7 +295,9 @@ impl IMAdapter for FeishuAdapter {
 
         let mut url = format!("{}/im/v1/messages?receive_id_type=open_id", FEISHU_API_BASE);
         if let Some(rid) = root_id {
-            url = format!("{}&root_id={}", url, rid);
+            let encoded_rid: String =
+                url::form_urlencoded::byte_serialize(rid.as_bytes()).collect();
+            url = format!("{}&root_id={}", url, encoded_rid);
         }
 
         let resp: SendResponse = self
@@ -348,7 +351,9 @@ impl IMAdapter for FeishuAdapter {
 
         let mut url = format!("{}/im/v1/messages?receive_id_type=chat_id", FEISHU_API_BASE);
         if let Some(rid) = root_id {
-            url = format!("{}&root_id={}", url, rid);
+            let encoded_rid: String =
+                url::form_urlencoded::byte_serialize(rid.as_bytes()).collect();
+            url = format!("{}&root_id={}", url, encoded_rid);
         }
 
         let resp: CardResponse = self
@@ -460,6 +465,7 @@ impl IMPlugin for FeishuPlugin {
                     channel: "feishu".to_string(),
                     timestamp: chrono::Utc::now().timestamp(),
                     metadata: HashMap::new(),
+                    thread_id: None,
                 };
                 self.adapter.send_message(&message, _thread_id).await
             }

--- a/src/im/feishu_tests.rs
+++ b/src/im/feishu_tests.rs
@@ -134,6 +134,7 @@ mod tests {
             channel: "feishu".into(),
             timestamp: 0,
             metadata: HashMap::new(),
+            thread_id: None,
         };
         assert!(a.send_message(&msg, None).await.is_err());
     }
@@ -341,5 +342,24 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(msg.thread_id, None);
+    }
+
+    // ── root_id URL encoding test ──────────────────────────────────────
+
+    #[test]
+    fn test_root_id_percent_encoding() {
+        // Bug #904: root_id with special characters should be percent-encoded.
+        let rid = "omt_abc=def&ghi";
+        let encoded: String = url::form_urlencoded::byte_serialize(rid.as_bytes()).collect();
+        assert_eq!(encoded, "omt_abc%3Ddef%26ghi");
+
+        // Verify the URL construction pattern used in feishu.rs
+        let base_url = "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=open_id";
+        let url = format!("{}&root_id={}", base_url, encoded);
+        assert!(
+            url.contains("root_id=omt_abc%3Ddef%26ghi"),
+            "URL should contain percent-encoded root_id, got: {}",
+            url
+        );
     }
 }

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -67,6 +67,22 @@ impl SessionRouter {
             .and_then(|v| v.as_str())
             .map(String::from)
     }
+
+    /// Extract thread_id from the raw webhook with priority:
+    /// `message.thread_id` > `message.root_id` > `message.parent_id`.
+    fn extract_thread_id(raw: &Value) -> Option<String> {
+        raw.get("message").and_then(|m| {
+            m.get("thread_id")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| m.get("root_id").and_then(|v| v.as_str()).map(String::from))
+                .or_else(|| {
+                    m.get("parent_id")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+        })
+    }
 }
 
 #[async_trait]
@@ -103,6 +119,9 @@ impl MessageProcessor for SessionRouter {
         let channel = Self::extract_channel(raw);
         let account_id = Self::extract_account_id(raw);
 
+        // Extract thread_id from the raw webhook.
+        let thread_id = Self::extract_thread_id(raw);
+
         // Reconstruct a minimal Message for SessionManager::find_or_create.
         let msg_content = raw
             .get("message")
@@ -129,6 +148,7 @@ impl MessageProcessor for SessionRouter {
                 .and_then(|s| s.parse::<i64>().ok())
                 .unwrap_or_else(|| chrono::Utc::now().timestamp()),
             metadata: std::collections::HashMap::new(),
+            thread_id,
         };
 
         // Resolve session.

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -6,13 +6,13 @@
 mod archive_support;
 
 #[cfg(test)]
+mod bug904_tests;
+#[cfg(test)]
 mod tests;
 
 use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use tokio::task::spawn_blocking;
@@ -22,14 +22,6 @@ use tokio::task::spawn_blocking;
 pub struct SqliteStorage {
     data_dir: PathBuf,
 }
-/// Transcript message entry written to .jsonl files
-#[derive(Debug, Serialize, Deserialize)]
-struct TranscriptEntry {
-    role: String,
-    content: String,
-    timestamp: DateTime<Utc>,
-}
-
 impl SqliteStorage {
     /// Create a new SqliteStorage instance
     ///
@@ -99,41 +91,32 @@ impl SqliteStorage {
 
             CREATE INDEX IF NOT EXISTS idx_sessions_agent_role
                 ON sessions(agent_id, role);
-
-            ALTER TABLE sessions ADD COLUMN thread_id TEXT;
             "#,
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+
+        // Idempotent migration: only add thread_id column if it doesn't already exist.
+        let column_exists: bool = {
+            let mut stmt = conn
+                .prepare("PRAGMA table_info(sessions)")
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+            let has_column = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?
+                .filter_map(|r| r.ok())
+                .any(|name| name == "thread_id");
+            has_column
+        };
+        if !column_exists {
+            conn.execute("ALTER TABLE sessions ADD COLUMN thread_id TEXT", [])
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+        }
+
         Ok(())
     }
     /// Returns the data directory path
     pub fn data_dir(&self) -> &Path {
         &self.data_dir
-    }
-
-    /// Write transcript entries to a .jsonl file
-    fn write_transcript(
-        path: &Path,
-        checkpoint: &SessionCheckpoint,
-    ) -> Result<(), PersistenceError> {
-        let file = std::fs::File::create(path).map_err(PersistenceError::Io)?;
-        let mut writer = std::io::BufWriter::new(file);
-        for msg in &checkpoint.pending_messages {
-            let entry = TranscriptEntry {
-                role: msg.message_id.clone(),
-                content: msg.content.clone(),
-                timestamp: msg.created_at,
-            };
-            serde_json::to_writer(&mut writer, &entry).map_err(PersistenceError::Serialization)?;
-            use std::io::Write;
-            writeln!(&mut writer).map_err(PersistenceError::Io)?;
-        }
-        Ok(())
-    }
-
-    /// Delete transcript file, ignoring if it does not exist
-    fn delete_transcript(path: &Path) {
-        let _ = std::fs::remove_file(path);
     }
 
     /// List IDs of active sessions idle for at least `idle_minutes`.
@@ -327,7 +310,7 @@ impl PersistenceService for SqliteStorage {
             let transcript_path = data_dir
                 .join("sessions")
                 .join(format!("{}.jsonl", checkpoint.session_id));
-            Self::write_transcript(&transcript_path, &checkpoint)?;
+            archive_support::write_transcript(&transcript_path, &checkpoint)?;
 
             Ok(())
         })
@@ -373,12 +356,12 @@ impl PersistenceService for SqliteStorage {
             let active_path = data_dir
                 .join("sessions")
                 .join(format!("{session_id}.jsonl"));
-            Self::delete_transcript(&active_path);
+            archive_support::delete_transcript(&active_path);
 
             let archived_path = data_dir
                 .join("archived_sessions")
                 .join(format!("{session_id}.jsonl"));
-            Self::delete_transcript(&archived_path);
+            archive_support::delete_transcript(&archived_path);
 
             Ok(())
         })

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -39,6 +39,32 @@ pub fn delete_transcript(path: &Path) {
     let _ = std::fs::remove_file(path);
 }
 
+/// Write transcript entries to a .jsonl file.
+pub fn write_transcript(
+    path: &Path,
+    checkpoint: &SessionCheckpoint,
+) -> Result<(), PersistenceError> {
+    #[derive(serde::Serialize)]
+    struct TranscriptEntry {
+        role: String,
+        content: String,
+        timestamp: DateTime<Utc>,
+    }
+    let file = std::fs::File::create(path).map_err(PersistenceError::Io)?;
+    let mut writer = std::io::BufWriter::new(file);
+    for msg in &checkpoint.pending_messages {
+        let entry = TranscriptEntry {
+            role: msg.message_id.clone(),
+            content: msg.content.clone(),
+            timestamp: msg.created_at,
+        };
+        serde_json::to_writer(&mut writer, &entry).map_err(PersistenceError::Serialization)?;
+        use std::io::Write;
+        writeln!(&mut writer).map_err(PersistenceError::Io)?;
+    }
+    Ok(())
+}
+
 /// Archive a checkpoint: move its active transcript to archived_sessions/
 /// and mark the DB record as archived.
 pub fn do_archive(data_dir: &Path, checkpoint: &SessionCheckpoint) -> Result<(), PersistenceError> {

--- a/src/session/storage/sqlite/bug904_tests.rs
+++ b/src/session/storage/sqlite/bug904_tests.rs
@@ -1,0 +1,45 @@
+//! Bug #904 tests for SQLite storage
+
+use crate::session::storage::SqliteStorage;
+
+// ===================================================================
+// 10. Bug #904: init_schema idempotent with existing thread_id column
+// ===================================================================
+#[tokio::test]
+async fn test_init_schema_idempotent_with_existing_thread_id_column() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let db_path = temp.path().join("test.db");
+
+    // Create a DB and manually add thread_id column (simulating a DB from a previous version)
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                agent_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                channel TEXT NOT NULL,
+                chat_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                title TEXT,
+                last_message_at INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                archived_at INTEGER,
+                message_count INTEGER DEFAULT 0,
+                metadata TEXT,
+                thread_id TEXT
+            );
+            "#,
+        )
+        .unwrap();
+    }
+
+    // Now open via SqliteStorage::new which calls init_schema — should not error
+    let result = SqliteStorage::new(temp.path());
+    assert!(
+        result.is_ok(),
+        "init_schema should be idempotent: {:?}",
+        result.err()
+    );
+}

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -279,6 +279,7 @@ async fn create_test_session(sm: &SessionManager) -> String {
         channel: "feishu".to_string(),
         timestamp: 0,
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     };
     let account_id: Option<&str> = None;
     sm.find_or_create("feishu", &msg, account_id)

--- a/src/slash/handlers_tests_new.rs
+++ b/src/slash/handlers_tests_new.rs
@@ -50,6 +50,7 @@ async fn create_test_session(sm: &SessionManager) -> String {
         channel: "feishu".to_string(),
         timestamp: 0,
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     };
     sm.find_or_create("feishu", &msg, None)
         .await

--- a/src/slash/handlers_tests_system.rs
+++ b/src/slash/handlers_tests_system.rs
@@ -40,6 +40,7 @@ async fn create_test_session(sm: &SessionManager) -> String {
         channel: "feishu".to_string(),
         timestamp: 0,
         metadata: std::collections::HashMap::new(),
+        thread_id: None,
     };
     sm.find_or_create("feishu", &msg, None)
         .await

--- a/tests/feishu_adapter_tests.rs
+++ b/tests/feishu_adapter_tests.rs
@@ -105,6 +105,7 @@ async fn test_error_cases() {
         channel: "feishu".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     };
     assert!(a.send_message(&msg, None).await.is_err());
 }

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -163,6 +163,7 @@ pub(crate) fn make_outbound_message(to: &str, content: &str) -> Message {
         channel: "tracking".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/tests/integration_llm_busy.rs
+++ b/tests/integration_llm_busy.rs
@@ -42,6 +42,7 @@ fn make_msg() -> Message {
         channel: "ch".into(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/tests/integration_pending_messages.rs
+++ b/tests/integration_pending_messages.rs
@@ -42,6 +42,7 @@ fn make_msg() -> Message {
         channel: "ch".into(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 

--- a/tests/integration_shutdown_checkpoint.rs
+++ b/tests/integration_shutdown_checkpoint.rs
@@ -44,6 +44,7 @@ fn make_msg() -> Message {
         channel: "ch".into(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 


### PR DESCRIPTION
fix(im): thread_id 端到端入站写入修复 + SQLite schema 迁移修复

修复 thread_id 端到端链路的 3 个 bug：
- Bug 1: daemon 重启时 SQLite schema 迁移 crash（改为 PRAGMA 探测 + 条件 ALTER）
- Bug 2: 入站 thread_id 从未写入 SessionCheckpoint（Message 加字段 → SessionRouter 提取 → find_or_create 写入）
- Bug 3: flush_all 丢弃已有 thread_id（改为 load-modify-save 模式）
- 次要: 飞书 root_id URL percent-encoding

Source: issue #904
Type: fix
