### PR TITLE
feat: 从 LLMProvider 剥离模型发现能力为独立 ModelLister trait

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -13,7 +13,7 @@ use crate::config::providers::{
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
 use crate::llm::{
-    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelDiscovery,
+    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
     ProviderModelKnowledge, VolcEngineProvider,
 };
 use dialoguer::{Input, Select};
@@ -223,6 +223,17 @@ fn build_provider(info: &ProviderInfo, credential: &str) -> Arc<dyn LLMProvider>
     }
 }
 
+/// Build an `Arc<dyn ModelLister>` from the selected `ProviderInfo`.
+/// Same provider instances as `build_provider`, but typed for model discovery.
+fn build_model_lister(info: &ProviderInfo, credential: &str) -> Arc<dyn ModelLister> {
+    match info.provider_type {
+        ProviderType::Minimax => Arc::new(MiniMaxProvider::new(credential.to_string())),
+        ProviderType::Glm => Arc::new(GlmProvider::new(credential.to_string())),
+        ProviderType::Volcengine => Arc::new(VolcEngineProvider::new(credential.to_string())),
+        ProviderType::Deepseek => Arc::new(DeepSeekProvider::new(credential.to_string())),
+    }
+}
+
 /// Run the interactive config wizard.
 ///
 /// Returns `Ok(Some(output))` on success, `Ok(None)` on clean Ctrl+C exit,
@@ -286,17 +297,17 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         let info = ctx.selected_provider.as_ref().unwrap();
         let cred = ctx.credential.as_ref().unwrap();
         ctx.provider = Some(build_provider(info, cred));
-        let provider = ctx.provider.as_ref().unwrap();
+        let model_lister = build_model_lister(info, cred);
 
         print!("Fetching models from provider...");
         std::io::Write::flush(&mut std::io::stdout()).ok();
         let discovery = ModelDiscovery::new();
-        let p = Arc::clone(provider);
+        let ml = Arc::clone(&model_lister);
         let models = discovery
             .discover(info.id, cred, move |cred: &str| {
-                let p = Arc::clone(&p);
+                let ml = Arc::clone(&ml);
                 let cred = cred.to_string();
-                async move { p.fetch_model_list(&cred).await }
+                async move { ml.fetch_model_list(&cred).await }
             })
             .await;
         println!(" done");

--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -10,7 +10,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, Usage};
+use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, ModelLister, Usage};
 
 /// DeepSeek API endpoint
 const DEEPSEEK_API_URL: &str = "https://api.deepseek.com";
@@ -308,6 +308,74 @@ impl LLMProvider for DeepSeekProvider {
                 // DeepSeek does not expose a reasoning flag in /models response.
                 // The reasoning_content field in chat responses indicates a reasoning model,
                 // but we cannot determine this from /models alone. Conservatively set reasoning=false.
+                ModelInfo {
+                    id: m.id.clone(),
+                    name: m.display_name.clone().unwrap_or_else(|| m.id.clone()),
+                    context_window: m.context_window.unwrap_or(64_000),
+                    max_tokens: m.max_output_tokens.unwrap_or(8_192),
+                    default_temperature: None,
+                    reasoning: false,
+                    input_types,
+                }
+            })
+            .collect();
+
+        Ok(models)
+    }
+}
+
+#[async_trait]
+impl ModelLister for DeepSeekProvider {
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        let url = format!("{}/models", self.base_url.trim_end_matches('/'));
+        let response = self
+            .http_client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", bearer_token))
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| LLMError::NetworkError(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::map_http_error(status, &body));
+        }
+
+        let api_resp: DeepSeekModelsResponse = response.json().await.map_err(|e| {
+            LLMError::ApiError(format!("failed to parse DeepSeek /models response: {}", e))
+        })?;
+
+        let models: Vec<ModelInfo> = api_resp
+            .data
+            .into_iter()
+            // Filter: only models that are not deprecated/shutdown
+            .filter(|m| {
+                m.status
+                    .as_ref()
+                    .map(|s| {
+                        !s.eq_ignore_ascii_case("deprecated") && !s.eq_ignore_ascii_case("shutdown")
+                    })
+                    .unwrap_or(true)
+            })
+            .map(|m| {
+                let input_types: Vec<crate::llm::InputType> = m
+                    .input_modalities
+                    .iter()
+                    .filter_map(|m| match m.to_lowercase().as_str() {
+                        "image" => Some(crate::llm::InputType::Image),
+                        _ => Some(crate::llm::InputType::Text),
+                    })
+                    .collect();
+                let input_types = if input_types.is_empty() {
+                    vec![crate::llm::InputType::Text]
+                } else {
+                    input_types
+                };
+
+                // DeepSeek does not expose reasoning flag in /models.
+                // Conservatively set reasoning=false.
                 ModelInfo {
                     id: m.id.clone(),
                     name: m.display_name.clone().unwrap_or_else(|| m.id.clone()),

--- a/src/llm/glm/mod.rs
+++ b/src/llm/glm/mod.rs
@@ -10,7 +10,8 @@ use tokio::time::timeout;
 
 use crate::llm::http_client::{HttpClient, ReqwestHttpClient};
 use crate::llm::{
-    ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, StreamingResponse, Usage,
+    ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, ModelLister, StreamingResponse,
+    Usage,
 };
 
 /// GLM API endpoint
@@ -308,28 +309,9 @@ impl GlmProvider {
             },
         })
     }
