### PR TITLE
chore: VolcEngine Provider 直接 impl Provider trait

### DIFF
--- a/src/llm/volcengine.rs
+++ b/src/llm/volcengine.rs
@@ -3,27 +3,23 @@
 //! Uses the Volcano Ark (方舟) API. Chat endpoint is OpenAI-compatible at
 //! `base_url/chat/completions`. Model list is fetched from `base_url/models`.
 
-#![allow(deprecated)]
-
 use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::header::HeaderMap;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use std::sync::OnceLock;
 use std::time::Duration;
+use tokio::sync::mpsc;
 
-use crate::llm::{ChatRequest, ChatResponse, LLMError, LLMProvider, ModelInfo, ModelLister, Usage};
+use crate::llm::provider::{Provider, ProviderError, SseStream};
+use crate::llm::types::{
+    InternalRequest, InternalResponse, ProtocolId, RawContentBlock, RawSseChunk, RawUsage,
+};
+use crate::llm::{LLMError, ModelInfo, ModelLister};
 
 /// VolcEngine API endpoint
-const VOLCENGINE_API_URL: &str = "https://ARK.cn-beijing.volces.com/api/v3/chat/completions";
-
-/// VolcEngine chat request body (OpenAI-compatible)
-#[derive(Debug, Serialize)]
-struct VolcEngineRequest<'a> {
-    model: &'a str,
-    messages: &'a [crate::llm::Message],
-    temperature: f32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
-}
+const VOLCENGINE_API_URL: &str = "https://ARK.cn-beijing.volces.com/api/v3";
 
 /// VolcEngine chat response body (OpenAI-compatible)
 #[allow(dead_code)]
@@ -38,7 +34,6 @@ struct VolcEngineResponse {
     error: Option<VolcEngineErrorBody>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct VolcEngineChoice {
     message: VolcEngineMessage,
@@ -46,9 +41,9 @@ struct VolcEngineChoice {
     finish_reason: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct VolcEngineMessage {
+    #[allow(dead_code)]
     role: String,
     content: String,
 }
@@ -119,6 +114,7 @@ pub struct VolcEngineProvider {
     api_key: String,
     base_url: String,
     http_client: Client,
+    supported_protocols: Vec<ProtocolId>,
 }
 
 impl VolcEngineProvider {
@@ -135,6 +131,7 @@ impl VolcEngineProvider {
             api_key,
             base_url,
             http_client,
+            supported_protocols: vec![ProtocolId::new("openai")],
         }
     }
 
@@ -147,184 +144,186 @@ impl VolcEngineProvider {
             _ => LLMError::ApiError(format!("unexpected status {}: {}", status, body)),
         }
     }
-
-    /// Extract visible content from a VolcEngine message.
-    /// VolcEngine does not use reasoning_content; we simply trim whitespace.
-    fn extract_content(msg: &VolcEngineMessage) -> String {
-        msg.content.trim().to_string()
-    }
-
-    fn models_static() -> Vec<&'static str> {
-        // Models hardcoded for the `models()` method (non-discovery path)
-        vec![
-            "doubao-1.5-pro",
-            "doubao-1.5-lite",
-            "doubao-1.5-pro-32k",
-            "doubao-1.5-lite-32k",
-        ]
-    }
 }
 
+// ── Provider trait implementation ─────────────────────────────────────────────
+
 #[async_trait]
