### PR TITLE
chore: OpenAI Provider 直接 impl Provider trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2023,12 +2024,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3075,6 +3078,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ anyhow = "1.0"
 libc = "0.2"
 
 # HTTP client (rustls for TLS, no OpenSSL required)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 
 # Async channels
 flume = "=0.11"

--- a/src/daemon/llm_init.rs
+++ b/src/daemon/llm_init.rs
@@ -41,15 +41,9 @@ impl Daemon {
             .or_else(|| std::env::var("OPENAI_API_KEY").ok())
             .filter(|k| !k.is_empty());
         if let Some(api_key) = openai_key {
-            let bridge = Arc::new(LegacyProviderBridge::new(
-                OpenAIProvider::new(api_key.clone()),
-                "https://api.openai.com/v1".to_string(),
-                api_key,
-                vec![],
-                client.clone(),
-                empty_headers.clone(),
-            ));
-            registry.register("openai".to_string(), bridge).await;
+            let provider: Arc<dyn crate::llm::provider::Provider> =
+                Arc::new(OpenAIProvider::new(api_key));
+            registry.register("openai".to_string(), provider).await;
             info!("OpenAI provider registered");
         }
 

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -1,23 +1,63 @@
-//! OpenAI LLM Provider
+//! OpenAI LLM Provider — pure HTTP transport for the OpenAI Chat Completions API.
+//!
+//! This provider carries configuration (URL, credentials, HTTP client)
+//! and performs the HTTP request/response cycle.
+//! Serialization/deserialization is handled by `OpenAiProtocol`.
 
-#![allow(deprecated)]
-
-use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, Usage};
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use futures::StreamExt;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::OnceLock;
+use tokio::sync::mpsc;
 
-#[derive(Debug, Serialize)]
-struct OpenAIRequest<'a> {
-    model: &'a str,
-    messages: &'a [crate::llm::Message],
-    temperature: f32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
+use crate::llm::provider::{Provider, ProviderError, Result, SseStream};
+use crate::llm::types::{
+    InternalRequest, InternalResponse, ProtocolId, RawContentBlock, RawSseChunk, RawUsage,
+};
+
+pub struct OpenAIProvider {
+    api_key: String,
+    base_url: String,
+    client: Client,
+    supported_protocols: Vec<ProtocolId>,
 }
 
