### PR TITLE
chore: Anthropic + Stub Provider 直接 impl Provider trait

### DIFF
--- a/src/daemon/llm_init.rs
+++ b/src/daemon/llm_init.rs
@@ -1,7 +1,5 @@
 //! LLM provider registration helpers
 
-#![allow(deprecated)]
-
 use super::*;
 use crate::config::providers::CredentialsProvider;
 use crate::llm::anthropic::AnthropicProvider;
@@ -61,15 +59,9 @@ impl Daemon {
             .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
             .filter(|k| !k.is_empty());
         if let Some(api_key) = anthropic_key {
-            let bridge = Arc::new(LegacyProviderBridge::new(
-                AnthropicProvider::new(api_key.clone()),
-                "https://api.anthropic.com".to_string(),
-                api_key,
-                vec![],
-                client.clone(),
-                empty_headers.clone(),
-            ));
-            registry.register("anthropic".to_string(), bridge).await;
+            let provider: Arc<dyn crate::llm::provider::Provider> =
+                Arc::new(AnthropicProvider::new(api_key.clone()));
+            registry.register("anthropic".to_string(), provider).await;
             info!("Anthropic provider registered");
         }
 

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,38 +1,73 @@
 //! Anthropic LLM Provider
 
-#![allow(deprecated)]
-
-use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider};
 use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use std::sync::OnceLock;
 
-#[allow(dead_code)]
+use crate::llm::provider::{Provider, ProviderError, Result, SseStream};
+use crate::llm::types::{InternalRequest, InternalResponse, ProtocolId};
+
 pub struct AnthropicProvider {
     api_key: String,
+    client: Client,
+    supported_protocols: Vec<ProtocolId>,
 }
 
 impl AnthropicProvider {
     pub fn new(api_key: String) -> Self {
-        Self { api_key }
+        Self {
+            api_key,
+            client: Client::new(),
+            supported_protocols: vec![ProtocolId::new("anthropic")],
+        }
     }
 }
 
 #[async_trait]
