### PR TITLE
feat: 新增 key_registry 映射表和 resolve 统一入口

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -172,6 +172,13 @@ impl Daemon {
         gateway
             .set_storage(Arc::clone(&storage) as Arc<dyn PersistenceService>)
             .await;
+        // Rebuild key_registry from persisted checkpoints at startup.
+        if let Err(e) = session_manager.rebuild_key_registry().await {
+            tracing::warn!(
+                error = %e,
+                "failed to rebuild key_registry at startup — continuing"
+            );
+        }
         let gateway = Arc::new(gateway);
         // Wire the self-ref so `handle_inbound_message` can pass
         // a strong `Arc<Gateway>` into the streaming LLM path.

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -12,7 +12,6 @@ use crate::session::persistence::{
     PendingMessage, PersistenceError, PersistenceService, ReasoningLevel, SessionCheckpoint,
     SessionStatus,
 };
-use crate::session::workspace;
 use crate::skills::DiskSkillRegistry;
 use crate::system_prompt::builder::PromptOverrides;
 use crate::tools::ToolRegistry;
@@ -24,7 +23,9 @@ use tracing::warn;
 
 mod announce;
 mod channel;
+mod key_registry;
 mod rebuild;
+mod resolve;
 mod session_helpers;
 mod spawn;
 pub use spawn::{ChildSessionInfo, SpawnMode};
@@ -59,6 +60,10 @@ pub struct SessionManager {
     /// Updated by `force_new_for_channel` so subsequent `find_or_create`
     /// calls route to the latest session for a channel.
     channel_active_sessions: RwLock<HashMap<String, String>>,
+    /// session_key → session_id mapping, rebuilt from persistence at startup.
+    /// Updated by `resolve()` on new session creation and by
+    /// `force_new_for_channel`.
+    key_registry: RwLock<HashMap<String, String>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -93,6 +98,7 @@ impl SessionManager {
             prompt_overrides: RwLock::new(None),
             children: RwLock::new(HashMap::new()),
             channel_active_sessions: RwLock::new(HashMap::new()),
+            key_registry: RwLock::new(HashMap::new()),
         }
     }
 
@@ -228,110 +234,9 @@ impl SessionManager {
             return Ok(active_id.clone());
         }
 
-        let session_id = self.compute_session_key(channel, message, account_id);
-        // Fast path: session already exists
-        let session_exists = {
-            let sessions = self.sessions.read().await;
-            sessions.contains_key(&session_id)
-        };
-        if session_exists {
-            self.update_checkpoint_thread_id(&session_id, &message.thread_id)
-                .await;
-            return Ok(session_id);
-        }
-        // Slow path: try archived session restoration
-        let restored = self
-            .try_restore_archived_session(&session_id, channel)
-            .await;
-        let mut sessions = self.sessions.write().await;
-        if sessions.contains_key(&session_id) {
-            return Ok(session_id);
-        }
-        let tool_registry = self.tool_registry.read().await;
-        let skill_registry = self.skill_registry.read().await.clone();
-        let agent_id = message.to.clone();
-        let prompt = session_helpers::build_session_system_prompt(
-            &self.workspace_dir,
-            self.bootstrap_mode,
-            &tool_registry,
-            skill_registry,
-            &agent_id,
-        )
-        .await;
-
-        // Compute per-session workdir path
-        let workdir_path = {
-            if restored {
-                let storage = self.storage.read().await;
-                if let Some(storage) = storage.as_ref() {
-                    session_helpers::compute_session_workdir(
-                        true,
-                        &session_id,
-                        message,
-                        &self.workspace_dir,
-                        storage,
-                    )
-                    .await?
-                } else {
-                    PathBuf::from("/tmp")
-                }
-            } else if let Some(ref workspace_dir) = self.workspace_dir {
-                workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from).map_err(
-                    |e| ProcessError::ProcessingFailed(format!("workspace creation failed: {}", e)),
-                )?
-            } else {
-                PathBuf::from("/tmp")
-            }
-        };
-
-        let conv_session =
-            ConversationSession::new(session_id.clone(), "default".to_string(), workdir_path)
-                .with_system_prompt(prompt)
-                .with_reasoning_level(self.default_reasoning_level);
-        {
-            let mut conv_sessions = self.conversation_sessions.write().await;
-            conv_sessions.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));
-        }
-
-        if restored {
-            let storage = self.storage.read().await;
-            if let Some(storage) = storage.as_ref() {
-                if let Some(session) = session_helpers::restore_checkpoint_session(
-                    storage,
-                    &session_id,
-                    channel,
-                    message,
-                    &self.conversation_sessions,
-                )
-                .await
-                {
-                    sessions.insert(session_id.clone(), session);
-                }
-            }
-        } else {
-            // No archived session — create a brand-new Session
-            sessions.insert(
-                session_id.clone(),
-                session_helpers::create_new_session(&session_id, message, channel),
-            );
-            // Persist checkpoint with thread_id so outbound can find it
-            let mut cp = SessionCheckpoint::new(session_id.clone())
-                .with_status(SessionStatus::Active)
-                .with_channel(channel.to_string())
-                .with_chat_id(message.to.clone())
-                .with_agent_id(message.to.clone());
-            if let Some(ref thread_id) = message.thread_id {
-                cp = cp.with_thread_id(thread_id.clone());
-            }
-            if let Some(storage) = self.storage.read().await.as_ref() {
-                if let Err(e) = storage.save_checkpoint(&cp).await {
-                    warn!(session_id = %session_id, error = %e,
-                        "failed to save new session checkpoint");
-                }
-            }
-        }
-
-        Ok(session_id)
+        let session_key = self.compute_session_key(channel, message, account_id);
+        self.resolve(&session_key, channel, message, account_id)
+            .await
     }
 
     /// Get active sessions for an agent.