+impl OpenAIProvider {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            base_url: "https://api.openai.com/v1".to_string(),
+            client: Client::new(),
+            supported_protocols: vec![ProtocolId::new("openai")],
+        }
+    }
+
+    pub fn new_with_base_url(api_key: String, base_url: &str) -> Self {
+        Self {
+            api_key,
+            base_url: base_url.to_string(),
+            client: Client::new(),
+            supported_protocols: vec![ProtocolId::new("openai")],
+        }
+    }
+
+    fn chat_url(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+
+    /// Map HTTP status code to the appropriate provider error.
+    fn map_status_error(status: reqwest::StatusCode, body: String) -> ProviderError {
+        ProviderError::Legacy(format!("OpenAI API error {}: {}", status, body))
+    }
+}
+
+// ── Raw OpenAI API response types (for deserialization) ──────────────────────
+
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct OpenAIResponse {
-    #[allow(dead_code)]
     id: String,
     model: String,
     choices: Vec<OpenAIChoice>,
@@ -25,15 +65,15 @@ struct OpenAIResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct OpenAIChoice {
-    #[allow(dead_code)]
-    finish_reason: String,
+    finish_reason: Option<String>,
     message: OpenAIMessage,
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct OpenAIMessage {
-    #[allow(dead_code)]
     role: String,
     content: String,
 }
@@ -45,110 +85,268 @@ struct OpenAIUsage {
     total_tokens: u32,
 }
 
-#[allow(dead_code)]
-pub struct OpenAIProvider {
-    api_key: String,
-    base_url: String,
-}
-
-impl OpenAIProvider {
-    pub fn new(api_key: String) -> Self {
-        Self {
-            api_key,
-            base_url: "https://api.openai.com/v1".to_string(),
-        }
-    }
-
-    pub fn new_with_base_url(api_key: String, base_url: &str) -> Self {
-        Self {
-            api_key,
-            base_url: base_url.to_string(),
-        }
-    }
-
-    fn chat_url(&self) -> String {
-        format!("{}/chat/completions", self.base_url)
-    }
-
-    /// Map HTTP status code to the appropriate LLM error.
-    fn map_status_error(status: reqwest::StatusCode, body: String) -> LLMError {
-        match status.as_u16() {
-            401 | 403 => LLMError::AuthFailed(format!("OpenAI API auth failed: {}", status)),
-            429 => LLMError::RateLimitExceeded,
-            _ => LLMError::ApiError(format!("OpenAI API error {}: {}", status, body)),
-        }
-    }
-}
+// ── Provider trait implementation ─────────────────────────────────────────────
 
 #[async_trait]
-impl LLMProvider for OpenAIProvider {
-    fn name(&self) -> &str {
+impl Provider for OpenAIProvider {
+    fn id(&self) -> &str {
         "openai"
     }
 
-    fn models(&self) -> Vec<&str> {
-        vec!["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"]
+    fn base_url(&self) -> &str {
+        &self.base_url
     }
 
-    async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, LLMError> {
+    fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &self.supported_protocols
+    }
+
+    fn http_client(&self) -> &Client {
+        &self.client
+    }
+
+    fn default_headers(&self) -> &HeaderMap {
+        static EMPTY: OnceLock<HeaderMap> = OnceLock::new();
+        EMPTY.get_or_init(HeaderMap::new)
+    }
+
+    async fn send(
+        &self,
+        _request: InternalRequest,
+        body: serde_json::Value,
+    ) -> Result<InternalResponse> {
         let url = self.chat_url();
 
-        let body = OpenAIRequest {
-            model: &request.model,
-            messages: &request.messages,
-            temperature: request.temperature,
-            max_tokens: request.max_tokens,
-        };
-
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
             .send()
-            .await
-            .map_err(|e| LLMError::NetworkError(e.to_string()))?;
+            .await?;
 
         if !response.status().is_success() {
             let status = response.status();
-            if status.as_u16() == 429 {
-                return Err(LLMError::RateLimitExceeded);
-            }
             let body = response.text().await.unwrap_or_default();
             return Err(Self::map_status_error(status, body));
         }
 
-        let openai_resp: OpenAIResponse = response
-            .json()
-            .await
-            .map_err(|e| LLMError::ApiError(format!("failed to parse OpenAI response: {}", e)))?;
+        let openai_resp: OpenAIResponse = response.json().await.map_err(ProviderError::Reqwest)?;
 
-        let choice = openai_resp
-            .choices
-            .into_iter()
-            .next()
-            .ok_or_else(|| LLMError::ApiError("no choices in OpenAI response".to_string()))?;
+        let choice =
+            openai_resp.choices.into_iter().next().ok_or_else(|| {
+                ProviderError::Legacy("no choices in OpenAI response".to_string())
+            })?;
 
-        Ok(ChatResponse {
-            content: choice.message.content,
-            model: openai_resp.model,
-            usage: Usage {
+        Ok(InternalResponse {
+            content_blocks: vec![RawContentBlock::Text(choice.message.content)],
+            usage: RawUsage {
                 prompt_tokens: openai_resp.usage.prompt_tokens,
                 completion_tokens: openai_resp.usage.completion_tokens,
-                total_tokens: openai_resp.usage.total_tokens,
+                total_tokens: Some(openai_resp.usage.total_tokens),
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
+            finish_reason: choice.finish_reason,
         })
+    }
+
+    async fn send_streaming(
+        &self,
+        _request: InternalRequest,
+        body: serde_json::Value,
+    ) -> Result<SseStream> {
+        let url = self.chat_url();
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Self::map_status_error(status, body));
+        }
+
+        let (tx, rx) = mpsc::channel(64);
+
+        tokio::spawn(async move {
+            let mut stream = response.bytes_stream();
+            let mut buffer = String::new();
+
+            while let Some(chunk_result) = stream.next().await {
+                let chunk = match chunk_result {
+                    Ok(c) => c,
+                    Err(_) => break,
+                };
+
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                // Process complete SSE events (separated by \n\n)
+                while let Some(pos) = buffer.find("\n\n") {
+                    let event_block = buffer[..pos].to_string();
+                    buffer = buffer[pos + 2..].to_string();
+
+                    for line in event_block.lines() {
+                        if let Some(data) = line.strip_prefix("data: ") {
+                            let data = data.trim().to_string();
+                            if data == "[DONE]" {
+                                return;
+                            }
+                            let _ = tx
+                                .send(RawSseChunk {
+                                    event_type: "message".into(),
+                                    data,
+                                })
+                                .await;
+                        }
+                    }
+                }
+            }
+
+            // Process any remaining data in buffer
+            if !buffer.is_empty() {
+                for line in buffer.lines() {
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        let data = data.trim().to_string();
+                        if data == "[DONE]" {
+                            return;
+                        }
+                        let _ = tx
+                            .send(RawSseChunk {
+                                event_type: "message".into(),
+                                data,
+                            })
+                            .await;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::types::InternalMessage;
+    use crate::session::persistence::ReasoningLevel;
     use mockito::Server;
 
+    // ── Provider accessor tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_openai_provider_id() {
+        let provider = OpenAIProvider::new("test-key".to_string());
+        assert_eq!(provider.id(), "openai");
+    }
+
+    #[test]
+    fn test_openai_provider_base_url() {
+        let provider = OpenAIProvider::new("key".to_string());
+        assert_eq!(provider.base_url(), "https://api.openai.com/v1");
+    }
+
+    #[test]
+    fn test_openai_provider_base_url_custom() {
+        let provider =
+            OpenAIProvider::new_with_base_url("key".to_string(), "https://custom.api.com");
+        assert_eq!(provider.base_url(), "https://custom.api.com");
+    }
+
+    #[test]
+    fn test_openai_provider_api_key() {
+        let provider = OpenAIProvider::new("sk-test".to_string());
+        assert_eq!(provider.api_key(), "sk-test");
+    }
+
+    #[test]
+    fn test_openai_provider_supported_protocols() {
+        let provider = OpenAIProvider::new("key".to_string());
+        let protocols = provider.supported_protocols();
+        assert_eq!(protocols.len(), 1);
+        assert_eq!(protocols[0].as_str(), "openai");
+    }
+
+    // ── send() success test ──────────────────────────────────────────────────
+
     #[tokio::test]
-    async fn test_chat_network_error() {
+    async fn test_openai_send_success() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/chat/completions")
+            .with_status(200)
+            .with_body(
+                r#"{
+                    "id": "chatcmpl-test",
+                    "model": "gpt-4",
+                    "choices": [{
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello there!"
+                        }
+                    }],
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "total_tokens": 15
+                    }
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        let provider = OpenAIProvider::new_with_base_url("test-key".to_string(), &server.url());
+        let request = InternalRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![InternalMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: ReasoningLevel::default(),
+        };
+
+        let response = provider
+            .send(request, serde_json::json!({"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}))
+            .await
+            .unwrap();
+        mock.assert_async().await;
+
+        assert_eq!(response.content_blocks.len(), 1);
+        match &response.content_blocks[0] {
+            RawContentBlock::Text(s) => assert_eq!(s, "Hello there!"),
+            other => panic!("Expected Text block, got: {:?}", other),
+        }
+        assert_eq!(response.usage.prompt_tokens, 10);
+        assert_eq!(response.usage.completion_tokens, 5);
+        assert_eq!(response.usage.total_tokens, Some(15));
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+    }
+
+    // ── send() auth error test ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_openai_send_auth_error() {
         let mut server = Server::new_async().await;
         let mock = server
             .mock("POST", "/chat/completions")
@@ -158,123 +356,114 @@ mod tests {
             .await;
 
         let provider = OpenAIProvider::new_with_base_url("bad-key".to_string(), &server.url());
-        let request = ChatRequest {
+        let request = InternalRequest {
             model: "gpt-4".to_string(),
             messages: vec![],
             temperature: 0.0,
             max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: ReasoningLevel::default(),
         };
-        let result = provider.chat(request).await;
+
+        let result = provider.send(request, serde_json::json!({})).await;
         mock.assert_async().await;
         assert!(result.is_err());
         match result.unwrap_err() {
-            LLMError::AuthFailed(_) => {}
-            _ => panic!("Expected AuthFailed"),
+            ProviderError::Legacy(msg) => assert!(msg.contains("401")),
+            other => panic!("Expected Legacy error for 401, got: {:?}", other),
         }
     }
 
-    #[test]
-    fn test_openai_provider_new() {
-        let provider = OpenAIProvider::new("test-key".to_string());
-        assert_eq!(provider.api_key, "test-key");
-        assert_eq!(provider.base_url, "https://api.openai.com/v1");
-    }
+    // ── send() rate limit test ───────────────────────────────────────────────
 
-    #[test]
-    fn test_openai_provider_name() {
-        let provider = OpenAIProvider::new("key".to_string());
-        assert_eq!(provider.name(), "openai");
-    }
+    #[tokio::test]
+    async fn test_openai_send_rate_limit() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/chat/completions")
+            .with_status(429)
+            .with_body(r#"{"error": {"message": "rate limited"}}"#)
+            .create_async()
+            .await;
 
-    #[test]
-    fn test_openai_provider_models() {
-        let provider = OpenAIProvider::new("key".to_string());
-        let models = provider.models();
-        assert_eq!(models, vec!["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"]);
-    }
-
-    #[test]
-    fn test_chat_url() {
-        let provider = OpenAIProvider::new("key".to_string());
-        assert_eq!(
-            provider.chat_url(),
-            "https://api.openai.com/v1/chat/completions"
-        );
-    }
-
-    #[test]
-    fn test_map_status_error_401() {
-        let err = OpenAIProvider::map_status_error(
-            reqwest::StatusCode::UNAUTHORIZED,
-            "bad key".to_string(),
-        );
-        match err {
-            LLMError::AuthFailed(msg) => assert!(msg.contains("401")),
-            _ => panic!("Expected AuthFailed"),
-        }
-    }
-
-    #[test]
-    fn test_map_status_error_403() {
-        let err = OpenAIProvider::map_status_error(
-            reqwest::StatusCode::FORBIDDEN,
-            "forbidden".to_string(),
-        );
-        assert!(matches!(err, LLMError::AuthFailed(_)));
-    }
-
-    #[test]
-    fn test_map_status_error_429() {
-        let err = OpenAIProvider::map_status_error(
-            reqwest::StatusCode::TOO_MANY_REQUESTS,
-            "rate limited".to_string(),
-        );
-        assert!(matches!(err, LLMError::RateLimitExceeded));
-    }
-
-    #[test]
-    fn test_map_status_error_500() {
-        let err = OpenAIProvider::map_status_error(
-            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            "server error".to_string(),
-        );
-        match err {
-            LLMError::ApiError(msg) => assert!(msg.contains("500")),
-            _ => panic!("Expected ApiError"),
-        }
-    }
-
-    #[test]
-    fn test_openai_request_serialization() {
-        let msg = crate::llm::Message {
-            role: "user".to_string(),
-            content: "hello".to_string(),
-        };
-        let req = OpenAIRequest {
-            model: "gpt-4",
-            messages: &[msg],
-            temperature: 0.7,
-            max_tokens: Some(100),
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("gpt-4"));
-        assert!(json.contains("hello"));
-        assert!(json.contains("100"));
-    }
-
-    #[test]
-    fn test_openai_request_no_max_tokens() {
-        let msg = crate::llm::Message {
-            role: "user".to_string(),
-            content: "hi".to_string(),
-        };
-        let req = OpenAIRequest {
-            model: "gpt-4",
-            messages: &[msg],
+        let provider = OpenAIProvider::new_with_base_url("test-key".to_string(), &server.url());
+        let request = InternalRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![],
             temperature: 0.0,
             max_tokens: None,
+            stream: false,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: ReasoningLevel::default(),
         };
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(!json.contains("max_tokens"));
+
+        let result = provider.send(request, serde_json::json!({})).await;
+        mock.assert_async().await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ProviderError::Legacy(msg) => assert!(msg.contains("429")),
+            other => panic!("Expected Legacy error for 429, got: {:?}", other),
+        }
+    }
+
+    // ── send_streaming() test ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_openai_send_streaming() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/chat/completions")
+            .with_status(200)
+            .with_body(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n\
+                 data: {\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n\
+                 data: [DONE]\n\n",
+            )
+            .create_async()
+            .await;
+
+        let provider = OpenAIProvider::new_with_base_url("test-key".to_string(), &server.url());
+        let request = InternalRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: true,
+            extra_body: serde_json::Map::new(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: ReasoningLevel::default(),
+        };
+
+        let mut stream = provider
+            .send_streaming(
+                request,
+                serde_json::json!({"model": "gpt-4", "stream": true}),
+            )
+            .await
+            .unwrap();
+        mock.assert_async().await;
+
+        let chunk1 = stream.recv().await.expect("should receive chunk 1");
+        assert_eq!(chunk1.event_type, "message");
+        assert!(chunk1.data.contains("Hello"));
+
+        let chunk2 = stream.recv().await.expect("should receive chunk 2");
+        assert_eq!(chunk2.event_type, "message");
+        assert!(chunk2.data.contains("world"));
+
+        let done = stream.recv().await;
+        assert!(done.is_none(), "channel should be closed after [DONE]");
     }
 }


### PR DESCRIPTION
将 `OpenAIProvider` 从 `impl LLMProvider`（deprecated）迁移到 `impl Provider`（新 trait），使其成为纯 HTTP 传输层。

主要变更：
- `OpenAIProvider` 新增 `client` 和 `supported_protocols` 字段，实现 `Provider` trait 全部 8 个方法
- `send()`：POST JSON body → 解析 `InternalResponse`，HTTP 错误映射为 `ProviderError`
- `send_streaming()`：SSE 流式读取，产出 `RawSseChunk`
- 移除 `#![allow(deprecated)]` 和旧的 `impl LLMProvider`
- `llm_init.rs` 注册点从 `LegacyProviderBridge` 改为直接 `Arc<dyn Provider>`
- 9 个 Provider 接口测试全部通过

Source: issue #914
Type: chore