-impl LLMProvider for AnthropicProvider {
-    fn name(&self) -> &str {
+impl Provider for AnthropicProvider {
+    fn id(&self) -> &str {
         "anthropic"
     }
 
-    fn models(&self) -> Vec<&str> {
-        vec!["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"]
+    fn base_url(&self) -> &str {
+        ""
     }
 
-    fn is_stub(&self) -> bool {
-        true
+    fn api_key(&self) -> &str {
+        &self.api_key
     }
 
-    async fn chat(&self, _request: ChatRequest) -> Result<ChatResponse, LLMError> {
-        Err(LLMError::ApiError(
-            "Anthropic provider is a stub — implement real API to enable LLM calls".to_string(),
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &self.supported_protocols
+    }
+
+    fn http_client(&self) -> &Client {
+        &self.client
+    }
+
+    fn default_headers(&self) -> &HeaderMap {
+        static EMPTY: OnceLock<HeaderMap> = OnceLock::new();
+        EMPTY.get_or_init(HeaderMap::new)
+    }
+
+    async fn send(
+        &self,
+        _request: InternalRequest,
+        _body: serde_json::Value,
+    ) -> Result<InternalResponse> {
+        Err(ProviderError::Legacy(
+            "Anthropic provider is a stub — implement real API to enable LLM calls".into(),
+        ))
+    }
+
+    async fn send_streaming(
+        &self,
+        _request: InternalRequest,
+        _body: serde_json::Value,
+    ) -> Result<SseStream> {
+        Err(ProviderError::Legacy(
+            "Anthropic provider is a stub — implement real API to enable LLM calls".into(),
         ))
     }
 }
@@ -44,46 +79,45 @@ mod tests {
     #[test]
     fn test_anthropic_provider_new() {
         let provider = AnthropicProvider::new("test-key".to_string());
-        assert_eq!(provider.name(), "anthropic");
+        assert_eq!(provider.id(), "anthropic");
+        assert_eq!(provider.api_key(), "test-key");
     }
 
     #[test]
-    fn test_anthropic_provider_name() {
+    fn test_anthropic_provider_id() {
         let provider = AnthropicProvider::new("key".to_string());
-        assert_eq!(provider.name(), "anthropic");
+        assert_eq!(provider.id(), "anthropic");
     }
 
     #[test]
-    fn test_anthropic_provider_models() {
+    fn test_anthropic_provider_supported_protocols() {
         let provider = AnthropicProvider::new("key".to_string());
-        let models = provider.models();
-        assert_eq!(
-            models,
-            vec!["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"]
-        );
-    }
-
-    #[test]
-    fn test_anthropic_is_stub() {
-        let provider = AnthropicProvider::new("key".to_string());
-        assert!(provider.is_stub());
+        let protocols = provider.supported_protocols();
+        assert_eq!(protocols.len(), 1);
+        assert_eq!(protocols[0].as_str(), "anthropic");
     }
 
     #[tokio::test]
-    async fn test_anthropic_chat_returns_error() {
+    async fn test_anthropic_send_returns_error() {
         let provider = AnthropicProvider::new("key".to_string());
-        let request = ChatRequest {
-            model: "claude-3-opus".to_string(),
+        let request = InternalRequest {
+            model: "claude-3-opus".into(),
             messages: vec![],
             temperature: 0.0,
             max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         };
-        let result = provider.chat(request).await;
+        let result = provider.send(request, serde_json::Value::Null).await;
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        match err {
-            LLMError::ApiError(msg) => assert!(msg.contains("stub")),
-            _ => panic!("Expected ApiError"),
+        match result.unwrap_err() {
+            ProviderError::Legacy(msg) => assert!(msg.contains("stub")),
+            other => panic!("Expected Legacy error, got: {:?}", other),
         }
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -313,18 +313,10 @@ impl LLMRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm::legacy::legacy_provider::LegacyProviderBridge;
     use crate::llm::stub::StubProvider;
 
-    fn stub_bridge() -> LegacyProviderBridge<StubProvider> {
-        LegacyProviderBridge::new(
-            StubProvider::new(),
-            String::new(),
-            String::new(),
-            vec![],
-            reqwest::Client::new(),
-            reqwest::header::HeaderMap::new(),
-        )
+    fn stub_provider() -> Arc<dyn Provider> {
+        Arc::new(StubProvider::new())
     }
 
     #[test]
@@ -349,10 +341,10 @@ mod tests {
     #[tokio::test]
     async fn test_registry_register_and_retrieve() {
         let registry = LLMRegistry::new();
-        let bridge = Arc::new(stub_bridge());
+        let provider = stub_provider();
 
         registry
-            .register("test-stub".to_string(), bridge.clone())
+            .register("test-stub".to_string(), provider.clone())
             .await;
 
         let retrieved = registry.get("test-stub").await;
@@ -363,38 +355,12 @@ mod tests {
     #[tokio::test]
     async fn test_registry_list() {
         let registry = LLMRegistry::new();
-        registry
-            .register("a".to_string(), Arc::new(stub_bridge()))
-            .await;
-        registry
-            .register("b".to_string(), Arc::new(stub_bridge()))
-            .await;
+        registry.register("a".to_string(), stub_provider()).await;
+        registry.register("b".to_string(), stub_provider()).await;
 
         let providers = registry.list().await;
         assert_eq!(providers.len(), 2);
         assert!(providers.contains(&"a".to_string()));
         assert!(providers.contains(&"b".to_string()));
-    }
-
-    // Test default implementations for new trait methods added in issue #525.
-    // provider_display_name defaults to name(); fetch_model_list defaults to ModelNotFound.
-    // All concrete providers (MiniMax, GLM, OpenAI, Anthropic, Stub, Fake) use these
-    // defaults, so we verify the defaults via StubProvider.
-
-    #[tokio::test]
-    async fn test_provider_display_name_default() {
-        let provider = StubProvider::new();
-        // Default impl of provider_display_name returns self.name()
-        assert_eq!(provider.provider_display_name(), provider.name());
-    }
-
-    #[tokio::test]
-    async fn test_fetch_model_list_default_returns_model_not_found() {
-        let provider = StubProvider::new();
-        let result: Result<Vec<crate::llm::ModelInfo>, LLMError> =
-            provider.fetch_model_list("fake-token").await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, LLMError::ModelNotFound(_)));
     }
 }

--- a/src/llm/stub.rs
+++ b/src/llm/stub.rs
@@ -1,22 +1,25 @@
 //! Stub LLM Provider - Returns fixed responses for testing
 
-#![allow(deprecated)]
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use std::sync::OnceLock;
+use tokio::sync::mpsc;
 
 use async_trait::async_trait;
 
-use super::{ChatRequest, ChatResponse, LLMError, LLMProvider, Usage};
-
-#[cfg(test)]
-use super::Message;
+use super::provider::{Provider, Result, SseStream};
+use super::types::{
+    InternalRequest, InternalResponse, ProtocolId, RawContentBlock, RawSseChunk, RawUsage,
+};
 
 /// A stub LLM provider that returns fixed responses.
-/// Always returns `is_stub() == true` so callers can detect test configurations.
+/// Always returns `id() == "stub"` so callers can detect test configurations.
 #[derive(Debug, Clone, Default)]
 pub struct StubProvider {
-    /// Fixed response content returned by `chat()`
+    /// Fixed response content returned by `send()`
     response: String,
-    /// Fixed model name in response
-    model: String,
+    /// HTTP client (satisfies the `http_client()` contract; unused by stub)
+    client: Client,
 }
 
 impl StubProvider {
@@ -24,7 +27,7 @@ impl StubProvider {
     pub fn new() -> Self {
         Self {
             response: "stub response".to_string(),
-            model: "stub-model".to_string(),
+            client: Client::new(),
         }
     }
 
@@ -32,20 +35,45 @@ impl StubProvider {
     pub fn with_response(response: impl Into<String>) -> Self {
         Self {
             response: response.into(),
-            model: "stub-model".to_string(),
+            client: Client::new(),
         }
     }
 }
 
 #[async_trait]
-impl LLMProvider for StubProvider {
-    fn name(&self) -> &str {
+impl Provider for StubProvider {
+    fn id(&self) -> &str {
         "stub"
     }
 
-    async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, LLMError> {
+    fn base_url(&self) -> &str {
+        ""
+    }
+
+    fn api_key(&self) -> &str {
+        ""
+    }
+
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &[]
+    }
+
+    fn http_client(&self) -> &Client {
+        &self.client
+    }
+
+    fn default_headers(&self) -> &HeaderMap {
+        static EMPTY: OnceLock<HeaderMap> = OnceLock::new();
+        EMPTY.get_or_init(HeaderMap::new)
+    }
+
+    async fn send(
+        &self,
+        request: InternalRequest,
+        _body: serde_json::Value,
+    ) -> Result<InternalResponse> {
         // Log the request for test inspection
-        eprintln!("[StubProvider] chat called with model={}", request.model);
+        eprintln!("[StubProvider] send called with model={}", request.model);
         eprintln!("[StubProvider] messages count={}", request.messages.len());
 
         let prompt_tokens = request
@@ -54,81 +82,126 @@ impl LLMProvider for StubProvider {
             .map(|m| m.content.len() as u32 / 4)
             .sum();
 
-        Ok(ChatResponse {
-            content: self.response.clone(),
-            model: self.model.clone(),
-            usage: Usage {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text(self.response.clone())],
+            usage: RawUsage {
                 prompt_tokens,
                 completion_tokens: self.response.len() as u32 / 4,
-                total_tokens: prompt_tokens + self.response.len() as u32 / 4,
+                total_tokens: Some(prompt_tokens + self.response.len() as u32 / 4),
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
+            finish_reason: None,
         })
     }
 
-    fn models(&self) -> Vec<&str> {
-        vec!["stub-model"]
-    }
-
-    fn is_stub(&self) -> bool {
-        true
+    async fn send_streaming(
+        &self,
+        request: InternalRequest,
+        body: serde_json::Value,
+    ) -> Result<SseStream> {
+        let response = self.send(request, body).await?;
+        let (tx, rx) = mpsc::channel(32);
+        tokio::spawn(async move {
+            for block in &response.content_blocks {
+                let chunk = match block {
+                    RawContentBlock::Text(s) => RawSseChunk {
+                        event_type: "message".into(),
+                        data: s.clone(),
+                    },
+                    _ => continue,
+                };
+                let _ = tx.send(chunk).await;
+            }
+            // Send done event
+            let done = serde_json::json!({"type": "message_end"});
+            let _ = tx
+                .send(RawSseChunk {
+                    event_type: "message".into(),
+                    data: done.to_string(),
+                })
+                .await;
+        });
+        Ok(rx)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::InternalMessage;
     use super::*;
 
-    #[tokio::test]
-    async fn test_stub_provider_is_stub() {
+    #[test]
+    fn test_stub_provider_is_stub() {
         let provider = StubProvider::new();
-        assert!(provider.is_stub());
+        assert_eq!(provider.id(), "stub");
     }
 
-    #[tokio::test]
-    async fn test_stub_provider_name() {
+    #[test]
+    fn test_stub_provider_name() {
         let provider = StubProvider::new();
-        assert_eq!(provider.name(), "stub");
-    }
-
-    #[tokio::test]
-    async fn test_stub_provider_models() {
-        let provider = StubProvider::new();
-        assert_eq!(provider.models(), vec!["stub-model"]);
+        assert_eq!(provider.id(), "stub");
     }
 
     #[tokio::test]
     async fn test_stub_provider_chat_returns_fixed_response() {
         let provider = StubProvider::new();
-        let request = ChatRequest {
+        let request = InternalRequest {
             model: "gpt-4".to_string(),
-            messages: vec![Message {
+            messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "hello".to_string(),
             }],
             temperature: 0.7,
             max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         };
 
-        let response = provider.chat(request).await.unwrap();
-        assert_eq!(response.content, "stub response");
-        assert_eq!(response.model, "stub-model");
-        assert!(response.usage.total_tokens > 0);
+        let response = provider
+            .send(request, serde_json::Value::Null)
+            .await
+            .unwrap();
+        assert_eq!(response.content_blocks.len(), 1);
+        match &response.content_blocks[0] {
+            RawContentBlock::Text(s) => assert_eq!(s, "stub response"),
+            other => panic!("Expected Text block, got: {:?}", other),
+        }
+        assert!(response.usage.total_tokens.unwrap() > 0);
     }
 
     #[tokio::test]
     async fn test_stub_provider_custom_response() {
         let provider = StubProvider::with_response("custom test response");
-        let request = ChatRequest {
+        let request = InternalRequest {
             model: "gpt-4".to_string(),
-            messages: vec![Message {
+            messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "test".to_string(),
             }],
             temperature: 0.0,
             max_tokens: Some(100),
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         };
 
-        let response = provider.chat(request).await.unwrap();
-        assert_eq!(response.content, "custom test response");
+        let response = provider
+            .send(request, serde_json::Value::Null)
+            .await
+            .unwrap();
+        match &response.content_blocks[0] {
+            RawContentBlock::Text(s) => assert_eq!(s, "custom test response"),
+            other => panic!("Expected Text block, got: {:?}", other),
+        }
     }
 }

--- a/tests/llm_tests.rs
+++ b/tests/llm_tests.rs
@@ -3,76 +3,94 @@
 //! Tests the StubProvider and LLMRegistry integration.
 //! These tests verify that the agent+LLM call chain works in CI.
 
-#![allow(deprecated)]
-
 use std::sync::Arc;
 
-use closeclaw::llm::legacy::legacy_provider::LegacyProviderBridge;
-use closeclaw::llm::{ChatRequest, LLMProvider, LLMRegistry, Message, StubProvider};
+use closeclaw::llm::provider::Provider;
+use closeclaw::llm::types::{InternalMessage, InternalRequest, RawContentBlock};
+use closeclaw::llm::{LLMRegistry, StubProvider};
+use closeclaw::session::ReasoningLevel;
 
-fn stub_bridge() -> LegacyProviderBridge<StubProvider> {
-    LegacyProviderBridge::new(
-        StubProvider::new(),
-        String::new(),
-        String::new(),
-        vec![],
-        reqwest::Client::new(),
-        reqwest::header::HeaderMap::new(),
-    )
+fn stub_provider() -> Arc<dyn Provider> {
+    Arc::new(StubProvider::new())
 }
 
 #[tokio::test]
 async fn test_stub_provider_is_stub() {
     let provider = StubProvider::new();
-    assert!(
-        provider.is_stub(),
-        "StubProvider should return true for is_stub()"
-    );
+    assert_eq!(provider.id(), "stub", "StubProvider id should be 'stub'");
 }
 
 #[tokio::test]
 async fn test_stub_provider_chat_returns_fixed_response() {
     let provider = StubProvider::new();
-    let request = ChatRequest {
+    let request = InternalRequest {
         model: "gpt-4".to_string(),
-        messages: vec![Message {
+        messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "Hello, world!".to_string(),
         }],
         temperature: 0.7,
         max_tokens: None,
+        stream: false,
+        extra_body: serde_json::Map::new(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
+        reasoning_level: ReasoningLevel::default(),
     };
+    let body = serde_json::to_value(&request).unwrap();
 
-    let response = provider.chat(request).await.unwrap();
-    assert_eq!(response.content, "stub response");
-    assert_eq!(response.model, "stub-model");
-    assert!(response.usage.total_tokens > 0);
+    let response = provider.send(request, body).await.unwrap();
+    assert_eq!(response.content_blocks.len(), 1);
+    match &response.content_blocks[0] {
+        RawContentBlock::Text(s) => {
+            assert_eq!(s, "stub response");
+        }
+        _ => panic!("Expected Text content block"),
+    }
+    assert!(response.usage.total_tokens.is_some());
+    assert!(response.usage.total_tokens.unwrap() > 0);
 }
 
 #[tokio::test]
 async fn test_stub_provider_custom_response() {
     let provider = StubProvider::with_response("custom test response");
-    let request = ChatRequest {
+    let request = InternalRequest {
         model: "claude-3".to_string(),
-        messages: vec![Message {
+        messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "test input".to_string(),
         }],
         temperature: 0.0,
         max_tokens: Some(100),
+        stream: false,
+        extra_body: serde_json::Map::new(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
+        reasoning_level: ReasoningLevel::default(),
     };
+    let body = serde_json::to_value(&request).unwrap();
 
-    let response = provider.chat(request).await.unwrap();
-    assert_eq!(response.content, "custom test response");
+    let response = provider.send(request, body).await.unwrap();
+    assert_eq!(response.content_blocks.len(), 1);
+    match &response.content_blocks[0] {
+        RawContentBlock::Text(s) => {
+            assert_eq!(s, "custom test response");
+        }
+        _ => panic!("Expected Text content block"),
+    }
 }
 
 #[tokio::test]
 async fn test_llm_registry_register_and_retrieve_stub_provider() {
     let registry = LLMRegistry::new();
-    let bridge = Arc::new(stub_bridge());
+    let provider = stub_provider();
 
     registry
-        .register("test-stub".to_string(), bridge.clone())
+        .register("test-stub".to_string(), provider.clone())
         .await;
 
     let retrieved = registry.get("test-stub").await;
@@ -90,19 +108,12 @@ async fn test_llm_registry_list_includes_stub() {
     let registry = LLMRegistry::new();
 
     registry
-        .register("stub-1".to_string(), Arc::new(stub_bridge()))
+        .register("stub-1".to_string(), stub_provider())
         .await;
     registry
         .register(
             "stub-2".to_string(),
-            Arc::new(LegacyProviderBridge::new(
-                StubProvider::with_response("other"),
-                String::new(),
-                String::new(),
-                vec![],
-                reqwest::Client::new(),
-                reqwest::header::HeaderMap::new(),
-            )),
+            Arc::new(StubProvider::with_response("other")),
         )
         .await;
 
@@ -114,20 +125,11 @@ async fn test_llm_registry_list_includes_stub() {
 
 #[tokio::test]
 async fn test_stub_provider_through_registry_chat() {
-    use closeclaw::llm::types::{InternalMessage, InternalRequest};
-
     let registry = LLMRegistry::new();
-    let bridge = Arc::new(LegacyProviderBridge::new(
-        StubProvider::with_response("agent response from stub"),
-        String::new(),
-        String::new(),
-        vec![],
-        reqwest::Client::new(),
-        reqwest::header::HeaderMap::new(),
-    ));
+    let provider = Arc::new(StubProvider::with_response("agent response from stub"));
 
     registry
-        .register("test-agent".to_string(), bridge.clone())
+        .register("test-agent".to_string(), provider.clone())
         .await;
 
     let agent_provider = registry.get("test-agent").await.unwrap();
@@ -145,7 +147,7 @@ async fn test_stub_provider_through_registry_chat() {
         system_dynamic: None,
         system_blocks: None,
         session_id: None,
-        reasoning_level: closeclaw::session::persistence::ReasoningLevel::default(),
+        reasoning_level: ReasoningLevel::default(),
     };
     let body = serde_json::to_value(&internal_req).unwrap();
 


### PR DESCRIPTION
将 AnthropicProvider 和 StubProvider 从旧 LLMProvider trait 迁移到新 Provider trait，移除 LegacyProviderBridge 包装，使两个 provider 可直接以 Arc<dyn Provider> 注册到 LLMRegistry。

**改动内容：**
- AnthropicProvider: 新增 client 字段，实现 Provider trait 全部方法，send/send_streaming 返回 stub 错误
- StubProvider: 新增 client 字段，实现 Provider trait，send 返回预设响应，send_streaming 包装为 SSE 流
- llm_init.rs: Anthropic 注册去掉 LegacyProviderBridge 包装
- 测试全部更新为 Provider trait 接口

Source: issue #913
Type: chore