### PR TITLE
fix: 移动优先级 prompt 检查到请求阶段，消除全局静态变量竞态

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -386,6 +386,9 @@ impl From<super::im::AdapterError> for GatewayError {
 }
 
 #[cfg(test)]
+#[path = "priority_prompt_tests.rs"]
+mod priority_prompt_tests;
+#[cfg(test)]
 mod session_handler_dynamic_tests;
 #[cfg(test)]
 mod session_handler_tests;

--- a/src/gateway/priority_prompt_tests.rs
+++ b/src/gateway/priority_prompt_tests.rs
@@ -1,0 +1,170 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Priority Prompt Override Tests (build_full_system_prompt)
+// ═══════════════════════════════════════════════════════════════════════════
+
+use super::session_handler::MessageMetadata;
+use super::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::system_prompt::builder::PromptOverrides;
+
+fn make_meta(sender: &str, channel: &str, ts: i64) -> MessageMetadata {
+    MessageMetadata {
+        sender_id: sender.to_string(),
+        channel: channel.to_string(),
+        timestamp: ts,
+    }
+}
+
+/// Test (a): Three-tier priority: override > agent > custom.
+/// When override_prompt is set, it wins over agent_prompt and custom_prompt.
+#[test]
+fn test_priority_override_wins_over_agent_and_custom() {
+    let overrides = PromptOverrides {
+        override_prompt: Some("override prompt".into()),
+        agent_prompt: Some("agent prompt".into()),
+        custom_prompt: Some("custom prompt".into()),
+    };
+    let meta = make_meta("u", "ch", 0);
+    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    assert!(full.contains("override prompt"));
+    assert!(!full.contains("agent prompt"));
+    assert!(!full.contains("custom prompt"));
+}
+
+/// Test (a): When override is None, agent_prompt wins over custom_prompt.
+#[test]
+fn test_priority_agent_wins_over_custom() {
+    let overrides = PromptOverrides {
+        override_prompt: None,
+        agent_prompt: Some("agent prompt".into()),
+        custom_prompt: Some("custom prompt".into()),
+    };
+    let meta = make_meta("u", "ch", 0);
+    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    assert!(full.contains("agent prompt"));
+    assert!(!full.contains("custom prompt"));
+}
+
+/// Test (a): When override and agent are None, custom_prompt is used.
+#[test]
+fn test_priority_custom_fallback() {
+    let overrides = PromptOverrides {
+        override_prompt: None,
+        agent_prompt: None,
+        custom_prompt: Some("custom prompt".into()),
+    };
+    let meta = make_meta("u", "ch", 0);
+    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    assert!(full.contains("custom prompt"));
+}
+
+/// Test (b): Mutual exclusivity — override takes precedence, agent/custom ignored.
+#[test]
+fn test_priority_override_mutual_exclusivity() {
+    let overrides = PromptOverrides {
+        override_prompt: Some("override wins".into()),
+        agent_prompt: Some("agent ignored".into()),
+        custom_prompt: Some("custom ignored".into()),
+    };
+    let meta = make_meta("u", "ch", 0);
+    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    // Only override prompt appears
+    assert!(full.contains("override wins"));
+    assert!(!full.contains("agent ignored"));
+    assert!(!full.contains("custom ignored"));
+    // Static prompt is replaced
+    assert!(!full.contains("static"));
+}
+
+/// Test (c): On priority hit, only AppendSection is appended;
+/// no ChannelContext/SessionState/GitStatus.
+#[test]
+fn test_priority_hit_only_appends_append_section() {
+    let overrides = PromptOverrides {
+        override_prompt: Some("override prompt".into()),
+        agent_prompt: None,
+        custom_prompt: None,
+    };
+    let meta = make_meta("alice", "telegram", 1700000000);
+    let dynamic = build_dynamic_sections(5, &meta, None, &["extra instruction".into()]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    // Override prompt is the base
+    assert!(full.contains("override prompt"));
+    // AppendSection is present
+    assert!(full.contains("extra instruction"));
+    assert!(full.contains("## Append"));
+    // Dynamic layers are NOT injected
+    assert!(
+        !full.contains("sender_id: alice"),
+        "ChannelContext should not appear on priority hit"
+    );
+    assert!(
+        !full.contains("turn_count: 5"),
+        "SessionState should not appear on priority hit"
+    );
+    assert!(
+        !full.contains("STATIC_LAYER_END"),
+        "Boundary marker should not appear on priority hit",
+    );
+}
+
+/// Test (c): AppendSection with multiple entries on priority hit.
+#[test]
+fn test_priority_hit_multiple_appends() {
+    let overrides = PromptOverrides {
+        agent_prompt: Some("agent prompt".into()),
+        ..Default::default()
+    };
+    let meta = make_meta("u", "ch", 0);
+    let dynamic = build_dynamic_sections(0, &meta, None, &["first".into(), "second".into()]);
+    let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
+
+    assert!(full.contains("agent prompt"));
+    assert!(full.contains("first"));
+    assert!(full.contains("second"));
+    assert!(!full.contains("sender_id"));
+    assert!(!full.contains("turn_count"));
+}
+
+/// Test (d): When no override matches, normal behavior is preserved.
+#[test]
+fn test_priority_no_hit_normal_behavior() {
+    let overrides = PromptOverrides::default(); // all None
+    let meta = make_meta("bob", "feishu", 1700000000);
+    let dynamic = build_dynamic_sections(3, &meta, None, &[]);
+    let full = build_full_system_prompt(Some("static prompt"), &dynamic, Some(&overrides));
+
+    // Static prompt is preserved
+    assert!(full.contains("static prompt"));
+    // Boundary marker present
+    assert!(full.contains("<!-- STATIC_LAYER_END -->"));
+    // Dynamic layers injected
+    assert!(full.contains("sender_id: bob"));
+    assert!(full.contains("turn_count: 3"));
+}
+
+/// Test (e): None overrides behaves identically to normal path.
+#[test]
+fn test_priority_none_overrides_normal_behavior() {
+    let meta = make_meta("carol", "ch", 1700000000);
+    let dynamic = build_dynamic_sections(2, &meta, None, &["appendix".into()]);
+    let full_none = build_full_system_prompt(Some("static"), &dynamic, None);
+    let full_default =
+        build_full_system_prompt(Some("static"), &dynamic, Some(&PromptOverrides::default()));
+
+    // Both should produce the same output
+    assert_eq!(full_none, full_default);
+    // Both contain static + dynamic
+    assert!(full_none.contains("static"));
+    assert!(full_none.contains("sender_id: carol"));
+    assert!(full_none.contains("turn_count: 2"));
+    assert!(full_none.contains("appendix"));
+}

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -240,7 +240,12 @@ impl SessionMessageHandler {
         );
 
         // ── Compose full prompt ─────────────────────────────────────────
-        let full_prompt = build_full_system_prompt(static_prompt_opt.as_deref(), &dynamic_sections);
+        let overrides = session_manager.get_prompt_overrides().await;
+        let full_prompt = build_full_system_prompt(
+            static_prompt_opt.as_deref(),
+            &dynamic_sections,
+            overrides.as_ref(),
+        );
 
         // ── Build ChatRequest with system + user messages ───────────────
         let mut messages = vec![];

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -256,7 +256,7 @@ fn test_build_dynamic_sections_append_section() {
 fn test_build_full_system_prompt_composition() {
     let meta = make_meta("alice", "telegram", 1700000000);
     let sections = build_dynamic_sections(3, &meta, None, &[]);
-    let full = build_full_system_prompt(Some("You are helpful."), &sections);
+    let full = build_full_system_prompt(Some("You are helpful."), &sections, None);
 
     // Contains static layer
     assert!(full.contains("You are helpful."));
@@ -273,7 +273,7 @@ fn test_build_full_system_prompt_composition() {
 fn test_build_full_system_prompt_no_static() {
     let meta = make_meta("bob", "ch", 0);
     let sections = build_dynamic_sections(0, &meta, None, &[]);
-    let full = build_full_system_prompt(None, &sections);
+    let full = build_full_system_prompt(None, &sections, None);
 
     // No boundary marker when no static prompt
     assert!(!full.contains("<!-- STATIC_LAYER_END -->"));
@@ -291,7 +291,7 @@ fn test_build_full_system_prompt_empty_dynamic() {
     let sections = build_dynamic_sections(0, &meta, None, &[]);
     // These two sections always render to non-empty strings, so dynamic is never truly empty.
     // But we verify the composition still works.
-    let full = build_full_system_prompt(Some("static"), &sections);
+    let full = build_full_system_prompt(Some("static"), &sections, None);
     assert!(full.contains("static"));
     assert!(full.contains("<!-- STATIC_LAYER_END -->"));
 }
@@ -410,3 +410,7 @@ fn test_workdir_path_no_config_dir_exposure() {
     assert!(!sanitized.contains(".closeclaw"));
     assert!(!sanitized.contains("/home/alice"));
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Priority Prompt Override Tests (build_full_system_prompt)
+// ═══════════════════════════════════════════════════════════════════════════

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -79,7 +79,12 @@ impl SessionMessageHandler {
             Some(workdir_path.as_str()),
             &system_appends,
         );
-        let full_prompt = build_full_system_prompt(static_prompt_opt.as_deref(), &dynamic_sections);
+        let overrides = session_manager.get_prompt_overrides().await;
+        let full_prompt = build_full_system_prompt(
+            static_prompt_opt.as_deref(),
+            &dynamic_sections,
+            overrides.as_ref(),
+        );
 
         let mut messages = vec![];
         if !full_prompt.is_empty() {

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -14,6 +14,7 @@ use crate::session::persistence::{
 };
 use crate::session::workspace;
 use crate::skills::DiskSkillRegistry;
+use crate::system_prompt::builder::PromptOverrides;
 use crate::tools::ToolRegistry;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -50,6 +51,8 @@ pub struct SessionManager {
     skill_registry: RwLock<Option<Arc<std::sync::RwLock<Option<DiskSkillRegistry>>>>>,
     /// Default reasoning level for new sessions
     default_reasoning_level: ReasoningLevel,
+    /// Priority prompt overrides (checked at request time, not session creation).
+    prompt_overrides: RwLock<Option<PromptOverrides>>,
     /// Children tracking table: parent_session_id → list of child sessions.
     children: RwLock<HashMap<String, Vec<ChildSessionInfo>>>,
     /// Channel → active session_id mapping.
@@ -87,9 +90,20 @@ impl SessionManager {
             tool_registry: RwLock::new(None),
             skill_registry: RwLock::new(None),
             default_reasoning_level,
+            prompt_overrides: RwLock::new(None),
             children: RwLock::new(HashMap::new()),
             channel_active_sessions: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Set priority prompt overrides.
+    pub async fn set_prompt_overrides(&self, overrides: Option<PromptOverrides>) {
+        *self.prompt_overrides.write().await = overrides;
+    }
+
+    /// Get the current priority prompt overrides, if set.
+    pub async fn get_prompt_overrides(&self) -> Option<PromptOverrides> {
+        self.prompt_overrides.read().await.clone()
     }
 
     /// Set the tool registry for building system prompt ToolsSection.

--- a/src/gateway/session_manager/rebuild_tests.rs
+++ b/src/gateway/session_manager/rebuild_tests.rs
@@ -2,17 +2,11 @@ use super::flush_tests::{test_config, test_message};
 use super::*;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
-use crate::system_prompt::{
-    invalidate_all_sections, set_agent_prompt, set_custom_prompt, set_override_prompt,
-};
-use serial_test::serial;
+use crate::system_prompt::invalidate_all_sections;
 use std::io::Write;
 use tempfile::TempDir;
 
 fn clear_global_prompt_state() {
-    set_override_prompt(None);
-    set_agent_prompt(None);
-    set_custom_prompt(None);
     invalidate_all_sections();
 }
 
@@ -41,7 +35,6 @@ fn make_test_mgr(workspace: Option<&std::path::Path>) -> SessionManager {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
-#[serial]
 async fn test_rebuild_system_prompt_normal() {
     clear_global_prompt_state();
     let tmp = make_temp_workspace(&[
@@ -66,7 +59,6 @@ async fn test_rebuild_system_prompt_normal() {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_rebuild_system_prompt_edge_cases() {
     // nonexistent session — should not panic
     let mgr = make_test_mgr(None);

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -2,20 +2,15 @@ use super::*;
 use crate::gateway::{GatewayConfig, Message};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::SessionCheckpoint;
-use crate::system_prompt::{
-    invalidate_all_sections, set_agent_prompt, set_custom_prompt, set_override_prompt,
-};
+use crate::system_prompt::invalidate_all_sections;
 use serial_test::serial;
 use std::io::Write;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
 
-/// Clear global prompt state and section cache. Must be called before tests
-/// that exercise system prompt generation (global SECTION_CACHE is shared).
+/// Clear section cache. Must be called before tests that exercise system prompt
+/// generation (global SECTION_CACHE is shared).
 pub(super) fn clear_global_prompt_state() {
-    set_override_prompt(None);
-    set_agent_prompt(None);
-    set_custom_prompt(None);
     invalidate_all_sections();
 }
 

--- a/src/gateway/system_prompt_inject.rs
+++ b/src/gateway/system_prompt_inject.rs
@@ -4,6 +4,7 @@
 //! system prompt.
 
 use crate::gateway::session_handler::MessageMetadata;
+use crate::system_prompt::builder::PromptOverrides;
 use crate::system_prompt::sections::Section;
 use crate::system_prompt::workdir;
 
@@ -64,10 +65,48 @@ pub(crate) fn build_dynamic_sections(
 /// Compose a full system prompt from static layer + dynamic sections.
 ///
 /// Inserts `<!-- STATIC_LAYER_END -->` between static and dynamic layers.
+///
+/// When `overrides` is provided and contains a non-None priority prompt,
+/// the resolution order is:
+///   1. `override_prompt` — highest priority
+///   2. `agent_prompt`    — agent-level prompt
+///   3. `custom_prompt`   — user-defined custom prompt
+///
+/// On a priority hit the matched prompt **replaces** the static layer and
+/// dynamic layers (ChannelContext / SessionState / GitStatus) are **not**
+/// injected — only `AppendSection` entries are appended.
 pub(crate) fn build_full_system_prompt(
     static_prompt: Option<&str>,
     dynamic_sections: &[Section],
+    overrides: Option<&PromptOverrides>,
 ) -> String {
+    // Check priority prompt overrides (override > agent > custom)
+    if let Some(ov) = overrides {
+        let priority = ov
+            .override_prompt
+            .as_deref()
+            .or(ov.agent_prompt.as_deref())
+            .or(ov.custom_prompt.as_deref());
+
+        if let Some(base) = priority {
+            // Filter AppendSection from dynamic sections to append separately
+            let append_parts: Vec<&str> = dynamic_sections
+                .iter()
+                .filter_map(|s| match s {
+                    Section::AppendSection(body) => Some(body.as_str()),
+                    _ => None,
+                })
+                .collect();
+
+            if append_parts.is_empty() {
+                return base.to_string();
+            }
+            let append_body = append_parts.join("\n");
+            return format!("{}\n\n## Append\n{}\n", base, append_body);
+        }
+    }
+
+    // Normal path: static + all dynamic sections
     let dynamic_rendered: String = dynamic_sections.iter().map(|s| s.render()).collect();
     if let Some(static_prompt) = static_prompt {
         if dynamic_rendered.is_empty() {

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -8,45 +8,24 @@ use crate::skills::DiskSkillRegistry;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
-#[cfg(test)]
-use crate::system_prompt::sections::invalidate_all_sections;
-
-/// Static override: if set, replaces the entire prompt
-static OVERRIDE_PROMPT: RwLock<Option<String>> = RwLock::new(None);
-
-/// Agent system prompt: loaded from agent config / workspace
-static AGENT_PROMPT: RwLock<Option<String>> = RwLock::new(None);
-
-/// Custom system prompt: from user config
-static CUSTOM_PROMPT: RwLock<Option<String>> = RwLock::new(None);
+/// Overrides for the three-tier priority prompt system.
+///
+/// When resolving the final system prompt, the caller (typically
+/// `build_full_system_prompt`) checks these in order:
+///   1. `override_prompt` — highest priority, replaces the entire static layer
+///   2. `agent_prompt`    — agent-level prompt
+///   3. `custom_prompt`   — user-defined custom prompt
+///
+/// If none is set, the normal section-based rendering is used.
+#[derive(Debug, Clone, Default)]
+pub struct PromptOverrides {
+    pub override_prompt: Option<String>,
+    pub agent_prompt: Option<String>,
+    pub custom_prompt: Option<String>,
+}
 
 /// Default system prompt fallback
 const DEFAULT_PROMPT: &str = "You are CloseClaw, a helpful AI assistant.";
-
-// ---------------------------------------------------------------------------
-// Override / agent / custom prompt management
-// ---------------------------------------------------------------------------
-
-/// Set an override system prompt (takes precedence over everything)
-pub fn set_override_prompt(prompt: Option<String>) {
-    if let Ok(mut guard) = OVERRIDE_PROMPT.write() {
-        *guard = prompt;
-    }
-}
-
-/// Set the agent-level system prompt
-pub fn set_agent_prompt(prompt: Option<String>) {
-    if let Ok(mut guard) = AGENT_PROMPT.write() {
-        *guard = prompt;
-    }
-}
-
-/// Set the custom system prompt
-pub fn set_custom_prompt(prompt: Option<String>) {
-    if let Ok(mut guard) = CUSTOM_PROMPT.write() {
-        *guard = prompt;
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Build
@@ -54,18 +33,14 @@ pub fn set_custom_prompt(prompt: Option<String>) {
 
 /// Build the complete system prompt from the given sections.
 ///
-/// Priority (highest to lowest):
-///  1. overrideSystemPrompt (if set)
-///  2. agentSystemPrompt (if set)
-///  3. CustomSystemPrompt (if set)
-///  4. defaultSystemPrompt
-///  5. appendSection (always appended last)
+/// This function only renders sections and appends the optional `append_section`.
+/// Priority-prompt resolution (override > agent > custom) is handled at the
+/// request stage by `build_full_system_prompt` in `gateway::system_prompt_inject`.
+///
+///  1. Renders all provided sections
+///  2. Falls back to DEFAULT_PROMPT when no sections produce output
+///  3. Appends `append_section` if provided
 pub fn build_system_prompt(sections: Vec<Section>, append_section: Option<String>) -> String {
-    // Check priority prompts first (early return)
-    if let Some(prompt) = get_priority_prompt() {
-        return append_append_section(prompt, append_section);
-    }
-
     // Render sections
     let rendered = render_sections(sections);
     let base = if rendered.is_empty() {
@@ -75,29 +50,6 @@ pub fn build_system_prompt(sections: Vec<Section>, append_section: Option<String
     };
 
     append_append_section(base, append_section)
-}
-
-/// Get the highest-priority prompt that is set
-fn get_priority_prompt() -> Option<String> {
-    // Check override
-    if let Ok(guard) = OVERRIDE_PROMPT.read() {
-        if let Some(ref prompt) = *guard {
-            return Some(prompt.clone());
-        }
-    }
-    // Check agent
-    if let Ok(guard) = AGENT_PROMPT.read() {
-        if let Some(ref prompt) = *guard {
-            return Some(prompt.clone());
-        }
-    }
-    // Check custom
-    if let Ok(guard) = CUSTOM_PROMPT.read() {
-        if let Some(ref prompt) = *guard {
-            return Some(prompt.clone());
-        }
-    }
-    None
 }
 
 /// Render all sections into a vector of strings
@@ -235,98 +187,41 @@ mod tests {
     use super::super::sections::Section;
     use super::*;
 
-    /// Clear all global prompt state to prevent cross-test pollution.
-    fn clear_all_prompts() {
-        set_override_prompt(None);
-        set_agent_prompt(None);
-        set_custom_prompt(None);
+    /// Clear cached sections to prevent cross-test pollution.
+    #[cfg(test)]
+    use crate::system_prompt::sections::invalidate_all_sections;
+
+    fn reset_sections() {
         invalidate_all_sections();
     }
 
     #[test]
-    fn test_build_system_prompt_with_override() {
-        set_override_prompt(Some("override prompt".to_string()));
-        let sections = vec![Section::RoleSection("should not appear".to_string())];
-        let result = build_system_prompt(sections, None);
-        assert!(result.contains("override prompt"));
-        set_override_prompt(None);
+    fn test_prompt_overrides_default() {
+        let overrides = PromptOverrides::default();
+        assert!(overrides.override_prompt.is_none());
+        assert!(overrides.agent_prompt.is_none());
+        assert!(overrides.custom_prompt.is_none());
     }
 
     #[test]
-    fn test_build_system_prompt_with_agent_prompt() {
-        clear_all_prompts();
-        set_agent_prompt(Some("agent prompt".to_string()));
-        let sections = vec![];
-        let result = build_system_prompt(sections, None);
-        assert!(result.contains("agent prompt"));
-        clear_all_prompts();
-    }
-
-    #[test]
-    fn test_build_system_prompt_with_custom_prompt() {
-        clear_all_prompts();
-        set_custom_prompt(Some("custom prompt".to_string()));
-        let sections = vec![];
-        let result = build_system_prompt(sections, None);
-        assert!(result.contains("custom prompt"));
-        clear_all_prompts();
-    }
-
-    #[test]
-    fn test_build_system_prompt_default() {
-        // Clear global state that could affect this test
-        set_override_prompt(None);
-        set_agent_prompt(None);
-        set_custom_prompt(None);
-        invalidate_all_sections();
-
+    fn test_build_system_prompt_renders_sections() {
+        reset_sections();
         let sections = vec![Section::RoleSection("role content".to_string())];
         let result = build_system_prompt(sections, None);
         assert!(result.contains("role content"));
     }
 
     #[test]
-    fn test_build_system_prompt_with_override_and_append() {
-        set_override_prompt(Some("override prompt".to_string()));
-        let sections = vec![Section::RoleSection("should not appear".to_string())];
-        let result = build_system_prompt(sections, Some("extra notes".to_string()));
-        assert!(result.contains("override prompt"));
-        assert!(result.contains("extra notes"));
-        assert!(result.contains("## Append"));
-        set_override_prompt(None);
-    }
-
-    #[test]
-    fn test_build_system_prompt_with_agent_prompt_and_append() {
-        clear_all_prompts();
-        set_agent_prompt(Some("agent prompt".to_string()));
+    fn test_build_system_prompt_fallback_default() {
+        reset_sections();
         let sections = vec![];
-        let result = build_system_prompt(sections, Some("append content".to_string()));
-        assert!(result.contains("agent prompt"));
-        assert!(result.contains("append content"));
-        assert!(result.contains("## Append"));
-        clear_all_prompts();
+        let result = build_system_prompt(sections, None);
+        assert!(result.contains(DEFAULT_PROMPT));
     }
 
     #[test]
-    fn test_build_system_prompt_with_custom_prompt_and_append() {
-        clear_all_prompts();
-        set_custom_prompt(Some("custom prompt".to_string()));
-        let sections = vec![];
-        let result = build_system_prompt(sections, Some("append notes".to_string()));
-        assert!(result.contains("custom prompt"));
-        assert!(result.contains("append notes"));
-        assert!(result.contains("## Append"));
-        clear_all_prompts();
-    }
-
-    #[test]
-    fn test_build_system_prompt_default_with_append() {
-        set_override_prompt(None);
-        set_agent_prompt(None);
-        set_custom_prompt(None);
-        invalidate_all_sections();
-
+    fn test_build_system_prompt_with_append() {
+        reset_sections();
         let sections = vec![Section::RoleSection("role content".to_string())];
         let result = build_system_prompt(sections, Some("additional info".to_string()));
         assert!(result.contains("role content"));
@@ -336,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_build_append_section_appended() {
-        clear_all_prompts();
+        reset_sections();
         let sections = vec![Section::RoleSection("base".to_string())];
         let result = build_system_prompt(sections, Some("extra notes".to_string()));
         assert!(result.contains("base"));
@@ -345,16 +240,15 @@ mod tests {
 
     #[test]
     fn test_append_section_not_shown_when_empty() {
-        clear_all_prompts();
+        reset_sections();
         let sections = vec![Section::RoleSection("base".to_string())];
         let result = build_system_prompt(sections, None);
-        // append section should not appear at all
         assert!(!result.contains("## Append"));
     }
 
     #[test]
     fn test_dynamic_sections_not_cached() {
-        clear_all_prompts();
+        reset_sections();
         let sections = vec![Section::SessionState {
             turn_count: 1,
             pending_tasks: vec![],

--- a/src/system_prompt/mod.rs
+++ b/src/system_prompt/mod.rs
@@ -14,8 +14,7 @@ pub mod tools_section;
 pub mod workdir;
 
 pub use builder::{
-    build_from_workspace, build_system_prompt, set_agent_prompt, set_custom_prompt,
-    set_override_prompt, WorkspaceBuildConfig,
+    build_from_workspace, build_system_prompt, PromptOverrides, WorkspaceBuildConfig,
 };
 pub use sections::{get_cached_section, invalidate_all_sections, invalidate_section, Section};
 pub use tools_section::build_tools_section;


### PR DESCRIPTION
## 概述

将优先级 prompt 检查从 session 创建阶段（`build_system_prompt()`）移到请求阶段（`build_full_system_prompt()`），遵循 `docs/design/system_prompt/README.md` 定义的数据流，同时消除全局静态变量导致的 CI 竞态问题。

## 背景

Design doc 明确规定优先级 prompt 检查发生在**请求阶段**（每次 API 调用时），而非 session 创建时。当前实现通过 3 个全局静态变量在 session 创建时检查优先级 prompt，导致：

1. 全局状态竞态，CI 测试 `test_find_or_create_with_tool_registry` 持续失败
2. 优先级 prompt 在 session 创建后无法动态变更
3. 与 design doc 数据流不一致

## 主要变更

- **删除** `builder.rs` 中 3 个全局静态变量及 setter/getter 函数
- **新增** `PromptOverrides` 结构体承载三级优先级 prompt（override > agent > custom）
- **修改** `build_full_system_prompt()` 增加 `overrides` 参数，命中时替代静态层，仅追加 AppendSection
- **修改** `SessionManager` 持有 `PromptOverrides`，`call_llm` / `call_llm_streaming` 传入
- **清理** 测试中的串行依赖和全局状态清理逻辑
- **拆分** `priority_prompt_tests.rs` 独立测试文件

## 测试结果

- `cargo test` 全部通过
- `test_find_or_create_with_tool_registry` 不再 flaky（消除了全局状态竞态）
- 所有文件 ≤ 500 行，格式通过 `cargo fmt --check`

Source: CI
Type: fix