-impl LLMProvider for VolcEngineProvider {
-    fn name(&self) -> &str {
+impl Provider for VolcEngineProvider {
+    fn id(&self) -> &str {
         "volcengine"
     }
 
-    fn models(&self) -> Vec<&str> {
-        Self::models_static()
+    fn base_url(&self) -> &str {
+        &self.base_url
     }
 
-    async fn chat(&self, request: ChatRequest) -> Result<ChatResponse, LLMError> {
-        let req_body = VolcEngineRequest {
-            model: &request.model,
-            messages: &request.messages,
-            temperature: request.temperature,
-            max_tokens: request.max_tokens,
-        };
+    fn api_key(&self) -> &str {
+        &self.api_key
+    }
 
-        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+    fn supported_protocols(&self) -> &[ProtocolId] {
+        &self.supported_protocols
+    }
+
+    fn http_client(&self) -> &Client {
+        &self.http_client
+    }
+
+    fn default_headers(&self) -> &HeaderMap {
+        static EMPTY: OnceLock<HeaderMap> = OnceLock::new();
+        EMPTY.get_or_init(HeaderMap::new)
+    }
+
+    async fn send(
+        &self,
+        _request: InternalRequest,
+        body: serde_json::Value,
+    ) -> crate::llm::provider::Result<InternalResponse> {
+        let url = format!("{}/chat/completions", self.base_url);
+
         let response = self
             .http_client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
-            .json(&req_body)
+            .json(&body)
             .send()
-            .await
-            .map_err(|e| LLMError::NetworkError(e.to_string()))?;
+            .await?;
 
-        let status = response.status();
-
-        if !status.is_success() {
+        if !response.status().is_success() {
+            let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(Self::map_http_error(status, &body));
+            return Err(ProviderError::Legacy(format!(
+                "VolcEngine API error {}: {}",
+                status, body
+            )));
         }
 
-        let api_resp: VolcEngineResponse = response.json().await.map_err(|e| {
-            LLMError::ApiError(format!("failed to parse VolcEngine response: {}", e))
-        })?;
+        let vol_resp: VolcEngineResponse = response.json().await.map_err(ProviderError::Reqwest)?;
 
         // Check for business-level error in response body
-        if let Some(ref err) = api_resp.error {
+        if let Some(ref err) = vol_resp.error {
             let code = err.code.as_deref().unwrap_or("");
             let msg = err.message.as_deref().unwrap_or("unknown error");
-            return Err(match code {
-                "1001" | "1002" => LLMError::AuthFailed(msg.to_string()),
-                "1103" => LLMError::ModelNotFound(msg.to_string()),
-                "1111" | "1112" => LLMError::InvalidRequest(msg.to_string()),
-                "2001" => LLMError::RateLimitExceeded,
-                _ => LLMError::ApiError(format!("VolcEngine API error {}: {}", code, msg)),
-            });
+            return Err(ProviderError::Legacy(format!(
+                "VolcEngine API error {}: {}",
+                code, msg
+            )));
         }
 
-        let msg = api_resp
-            .choices
-            .first()
-            .map(|c| &c.message)
-            .ok_or_else(|| LLMError::ApiError("no choices in VolcEngine response".to_string()))?;
+        let choice = vol_resp.choices.into_iter().next().ok_or_else(|| {
+            ProviderError::Legacy("no choices in VolcEngine response".to_string())
+        })?;
 
-        let content = Self::extract_content(msg);
-        let usage = api_resp.usage.as_ref();
+        let mut content_blocks = Vec::new();
 
-        Ok(ChatResponse {
-            content,
-            model: api_resp.model,
-            usage: Usage {
-                prompt_tokens: usage.and_then(|u| u.prompt_tokens).unwrap_or(0),
-                completion_tokens: usage.and_then(|u| u.completion_tokens).unwrap_or(0),
-                total_tokens: usage.and_then(|u| u.total_tokens).unwrap_or(0),
+        // content → Text block
+        if !choice.message.content.is_empty() {
+            content_blocks.push(RawContentBlock::Text(choice.message.content));
+        }
+
+        // Ensure at least one content block (fallback to empty text)
+        if content_blocks.is_empty() {
+            content_blocks.push(RawContentBlock::Text(String::new()));
+        }
+
+        let usage = vol_resp.usage.unwrap_or_default();
+
+        Ok(InternalResponse {
+            content_blocks,
+            usage: RawUsage {
+                prompt_tokens: usage.prompt_tokens.unwrap_or(0),
+                completion_tokens: usage.completion_tokens.unwrap_or(0),
+                total_tokens: usage.total_tokens,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
             },
+            finish_reason: choice.finish_reason,
         })
     }
 
-    async fn chat_streaming(
+    async fn send_streaming(
         &self,
-        request: ChatRequest,
-    ) -> Result<crate::llm::StreamingResponse, LLMError> {
-        // Default implementation: call chat() and wrap as single-chunk stream.
-        let (tx, rx) = tokio::sync::mpsc::channel(32);
-        let response = self.chat(request).await?;
-        let _ = tx
-            .send(crate::llm::ChatStreamChunk::Text(response.content))
-            .await;
-        let _ = tx
-            .send(crate::llm::ChatStreamChunk::Done {
-                model: response.model,
-                usage: response.usage,
-            })
-            .await;
-        Ok(rx)
-    }
+        _request: InternalRequest,
+        body: serde_json::Value,
+    ) -> crate::llm::provider::Result<SseStream> {
+        let url = format!("{}/chat/completions", self.base_url);
 
-    fn provider_display_name(&self) -> &str {
-        "VolcEngine"
-    }
-
-    async fn fetch_model_list(&self, bearer_token: &str) -> Result<Vec<ModelInfo>, LLMError> {
-        let url = format!("{}/models", self.base_url.trim_end_matches('/'));
         let response = self
             .http_client
-            .get(&url)
-            .header("Authorization", format!("Bearer {}", bearer_token))
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
             .send()
-            .await
-            .map_err(|e| LLMError::NetworkError(e.to_string()))?;
+            .await?;
 
-        let status = response.status();
-        if !status.is_success() {
+        if !response.status().is_success() {
+            let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(Self::map_http_error(status, &body));
+            return Err(ProviderError::Legacy(format!(
+                "VolcEngine API error {}: {}",
+                status, body
+            )));
         }
 
-        let api_resp: VolcEngineModelsResponse = response.json().await.map_err(|e| {
-            LLMError::ApiError(format!(
-                "failed to parse VolcEngine /models response: {}",
-                e
-            ))
-        })?;
+        let (tx, rx) = mpsc::channel(64);
 
-        let models: Vec<ModelInfo> = api_resp
-            .data
-            .into_iter()
-            // Filter: domain must be "LLM"; status must NOT be Shutdown or Retiring
-            .filter(|m| {
-                m.domain.eq_ignore_ascii_case("LLM")
-                    && !m.status.eq_ignore_ascii_case("Shutdown")
-                    && !m.status.eq_ignore_ascii_case("Retiring")
-            })
-            .map(|m| {
-                let model_id = m.model_id.clone();
-                let props = &m.properties;
-                let input_types: Vec<crate::llm::InputType> = props
-                    .input_modalities
-                    .iter()
-                    .filter_map(|m| match m.to_lowercase().as_str() {
-                        "image" => Some(crate::llm::InputType::Image),
-                        _ => Some(crate::llm::InputType::Text),
-                    })
-                    .collect();
-                let input_types = if input_types.is_empty() {
-                    vec![crate::llm::InputType::Text]
-                } else {
-                    input_types
+        tokio::spawn(async move {
+            let mut stream = response.bytes_stream();
+            let mut buffer = String::new();
+
+            while let Some(chunk_result) = stream.next().await {
+                let chunk = match chunk_result {
+                    Ok(c) => c,
+                    Err(_) => break,
                 };
 
-                ModelInfo {
-                    id: model_id.clone(),
-                    name: m.model_name.unwrap_or_else(|| model_id.clone()),
-                    context_window: props.context_window.unwrap_or(32_768),
-                    max_tokens: props.max_tokens.unwrap_or(4_096),
-                    default_temperature: props.temperature,
-                    // VolcEngine does not expose a reasoning flag directly;
-                    // we conservatively set reasoning=false here.
-                    reasoning: false,
-                    input_types,
-                }
-            })
-            .collect();
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-        Ok(models)
+                // Process complete SSE events (separated by \n\n)
+                while let Some(pos) = buffer.find("\n\n") {
+                    let event_block = buffer[..pos].to_string();
+                    buffer = buffer[pos + 2..].to_string();
+
+                    for line in event_block.lines() {
+                        if let Some(data) = line.strip_prefix("data: ") {
+                            let data = data.trim().to_string();
+                            if data == "[DONE]" {
+                                return;
+                            }
+                            let _ = tx
+                                .send(RawSseChunk {
+                                    event_type: "message".into(),
+                                    data,
+                                })
+                                .await;
+                        }
+                    }
+                }
+            }
+
+            // Process any remaining data in buffer
+            if !buffer.is_empty() {
+                for line in buffer.lines() {
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        let data = data.trim().to_string();
+                        if data == "[DONE]" {
+                            return;
+                        }
+                        let _ = tx
+                            .send(RawSseChunk {
+                                event_type: "message".into(),
+                                data,
+                            })
+                            .await;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
     }
 }
 
@@ -398,5 +397,5 @@ impl ModelLister for VolcEngineProvider {
 }
 
 #[cfg(test)]
-#[path = "tests.rs"]
+#[path = "volcengine/tests.rs"]
 mod tests;

--- a/src/llm/volcengine/tests.rs
+++ b/src/llm/volcengine/tests.rs
@@ -1,7 +1,10 @@
-//! Unit tests for the VolcEngine provider.
+//! Unit tests for the VolcEngine Provider implementation.
 
 use super::*;
-use mockito::Server;
+use crate::llm::provider::Provider;
+use crate::llm::types::{InternalMessage, InternalRequest, RawContentBlock};
+use crate::session::persistence::ReasoningLevel;
+use serde_json::json;
 
 // -------------------------------------------------------------------------
 // Helper utilities
@@ -11,33 +14,61 @@ fn provider_url(server: &mockito::Server) -> String {
     server.url()
 }
 
-fn chat_request(model: &str) -> ChatRequest {
-    ChatRequest {
+fn make_request(model: &str) -> InternalRequest {
+    InternalRequest {
         model: model.to_string(),
-        messages: vec![crate::llm::Message {
-            role: "user".to_string(),
-            content: "Say hi".to_string(),
+        messages: vec![InternalMessage {
+            role: "user".into(),
+            content: "Say hi".into(),
         }],
         temperature: 0.0,
         max_tokens: None,
+        stream: false,
+        extra_body: serde_json::Map::new(),
+        system_static: None,
+        system_dynamic: None,
+        system_blocks: None,
+        session_id: None,
+        reasoning_level: ReasoningLevel::default(),
     }
 }
 
 // -------------------------------------------------------------------------
-// Chat integration tests via mockito
+// Provider accessor tests
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_provider_accessors() {
+    let provider = VolcEngineProvider::new("fake-key".into());
+    assert_eq!(provider.id(), "volcengine");
+    assert_eq!(provider.base_url(), VOLCENGINE_API_URL);
+    assert_eq!(provider.api_key(), "fake-key");
+    let protocols = provider.supported_protocols();
+    assert_eq!(protocols.len(), 1);
+    assert_eq!(protocols[0].as_str(), "openai");
+    let _ = provider.http_client();
+    assert!(provider.default_headers().is_empty());
+
+    // Test custom base URL with a separate instance
+    let custom =
+        VolcEngineProvider::with_base_url("sk-test".into(), "https://custom.api.com".into());
+    assert_eq!(custom.base_url(), "https://custom.api.com");
+}
+
+// -------------------------------------------------------------------------
+// send() success tests
 // -------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_chat_success_mock() {
+async fn test_send_success() {
     let mut server = mockito::Server::new_async().await;
-    let fixture = include_str!("../../tests/fixtures/llm/volcengine/chat-success.json");
+    let fixture = include_str!("../../../tests/fixtures/llm/volcengine/chat-success.json");
     let m = server
         .mock("POST", "/chat/completions")
-        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-            "model": "doubao-1.5-pro",
-            "messages": [{"role": "user", "content": "Say hi"}],
-            "temperature": 0.0
-        })))
+        .match_header(
+            "authorization",
+            mockito::Matcher::Regex(r"Bearer fake-key".into()),
+        )
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -45,24 +76,37 @@ async fn test_chat_success_mock() {
         .await;
 
     let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
-    let resp = provider.chat(chat_request("doubao-1.5-pro")).await.unwrap();
+    let req = make_request("doubao-1.5-pro");
+    let body = json!({
+        "model": "doubao-1.5-pro",
+        "messages": [{"role": "user", "content": "Say hi"}],
+        "temperature": 0.0
+    });
+
+    let resp = provider.send(req, body).await.unwrap();
 
     m.assert_async().await;
-    assert!(!resp.content.is_empty(), "content should be non-empty");
+    assert_eq!(resp.content_blocks.len(), 1);
     assert_eq!(
-        resp.usage.prompt_tokens > 0,
-        true,
-        "prompt_tokens should be > 0"
+        resp.content_blocks[0],
+        RawContentBlock::Text("Hello! I'm doing well, thank you for asking.".into())
     );
+    assert_eq!(resp.usage.prompt_tokens, 12);
+    assert_eq!(resp.usage.completion_tokens, 9);
+    assert_eq!(resp.usage.total_tokens, Some(21));
+    assert_eq!(resp.finish_reason.as_deref(), Some("stop"));
 }
 
+// -------------------------------------------------------------------------
+// send() error tests (HTTP status code mapping)
+// -------------------------------------------------------------------------
+
 #[tokio::test]
-async fn test_chat_auth_failure_mock() {
+async fn test_send_auth_failure() {
     let mut server = mockito::Server::new_async().await;
-    let fixture = include_str!("../../tests/fixtures/llm/volcengine/error-auth.json");
+    let fixture = include_str!("../../../tests/fixtures/llm/volcengine/error-auth.json");
     let m = server
         .mock("POST", "/chat/completions")
-        .match_body(mockito::Matcher::Any)
         .with_status(401)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -70,22 +114,30 @@ async fn test_chat_auth_failure_mock() {
         .await;
 
     let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
-    let err = provider
-        .chat(chat_request("doubao-1.5-pro"))
-        .await
-        .unwrap_err();
+    let req = make_request("doubao-1.5-pro");
+    let body = json!({"model": "doubao-1.5-pro", "messages": []});
+
+    let err = provider.send(req, body).await.unwrap_err();
 
     m.assert_async().await;
-    matches!(err, LLMError::AuthFailed(_));
+    match err {
+        crate::llm::provider::ProviderError::Legacy(msg) => {
+            assert!(
+                msg.contains("401"),
+                "expected 401 in error message, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected Legacy error for 401, got: {:?}", other),
+    }
 }
 
 #[tokio::test]
-async fn test_chat_model_not_found_mock() {
+async fn test_send_model_not_found() {
     let mut server = mockito::Server::new_async().await;
-    let fixture = include_str!("../../tests/fixtures/llm/volcengine/error-not-found.json");
+    let fixture = include_str!("../../../tests/fixtures/llm/volcengine/error-not-found.json");
     let m = server
         .mock("POST", "/chat/completions")
-        .match_body(mockito::Matcher::Any)
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -93,21 +145,29 @@ async fn test_chat_model_not_found_mock() {
         .await;
 
     let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
-    let err = provider
-        .chat(chat_request("unknown-model"))
-        .await
-        .unwrap_err();
+    let req = make_request("unknown-model");
+    let body = json!({"model": "unknown-model", "messages": []});
+
+    let err = provider.send(req, body).await.unwrap_err();
 
     m.assert_async().await;
-    matches!(err, LLMError::ModelNotFound(_));
+    match err {
+        crate::llm::provider::ProviderError::Legacy(msg) => {
+            assert!(
+                msg.contains("404"),
+                "expected 404 in error message, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected Legacy error for 404, got: {:?}", other),
+    }
 }
 
 #[tokio::test]
-async fn test_chat_rate_limit_mock() {
+async fn test_send_rate_limit() {
     let mut server = mockito::Server::new_async().await;
     let m = server
         .mock("POST", "/chat/completions")
-        .match_body(mockito::Matcher::Any)
         .with_status(429)
         .with_header("content-type", "application/json")
         .with_body("{\"error\":{\"code\":\"2001\",\"message\":\"rate limit exceeded\"}}")
@@ -115,22 +175,30 @@ async fn test_chat_rate_limit_mock() {
         .await;
 
     let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
-    let err = provider
-        .chat(chat_request("doubao-1.5-pro"))
-        .await
-        .unwrap_err();
+    let req = make_request("doubao-1.5-pro");
+    let body = json!({"model": "doubao-1.5-pro", "messages": []});
+
+    let err = provider.send(req, body).await.unwrap_err();
 
     m.assert_async().await;
-    matches!(err, LLMError::RateLimitExceeded);
+    match err {
+        crate::llm::provider::ProviderError::Legacy(msg) => {
+            assert!(
+                msg.contains("429"),
+                "expected 429 in error message, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected Legacy error for 429, got: {:?}", other),
+    }
 }
 
 #[tokio::test]
-async fn test_chat_business_error_mock() {
+async fn test_send_business_error() {
     let mut server = mockito::Server::new_async().await;
-    let fixture = include_str!("../../tests/fixtures/llm/volcengine/error-business.json");
+    let fixture = include_str!("../../../tests/fixtures/llm/volcengine/error-business.json");
     let m = server
         .mock("POST", "/chat/completions")
-        .match_body(mockito::Matcher::Any)
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(fixture)
@@ -138,24 +206,137 @@ async fn test_chat_business_error_mock() {
         .await;
 
     let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
-    let err = provider
-        .chat(chat_request("doubao-1.5-pro"))
-        .await
-        .unwrap_err();
+    let req = make_request("doubao-1.5-pro");
+    let body = json!({"model": "doubao-1.5-pro", "messages": []});
+
+    let err = provider.send(req, body).await.unwrap_err();
 
     m.assert_async().await;
-    // Business error with code="1103" should map to ModelNotFound
-    matches!(err, LLMError::ModelNotFound(_));
+    // Business error with code="1103" should produce a Legacy error
+    match err {
+        crate::llm::provider::ProviderError::Legacy(msg) => {
+            assert!(
+                msg.contains("1103"),
+                "expected business error code 1103, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected Legacy error for business error, got: {:?}", other),
+    }
 }
 
 // -------------------------------------------------------------------------
-// fetch_model_list tests
+// send_streaming() tests
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_send_streaming_success() {
+    let mut server = mockito::Server::new_async().await;
+
+    // Build SSE response body with multiple chunks and [DONE]
+    let sse_body = "\
+data: {\"id\":\"volc-sse-001\",\"object\":\"chat.completion.chunk\",\"model\":\"doubao-1.5-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}
+
+data: {\"id\":\"volc-sse-001\",\"object\":\"chat.completion.chunk\",\"model\":\"doubao-1.5-pro\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":null}]}
+
+data: {\"id\":\"volc-sse-001\",\"object\":\"chat.completion.chunk\",\"model\":\"doubao-1.5-pro\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}
+
+data: [DONE]
+
+";
+
+    let m = server
+        .mock("POST", "/chat/completions")
+        .match_header(
+            "authorization",
+            mockito::Matcher::Regex(r"Bearer fake-key".into()),
+        )
+        .with_status(200)
+        .with_header("content-type", "text/event-stream")
+        .with_body(sse_body)
+        .create_async()
+        .await;
+
+    let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
+    let mut req = make_request("doubao-1.5-pro");
+    req.stream = true;
+    let body = json!({
+        "model": "doubao-1.5-pro",
+        "messages": [{"role": "user", "content": "Say hi"}],
+        "stream": true
+    });
+
+    let mut rx = provider
+        .send_streaming(req, body)
+        .await
+        .expect("send_streaming should succeed");
+
+    m.assert_async().await;
+
+    let mut chunks = Vec::new();
+    while let Some(chunk) = rx.recv().await {
+        chunks.push(chunk);
+    }
+
+    // Should receive 3 chunks (the [DONE] frame does not produce a chunk)
+    assert_eq!(
+        chunks.len(),
+        3,
+        "expected 3 SSE chunks, got {}",
+        chunks.len()
+    );
+
+    // Each chunk should be a RawSseChunk with event_type "message"
+    assert!(chunks[0].data.contains("Hello"));
+    assert_eq!(chunks[0].event_type, "message");
+
+    assert!(chunks[1].data.contains(" world"));
+    assert_eq!(chunks[1].event_type, "message");
+
+    assert!(chunks[2].data.contains("finish_reason"));
+    assert_eq!(chunks[2].event_type, "message");
+}
+
+#[tokio::test]
+async fn test_send_streaming_error_401() {
+    let mut server = mockito::Server::new_async().await;
+
+    let m = server
+        .mock("POST", "/chat/completions")
+        .with_status(401)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":{"code":"invalid_api_key","message":"Invalid"}}"#)
+        .create_async()
+        .await;
+
+    let provider = VolcEngineProvider::with_base_url("fake-key".into(), provider_url(&server));
+    let mut req = make_request("doubao-1.5-pro");
+    req.stream = true;
+    let body = json!({"model": "doubao-1.5-pro", "messages": [], "stream": true});
+
+    let err = provider.send_streaming(req, body).await.unwrap_err();
+
+    m.assert_async().await;
+    match err {
+        crate::llm::provider::ProviderError::Legacy(msg) => {
+            assert!(
+                msg.contains("401"),
+                "expected 401 in error message, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected Legacy error for 401, got: {:?}", other),
+    }
+}
+
+// -------------------------------------------------------------------------
+// fetch_model_list tests (ModelLister interface unchanged)
 // -------------------------------------------------------------------------
 
 #[tokio::test]
 async fn test_fetch_model_list_success_mock() {
     let mut server = mockito::Server::new_async().await;
-    let fixture = include_str!("../../tests/fixtures/llm/volcengine/models-list.json");
+    let fixture = include_str!("../../../tests/fixtures/llm/volcengine/models-list.json");
 
     let m = server
         .mock("GET", "/models")
@@ -203,37 +384,4 @@ async fn test_fetch_model_list_http_error_mock() {
 
     m.assert_async().await;
     matches!(err, LLMError::AuthFailed(_));
-}
-
-// -------------------------------------------------------------------------
-// Unit tests
-// -------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_extract_content() {
-    let msg = VolcEngineMessage {
-        role: "assistant".to_string(),
-        content: "  Hello, world!  ".to_string(),
-    };
-    assert_eq!(VolcEngineProvider::extract_content(&msg), "Hello, world!");
-}
-
-#[tokio::test]
-async fn test_provider_display_name() {
-    let provider = VolcEngineProvider::new("fake-key".into());
-    assert_eq!(provider.provider_display_name(), "VolcEngine");
-}
-
-#[tokio::test]
-async fn test_name() {
-    let provider = VolcEngineProvider::new("fake-key".into());
-    assert_eq!(provider.name(), "volcengine");
-}
-
-#[tokio::test]
-async fn test_models() {
-    let provider = VolcEngineProvider::new("fake-key".into());
-    let models = provider.models();
-    assert!(!models.is_empty());
-    assert!(models.contains(&"doubao-1.5-pro"));
 }

--- a/tests/fixtures/llm/volcengine/error-business.json
+++ b/tests/fixtures/llm/volcengine/error-business.json
@@ -1,4 +1,7 @@
 {
+  "id": "chatcmpl-volc-biz-err-001",
+  "model": "doubao-1.5-pro",
+  "choices": [],
   "error": {
     "code": "1103",
     "message": "Model not found: unknown-model"


### PR DESCRIPTION
## 概述

将 VolcEngineProvider 从已废弃的 LLMProvider trait 迁移到 Provider trait，与 OpenAI/Anthropic/DeepSeek 模式保持一致。

### 变更内容
- 实现 Provider trait 全部方法（id, base_url, api_key, supported_protocols, http_client, default_headers, send, send_streaming）
- 修正 VOLCENGINE_API_URL 为根路径 `https://ARK.cn-beijing.volces.com/api/v3`（修复 chat() 中 URL 重复拼接问题）
- 实现真实 SSE 流式支持（替代原有 chat() + wrap 的 shim 实现）
- 移除旧 LLMProvider impl 和 #![allow(deprecated)]
- 清理不必要的 #[allow(dead_code)] 标注
- 更新测试：10 个测试覆盖 send/send_streaming/Provider accessor/ModelLister

Source: issue #941
Type: chore