-}
 
-#[async_trait]
-impl LLMProvider for GlmProvider {
-    fn name(&self) -> &str {
-        "glm"
-    }
-
-    fn models(&self) -> Vec<&str> {
-        vec![
-            "glm-5.1",
-            "glm-4.7",
-            "glm-4.5-air",
-            "GLM-4.5-Air",
-            "GLM-4.7",
-            "glm-5-turbo",
-        ]
-    }
-    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
-        // GLM /models endpoint is at /api/paas/v4/models (not /coding/paas/v4!)
-        // base_url is the chat endpoint (e.g. https://open.bigmodel.cn/api/coding/paas/v4/chat/completions);
-        // Replace /coding/paas/v4/chat/completions with /paas/v4/models
+    /// Shared model-listing logic used by both `LLMProvider` and `ModelLister`.
+    async fn fetch_model_list_impl(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
         let models_url = self
             .base_url
             .replace("/coding/paas/v4/chat/completions", "/paas/v4/models")
@@ -370,7 +352,6 @@ impl LLMProvider for GlmProvider {
             .map(|m| {
                 use crate::llm::InputType;
                 let model_id = m.id.clone();
-                // Look up knowledge base for metadata; safe defaults if not found.
                 let kb = crate::llm::ProviderModelKnowledge::new();
                 let params = kb.find("glm", &model_id);
                 let (context_window, max_tokens, default_temperature, reasoning, input_types) =
@@ -403,6 +384,27 @@ impl LLMProvider for GlmProvider {
             .collect();
 
         Ok(models)
+    }
+}
+
+#[async_trait]
+impl LLMProvider for GlmProvider {
+    fn name(&self) -> &str {
+        "glm"
+    }
+
+    fn models(&self) -> Vec<&str> {
+        vec![
+            "glm-5.1",
+            "glm-4.7",
+            "glm-4.5-air",
+            "GLM-4.5-Air",
+            "GLM-4.7",
+            "glm-5-turbo",
+        ]
+    }
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        self.fetch_model_list_impl(bearer_token).await
     }
 
     async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, LLMError> {
@@ -453,6 +455,13 @@ impl LLMProvider for GlmProvider {
 
     async fn chat_streaming(&self, request: ChatRequest) -> Result<StreamingResponse, LLMError> {
         crate::llm::glm_stream::send_streaming_request(self, request).await
+    }
+}
+
+#[async_trait]
+impl ModelLister for GlmProvider {
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        self.fetch_model_list_impl(bearer_token).await
     }
 }
 

--- a/src/llm/glm/tests/mod.rs
+++ b/src/llm/glm/tests/mod.rs
@@ -4,6 +4,7 @@
 
 use super::*;
 use crate::llm::http_client::MockTimeoutHttpClient;
+use crate::llm::LLMProvider;
 use mockito::Server;
 
 // ---------------------------------------------------------------------------//
@@ -232,7 +233,9 @@ async fn test_fetch_model_list_success_mock() {
         "fake-key".into(),
         format!("{}/api/coding/paas/v4/chat/completions", server.url()),
     );
-    let models = provider.fetch_model_list("fake-key").await.unwrap();
+    let models = LLMProvider::fetch_model_list(&provider, "fake-key")
+        .await
+        .unwrap();
 
     m.assert_async().await;
     assert!(!models.is_empty(), "expected at least one model");
@@ -258,7 +261,9 @@ async fn test_glm_fetch_model_list_timeout_mock() {
         http_client,
     );
 
-    let err = provider.fetch_model_list("fake-key").await.unwrap_err();
+    let err = LLMProvider::fetch_model_list(&provider, "fake-key")
+        .await
+        .unwrap_err();
     assert!(matches!(err, LLMError::NetworkError(_)));
 }
 
@@ -281,7 +286,9 @@ async fn test_fetch_model_list_http_auth_failure_mock() {
         "fake-key".into(),
         format!("{}/api/coding/paas/v4/chat/completions", server.url()),
     );
-    let err = provider.fetch_model_list("fake-key").await.unwrap_err();
+    let err = LLMProvider::fetch_model_list(&provider, "fake-key")
+        .await
+        .unwrap_err();
 
     m.assert_async().await;
     matches!(err, LLMError::AuthFailed(_));

--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::llm::ReqwestHttpClient;
-use crate::llm::{ChatRequest, ChatResponse, HttpClient, LLMError, LLMProvider, ModelInfo, Usage};
+use crate::llm::{
+    ChatRequest, ChatResponse, HttpClient, LLMError, LLMProvider, ModelInfo, ModelLister, Usage,
+};
 
 #[path = "minimax_stream.rs"]
 pub(crate) mod minimax_stream;
@@ -351,6 +353,81 @@ impl LLMProvider for MiniMaxProvider {
         request: ChatRequest,
     ) -> Result<crate::llm::StreamingResponse, LLMError> {
         minimax_stream::send_streaming_request(self, request).await
+    }
+}
+
+#[async_trait]
+impl ModelLister for MiniMaxProvider {
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        let base = self
+            .base_url
+            .trim_end_matches("/chat/completions")
+            .trim_end_matches("/v1");
+        let url = format!("{}/v1/models", base);
+
+        let req = reqwest::Request::new(
+            reqwest::Method::GET,
+            reqwest::Url::parse(&url).expect("invalid URL"),
+        );
+        let mut req = req;
+        req.headers_mut().insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", bearer_token).parse().unwrap(),
+        );
+
+        let response = match timeout(Duration::from_secs(10), self.http_client.execute(req)).await {
+            Ok(Ok(resp)) => resp,
+            Ok(Err(e)) => return Err(LLMError::NetworkError(e.to_string())),
+            Err(_) => {
+                return Err(LLMError::NetworkError(
+                    "fetch_model_list timed out after 10s".to_string(),
+                ))
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::map_status_error(status, body));
+        }
+
+        let api_resp: MiniMaxModelsResponse = response
+            .json()
+            .await
+            .map_err(|e| LLMError::ApiError(e.to_string()))?;
+
+        let models: Vec<ModelInfo> = api_resp
+            .data
+            .into_iter()
+            .map(|m| {
+                use crate::llm::InputType;
+                let model_id = m.id.clone();
+                let kb = crate::llm::ProviderModelKnowledge::new();
+                let params = kb.find("minimax", &model_id);
+                let (context_window, max_tokens, default_temperature, reasoning, input_types) =
+                    match params {
+                        Some(p) => (
+                            p.context_window,
+                            p.max_tokens,
+                            Some(p.default_temperature),
+                            p.reasoning,
+                            p.input_types,
+                        ),
+                        None => (32_768, 8_192, Some(0.7), false, vec![InputType::Text]),
+                    };
+                ModelInfo {
+                    id: model_id.clone(),
+                    name: format!("MiniMax {}", model_id.trim_start_matches("MiniMax-")),
+                    context_window,
+                    max_tokens,
+                    default_temperature,
+                    reasoning,
+                    input_types,
+                }
+            })
+            .collect();
+
+        Ok(models)
     }
 }
 

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -3,7 +3,7 @@
 #![allow(deprecated)]
 
 use super::*;