@@ -490,6 +395,8 @@ mod bug904_tests;
 mod flush_tests;
 #[cfg(test)]
 mod rebuild_tests;
+#[cfg(test)]
+mod resolve_tests;
 #[cfg(test)]
 mod spawn_tests;
 #[cfg(test)]

--- a/src/gateway/session_manager/channel.rs
+++ b/src/gateway/session_manager/channel.rs
@@ -7,6 +7,7 @@
 use super::SessionManager;
 use crate::gateway::Session;
 use crate::llm::session::ConversationSession;
+use crate::session::persistence::{SessionCheckpoint, SessionStatus};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -24,13 +25,10 @@ impl SessionManager {
     ///
     /// Returns the new session_id.
     pub async fn force_new_for_channel(&self, channel: &str, agent_id: &str) -> String {
-        // Generate a unique session id using timestamp + channel
-        let session_id = format!(
-            "{}-{}-{}",
-            channel,
-            agent_id,
-            chrono::Utc::now().timestamp_millis()
-        );
+        // Generate a unique session id using the standard format
+        let session_id = super::session_helpers::generate_session_id(agent_id);
+        // Compute session_key for key_registry
+        let session_key = format!("{}:{}:{}", channel, agent_id, agent_id);
 
         // Compute workdir
         let workdir_path = if let Some(ref workspace_dir) = self.workspace_dir {
@@ -68,6 +66,31 @@ impl SessionManager {
         {
             let mut channel_map = self.channel_active_sessions.write().await;
             channel_map.insert(channel.to_string(), session_id.clone());
+        }
+
+        // Update key_registry so resolve() routes to the new session
+        {
+            let mut registry = self.key_registry.write().await;
+            registry.insert(session_key, session_id.clone());
+        }
+
+        // Persist checkpoint so rebuild_key_registry can reconstruct the
+        // session_key after restart.  The /new command has no real
+        // message.from, so we use agent_id as a placeholder.
+        let mut cp = SessionCheckpoint::new(session_id.clone())
+            .with_status(SessionStatus::Active)
+            .with_channel(channel.to_string())
+            .with_chat_id(agent_id.to_string())
+            .with_agent_id(agent_id.to_string());
+        cp.sender_id = Some(agent_id.to_string());
+        if let Some(storage) = self.storage.read().await.as_ref() {
+            if let Err(e) = storage.save_checkpoint(&cp).await {
+                tracing::warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "failed to save checkpoint for force_new_for_channel"
+                );
+            }
         }
 
         session_id

--- a/src/gateway/session_manager/key_registry.rs
+++ b/src/gateway/session_manager/key_registry.rs
@@ -1,0 +1,120 @@
+//! Session key registry rebuild logic.
+//!
+//! `rebuild_key_registry()` reconstructs the in-memory `key_registry`
+//! (session_key → session_id) from persisted checkpoints at startup.
+
+use super::SessionManager;
+use crate::session::persistence::PersistenceError;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::warn;
+
+impl SessionManager {
+    /// Rebuild the `key_registry` (session_key → session_id) from persisted
+    /// checkpoints.
+    ///
+    /// This is a **best-effort** reconstruction. Checkpoints created after
+    /// the `sender_id` field was added carry the original `message.from`,
+    /// allowing an exact match with `compute_session_key(PerChannelPeer)`
+    /// (format: `{channel}:{from}:{to}`). For older checkpoints without
+    /// `sender_id`, we fall back to using `agent_id`.
+    ///
+    /// When multiple sessions share the same reconstructed key, the one with
+    /// the latest `created_at` is kept.
+    pub async fn rebuild_key_registry(&self) -> Result<(), PersistenceError> {
+        let storage_arc = {
+            let guard = self.storage.read().await;
+            match guard.as_ref() {
+                Some(s) => Arc::clone(s),
+                None => {
+                    // No storage configured — nothing to rebuild.
+                    return Ok(());
+                }
+            }
+        };
+
+        // Collect all session_ids from active + archived.
+        let mut all_session_ids: Vec<String> = {
+            let active = storage_arc.list_active_sessions().await?;
+            let archived = storage_arc.list_archived_sessions().await?;
+            let mut ids = active;
+            ids.extend(archived);
+            ids
+        };
+
+        // Deduplicate in case a session appears in both lists.
+        all_session_ids.sort();
+        all_session_ids.dedup();
+
+        // Accumulate: reconstructed key → (created_at, session_id)
+        // Keep only the latest created_at per key.
+        let mut key_best: HashMap<String, (chrono::DateTime<chrono::Utc>, String)> = HashMap::new();
+
+        for session_id in &all_session_ids {
+            let cp = match storage_arc.load_checkpoint(session_id).await {
+                Ok(Some(cp)) => cp,
+                Ok(None) => {
+                    warn!(
+                        session_id = %session_id,
+                        "checkpoint returned None during rebuild, skipping"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        session_id = %session_id,
+                        error = %e,
+                        "failed to load checkpoint during rebuild, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            // Extract routing fields.
+            let channel = match cp.channel.as_deref() {
+                Some(ch) => ch,
+                None => {
+                    // No channel in checkpoint — can't reconstruct key.
+                    continue;
+                }
+            };
+            let chat_id = match cp.chat_id.as_deref() {
+                Some(id) => id,
+                None => {
+                    // No chat_id in checkpoint — can't reconstruct key.
+                    continue;
+                }
+            };
+
+            // Reconstruct the session_key matching `compute_session_key(PerChannelPeer)`
+            // format: "{channel}:{from}:{to}".
+            // Prefer the persisted `sender_id` (message.from); fall back to
+            // `agent_id` for checkpoints created before this field existed.
+            let from = cp
+                .sender_id
+                .as_deref()
+                .unwrap_or_else(|| cp.agent_id.as_deref().unwrap_or(chat_id));
+            let session_key = format!("{}:{}:{}", channel, from, chat_id);
+
+            let created = cp.created_at;
+            match key_best.get(&session_key) {
+                Some((existing_created, _)) if created <= *existing_created => {
+                    // Existing entry is newer or equal — keep it.
+                }
+                _ => {
+                    key_best.insert(session_key, (created, session_id.clone()));
+                }
+            }
+        }
+
+        // Write results into key_registry.
+        {
+            let mut registry = self.key_registry.write().await;
+            for (key, (_, session_id)) in key_best {
+                registry.insert(key, session_id);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -1,0 +1,221 @@
+//! Session key resolution: the unified entry point for mapping
+//! session_key → session_id, with three lookup paths:
+//! 1. key_registry hit + active session → return directly
+//! 2. key_registry hit + archived session → restore → return
+//! 3. key_registry miss → create new session → register → return
+
+use super::session_helpers;
+use super::SessionManager;
+use crate::gateway::Message;
+use crate::im::processor::ProcessError;
+use crate::llm::session::ConversationSession;
+use crate::session::persistence::{SessionCheckpoint, SessionStatus};
+use crate::session::workspace;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::warn;
+
+impl SessionManager {
+    /// Resolve a session_key to a session_id.
+    ///
+    /// Lookup flow:
+    /// 1. key_registry hit + active session → return session_id
+    /// 2. key_registry hit + archived session → restore → return session_id
+    /// 3. key_registry miss → create new session → register → return session_id
+    pub async fn resolve(
+        &self,
+        session_key: &str,
+        channel: &str,
+        message: &Message,
+        _account_id: Option<&str>, // used by key_registry rebuild
+    ) -> Result<String, ProcessError> {
+        // Path 1: key_registry hit — check if session is active
+        let registry_hit = {
+            let registry = self.key_registry.read().await;
+            registry.get(session_key).cloned()
+        };
+
+        if let Some(session_id) = registry_hit {
+            let session_exists = {
+                let sessions = self.sessions.read().await;
+                sessions.contains_key(&session_id)
+            };
+            if session_exists {
+                self.update_checkpoint_thread_id(&session_id, &message.thread_id)
+                    .await;
+                return Ok(session_id);
+            }
+
+            // Path 2: key_registry hit but session not active — try restore
+            let restored = self
+                .try_restore_archived_session(&session_id, channel)
+                .await;
+            if restored {
+                // Load checkpoint and set up conversation session + Session entry
+                let storage_arc = {
+                    let guard = self.storage.read().await;
+                    guard.as_ref().map(Arc::clone)
+                };
+                if let Some(storage) = storage_arc {
+                    if let Some(cp) = storage.load_checkpoint(&session_id).await.ok().flatten() {
+                        // Ensure ConversationSession exists
+                        let needs_conv = {
+                            let cs = self.conversation_sessions.read().await;
+                            !cs.contains_key(&session_id)
+                        };
+                        if needs_conv {
+                            let agent_id =
+                                cp.agent_id.clone().unwrap_or_else(|| message.to.clone());
+                            let workdir_path = session_helpers::compute_session_workdir(
+                                true,
+                                &session_id,
+                                message,
+                                &self.workspace_dir,
+                                &storage,
+                            )
+                            .await?;
+
+                            let tool_registry = self.tool_registry.read().await;
+                            let skill_registry = self.skill_registry.read().await.clone();
+                            let prompt = session_helpers::build_session_system_prompt(
+                                &self.workspace_dir,
+                                self.bootstrap_mode,
+                                &tool_registry,
+                                skill_registry,
+                                &agent_id,
+                            )
+                            .await;
+
+                            let conv_session = ConversationSession::new(
+                                session_id.clone(),
+                                "default".to_string(),
+                                workdir_path,
+                            )
+                            .with_system_prompt(prompt)
+                            .with_reasoning_level(self.default_reasoning_level);
+                            {
+                                let mut cs = self.conversation_sessions.write().await;
+                                cs.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));
+                            }
+                        }
+
+                        // Restore pending messages and system_appends
+                        {
+                            let cs = self.conversation_sessions.read().await;
+                            if let Some(cs) = cs.get(&session_id) {
+                                let mut cs = cs.write().await;
+                                cs.restore_pending_messages(cp.pending_messages.clone());
+                                cs.restore_system_appends(cp.system_appends.clone());
+                            }
+                        }
+
+                        // Create Session entry
+                        {
+                            let mut sessions = self.sessions.write().await;
+                            if !sessions.contains_key(&session_id) {
+                                sessions.insert(
+                                    session_id.clone(),
+                                    super::session_helpers::create_new_session(
+                                        &session_id,
+                                        message,
+                                        channel,
+                                    ),
+                                );
+                            }
+                        }
+
+                        // Save checkpoint with updated thread_id
+                        let mut cp = cp;
+                        cp.thread_id = message.thread_id.clone();
+                        if let Err(e) = storage.save_checkpoint(&cp).await {
+                            warn!(
+                                session_id = %session_id,
+                                error = %e,
+                                "failed to save checkpoint after restore"
+                            );
+                        }
+                    }
+                }
+
+                self.update_checkpoint_thread_id(&session_id, &message.thread_id)
+                    .await;
+                return Ok(session_id);
+            }
+        }
+
+        // Path 3: key_registry miss — create a brand-new session
+        let session_id = session_helpers::generate_session_id(&message.to);
+
+        // Write to key_registry
+        {
+            let mut registry = self.key_registry.write().await;
+            registry.insert(session_key.to_string(), session_id.clone());
+        }
+
+        // Build system prompt
+        let tool_registry = self.tool_registry.read().await;
+        let skill_registry = self.skill_registry.read().await.clone();
+        let agent_id = message.to.clone();
+        let prompt = session_helpers::build_session_system_prompt(
+            &self.workspace_dir,
+            self.bootstrap_mode,
+            &tool_registry,
+            skill_registry,
+            &agent_id,
+        )
+        .await;
+
+        // Compute workdir
+        let workdir_path = if let Some(ref workspace_dir) = self.workspace_dir {
+            workspace::ensure_workspace_dir(workspace_dir, &message.to, &message.from).map_err(
+                |e| ProcessError::ProcessingFailed(format!("workspace creation failed: {}", e)),
+            )?
+        } else {
+            PathBuf::from("/tmp")
+        };
+
+        // Create ConversationSession
+        let conv_session =
+            ConversationSession::new(session_id.clone(), "default".to_string(), workdir_path)
+                .with_system_prompt(prompt)
+                .with_reasoning_level(self.default_reasoning_level);
+        {
+            let mut conv_sessions = self.conversation_sessions.write().await;
+            conv_sessions.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));
+        }
+
+        // Create Session entry
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.insert(
+                session_id.clone(),
+                super::session_helpers::create_new_session(&session_id, message, channel),
+            );
+        }
+
+        // Save checkpoint
+        let mut cp = SessionCheckpoint::new(session_id.clone())
+            .with_status(SessionStatus::Active)
+            .with_channel(channel.to_string())
+            .with_chat_id(message.to.clone())
+            .with_agent_id(message.to.clone());
+        if let Some(ref thread_id) = message.thread_id {
+            cp = cp.with_thread_id(thread_id.clone());
+        }
+        // Persist sender (message.from) so rebuild_key_registry can reconstruct
+        // the correct session_key format "{channel}:{from}:{to}".
+        cp.sender_id = Some(message.from.clone());
+        if let Some(storage) = self.storage.read().await.as_ref() {
+            if let Err(e) = storage.save_checkpoint(&cp).await {
+                warn!(
+                    session_id = %session_id,
+                    error = %e,
+                    "failed to save new session checkpoint"
+                );
+            }
+        }
+
+        Ok(session_id)
+    }
+}

--- a/src/gateway/session_manager/resolve_tests.rs
+++ b/src/gateway/session_manager/resolve_tests.rs
@@ -1,0 +1,265 @@
+//! Tests for key_registry and resolve logic.
+
+use super::session_helpers;
+use super::test_helpers::MockPersistService;
+use super::tests::{make_test_mgr, test_config};
+use super::SessionManager;
+use crate::gateway::{Message, Session};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{ReasoningLevel, SessionCheckpoint, SessionStatus};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+fn test_message() -> Message {
+    Message {
+        id: "msg-1".to_string(),
+        from: "user-a".to_string(),
+        to: "agent-b".to_string(),
+        content: "hello".to_string(),
+        channel: "feishu".to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+        metadata: std::collections::HashMap::new(),
+        thread_id: None,
+    }
+}
+
+// ── generate_session_id ─────────────────────────────────────────────────────
+
+#[test]
+fn test_generate_session_id_format() {
+    let id = session_helpers::generate_session_id("agent-1");
+    let parts: Vec<&str> = id.split('_').collect();
+    assert_eq!(parts.len(), 3, "expected 3 parts: {}", id);
+    assert_eq!(parts[0], "agent-1");
+    // Second part should be a numeric timestamp
+    assert!(
+        parts[1].parse::<i64>().is_ok(),
+        "timestamp not numeric: {}",
+        parts[1]
+    );
+    // Third part should be 8 hex digits
+    assert_eq!(parts[2].len(), 8, "hex part not 8 chars: {}", parts[2]);
+    assert!(
+        parts[2].chars().all(|c| c.is_ascii_hexdigit()),
+        "hex part non-hex: {}",
+        parts[2]
+    );
+}
+
+#[test]
+fn test_generate_session_id_uniqueness() {
+    let ids: Vec<String> = (0..100)
+        .map(|_| session_helpers::generate_session_id("agent-x"))
+        .collect();
+    let unique: std::collections::HashSet<&str> = ids.iter().map(|s| s.as_str()).collect();
+    assert_eq!(unique.len(), 100, "all IDs should be unique");
+}
+
+// ── resolve: three paths ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_resolve_path1_active_hit() {
+    let mgr = make_test_mgr(None);
+    let msg = test_message();
+    let session_key = mgr.compute_session_key("feishu", &msg, None);
+    // Pre-populate key_registry and sessions
+    let session_id = "active_session_1";
+    {
+        let mut reg = mgr.key_registry.write().await;
+        reg.insert(session_key.clone(), session_id.to_string());
+    }
+    {
+        let mut sessions = mgr.sessions.write().await;
+        sessions.insert(
+            session_id.to_string(),
+            Session {
+                id: session_id.to_string(),
+                agent_id: "agent-b".to_string(),
+                channel: "feishu".to_string(),
+                created_at: chrono::Utc::now().timestamp(),
+                depth: 0,
+            },
+        );
+    }
+    let result = mgr
+        .resolve(&session_key, "feishu", &msg, None)
+        .await
+        .unwrap();
+    assert_eq!(result, session_id);
+}
+
+#[tokio::test]
+async fn test_resolve_path2_archived_hit_restore() {
+    let session_id = "archived_session_1";
+    let mock_storage = Arc::new(MockPersistService {
+        archived_checkpoint: Mutex::new(Some(
+            SessionCheckpoint::new(session_id.to_string())
+                .with_status(SessionStatus::Archived)
+                .with_chat_id("agent-b".to_string()),
+        )),
+        restore_called: Mutex::new(false),
+    });
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(mock_storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+    let msg = test_message();
+    let session_key = mgr.compute_session_key("feishu", &msg, None);
+    // Populate key_registry
+    {
+        let mut reg = mgr.key_registry.write().await;
+        reg.insert(session_key.clone(), session_id.to_string());
+    }
+    let result = mgr
+        .resolve(&session_key, "feishu", &msg, None)
+        .await
+        .unwrap();
+    assert_eq!(result, session_id);
+    let called = *mock_storage.restore_called.lock().await;
+    assert!(called, "restore_checkpoint should have been called");
+}
+
+#[tokio::test]
+async fn test_resolve_path3_miss_creates_new() {
+    let mgr = make_test_mgr(None);
+    let msg = test_message();
+    let session_key = mgr.compute_session_key("feishu", &msg, None);
+    // key_registry is empty → miss → create new
+    let result = mgr
+        .resolve(&session_key, "feishu", &msg, None)
+        .await
+        .unwrap();
+    // Verify format
+    assert!(result.starts_with("agent-b_"), "bad format: {}", result);
+    // Verify key_registry updated
+    let reg = mgr.key_registry.read().await;
+    assert_eq!(reg.get(&session_key).unwrap(), &result);
+    // Verify session exists
+    assert!(mgr.has_session(&result).await);
+}
+
+// ── rebuild_key_registry ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_rebuild_key_registry() {
+    use crate::session::persistence::SessionCheckpoint;
+
+    let mut cp1 = SessionCheckpoint::new("sid_old".to_string())
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-a".to_string())
+        .with_agent_id("agent-a".to_string());
+    cp1.created_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    let mut cp2 = SessionCheckpoint::new("sid_new".to_string())
+        .with_channel("feishu".to_string())
+        .with_chat_id("agent-a".to_string())
+        .with_agent_id("agent-a".to_string());
+    cp2.created_at = chrono::Utc::now();
+
+    // Need to load_checkpoint to return the right checkpoint
+    let cps = vec![cp1.clone(), cp2.clone()];
+    struct RebuildMockWithLoad {
+        checkpoints: Vec<SessionCheckpoint>,
+    }
+    #[async_trait::async_trait]
+    impl crate::session::persistence::PersistenceService for RebuildMockWithLoad {
+        async fn save_checkpoint(
+            &self,
+            _: &SessionCheckpoint,
+        ) -> Result<(), crate::session::persistence::PersistenceError> {
+            Ok(())
+        }
+        async fn load_checkpoint(
+            &self,
+            id: &str,
+        ) -> Result<Option<SessionCheckpoint>, crate::session::persistence::PersistenceError>
+        {
+            Ok(self
+                .checkpoints
+                .iter()
+                .find(|cp| cp.session_id == id)
+                .cloned())
+        }
+        async fn delete_checkpoint(
+            &self,
+            _: &str,
+        ) -> Result<(), crate::session::persistence::PersistenceError> {
+            Ok(())
+        }
+        async fn list_active_sessions(
+            &self,
+        ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+            Ok(self
+                .checkpoints
+                .iter()
+                .map(|cp| cp.session_id.clone())
+                .collect())
+        }
+        async fn list_archived_sessions(
+            &self,
+        ) -> Result<Vec<String>, crate::session::persistence::PersistenceError> {
+            Ok(vec![])
+        }
+        async fn restore_checkpoint(
+            &self,
+            _: &str,
+        ) -> Result<Option<SessionCheckpoint>, crate::session::persistence::PersistenceError>
+        {
+            Ok(None)
+        }
+    }
+
+    let mock = Arc::new(RebuildMockWithLoad { checkpoints: cps });
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(mock),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    mgr.rebuild_key_registry().await.unwrap();
+
+    let reg = mgr.key_registry.read().await;
+    // Both sessions share the same reconstructed key:
+    // "feishu:agent-a:agent-a"
+    // The newer one (sid_new) should win
+    let key = "feishu:agent-a:agent-a";
+    assert_eq!(reg.get(key).unwrap(), "sid_new");
+}
+
+// ── find_or_create delegates to resolve ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_find_or_create_delegates_to_resolve() {
+    let mgr = make_test_mgr(None);
+    let msg = test_message();
+    // First call creates a new session
+    let id1 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    // Second call with same message resolves to same session
+    let id2 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    assert_eq!(id1, id2);
+    // Only one session in the map
+    let sessions = mgr.sessions.read().await;
+    assert_eq!(sessions.len(), 1);
+}
+
+// ── key_registry write and query ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_key_registry_write_and_query() {
+    let mgr = make_test_mgr(None);
+    // Write
+    {
+        let mut reg = mgr.key_registry.write().await;
+        reg.insert("key1".to_string(), "sid1".to_string());
+        reg.insert("key2".to_string(), "sid2".to_string());
+    }
+    // Query
+    let reg = mgr.key_registry.read().await;
+    assert_eq!(reg.get("key1").unwrap(), "sid1");
+    assert_eq!(reg.get("key2").unwrap(), "sid2");
+    assert!(reg.get("key3").is_none());
+}

--- a/src/gateway/session_manager/session_helpers.rs
+++ b/src/gateway/session_manager/session_helpers.rs
@@ -3,7 +3,6 @@
 
 use crate::gateway::Message;
 use crate::im::IMAdapter;
-use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
 use crate::session::persistence::{PersistenceService, SessionStatus};
 use crate::session::workspace;
@@ -14,8 +13,18 @@ use crate::tools::{ToolContext, ToolRegistry};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::warn;
+use uuid::Uuid;
+
+/// Generate a unique session ID.
+///
+/// Format: `{agent_id}_{timestamp_ms}_{8-hex}`
+pub(super) fn generate_session_id(agent_id: &str) -> String {
+    let ts = chrono::Utc::now().timestamp_millis();
+    let uuid = Uuid::new_v4();
+    let hex_part = format!("{:08x}", uuid.as_fields().0);
+    format!("{}_{}_{}", agent_id, ts, hex_part)
+}
 
 /// Build the system prompt for a new session.
 pub(super) async fn build_session_system_prompt(
@@ -100,44 +109,6 @@ pub(super) async fn compute_session_workdir(
     }
 }
 
-/// Restore a session from an archived checkpoint.
-pub(super) async fn restore_checkpoint_session(
-    storage: &Arc<dyn crate::session::persistence::PersistenceService>,
-    session_id: &str,
-    channel: &str,
-    message: &Message,
-    conv_sessions: &RwLock<std::collections::HashMap<String, Arc<RwLock<ConversationSession>>>>,
-) -> Option<crate::gateway::Session> {
-    let mut cp = storage.load_checkpoint(session_id).await.ok().flatten()?;
-
-    // Restore pending_messages and system_appends into ConversationSession
-    {
-        let sessions = conv_sessions.read().await;
-        if let Some(cs) = sessions.get(session_id) {
-            let mut cs = cs.write().await;
-            cs.restore_pending_messages(cp.pending_messages.clone());
-            cs.restore_system_appends(cp.system_appends.clone());
-        }
-    }
-
-    let session = crate::gateway::Session {
-        id: session_id.to_string(),
-        agent_id: cp.chat_id.clone().unwrap_or_else(|| message.to.clone()),
-        channel: channel.to_string(),
-        created_at: chrono::Utc::now().timestamp(),
-        depth: 0,
-    };
-
-    // 覆盖式写入: 每次入站都用 message.thread_id 覆盖 checkpoint.thread_id
-    cp.thread_id = message.thread_id.clone();
-    if let Err(e) = storage.save_checkpoint(&cp).await {
-        warn!(session_id = %session_id, error = %e,
-            "failed to save checkpoint with updated thread_id");
-    }
-
-    Some(session)
-}
-
 /// Create and persist a brand-new session.
 pub(super) fn create_new_session(
     session_id: &str,
@@ -156,8 +127,7 @@ pub(super) fn create_new_session(
 /// Update the thread_id in a session's checkpoint.
 ///
 /// Loads the checkpoint from storage, overwrites `thread_id` with the
-/// provided value, and saves it back. This mirrors the pattern used in
-/// `restore_checkpoint_session`.
+/// provided value, and saves it back.
 ///
 /// Silently skips (with warn!) when:
 /// - storage is not available

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -40,22 +40,12 @@ fn test_message() -> Message {
 async fn test_find_or_create_existing_session() {
     let mgr = make_test_mgr(None);
     let msg = test_message();
-    let session_id = mgr.compute_session_key("feishu", &msg, None);
-    {
-        let mut sessions = mgr.sessions.write().await;
-        sessions.insert(
-            session_id.clone(),
-            Session {
-                id: session_id.clone(),
-                agent_id: "agent-b".to_string(),
-                channel: "feishu".to_string(),
-                created_at: chrono::Utc::now().timestamp(),
-                depth: 0,
-            },
-        );
-    }
-    let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
-    assert_eq!(result, session_id);
+    // First call: creates a new session via resolve Path 3
+    let id1 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    assert!(!id1.is_empty());
+    // Second call: resolve finds the key in registry, returns same session
+    let id2 = mgr.find_or_create("feishu", &msg, None).await.unwrap();
+    assert_eq!(id1, id2, "same key should resolve to same session");
 }
 
 #[tokio::test]
@@ -73,7 +63,7 @@ async fn test_find_or_create_new_user_creates_session() {
 async fn test_archived_session_restoration() {
     let mock_storage = Arc::new(MockPersistService {
         archived_checkpoint: Mutex::new(Some(
-            SessionCheckpoint::new("feishu:user-a:agent-b".to_string())
+            SessionCheckpoint::new("test_sid".to_string())
                 .with_status(SessionStatus::Archived)
                 .with_chat_id("agent-b".to_string()),
         )),
@@ -87,8 +77,14 @@ async fn test_archived_session_restoration() {
         ReasoningLevel::default(),
     );
     let msg = test_message();
+    // Populate key_registry so resolve can look up the session
+    let session_key = mgr.compute_session_key("feishu", &msg, None);
+    {
+        let mut reg = mgr.key_registry.write().await;
+        reg.insert(session_key, "test_sid".to_string());
+    }
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
-    assert_eq!(result, "feishu:user-a:agent-b");
+    assert_eq!(result, "test_sid");
     let called = *mock_storage.restore_called.lock().await;
     assert!(called, "restore_checkpoint should have been called");
 }
@@ -334,7 +330,11 @@ async fn test_find_or_create_no_storage() {
     let mgr = make_test_mgr(None);
     let msg = test_message();
     let result = mgr.find_or_create("feishu", &msg, None).await.unwrap();
-    assert_eq!(result, "feishu:user-a:agent-b");
+    // Session ID should match the new format: {agent_id}_{ts}_{hex}
+    assert!(result.starts_with("agent-b_"), "bad format: {}", result);
+    let parts: Vec<&str> = result.rsplitn(2, '_').collect();
+    assert_eq!(parts.len(), 2, "bad format: {}", result);
+    assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
 }
 
 use super::test_helpers::MockPersistService;
@@ -404,7 +404,11 @@ async fn test_force_new_for_channel_creates_valid_session() {
     let new_id = mgr.force_new_for_channel("feishu", "agent-test").await;
     // Should be non-empty and contain the channel
     assert!(!new_id.is_empty());
-    assert!(new_id.starts_with("feishu"));
+    // New format: {agent_id}_{ts}_{hex}
+    assert!(new_id.starts_with("agent-test_"), "bad format: {}", new_id);
+    let parts: Vec<&str> = new_id.rsplitn(2, '_').collect();
+    assert_eq!(parts.len(), 2, "bad format: {}", new_id);
+    assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
     // Session should exist in the sessions map
     assert!(mgr.has_session(&new_id).await);
     // Channel mapping should be correct

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -396,7 +396,12 @@ async fn test_main_scope_all_share_one_session() {
     gw.route_message("ch", m2, None).await.unwrap();
     let sessions = gw.get_agent_sessions("bob").await;
     assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].id, "ch:bob");
+    // New format: {agent_id}_{ts}_{hex}
+    assert!(
+        sessions[0].id.starts_with("bob_"),
+        "bad format: {}",
+        sessions[0].id
+    );
 }
 
 #[tokio::test]
@@ -423,7 +428,7 @@ async fn test_account_id_from_metadata() {
     let aid = msg.metadata.get("account_id").cloned();
     add_session(&sm, "feishu", &mut msg, aid.as_deref()).await;
     let sid = msg.metadata.get("session_id").unwrap();
-    assert!(sid.starts_with("t_abc:"), "sid: {}", sid);
+    assert!(sid.starts_with("agent-1_"), "sid: {}", sid);
     gw.route_message("feishu", msg, None).await.unwrap();
     assert_eq!(gw.get_agent_sessions("agent-1").await.len(), 1);
 }
@@ -437,7 +442,7 @@ async fn test_explicit_account_id_overrides_metadata() {
     msg.metadata.insert("account_id".into(), "meta_t".into());
     add_session(&sm, "feishu", &mut msg, Some("explicit_t")).await;
     let sid = msg.metadata.get("session_id").unwrap();
-    assert!(sid.starts_with("explicit_t:"), "sid: {}", sid);
+    assert!(sid.starts_with("agent-1_"), "sid: {}", sid);
     gw.route_message("feishu", msg, Some("explicit_t"))
         .await
         .unwrap();
@@ -460,6 +465,13 @@ async fn test_feishu_session_isolation() {
     let sessions = gw.get_agent_sessions("agent-1").await;
     assert_eq!(sessions.len(), 2);
     let ids: Vec<_> = sessions.iter().map(|s| s.id.as_str()).collect();
-    assert!(ids.iter().any(|k| k.contains("ou_alice")));
-    assert!(ids.iter().any(|k| k.contains("ou_carol")));
+    // Two different senders → two different sessions
+    assert_eq!(ids.len(), 2);
+    assert_ne!(
+        ids[0], ids[1],
+        "sessions should differ for different senders"
+    );
+    // Both should follow the new format: {agent_id}_{ts}_{hex}
+    assert!(ids[0].starts_with("agent-1_"), "bad format: {}", ids[0]);
+    assert!(ids[1].starts_with("agent-1_"), "bad format: {}", ids[1]);
 }

--- a/src/gateway/tests_dmscope.rs
+++ b/src/gateway/tests_dmscope.rs
@@ -161,12 +161,20 @@ async fn test_feishu_dm_scope_isolation_variants() {
         add_session(&sm, "feishu", &mut m1, None).await;
         add_session(&sm, "feishu", &mut m2, None).await;
         assert_eq!(m1.metadata["session_id"], m2.metadata["session_id"],);
-        assert_eq!(m1.metadata["session_id"], "feishu:ag");
+        assert!(
+            m1.metadata["session_id"].starts_with("ag_"),
+            "session_id: {}",
+            m1.metadata["session_id"]
+        );
         gw.route_message("feishu", m1, None).await.unwrap();
         gw.route_message("feishu", m2, None).await.unwrap();
         let sessions = gw.get_agent_sessions("ag").await;
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].id, "feishu:ag");
+        assert!(
+            sessions[0].id.starts_with("ag_"),
+            "session id: {}",
+            sessions[0].id
+        );
     }
     // V3: PerAccountChannelPeer — different tenants → different sessions
     {
@@ -186,8 +194,16 @@ async fn test_feishu_dm_scope_isolation_variants() {
         let a2 = m2.metadata.get("account_id").cloned();
         add_session(&sm, "feishu", &mut m1, a1.as_deref()).await;
         add_session(&sm, "feishu", &mut m2, a2.as_deref()).await;
-        assert!(m1.metadata["session_id"].starts_with("ta:"));
-        assert!(m2.metadata["session_id"].starts_with("tb:"));
+        assert!(
+            m1.metadata["session_id"].starts_with("ag_"),
+            "session_id: {}",
+            m1.metadata["session_id"]
+        );
+        assert!(
+            m2.metadata["session_id"].starts_with("ag_"),
+            "session_id: {}",
+            m2.metadata["session_id"]
+        );
         gw.route_message("feishu", m1, None).await.unwrap();
         gw.route_message("feishu", m2, None).await.unwrap();
         let sessions = gw.get_agent_sessions("ag").await;

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -251,9 +251,21 @@ mod tests {
             .await
             .unwrap();
         let session_id = result.metadata.get("session_id").unwrap();
-        assert!(session_id.contains("feishu"), "{}", session_id);
-        assert!(session_id.contains("ou_user_a"), "{}", session_id);
-        assert!(session_id.contains("oc_agent_b"), "{}", session_id);
+        // New format: {agent_id}_{timestamp_ms}_{8hex}
+        assert!(
+            session_id.starts_with("oc_agent_b_"),
+            "bad format: {}",
+            session_id
+        );
+        // Should end with _<8-hex-digits>
+        let parts: Vec<&str> = session_id.rsplitn(2, '_').collect();
+        assert_eq!(parts.len(), 2, "bad format: {}", session_id);
+        assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
+        assert!(
+            parts[0].chars().all(|c| c.is_ascii_hexdigit()),
+            "hex part non-hex: {}",
+            parts[0]
+        );
     }
 
     #[tokio::test]
@@ -326,10 +338,20 @@ mod tests {
             .await
             .unwrap();
         let session_id = result.metadata.get("session_id").unwrap();
+        // New format: {agent_id}_{timestamp_ms}_{8hex}
         assert!(
-            session_id.starts_with("tenant_abc:"),
-            "session_id should include tenant_key prefix: {}",
+            session_id.starts_with("oc_agent_b_"),
+            "session_id should start with agent_id: {}",
             session_id
+        );
+        // Should end with _<8-hex-digits>
+        let parts: Vec<&str> = session_id.rsplitn(2, '_').collect();
+        assert_eq!(parts.len(), 2, "bad format: {}", session_id);
+        assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
+        assert!(
+            parts[0].chars().all(|c| c.is_ascii_hexdigit()),
+            "hex part non-hex: {}",
+            parts[0]
         );
     }
 

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -51,6 +51,15 @@ pub struct SessionCheckpoint {
     /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为 None）。
     #[serde(default)]
     pub thread_id: Option<String>,
+    /// 消息发送者 ID（用于 session_key 重建）
+    ///
+    /// 存储原始消息的 `from` 字段，使得 `rebuild_key_registry` 在重启后
+    /// 能用 `compute_session_key(PerChannelPeer)` 的格式
+    /// `"{channel}:{from}:{to}"` 正确重建 key → session_id 映射。
+    ///
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为 None）。
+    #[serde(default)]
+    pub sender_id: Option<String>,
 }
 
 impl SessionCheckpoint {
@@ -76,6 +85,7 @@ impl SessionCheckpoint {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         }
     }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -140,6 +140,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         }
     }
 

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -147,6 +147,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         }
     }
 

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -112,6 +112,23 @@ impl SqliteStorage {
                 .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
         }
 
+        // Idempotent migration: only add sender_id column if it doesn't already exist.
+        let sender_id_exists: bool = {
+            let mut stmt = conn
+                .prepare("PRAGMA table_info(sessions)")
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+            let has_column = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?
+                .filter_map(|r| r.ok())
+                .any(|name| name == "sender_id");
+            has_column
+        };
+        if !sender_id_exists {
+            conn.execute("ALTER TABLE sessions ADD COLUMN sender_id TEXT", [])
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+        }
+
         Ok(())
     }
     /// Returns the data directory path
@@ -280,8 +297,9 @@ impl PersistenceService for SqliteStorage {
             conn.execute(
                 "INSERT OR REPLACE INTO sessions
                  (id, agent_id, role, channel, chat_id, status, title,
-                  last_message_at, created_at, archived_at, message_count, metadata, thread_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                  last_message_at, created_at, archived_at, message_count, metadata, thread_id,
+                  sender_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     checkpoint.session_id,
                     checkpoint.agent_id.as_deref().unwrap_or("unknown"),
@@ -302,6 +320,7 @@ impl PersistenceService for SqliteStorage {
                     checkpoint.message_count as i64,
                     metadata_json,
                     checkpoint.thread_id.as_deref(),
+                    checkpoint.sender_id.as_deref(),
                 ],
             )
             .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -175,7 +175,8 @@ pub fn load_checkpoint_inner(
     let mut stmt = conn
         .prepare(
             "SELECT agent_id, role, channel, chat_id, status, title,
-             last_message_at, created_at, archived_at, message_count, metadata, thread_id
+             last_message_at, created_at, archived_at, message_count, metadata, thread_id,
+             sender_id
              FROM sessions WHERE id = ?1",
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
@@ -194,6 +195,7 @@ pub fn load_checkpoint_inner(
             row.get::<_, i64>(9)?,
             row.get::<_, Option<String>>(10)?,
             row.get::<_, Option<String>>(11)?,
+            row.get::<_, Option<String>>(12)?,
         ))
     }) {
         Ok(r) => r,
@@ -214,6 +216,7 @@ pub fn load_checkpoint_inner(
         msg_count,
         metadata,
         thread_id,
+        sender_id,
     ) = row;
 
     let status = match status_db.as_str() {
@@ -307,6 +310,7 @@ pub fn load_checkpoint_inner(
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
         system_appends,
         thread_id,
+        sender_id,
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -29,6 +29,7 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         reasoning_level: ReasoningLevel::default(),
         system_appends: Vec::new(),
         thread_id: None,
+        sender_id: None,
     }
 }
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -31,6 +31,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         }
     }
 
@@ -387,6 +388,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -425,6 +427,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -463,6 +466,7 @@ mod tests {
             reasoning_level: ReasoningLevel::default(),
             system_appends: Vec::new(),
             thread_id: None,
+            sender_id: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 


### PR DESCRIPTION
实现 SessionManager 的 key_registry 映射表和 resolve 统一入口，解决设计文档要求的 session_key → session_id 映射缺失问题。

## 变更内容

- 新增 `key_registry: RwLock<HashMap<String, String>>` 映射表
- 实现 `resolve(session_key)` 方法，支持三条路径：active hit / archived hit+restore / miss→create
- 实现 `rebuild_key_registry()` 启动时从持久化 checkpoint 重建映射
- `SessionCheckpoint` 新增 `sender_id` 字段，确保重启后 key 重建正确
- session_id 格式统一为 `{agent_id}_{timestamp_ms}_{8hex}`
- `find_or_create` 委托 `resolve`
- `force_new_for_channel` 使用新格式并同步写入 key_registry

Source: issue #934
Type: feat
