### PR TITLE
fix(session): find_or_create fast path 更新 thread_id

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -156,46 +156,40 @@ impl SessionManager {
     /// Attempt to restore an archived session.
     /// Returns true iff restoration was attempted and succeeded.
     async fn try_restore_archived_session(&self, session_id: &str, channel: &str) -> bool {
-        let storage = self.storage.read().await;
-        let Some(storage) = storage.as_ref() else {
-            return false;
-        };
-        let checkpoint = match storage.load_checkpoint(session_id).await {
-            Ok(Some(cp)) => cp,
-            Ok(None) | Err(_) => return false,
-        };
-        if checkpoint.status != SessionStatus::Archived {
-            return false;
-        }
-        // Send restore notification
-        let adapters = self.adapters.read().await;
-        if let Some(adapter) = adapters.get(channel) {
-            let notification = Message {
-                id: format!("restore-{}", session_id),
-                from: "system".to_string(),
-                to: checkpoint
-                    .chat_id
-                    .as_deref()
-                    .unwrap_or(session_id)
-                    .to_string(),
-                content: "正在恢复会话...".to_string(),
-                channel: channel.to_string(),
-                timestamp: chrono::Utc::now().timestamp(),
-                metadata: std::collections::HashMap::new(),
-                thread_id: None,
-            };
-            if let Err(e) = adapter.send_message(&notification, None).await {
-                warn!(session_id = %session_id, error = %e,
-                    "failed to send restore notification");
+        let storage_arc = {
+            let storage_guard = self.storage.read().await;
+            match storage_guard.as_ref() {
+                Some(s) => Arc::clone(s),
+                None => return false,
             }
-        }
+        };
+        let adapters = self.adapters.read().await;
+        session_helpers::try_restore_archived_session_inner(
+            &storage_arc,
+            &adapters,
+            session_id,
+            channel,
+        )
+        .await
+    }
 
-        if let Err(e) = storage.restore_checkpoint(session_id).await {
-            warn!(session_id = %session_id, error = %e,
-                "failed to restore archived session");
-            return false;
-        }
-        true
+    /// Update the thread_id in a session's checkpoint.
+    /// Delegates to `session_helpers::update_checkpoint_thread_id`.
+    async fn update_checkpoint_thread_id(&self, session_id: &str, thread_id: &Option<String>) {
+        let storage_arc = {
+            let storage_guard = self.storage.read().await;
+            match storage_guard.as_ref() {
+                Some(s) => Arc::clone(s),
+                None => {
+                    warn!(
+                        session_id = %session_id,
+                        "storage not available, skipping thread_id update"
+                    );
+                    return;
+                }
+            }
+        };
+        session_helpers::update_checkpoint_thread_id(&storage_arc, session_id, thread_id).await;
     }
 
     /// Find or create a session for the given channel and message.
@@ -215,23 +209,35 @@ impl SessionManager {
     ) -> Result<String, ProcessError> {
         // Channel-level override: if a channel has an active session
         // (e.g. from /new), route directly to it.
-        {
+        let channel_override = {
             let channel_map = self.channel_active_sessions.read().await;
             if let Some(active_id) = channel_map.get(channel) {
                 let sessions = self.sessions.read().await;
                 if sessions.contains_key(active_id) {
-                    return Ok(active_id.clone());
+                    Some(active_id.clone())
+                } else {
+                    None
                 }
+            } else {
+                None
             }
+        };
+        if let Some(active_id) = &channel_override {
+            self.update_checkpoint_thread_id(active_id, &message.thread_id)
+                .await;
+            return Ok(active_id.clone());
         }
 
         let session_id = self.compute_session_key(channel, message, account_id);
         // Fast path: session already exists
-        {
+        let session_exists = {
             let sessions = self.sessions.read().await;
-            if sessions.contains_key(&session_id) {
-                return Ok(session_id);
-            }
+            sessions.contains_key(&session_id)
+        };
+        if session_exists {
+            self.update_checkpoint_thread_id(&session_id, &message.thread_id)
+                .await;
+            return Ok(session_id);
         }
         // Slow path: try archived session restoration
         let restored = self

--- a/src/gateway/session_manager/bug904_tests.rs
+++ b/src/gateway/session_manager/bug904_tests.rs
@@ -197,3 +197,198 @@ async fn test_flush_all_preserves_existing_thread_id() {
         "flush_all must preserve the existing thread_id"
     );
 }
+
+// ===================================================================
+// Bug #920: fast path updates thread_id in checkpoint
+// ===================================================================
+
+#[tokio::test]
+async fn test_active_session_fast_path_updates_thread_id() {
+    // Bug #920: When a session already exists (active session fast path),
+    // find_or_create should update the checkpoint's thread_id.
+    let storage = Arc::new(Bug904MockStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    // Step 1: Create session via slow path (first find_or_create)
+    let mut msg1 = test_message();
+    msg1.thread_id = Some("omt_initial".to_string());
+    let session_id = mgr
+        .find_or_create("feishu", &msg1, None)
+        .await
+        .expect("first find_or_create should succeed");
+
+    // Verify slow path created checkpoint with initial thread_id
+    let saved = storage.saved_checkpoints.lock().await;
+    let cp_initial = saved
+        .iter()
+        .find(|c| c.session_id == session_id)
+        .expect("should have saved checkpoint on slow path");
+    assert_eq!(
+        cp_initial.thread_id.as_deref(),
+        Some("omt_initial"),
+        "slow path should set thread_id"
+    );
+    drop(saved);
+
+    // Step 2: Seed checkpoint for fast path update (mock removes on load)
+    let reseed = SessionCheckpoint::new(session_id.clone())
+        .with_status(SessionStatus::Active)
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-b".to_string())
+        .with_agent_id("agent-b".to_string())
+        .with_thread_id("omt_initial".to_string());
+    {
+        storage
+            .loaded_checkpoints
+            .lock()
+            .unwrap()
+            .insert(session_id.clone(), reseed);
+    }
+
+    // Step 3: Second find_or_create hits active session fast path
+    let mut msg2 = test_message();
+    msg2.thread_id = Some("omt_updated".to_string());
+    let session_id2 = mgr
+        .find_or_create("feishu", &msg2, None)
+        .await
+        .expect("second find_or_create should succeed");
+    assert_eq!(session_id, session_id2, "session_id should be the same");
+
+    // Verify fast path updated checkpoint thread_id
+    let saved = storage.saved_checkpoints.lock().await;
+    let cp_updated = saved
+        .iter()
+        .rfind(|c| c.session_id == session_id)
+        .expect("should have saved checkpoint on fast path");
+    assert_eq!(
+        cp_updated.thread_id.as_deref(),
+        Some("omt_updated"),
+        "active session fast path should update thread_id"
+    );
+}
+
+#[tokio::test]
+async fn test_channel_override_fast_path_updates_thread_id() {
+    // Bug #920: When a channel override is active (channel-level fast path),
+    // find_or_create should update the checkpoint's thread_id.
+    let storage = Arc::new(Bug904MockStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    // Step 1: Create session via slow path
+    let mut msg1 = test_message();
+    msg1.thread_id = None;
+    let session_id = mgr
+        .find_or_create("feishu", &msg1, None)
+        .await
+        .expect("first find_or_create should succeed");
+
+    // Step 2: Register channel override so subsequent calls take fast path
+    {
+        let mut channel_map = mgr.channel_active_sessions.write().await;
+        channel_map.insert("feishu".to_string(), session_id.clone());
+    }
+
+    // Step 3: Seed checkpoint for fast path update
+    let reseed = SessionCheckpoint::new(session_id.clone())
+        .with_status(SessionStatus::Active)
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-b".to_string())
+        .with_agent_id("agent-b".to_string());
+    {
+        storage
+            .loaded_checkpoints
+            .lock()
+            .unwrap()
+            .insert(session_id.clone(), reseed);
+    }
+
+    // Step 4: find_or_create hits channel override fast path
+    let mut msg2 = test_message();
+    msg2.thread_id = Some("omt_channel".to_string());
+    let session_id2 = mgr
+        .find_or_create("feishu", &msg2, None)
+        .await
+        .expect("second find_or_create should succeed");
+    assert_eq!(session_id, session_id2, "session_id should be the same");
+
+    // Verify channel override fast path updated checkpoint thread_id
+    let saved = storage.saved_checkpoints.lock().await;
+    let cp_updated = saved
+        .iter()
+        .rfind(|c| c.session_id == session_id)
+        .expect("should have saved checkpoint on fast path");
+    assert_eq!(
+        cp_updated.thread_id.as_deref(),
+        Some("omt_channel"),
+        "channel override fast path should update thread_id"
+    );
+}
+
+#[tokio::test]
+async fn test_fast_path_thread_id_none_overwrites_old_value() {
+    // Bug #920: When thread_id is None, the fast path should overwrite
+    // the existing thread_id value in the checkpoint.
+    let storage = Arc::new(Bug904MockStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    // Step 1: Create session with a thread_id via slow path
+    let mut msg1 = test_message();
+    msg1.thread_id = Some("omt_old".to_string());
+    let session_id = mgr
+        .find_or_create("feishu", &msg1, None)
+        .await
+        .expect("first find_or_create should succeed");
+
+    // Step 2: Seed checkpoint with old thread_id for fast path update
+    let reseed = SessionCheckpoint::new(session_id.clone())
+        .with_status(SessionStatus::Active)
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-b".to_string())
+        .with_agent_id("agent-b".to_string())
+        .with_thread_id("omt_old".to_string());
+    {
+        storage
+            .loaded_checkpoints
+            .lock()
+            .unwrap()
+            .insert(session_id.clone(), reseed);
+    }
+
+    // Step 3: Second find_or_create with thread_id = None (fast path)
+    let mut msg2 = test_message();
+    msg2.thread_id = None;
+    let session_id2 = mgr
+        .find_or_create("feishu", &msg2, None)
+        .await
+        .expect("second find_or_create should succeed");
+    assert_eq!(session_id, session_id2, "session_id should be the same");
+
+    // Verify thread_id was overwritten to None
+    let saved = storage.saved_checkpoints.lock().await;
+    let cp_updated = saved
+        .iter()
+        .rfind(|c| c.session_id == session_id)
+        .expect("should have saved checkpoint on fast path");
+    assert_eq!(
+        cp_updated.thread_id, None,
+        "fast path should overwrite thread_id with None"
+    );
+}

--- a/src/gateway/session_manager/session_helpers.rs
+++ b/src/gateway/session_manager/session_helpers.rs
@@ -2,13 +2,16 @@
 //! to keep the main file under the 500-line limit.
 
 use crate::gateway::Message;
+use crate::im::IMAdapter;
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
+use crate::session::persistence::{PersistenceService, SessionStatus};
 use crate::session::workspace;
 use crate::skills::DiskSkillRegistry;
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::{ToolContext, ToolRegistry};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -148,4 +151,83 @@ pub(super) fn create_new_session(
         created_at: chrono::Utc::now().timestamp(),
         depth: 0,
     }
+}
+
+/// Update the thread_id in a session's checkpoint.
+///
+/// Loads the checkpoint from storage, overwrites `thread_id` with the
+/// provided value, and saves it back. This mirrors the pattern used in
+/// `restore_checkpoint_session`.
+///
+/// Silently skips (with warn!) when:
+/// - storage is not available
+/// - checkpoint does not exist
+pub(super) async fn update_checkpoint_thread_id(
+    storage: &Arc<dyn PersistenceService>,
+    session_id: &str,
+    thread_id: &Option<String>,
+) {
+    let mut cp = match storage.load_checkpoint(session_id).await {
+        Ok(Some(cp)) => cp,
+        Ok(None) | Err(_) => {
+            warn!(
+                session_id = %session_id,
+                "checkpoint not found, skipping thread_id update"
+            );
+            return;
+        }
+    };
+    cp.thread_id = thread_id.clone();
+    if let Err(e) = storage.save_checkpoint(&cp).await {
+        warn!(
+            session_id = %session_id,
+            error = %e,
+            "failed to save checkpoint with updated thread_id"
+        );
+    }
+}
+
+/// Attempt to restore an archived session.
+///
+/// Returns `true` if restoration was attempted and succeeded.
+pub(super) async fn try_restore_archived_session_inner(
+    storage: &Arc<dyn PersistenceService>,
+    adapters: &HashMap<String, Arc<dyn IMAdapter>>,
+    session_id: &str,
+    channel: &str,
+) -> bool {
+    let checkpoint = match storage.load_checkpoint(session_id).await {
+        Ok(Some(cp)) => cp,
+        Ok(None) | Err(_) => return false,
+    };
+    if checkpoint.status != SessionStatus::Archived {
+        return false;
+    }
+    // Send restore notification
+    if let Some(adapter) = adapters.get(channel) {
+        let notification = Message {
+            id: format!("restore-{}", session_id),
+            from: "system".to_string(),
+            to: checkpoint
+                .chat_id
+                .as_deref()
+                .unwrap_or(session_id)
+                .to_string(),
+            content: "正在恢复会话...".to_string(),
+            channel: channel.to_string(),
+            timestamp: chrono::Utc::now().timestamp(),
+            metadata: std::collections::HashMap::new(),
+            thread_id: None,
+        };
+        if let Err(e) = adapter.send_message(&notification, None).await {
+            warn!(session_id = %session_id, error = %e,
+                "failed to send restore notification");
+        }
+    }
+    if let Err(e) = storage.restore_checkpoint(session_id).await {
+        warn!(session_id = %session_id, error = %e,
+            "failed to restore archived session");
+        return false;
+    }
+    true
 }


### PR DESCRIPTION
fix(session): find_or_create fast path 更新 thread_id

修复 SessionManager::find_or_create 中两条 fast path 不更新 checkpoint
thread_id 的问题。用户在 DM 话题和主消息流之间切换时，bot 回复位置
不正确。

## 改动

- 添加 `update_checkpoint_thread_id` helper 方法到 session_helpers.rs
- 修改 channel-level override fast path：return 前更新 thread_id
- 修改 active session fast path：return 前更新 thread_id
- session_manager.rs 从 554 行降至 497 行（提取 helper 到子模块）

## 测试

- 新增 3 个单元测试：active session fast path、channel override fast path、None 覆盖旧值
- 全量测试 1960 passed, 1 pre-existing flaky failure

Source: issue #920
Type: fix