-use crate::llm::{Message, ReqwestHttpClient};
+use crate::llm::{LLMProvider, Message, ReqwestHttpClient};
 
 // --- Fixture-based deserialization and content extraction tests ---
 
@@ -145,7 +145,9 @@ async fn test_fetch_model_list_success_mock() {
         .await;
 
     let provider = mock_provider(&server);
-    let models = provider.fetch_model_list("test-key").await.unwrap();
+    let models = LLMProvider::fetch_model_list(&provider, "test-key")
+        .await
+        .unwrap();
 
     m.assert_async().await;
     assert!(!models.is_empty());
@@ -171,7 +173,9 @@ async fn test_fetch_model_list_auth_failure_mock() {
         .await;
 
     let provider = mock_provider(&server);
-    let err = provider.fetch_model_list("test-key").await.unwrap_err();
+    let err = LLMProvider::fetch_model_list(&provider, "test-key")
+        .await
+        .unwrap_err();
 
     m.assert_async().await;
     assert!(matches!(err, LLMError::AuthFailed(_)));
@@ -187,7 +191,9 @@ async fn test_minimax_fetch_model_list_timeout_mock() {
         Arc::new(MockTimeoutHttpClient::new()),
     );
 
-    let err = provider.fetch_model_list("test-key").await.unwrap_err();
+    let err = LLMProvider::fetch_model_list(&provider, "test-key")
+        .await
+        .unwrap_err();
 
     assert!(matches!(err, LLMError::NetworkError(_)));
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -76,6 +76,14 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+/// Model discovery — query provider for available model list.
+/// Independent from Provider trait (HTTP transport) and LLMProvider (legacy).
+#[async_trait]
+pub trait ModelLister: Send + Sync {
+    /// Fetch available models from provider API.
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError>;
+}
+
 /// LLM message
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Message {

--- a/src/llm/volcengine.rs
+++ b/src/llm/volcengine.rs
@@ -10,7 +10,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, Usage};
+use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, ModelLister, Usage};
 
 /// VolcEngine API endpoint
 const VOLCENGINE_API_URL: &str = "https://ARK.cn-beijing.volces.com/api/v3/chat/completions";
@@ -261,6 +261,75 @@ impl LLMProvider for VolcEngineProvider {
         "VolcEngine"
     }
 
+    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
+        let url = format!("{}/models", self.base_url.trim_end_matches('/'));
+        let response = self
+            .http_client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", bearer_token))
+            .send()
+            .await
+            .map_err(|e| LLMError::NetworkError(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::map_http_error(status, &body));
+        }
+
+        let api_resp: VolcEngineModelsResponse = response.json().await.map_err(|e| {
+            LLMError::ApiError(format!(
+                "failed to parse VolcEngine /models response: {}",
+                e
+            ))
+        })?;
+
+        let models: Vec<ModelInfo> = api_resp
+            .data
+            .into_iter()
+            // Filter: domain must be "LLM"; status must NOT be Shutdown or Retiring
+            .filter(|m| {
+                m.domain.eq_ignore_ascii_case("LLM")
+                    && !m.status.eq_ignore_ascii_case("Shutdown")
+                    && !m.status.eq_ignore_ascii_case("Retiring")
+            })
+            .map(|m| {
+                let model_id = m.model_id.clone();
+                let props = &m.properties;
+                let input_types: Vec<crate::llm::InputType> = props
+                    .input_modalities
+                    .iter()
+                    .filter_map(|m| match m.to_lowercase().as_str() {
+                        "image" => Some(crate::llm::InputType::Image),
+                        _ => Some(crate::llm::InputType::Text),
+                    })
+                    .collect();
+                let input_types = if input_types.is_empty() {
+                    vec![crate::llm::InputType::Text]
+                } else {
+                    input_types
+                };
+
+                ModelInfo {
+                    id: model_id.clone(),
+                    name: m.model_name.unwrap_or_else(|| model_id.clone()),
+                    context_window: props.context_window.unwrap_or(32_768),
+                    max_tokens: props.max_tokens.unwrap_or(4_096),
+                    default_temperature: props.temperature,
+                    // VolcEngine does not expose a reasoning flag directly;
+                    // we conservatively set reasoning=false here.
+                    reasoning: false,
+                    input_types,
+                }
+            })
+            .collect();
+
+        Ok(models)
+    }
+}
+
+#[async_trait]
+impl ModelLister for VolcEngineProvider {
     async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
         let url = format!("{}/models", self.base_url.trim_end_matches('/'));
         let response = self


### PR DESCRIPTION
从 LLMProvider trait 中剥离模型发现能力为独立的 ModelLister trait。

## 变更内容
- 新增 `ModelLister` trait，定义 `fetch_model_list` 方法
- DeepSeekProvider、GlmProvider、MiniMaxProvider、VolcEngineProvider 各实现 `ModelLister`
- `config_wizard` 的模型发现路径改用 `dyn ModelLister`，不再依赖 `LLMProvider`
- 测试中 `fetch_model_list` 调用改用 UFCS 消除 trait 方法歧义
- `LLMProvider::fetch_model_list()` 默认实现保留，待 #843 最终清理期移除

## 关联
Closes #916

Source: issue #916
Type: feat
