### PR TITLE
fix: config_wizard DeepSeek 选择路径 panic

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -13,7 +13,7 @@ use crate::config::providers::{
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
 use crate::llm::{
-    DeepSeekProvider, GlmProvider, LLMProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
+    DeepSeekProvider, GlmProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
     ProviderModelKnowledge, VolcEngineProvider,
 };
 use dialoguer::{Input, Select};
@@ -213,21 +213,8 @@ fn find_models_config() -> Option<std::path::PathBuf> {
         .find(|p| p.exists())
 }
 
-/// Build an `Arc<dyn LLMProvider>` from the selected `ProviderInfo`.
-fn build_provider(info: &ProviderInfo, credential: &str) -> Arc<dyn LLMProvider> {
-    match info.provider_type {
-        ProviderType::Minimax => Arc::new(MiniMaxProvider::new(credential.to_string())),
-        ProviderType::Glm => Arc::new(GlmProvider::new(credential.to_string())),
-        ProviderType::Volcengine => Arc::new(VolcEngineProvider::new(credential.to_string())),
-        // DeepSeek migrated to Provider trait; ctx.provider is dead code
-        ProviderType::Deepseek => {
-            panic!("DeepSeek no longer implements LLMProvider; use build_model_lister")
-        }
-    }
-}
-
 /// Build an `Arc<dyn ModelLister>` from the selected `ProviderInfo`.
-/// Same provider instances as `build_provider`, but typed for model discovery.
+/// Build provider instances and return as a `ModelLister`.
 fn build_model_lister(info: &ProviderInfo, credential: &str) -> Arc<dyn ModelLister> {
     match info.provider_type {
         ProviderType::Minimax => Arc::new(MiniMaxProvider::new(credential.to_string())),
@@ -299,7 +286,6 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
     {
         let info = ctx.selected_provider.as_ref().unwrap();
         let cred = ctx.credential.as_ref().unwrap();
-        ctx.provider = Some(build_provider(info, cred));
         let model_lister = build_model_lister(info, cred);
 
         print!("Fetching models from provider...");

--- a/src/cli/config_wizard/types.rs
+++ b/src/cli/config_wizard/types.rs
@@ -4,8 +4,7 @@
 
 use std::collections::HashMap;
 
-use crate::llm::{model_info::ModelInfo, LLMProvider};
-use std::sync::Arc;
+use crate::llm::model_info::ModelInfo;
 
 use serde::{Deserialize, Serialize};
 
@@ -70,7 +69,6 @@ pub struct WizardContext {
     pub fetched_models: Vec<ModelInfo>,
     pub selected_models: Vec<ModelInfo>,
     pub existing_config: HashMap<String, serde_json::Value>,
-    pub provider: Option<Arc<dyn LLMProvider>>,
 }
 
 impl Default for WizardContext {
@@ -82,7 +80,6 @@ impl Default for WizardContext {
             fetched_models: Vec::new(),
             selected_models: Vec::new(),
             existing_config: HashMap::new(),
-            provider: None,
         }
     }
 }

--- a/src/llm/deepseek/tests_model_lister.rs
+++ b/src/llm/deepseek/tests_model_lister.rs
@@ -1,7 +1,7 @@
 //! Model lister tests for DeepSeek Provider.
 
-use super::super::{DeepSeekProvider, LLMError, DEEPSEEK_API_URL};
-use crate::llm::provider::ModelLister;
+use super::*;
+use crate::llm::ModelLister;
 
 #[tokio::test]
 async fn test_fetch_model_list_success() {


### PR DESCRIPTION
修复 config_wizard 选择 DeepSeek 时 panic 崩溃。

- 移除 `build_provider` 函数（含 DeepSeek panic 分支）
- 移除 `WizardContext.provider` 死代码字段
- 修复 #935 引入的 `tests_model_lister.rs` 导入路径错误
- 修正 `build_model_lister` 残留 doc comment

Source: issue #936
Type: fix
