### PR TITLE
feat: DeepSeek reasoning_content 归一化到 ModelInterpreter

### DIFF
--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -155,20 +155,6 @@ impl DeepSeekProvider {
         }
     }
 
-    /// Extract visible content from a DeepSeek message.
-    /// Prefer `content`; if it's empty or pure whitespace, fall back to `reasoning_content`.
-    fn extract_content(msg: &DeepSeekMessage) -> String {
-        if !msg.content.trim().is_empty() {
-            msg.content.trim().to_string()
-        } else {
-            msg.reasoning_content
-                .as_ref()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_default()
-        }
-    }
-
     fn models_static() -> Vec<&'static str> {
         vec!["deepseek-v4-flash", "deepseek-v4-pro"]
     }
@@ -234,7 +220,7 @@ impl LLMProvider for DeepSeekProvider {
             .map(|c| &c.message)
             .ok_or_else(|| LLMError::ApiError("no choices in DeepSeek response".to_string()))?;
 
-        let content = Self::extract_content(msg);
+        let content = msg.content.clone();
         let usage = api_resp.usage.as_ref();
 
         Ok(ChatResponse {

--- a/src/llm/deepseek/tests.rs
+++ b/src/llm/deepseek/tests.rs
@@ -294,66 +294,6 @@ impl DeepSeekProviderWithCustomClient {
 }
 
 // -------------------------------------------------------------------------
-// extract_content() unit tests
-// -------------------------------------------------------------------------
-
-#[test]
-fn test_extract_content_with_content() {
-    let msg = DeepSeekMessage {
-        role: "assistant".to_string(),
-        content: "Hello, world!".to_string(),
-        reasoning_content: Some("Let me think...".to_string()),
-    };
-    // content takes priority
-    assert_eq!(DeepSeekProvider::extract_content(&msg), "Hello, world!");
-}
-
-#[test]
-fn test_extract_content_fallback_to_reasoning() {
-    let msg = DeepSeekMessage {
-        role: "assistant".to_string(),
-        content: "".to_string(),
-        reasoning_content: Some("I should help with that.".to_string()),
-    };
-    // empty content falls back to reasoning_content
-    assert_eq!(
-        DeepSeekProvider::extract_content(&msg),
-        "I should help with that."
-    );
-}
-
-#[test]
-fn test_extract_content_whitespace_trimmed() {
-    let msg = DeepSeekMessage {
-        role: "assistant".to_string(),
-        content: "  Hello, world!  ".to_string(),
-        reasoning_content: None,
-    };
-    assert_eq!(DeepSeekProvider::extract_content(&msg), "Hello, world!");
-}
-
-#[test]
-fn test_extract_content_both_empty() {
-    let msg = DeepSeekMessage {
-        role: "assistant".to_string(),
-        content: "".to_string(),
-        reasoning_content: None,
-    };
-    assert_eq!(DeepSeekProvider::extract_content(&msg), "");
-}
-
-#[test]
-fn test_extract_content_whitespace_only_content() {
-    let msg = DeepSeekMessage {
-        role: "assistant".to_string(),
-        content: "  \n\t  ".to_string(),
-        reasoning_content: Some("reasoning".to_string()),
-    };
-    // whitespace-only content should fall back to reasoning_content
-    assert_eq!(DeepSeekProvider::extract_content(&msg), "reasoning");
-}
-
-// -------------------------------------------------------------------------
 // name / provider_display_name / models unit tests
 // -------------------------------------------------------------------------
 

--- a/src/llm/interpreter.rs
+++ b/src/llm/interpreter.rs
@@ -310,9 +310,9 @@ impl ModelInterpreter for GlmInterpreter {
 /// Interpreter for DeepSeek provider.
 ///
 /// DeepSeek uses an OpenAI-compatible wire format with `reasoning_content`
-/// support for reasoning models. Since the protocol layer already normalises
-/// the response into `RawContentBlock` variants, this interpreter applies the
-/// same identity transformation as [`DefaultInterpreter`].
+/// support for reasoning models. When the text content is empty, the
+/// `reasoning_content` is mapped to a [`ContentBlock::Thinking`] block.
+/// This mirrors the merging rule used by [`MinimaxInterpreter`].
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DeepSeekInterpreter;
 
@@ -320,9 +320,46 @@ impl ModelInterpreter for DeepSeekInterpreter {
     fn name(&self) -> &str {
         "deepseek"
     }
+
     fn interpret_response(&self, response: InternalResponse) -> UnifiedResponse {
-        DefaultInterpreter.interpret_response(response)
+        let mut text_parts: Vec<String> = vec![];
+        let mut thinking_parts: Vec<String> = vec![];
+        for block in response.content_blocks {
+            match block {
+                RawContentBlock::Text(s) => text_parts.push(s),
+                RawContentBlock::Thinking(s) => thinking_parts.push(s),
+                RawContentBlock::ToolUse { id, name, input } => {
+                    text_parts.push(format!("id:{id} name:{name} input:{input}"))
+                }
+                RawContentBlock::ToolResult {
+                    tool_call_id,
+                    content,
+                } => text_parts.push(format!("tool_call_id:{tool_call_id} content:{content}")),
+            }
+        }
+        let content_blocks: Vec<ContentBlock> = if text_parts.iter().all(|s| s.is_empty()) {
+            if !thinking_parts.is_empty() {
+                vec![ContentBlock::Thinking(thinking_parts.join(""))]
+            } else {
+                vec![]
+            }
+        } else {
+            vec![ContentBlock::Text(text_parts.join(""))]
+        };
+        UnifiedResponse {
+            content_blocks,
+            usage: UnifiedUsage {
+                prompt_tokens: response.usage.prompt_tokens,
+                completion_tokens: response.usage.completion_tokens,
+                total_tokens: response.usage.total_tokens,
+                reasoning_tokens: None,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            },
+            finish_reason: response.finish_reason,
+        }
     }
+
     fn interpret_stream_event(&self, event: StreamEvent) -> Option<StreamEvent> {
         Some(event)
     }

--- a/src/llm/interpreter_test.rs
+++ b/src/llm/interpreter_test.rs
@@ -302,7 +302,53 @@ fn test_deepseek_interpreter_name() {
 }
 
 #[test]
-fn test_deepseek_interpreter_response_identity() {
+fn test_deepseek_interpreter_empty_content_uses_reasoning() {
+    let response = InternalResponse {
+        content_blocks: vec![RawContentBlock::Thinking(
+            "Let me think step by step...".into(),
+        )],
+        usage: RawUsage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    };
+    let unified = DeepSeekInterpreter.interpret_response(response);
+    assert_eq!(unified.content_blocks.len(), 1);
+    assert!(
+        matches!(&unified.content_blocks[0], ContentBlock::Thinking(s) if s == "Let me think step by step..."),
+        "expected Thinking block, got {:?}",
+        unified.content_blocks[0]
+    );
+}
+
+#[test]
+fn test_deepseek_interpreter_text_content_preferred() {
+    let response = InternalResponse {
+        content_blocks: vec![RawContentBlock::Text("Hello world".into())],
+        usage: RawUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: None,
+    };
+    let unified = DeepSeekInterpreter.interpret_response(response);
+    assert_eq!(unified.content_blocks.len(), 1);
+    assert!(
+        matches!(&unified.content_blocks[0], ContentBlock::Text(s) if s == "Hello world"),
+        "expected Text block, got {:?}",
+        unified.content_blocks[0]
+    );
+}
+
+#[test]
+fn test_deepseek_interpreter_text_and_reasoning_prefers_text() {
     let response = InternalResponse {
         content_blocks: vec![
             RawContentBlock::Text("hello".into()),
@@ -318,16 +364,11 @@ fn test_deepseek_interpreter_response_identity() {
         finish_reason: Some("stop".into()),
     };
     let unified = DeepSeekInterpreter.interpret_response(response);
-    assert_eq!(unified.content_blocks.len(), 2);
+    assert_eq!(unified.content_blocks.len(), 1);
     assert!(
         matches!(&unified.content_blocks[0], ContentBlock::Text(s) if s == "hello"),
-        "expected Text block, got {:?}",
+        "expected Text block when text is non-empty, got {:?}",
         unified.content_blocks[0]
-    );
-    assert!(
-        matches!(&unified.content_blocks[1], ContentBlock::Thinking(s) if s == "thinking..."),
-        "expected Thinking block, got {:?}",
-        unified.content_blocks[1]
     );
 }
 

--- a/src/llm/protocol/openai.rs
+++ b/src/llm/protocol/openai.rs
@@ -104,13 +104,21 @@ impl ChatProtocol for OpenAiProtocol {
     }
 
     fn parse_response(&self, body: serde_json::Value) -> Result<InternalResponse> {
-        let choices = body
+        let message = body
             .get("choices")
             .and_then(|v| v.as_array())
             .and_then(|arr| arr.first())
-            .and_then(|choice| choice.get("message"))
+            .and_then(|choice| choice.get("message"));
+
+        let content = message
             .and_then(|msg| msg.get("content"))
             .and_then(|c| c.as_str())
+            .map(|s| s.to_string());
+
+        let reasoning_content = message
+            .and_then(|msg| msg.get("reasoning_content"))
+            .and_then(|c| c.as_str())
+            .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
 
         let finish_reason = body
@@ -123,9 +131,10 @@ impl ChatProtocol for OpenAiProtocol {
 
         let usage = parse_usage(&body);
 
-        let content_blocks = choices
-            .map(|text| vec![RawContentBlock::Text(text)])
-            .unwrap_or_default();
+        let mut content_blocks = vec![RawContentBlock::Text(content.unwrap_or_default())];
+        if let Some(thinking) = reasoning_content {
+            content_blocks.push(RawContentBlock::Thinking(thinking));
+        }
 
         Ok(InternalResponse {
             content_blocks,
@@ -214,6 +223,47 @@ impl ChatProtocol for OpenAiProtocol {
                         }
                     };
                     yield StreamEvent::BlockDelta { index: idx, delta: ContentDelta::Text { text: text.to_string() } };
+                }
+
+                // reasoning_content delta
+                if let Some(thinking) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
+                    if thinking.is_empty() {
+                        continue;
+                    }
+                    let idx = match block_index {
+                        Some(i) if active_block_type == Some(ContentBlockType::Thinking) => i,
+                        _ => {
+                            // End current block if any
+                            if let Some(prev_idx) = block_index {
+                                let prev_type = active_block_type.unwrap_or(
+                                    ContentBlockType::Text,
+                                );
+                                let event = StreamEvent::BlockEnd {
+                                    index: prev_idx,
+                                    block_type: prev_type,
+                                };
+                                yield event;
+                            }
+                            let idx = next_block_index;
+                            next_block_index += 1;
+                            block_index = Some(idx);
+                            active_block_type = Some(ContentBlockType::Thinking);
+                            let event = StreamEvent::BlockStart {
+                                index: idx,
+                                block_type: ContentBlockType::Thinking,
+                            };
+                            yield event;
+                            idx
+                        }
+                    };
+                    let delta = ContentDelta::Thinking {
+                        thinking: thinking.to_string(),
+                    };
+                    let event = StreamEvent::BlockDelta {
+                        index: idx,
+                        delta,
+                    };
+                    yield event;
                 }
 
                 // tool_calls delta

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -3,7 +3,7 @@ use super::{
     ChatProtocol, ContentBlockType, ContentDelta, IncomingSseStream, InternalRequest,
     OpenAiProtocol, StreamEvent,
 };
-use crate::llm::types::RawSseChunk;
+use crate::llm::types::{RawContentBlock, RawSseChunk};
 use futures::StreamExt;
 
 use crate::session::persistence::ReasoningLevel;
@@ -215,6 +215,85 @@ async fn test_parse_sse_text_then_tool_calls() {
     assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
 
     assert!(stream.next().await.is_none());
+}
+
+#[test]
+fn test_parse_response_with_reasoning_content() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "Let me think about this..."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // Empty content → Text(""), reasoning → Thinking block
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::Thinking(s) if s == "Let me think about this...")
+    );
+}
+
+#[test]
+fn test_parse_response_with_both_content_and_reasoning() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_content": "Let me think about this..."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // Both content and reasoning → Text + Thinking
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(
+        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "The answer is 42.")
+    );
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::Thinking(s) if s == "Let me think about this...")
+    );
+}
+
+#[test]
+fn test_parse_response_no_reasoning_content() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Hello!"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // No reasoning_content → only Text block
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Hello!"));
 }
 
 // ── reasoning_level → reasoning_effort mapping tests ───────────────────────


### PR DESCRIPTION
将 DeepSeek reasoning_content 处理从 Provider 层迁移到 Protocol + Interpreter 层。

- OpenAiProtocol 从响应中同时提取 content 和 reasoning_content，产出 RawContentBlock::Thinking
- OpenAiProtocol 流式路径同步处理 reasoning_content delta
- DeepSeekInterpreter 参照 MinimaxInterpreter 合并规则：空 content + reasoning → Thinking 块
- 移除 DeepSeekProvider::extract_content（功能由 protocol + interpreter 接力完成）

Closes #918

Source: issue #918
Type: feat
