### PR TITLE
fix: 修复 config reload agents/ 目录监听路径不一致

### DIFF
--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -41,7 +41,7 @@ fn setup_watcher(
     config_dir: &str,
 ) -> anyhow::Result<(RecommendedWatcher, mpsc::Receiver<notify::Result<Event>>)> {
     let config_path = Path::new(config_dir);
-    let agents_dir = config_path.join("agents");
+    let agents_dir = config_path.parent().unwrap_or(config_path).join("agents");
 
     let config_files: Vec<PathBuf> = [
         "models.json",
@@ -185,7 +185,7 @@ pub(crate) fn init_config_hot_reload(
     spawn_event_consumer(rx, Arc::clone(&config_manager));
 
     let config_path = Path::new(config_dir);
-    let agents_dir = config_path.join("agents");
+    let agents_dir = config_path.parent().unwrap_or(config_path).join("agents");
     let watch_count = [
         "models.json",
         "channels.json",

--- a/src/daemon/config_reload_tests.rs
+++ b/src/daemon/config_reload_tests.rs
@@ -28,3 +28,31 @@ fn test_filename_to_section() {
     assert_eq!(filename_to_section("agents.json"), None);
     assert_eq!(filename_to_section("unknown.json"), None);
 }
+
+/// Replicate the agents_dir path construction used by both
+/// `setup_watcher()` and `init_config_hot_reload()` so the logic
+/// can be tested without filesystem side-effects.
+fn agents_dir_for_config(config_dir: &str) -> std::path::PathBuf {
+    let config_path = std::path::Path::new(config_dir);
+    config_path.parent().unwrap_or(config_path).join("agents")
+}
+
+#[test]
+fn test_agents_dir_normal_config() {
+    let result = agents_dir_for_config("~/.closeclaw/config");
+    assert_eq!(result, std::path::PathBuf::from("~/.closeclaw/agents"));
+}
+
+#[test]
+fn test_agents_dir_root_config() {
+    let result = agents_dir_for_config("/config");
+    assert_eq!(result, std::path::PathBuf::from("/agents"));
+}
+
+#[test]
+fn test_agents_dir_fallback_no_parent() {
+    // When config_dir is "/" (root), parent() returns None,
+    // so unwrap_or falls back to the path itself.
+    let result = agents_dir_for_config("/");
+    assert_eq!(result, std::path::PathBuf::from("/agents"));
+}


### PR DESCRIPTION
修复 `daemon/config_reload.rs` 中 `setup_watcher()` 和 `init_config_hot_reload()` 的 agents/ 目录路径构造。

**问题**：两处使用 `config_path.join("agents")`，将 agents/ 当作 config/ 的子目录。
**修复**：改为 `config_path.parent().unwrap_or(config_path).join("agents")`，与 `agent_loader.rs` 一致。
**测试**：新增 3 个单元测试覆盖路径构造逻辑。

Source: issue #921
Type: fix
