### PR TITLE
feat: add RawLogProcessor to inbound processor chain

### DIFF
--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -29,6 +29,7 @@ fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -160,6 +160,7 @@ impl Daemon {
             rate_limit_per_minute: 60,
             max_message_size: 16_384,
             dm_scope: DmScope::default(),
+            ..Default::default()
         };
         let session_manager = Arc::new(SessionManager::new(
             &gateway_config,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -102,6 +102,23 @@ pub struct GatewayConfig {
     pub max_message_size: usize,
     #[serde(default)]
     pub dm_scope: DmScope,
+    /// Directory for raw inbound log files.
+    /// When `None` (default), raw logging is disabled.
+    #[serde(default)]
+    pub raw_log_dir: Option<std::path::PathBuf>,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            rate_limit_per_minute: 0,
+            max_message_size: 0,
+            dm_scope: DmScope::default(),
+            raw_log_dir: None,
+        }
+    }
 }
 
 /// Session - represents an active conversation

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -304,6 +304,7 @@ async fn test_handle_message_backward_compat() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,

--- a/src/gateway/session_handler_tests.rs
+++ b/src/gateway/session_handler_tests.rs
@@ -164,6 +164,7 @@ async fn test_idle_message_returns_llm_started() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -185,6 +186,7 @@ async fn test_busy_message_returns_queued() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -220,6 +222,7 @@ async fn test_no_pending_no_recursion() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -249,6 +252,7 @@ async fn test_llm_failure_resets_busy() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -287,6 +291,7 @@ async fn test_pending_consumed_after_llm_done() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -324,6 +329,7 @@ async fn test_multiple_pending_fifo_order() {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,

--- a/src/gateway/session_manager/bug904_tests.rs
+++ b/src/gateway/session_manager/bug904_tests.rs
@@ -90,6 +90,7 @@ pub(super) fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 65536,
         dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
     }
 }
 

--- a/src/gateway/session_manager/flush_tests.rs
+++ b/src/gateway/session_manager/flush_tests.rs
@@ -14,6 +14,7 @@ pub(super) fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 65536,
         dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
     }
 }
 

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -20,6 +20,7 @@ pub(crate) fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 65536,
         dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -85,6 +85,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests_archive.rs
+++ b/src/gateway/tests_archive.rs
@@ -228,6 +228,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 10000,
         dm_scope: crate::gateway::DmScope::PerChannelPeer,
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests_checkpoint.rs
+++ b/src/gateway/tests_checkpoint.rs
@@ -172,13 +172,13 @@ impl PersistenceService for MockPersistence {
 }
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
-
 fn make_config() -> GatewayConfig {
     GatewayConfig {
         name: "test".to_string(),
         rate_limit_per_minute: 100,
         max_message_size: 10000,
         dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
     }
 }
 
@@ -211,7 +211,6 @@ async fn add_session(msg: &mut Message, sm: &SessionManager) {
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
-
 /// Test: `with_checkpoint_manager` stores the CheckpointManager.
 #[tokio::test]
 async fn test_with_checkpoint_manager_stores_cm() {
@@ -384,7 +383,9 @@ async fn test_send_failure_does_not_trigger_checkpoint() {
     add_session(&mut msg, &sm).await;
     let session_id = msg.metadata["session_id"].clone();
 
-    let result = gw.send_outbound("test_channel", &session_id, "hello", vec![]).await;
+    let result = gw
+        .send_outbound("test_channel", &session_id, "hello", vec![])
+        .await;
     assert!(result.is_err(), "send should fail");
 
     // Verify: no checkpoint was saved
@@ -413,7 +414,6 @@ async fn test_send_outbound_interactive_triggers_checkpoint() {
     ));
     let persistence = Arc::new(MockPersistence::default());
     let gw = make_gw_with_cm(config.clone(), Arc::clone(&sm), persistence.clone());
-
     let adapter = Arc::new(MockAdapter::new());
     gw.register_adapter(
         "test_channel".into(),

--- a/src/gateway/tests_dmscope.rs
+++ b/src/gateway/tests_dmscope.rs
@@ -73,6 +73,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests_plugin.rs
+++ b/src/gateway/tests_plugin.rs
@@ -73,6 +73,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: crate::gateway::DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -66,6 +66,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -139,6 +139,7 @@ fn make_gateway() -> Arc<Gateway> {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: Default::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &config,

--- a/src/gateway/tests_thread.rs
+++ b/src/gateway/tests_thread.rs
@@ -21,6 +21,7 @@ fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 65536,
         dm_scope: super::DmScope::PerAccountChannelPeer,
+        ..Default::default()
     }
 }
 

--- a/src/im/processor/mod.rs
+++ b/src/im/processor/mod.rs
@@ -7,6 +7,7 @@
 //! - `session_router.rs` — `SessionRouter` (inbound, priority 20) + session routing
 
 mod cleaner;
+mod raw_log_processor;
 mod session_router;
 
 use async_trait::async_trait;
@@ -16,6 +17,7 @@ use std::sync::Arc;
 
 use crate::gateway::SessionManager;
 pub use cleaner::FeishuMessageCleaner;
+pub use raw_log_processor::{RawLogConfig, RawLogProcessor};
 use serde_json::Value;
 pub use session_router::SessionRouter;
 
@@ -121,8 +123,23 @@ impl ProcessorRegistry {
     /// - [`SessionRouter`] (inbound, priority 20) — resolves session IDs
     /// - [`FeishuMessageCleaner`] (inbound, priority 30)
     /// - [`FeishuMessageCleaner`] (inbound, priority 30)
-    pub fn new(session_manager: Arc<SessionManager>) -> Self {
+    pub fn new(session_manager: Arc<SessionManager>, raw_log_config: Option<RawLogConfig>) -> Self {
         let mut registry = Self::default();
+        match raw_log_config {
+            Some(config) => {
+                let p = RawLogProcessor::new(config).expect("RawLogProcessor init failed");
+                registry.register(p);
+            }
+            None => {
+                let config = RawLogConfig {
+                    enabled: false,
+                    dir: std::path::PathBuf::new(),
+                    retention_days: 7,
+                };
+                let p = RawLogProcessor::new(config).expect("RawLogProcessor init failed");
+                registry.register(p);
+            }
+        }
         registry.register(SessionRouter::new(session_manager));
         registry.register(FeishuMessageCleaner);
         registry
@@ -146,6 +163,8 @@ impl ProcessorRegistry {
     /// result is returned.
     pub async fn process_inbound(&self, msg: &Value) -> Result<ProcessedMessage, ProcessError> {
         let mut ctx = MessageContext::default();
+        ctx.metadata
+            .insert("_raw_webhook".to_string(), msg.to_string());
         let mut current: Value = msg.clone();
 
         let mut inbound_iter = self.inbound.values();
@@ -242,6 +261,7 @@ mod tests {
                 rate_limit_per_minute: 100,
                 max_message_size: 65536,
                 dm_scope: crate::gateway::DmScope::PerChannelPeer,
+                ..Default::default()
             },
             None,
             None,
@@ -338,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn test_registry_default_has_all_processors() {
         let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
+        let registry = ProcessorRegistry::new(mgr, None);
         // FeishuMessageCleaner (inbound, prio 30)
         assert!(!registry.inbound.is_empty());
     }
@@ -395,7 +415,7 @@ mod tests {
     #[tokio::test]
     async fn test_inbound_chain_simple_text() {
         let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
+        let registry = ProcessorRegistry::new(mgr, None);
         let raw =
             load_raw_fixture("im-message-receive_v1-no-event-id-2026-04-26T18-53-09-967Z.json");
         let expected = load_expected_fixture("expected/01_text_simple.json");
@@ -407,7 +427,7 @@ mod tests {
     #[tokio::test]
     async fn test_inbound_chain_post_lists() {
         let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr);
+        let registry = ProcessorRegistry::new(mgr, None);
         let raw =
             load_raw_fixture("im-message-receive_v1-no-event-id-2026-04-27T02-58-21-195Z.json");
         let expected = load_expected_fixture("expected/03_post_lists.json");

--- a/src/im/processor/raw_log_processor.rs
+++ b/src/im/processor/raw_log_processor.rs
@@ -1,0 +1,433 @@
+//! RawLogProcessor — inbound processor that writes raw webhook JSON to files.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tracing::{debug, error, level_enabled};
+
+use super::{MessageContext, MessageProcessor, ProcessError, ProcessPhase, ProcessedMessage};
+
+/// Configuration for [`RawLogProcessor`].
+#[derive(Debug, Clone)]
+pub struct RawLogConfig {
+    /// Whether to write log files regardless of log level.
+    pub enabled: bool,
+    /// Directory to write log files into.
+    pub dir: PathBuf,
+    /// Number of days to retain log files.
+    pub retention_days: u32,
+}
+
+/// Processor that writes raw webhook JSON to a file for auditing.
+#[derive(Debug)]
+pub struct RawLogProcessor {
+    config: RawLogConfig,
+}
+
+impl RawLogProcessor {
+    /// Creates a new processor, cleaning up expired logs on startup.
+    pub fn new(config: RawLogConfig) -> std::io::Result<Self> {
+        let processor = Self { config };
+        processor.retain_logs()?;
+        Ok(processor)
+    }
+
+    /// Deletes log files whose embedded timestamp is older than retention_days.
+    fn retain_logs(&self) -> std::io::Result<()> {
+        let dir = &self.config.dir;
+        if !dir.is_dir() {
+            return Ok(());
+        }
+        let cutoff = Self::cutoff_secs(self.config.retention_days);
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(age) = parse_file_timestamp(&path) {
+                    if age < cutoff {
+                        let _ = std::fs::remove_file(path);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the cutoff timestamp in seconds since epoch.
+    fn cutoff_secs(retention_days: u32) -> i64 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch");
+        let retention_secs = (retention_days as u64) * 86400;
+        (now.as_secs() - retention_secs) as i64
+    }
+}
+
+/// Extracts the platform from raw JSON `channel` field, defaults to "feishu".
+fn extract_platform(raw: &Value) -> String {
+    raw.get("channel")
+        .and_then(|v| v.as_str())
+        .unwrap_or("feishu")
+        .to_string()
+}
+
+/// Extracts the timestamp millis from `message.create_time`, falls back to now.
+fn extract_timestamp_ms(raw: &Value) -> i64 {
+    raw.get("message")
+        .and_then(|m| m.get("create_time"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or_else(current_timestamp_ms)
+}
+
+/// Returns current time in milliseconds since UNIX epoch.
+fn current_timestamp_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as i64
+}
+
+/// Extracts the message_id from raw JSON `message.message_id`.
+fn extract_message_id(raw: &Value) -> String {
+    raw.get("message")
+        .and_then(|m| m.get("message_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// Extracts the content string from raw JSON `message.content`.
+fn extract_content(raw: &Value) -> String {
+    raw.get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Parses the timestamp from a log filename in milliseconds since epoch.
+///
+/// Expected format: `{platform}_{timestamp_millis}_{message_id}.json`
+fn parse_file_timestamp(path: &Path) -> Option<i64> {
+    let name = path.file_stem()?.to_str()?;
+    let segments: Vec<&str> = name.split('_').collect();
+    if segments.len() >= 2 {
+        segments[1].parse::<i64>().ok().map(|ms| ms / 1000)
+    } else {
+        None
+    }
+}
+
+#[async_trait]
+impl MessageProcessor for RawLogProcessor {
+    fn priority(&self) -> i32 {
+        10
+    }
+
+    fn phase(&self) -> ProcessPhase {
+        ProcessPhase::Inbound
+    }
+
+    async fn process(
+        &self,
+        ctx: &MessageContext,
+        msg: &Value,
+    ) -> Result<ProcessedMessage, ProcessError> {
+        let is_enabled = self.config.enabled || level_enabled!(tracing::Level::DEBUG);
+        if !is_enabled {
+            debug!("raw_log disabled, bypassing");
+            return passthrough(msg, ctx);
+        }
+
+        let raw_webhook = match ctx.metadata.get("_raw_webhook") {
+            Some(wh) => wh,
+            None => {
+                error!("no _raw_webhook in context, bypassing");
+                return passthrough(msg, ctx);
+            }
+        };
+
+        let raw: Value = match serde_json::from_str(raw_webhook) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("failed to parse _raw_webhook: {e}");
+                return passthrough(msg, ctx);
+            }
+        };
+
+        write_log_file(&self.config.dir, &raw).await;
+
+        let content = extract_content(&raw);
+        Ok(ProcessedMessage {
+            content,
+            metadata: ctx.metadata.clone(),
+        })
+    }
+}
+
+/// Writes the raw JSON to a file under the configured directory.
+async fn write_log_file(dir: &Path, raw: &Value) {
+    let platform = extract_platform(raw);
+    let ts = extract_timestamp_ms(raw);
+    let msg_id = extract_message_id(raw);
+    let filename = format!("{platform}_{ts}_{msg_id}.json");
+    let path = dir.join(&filename);
+
+    let json = match serde_json::to_string_pretty(raw) {
+        Ok(j) => j,
+        Err(e) => {
+            error!("failed to serialize raw log: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = tokio::fs::write(&path, json).await {
+        error!("failed to write raw log file {}: {e}", path.display());
+    }
+}
+
+/// Returns a passthrough result: original content + upstream metadata.
+fn passthrough(msg: &Value, ctx: &MessageContext) -> Result<ProcessedMessage, ProcessError> {
+    let content = msg
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    Ok(ProcessedMessage {
+        content,
+        metadata: ctx.metadata.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn test_config(dir: &Path) -> RawLogConfig {
+        RawLogConfig {
+            enabled: true,
+            dir: dir.to_path_buf(),
+            retention_days: 7,
+        }
+    }
+
+    fn raw_webhook_fixture() -> Value {
+        serde_json::json!({
+            "channel": "wecom",
+            "message": {
+                "message_id": "msg_abc123",
+                "create_time": "1717737600000",
+                "content": "{\"text\":\"hello\"}"
+            }
+        })
+    }
+
+    fn ctx_with_raw_webhook(raw: &Value) -> MessageContext {
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            "_raw_webhook".to_string(),
+            serde_json::to_string(raw).unwrap(),
+        );
+        MessageContext { metadata }
+    }
+
+    #[tokio::test]
+    async fn test_bypass_when_disabled_and_no_debug() {
+        let tmp = TempDir::new().unwrap();
+        let config = RawLogConfig {
+            enabled: false,
+            dir: tmp.path().to_path_buf(),
+            retention_days: 7,
+        };
+        let processor = RawLogProcessor::new(config).unwrap();
+        let ctx = MessageContext::default();
+        let msg = raw_webhook_fixture();
+
+        let result = processor.process(&ctx, &msg).await.unwrap();
+        assert_eq!(result.content, "{\"text\":\"hello\"}");
+        assert!(tmp.path().read_dir().unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_write_file_when_enabled() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let processor = RawLogProcessor::new(config).unwrap();
+        let raw = raw_webhook_fixture();
+        let ctx = ctx_with_raw_webhook(&raw);
+
+        let result = processor.process(&ctx, &raw).await.unwrap();
+        assert_eq!(result.content, "{\"text\":\"hello\"}");
+
+        let files: Vec<_> = tmp.path().read_dir().unwrap().flatten().collect();
+        assert_eq!(files.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_filename_format() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let processor = RawLogProcessor::new(config).unwrap();
+        let raw = raw_webhook_fixture();
+        let ctx = ctx_with_raw_webhook(&raw);
+
+        processor.process(&ctx, &raw).await.unwrap();
+
+        let entries: Vec<_> = tmp.path().read_dir().unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1);
+        let name = entries[0].file_name().to_string_lossy().into_owned();
+        assert!(
+            name.starts_with("wecom_"),
+            "filename should start with platform: {name}"
+        );
+        assert!(
+            name.ends_with("_msg_abc123.json"),
+            "filename should end with _msg_id.json: {name}"
+        );
+        let stem = Path::new(name.as_str())
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let parts: Vec<&str> = stem.splitn(3, '_').collect();
+        assert_eq!(parts.len(), 3, "expected 3 segments: {stem}");
+        assert_eq!(parts[0], "wecom");
+        assert_eq!(parts[2], "msg_abc123");
+        parts[1].parse::<i64>().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_platform_defaults_to_feishu() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let processor = RawLogProcessor::new(config).unwrap();
+        let raw = serde_json::json!({
+            "message": {
+                "message_id": "msg_001",
+                "content": "{}"
+            }
+        });
+        let ctx = ctx_with_raw_webhook(&raw);
+
+        processor.process(&ctx, &raw).await.unwrap();
+
+        let entries: Vec<_> = tmp.path().read_dir().unwrap().flatten().collect();
+        let name = entries[0].file_name().to_string_lossy().into_owned();
+        assert!(name.starts_with("feishu_"), "default platform: {name}");
+    }
+
+    #[tokio::test]
+    async fn test_retain_logs_deletes_old_files() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let stale_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 100 * 86400;
+        let stale_ms = (stale_secs * 1000) as i64;
+        let stale = format!("feishu_{stale_ms}_stale_msg.json");
+        std::fs::write(dir.join(&stale), "{}").unwrap();
+
+        let fresh_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 86400;
+        let fresh_ms = (fresh_secs * 1000) as i64;
+        let fresh = format!("feishu_{fresh_ms}_fresh_msg.json");
+        std::fs::write(dir.join(&fresh), "{}").unwrap();
+
+        let config = test_config(dir);
+        let _processor = RawLogProcessor::new(config).unwrap();
+
+        let names: Vec<String> = dir
+            .read_dir()
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.iter().any(|n| n.contains("fresh_msg")),
+            "fresh file should remain: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("stale_msg")),
+            "stale file should be deleted: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_priority_and_phase() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let processor = RawLogProcessor::new(config).unwrap();
+        assert_eq!(processor.priority(), 10);
+        assert_eq!(processor.phase(), ProcessPhase::Inbound);
+    }
+
+    #[tokio::test]
+    async fn test_preserves_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let processor = RawLogProcessor::new(config).unwrap();
+        let raw = raw_webhook_fixture();
+        let mut ctx = ctx_with_raw_webhook(&raw);
+        ctx.metadata
+            .insert("chat_type".to_string(), "group".to_string());
+
+        let result = processor.process(&ctx, &raw).await.unwrap();
+        assert_eq!(result.metadata.get("chat_type").unwrap(), "group");
+    }
+
+    /// Fail-open: write failure must not block the message flow.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_write_failure_does_not_block_message() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Make the directory immutable so that file creation inside it
+        // will fail with EPERM, exercising the fail-open error path.
+        let is_root = unsafe { libc::getuid() == 0 };
+        if is_root {
+            let _ = std::process::Command::new("chattr")
+                .args(["+i", &dir.to_string_lossy()])
+                .output();
+        } else {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555));
+        }
+
+        let config = test_config(dir);
+        let processor = RawLogProcessor::new(config).unwrap();
+        let raw = raw_webhook_fixture();
+        let ctx = ctx_with_raw_webhook(&raw);
+
+        // process() must succeed (fail-open) even when the write fails.
+        let result = processor.process(&ctx, &raw).await.unwrap();
+        assert_eq!(result.content, "{\"text\":\"hello\"}");
+
+        // Clean up: remove immutable flag.
+        if is_root {
+            let _ = std::process::Command::new("chattr")
+                .args(["-i", &dir.to_string_lossy()])
+                .output();
+        }
+    }
+}

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -83,6 +83,77 @@ impl SessionRouter {
                 })
         })
     }
+
+    /// Resolve the original webhook JSON.
+    ///
+    /// When a RawLogProcessor runs upstream, `raw` becomes a serialized
+    /// `ProcessedMessage` (only `content` + `metadata`). This method
+    /// recovers the original webhook so routing fields can be read.
+    fn get_webhook_raw(raw: &Value, ctx: &MessageContext) -> Value {
+        // If raw already looks like an original webhook, use it.
+        if raw.get("sender").is_some() || raw.get("message").is_some() {
+            return raw.clone();
+        }
+        // Otherwise try ctx metadata (set by process_inbound).
+        if let Some(wh) = ctx.metadata.get("_raw_webhook") {
+            if let Ok(parsed) = serde_json::from_str::<Value>(wh) {
+                return parsed;
+            }
+        }
+        raw.clone()
+    }
+
+    /// Extract message content, supporting both webhook and
+    /// ProcessedMessage layouts.
+    fn extract_msg_content(webhook: &Value, raw: &Value) -> String {
+        // Webhook layout: raw.message.content
+        webhook
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            // ProcessedMessage layout: raw.content
+            .or_else(|| {
+                raw.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+            .unwrap_or_default()
+    }
+
+    /// Build a [`Message`] from webhook + extracted routing fields.
+    fn build_message(
+        webhook: &Value,
+        raw: &Value,
+        from: &str,
+        to: &str,
+        channel: &str,
+        thread_id: Option<String>,
+    ) -> Message {
+        let content = Self::extract_msg_content(webhook, raw);
+        let id = webhook
+            .get("message")
+            .and_then(|m| m.get("message_id"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| "unknown".to_string());
+        let timestamp = webhook
+            .get("message")
+            .and_then(|m| m.get("create_time"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or_else(|| chrono::Utc::now().timestamp());
+        Message {
+            id,
+            from: from.to_string(),
+            to: to.to_string(),
+            content,
+            channel: channel.to_string(),
+            timestamp,
+            metadata: std::collections::HashMap::new(),
+            thread_id,
+        }
+    }
 }
 
 #[async_trait]
@@ -100,8 +171,10 @@ impl MessageProcessor for SessionRouter {
         ctx: &MessageContext,
         raw: &Value,
     ) -> Result<ProcessedMessage, ProcessError> {
+        let webhook = Self::get_webhook_raw(raw, ctx);
+
         // Group chats are not supported.
-        let is_group = raw
+        let is_group = webhook
             .get("message")
             .and_then(|m| m.get("chat_type"))
             .and_then(|v| v.as_str())
@@ -109,56 +182,24 @@ impl MessageProcessor for SessionRouter {
             .unwrap_or(false);
 
         if is_group {
-            let channel = Self::extract_channel(raw);
+            let channel = Self::extract_channel(&webhook);
             return Err(ProcessError::SessionNotSupportedForChannel(channel));
         }
 
-        // Extract feishu routing fields directly from the raw webhook.
-        let from = Self::extract_from(raw)?;
-        let to = Self::extract_to(raw)?;
-        let channel = Self::extract_channel(raw);
-        let account_id = Self::extract_account_id(raw);
+        let from = Self::extract_from(&webhook)?;
+        let to = Self::extract_to(&webhook)?;
+        let channel = Self::extract_channel(&webhook);
+        let account_id = Self::extract_account_id(&webhook);
+        let thread_id = Self::extract_thread_id(&webhook);
 
-        // Extract thread_id from the raw webhook.
-        let thread_id = Self::extract_thread_id(raw);
+        let msg = Self::build_message(&webhook, raw, &from, &to, &channel, thread_id);
 
-        // Reconstruct a minimal Message for SessionManager::find_or_create.
-        let msg_content = raw
-            .get("message")
-            .and_then(|m| m.get("content"))
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .unwrap_or_default();
-
-        let msg = Message {
-            id: raw
-                .get("message")
-                .and_then(|m| m.get("message_id"))
-                .and_then(|v| v.as_str())
-                .map(String::from)
-                .unwrap_or_else(|| "unknown".to_string()),
-            from: from.clone(),
-            to: to.clone(),
-            content: msg_content.clone(),
-            channel: channel.clone(),
-            timestamp: raw
-                .get("message")
-                .and_then(|m| m.get("create_time"))
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<i64>().ok())
-                .unwrap_or_else(|| chrono::Utc::now().timestamp()),
-            metadata: std::collections::HashMap::new(),
-            thread_id,
-        };
-
-        // Resolve session.
         let session_id = self
             .manager
             .find_or_create(&channel, &msg, account_id.as_deref())
             .await
             .map_err(|e| ProcessError::ProcessingFailed(e.to_string()))?;
 
-        // Preserve all upstream metadata (from ctx) and add our own fields.
         let mut metadata = ctx.metadata.clone();
         let acc_id = account_id.unwrap_or_else(|| "default".to_string());
         metadata.insert("account_id".to_string(), acc_id);
@@ -167,10 +208,8 @@ impl MessageProcessor for SessionRouter {
         metadata.insert("channel".to_string(), channel);
         metadata.insert("session_id".to_string(), session_id);
 
-        // Pass the original raw webhook through so downstream FeishuMessageCleaner
-        // (priority 30) can extract and clean the content.
         Ok(ProcessedMessage {
-            content: msg_content,
+            content: msg.content,
             metadata,
         })
     }
@@ -194,7 +233,32 @@ mod tests {
             rate_limit_per_minute: 100,
             max_message_size: 65536,
             dm_scope: DmScope::PerAccountChannelPeer,
+            ..Default::default()
         }
+    }
+
+    fn make_router() -> SessionRouter {
+        let mgr = Arc::new(SessionManager::new(
+            &test_config(),
+            None,
+            None,
+            BootstrapMode::Full,
+            ReasoningLevel::default(),
+        ));
+        SessionRouter::new(mgr)
+    }
+
+    fn assert_session_id_format(sid: &str, agent_id: &str) {
+        assert!(
+            sid.starts_with(&format!("{agent_id}_")),
+            "bad format: {sid}"
+        );
+        let hex = sid.rsplitn(2, '_').next().unwrap();
+        assert_eq!(hex.len(), 8, "hex part wrong: {hex}");
+        assert!(
+            hex.chars().all(|c| c.is_ascii_hexdigit()),
+            "hex part non-hex: {hex}"
+        );
     }
 
     /// Minimal feishu DM webhook fixture.
@@ -236,77 +300,37 @@ mod tests {
 
     #[tokio::test]
     async fn test_private_chat_creates_session() {
-        let mgr = Arc::new(SessionManager::new(
-            &test_config(),
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        let router = SessionRouter::new(mgr.clone());
+        let router = make_router();
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
-
         let result = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
-        let session_id = result.metadata.get("session_id").unwrap();
-        // New format: {agent_id}_{timestamp_ms}_{8hex}
-        assert!(
-            session_id.starts_with("oc_agent_b_"),
-            "bad format: {}",
-            session_id
-        );
-        // Should end with _<8-hex-digits>
-        let parts: Vec<&str> = session_id.rsplitn(2, '_').collect();
-        assert_eq!(parts.len(), 2, "bad format: {}", session_id);
-        assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
-        assert!(
-            parts[0].chars().all(|c| c.is_ascii_hexdigit()),
-            "hex part non-hex: {}",
-            parts[0]
-        );
+        let sid = result.metadata.get("session_id").unwrap();
+        assert_session_id_format(sid, "oc_agent_b");
     }
 
     #[tokio::test]
     async fn test_existing_session_not_duplicated() {
-        let mgr = Arc::new(SessionManager::new(
-            &test_config(),
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        let router = SessionRouter::new(mgr.clone());
+        let router = make_router();
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
-
         let r1 = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
         let id1 = r1.metadata.get("session_id").unwrap().clone();
-
         let r2 = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
         let id2 = r2.metadata.get("session_id").unwrap().clone();
-
         assert_eq!(id1, id2, "session should not be duplicated");
     }
 
     #[tokio::test]
     async fn test_group_chat_returns_error() {
-        let mgr = Arc::new(SessionManager::new(
-            &test_config(),
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        let router = SessionRouter::new(mgr.clone());
+        let router = make_router();
         let raw = feishu_group_webhook("ou_user_a", "oc_chat");
-
         let result = router.process(&MessageContext::default(), &raw).await;
         assert!(matches!(
             result,
@@ -314,7 +338,7 @@ mod tests {
         ));
         let err = result.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("feishu") || msg.contains("oc_chat"), "{}", msg);
+        assert!(msg.contains("feishu") || msg.contains("oc_chat"), "{msg}");
     }
 
     #[tokio::test]
@@ -330,58 +354,104 @@ mod tests {
             BootstrapMode::Full,
             ReasoningLevel::default(),
         ));
-        let router = SessionRouter::new(mgr.clone());
+        let router = SessionRouter::new(mgr);
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
-
         let result = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
-        let session_id = result.metadata.get("session_id").unwrap();
-        // New format: {agent_id}_{timestamp_ms}_{8hex}
-        assert!(
-            session_id.starts_with("oc_agent_b_"),
-            "session_id should start with agent_id: {}",
-            session_id
-        );
-        // Should end with _<8-hex-digits>
-        let parts: Vec<&str> = session_id.rsplitn(2, '_').collect();
-        assert_eq!(parts.len(), 2, "bad format: {}", session_id);
-        assert_eq!(parts[0].len(), 8, "hex part wrong: {}", parts[0]);
-        assert!(
-            parts[0].chars().all(|c| c.is_ascii_hexdigit()),
-            "hex part non-hex: {}",
-            parts[0]
-        );
+        let sid = result.metadata.get("session_id").unwrap();
+        assert_session_id_format(sid, "oc_agent_b");
     }
 
     #[tokio::test]
     async fn test_metadata_preserves_upstream_fields() {
-        let mgr = Arc::new(SessionManager::new(
-            &test_config(),
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        let router = SessionRouter::new(mgr.clone());
+        let router = make_router();
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
-
         let mut ctx = MessageContext::default();
         ctx.metadata
             .insert("existing_key".to_string(), "existing_value".to_string());
-
         let result = router.process(&ctx, &raw).await.unwrap();
-        // Upstream metadata should be preserved.
         assert_eq!(
             result.metadata.get("existing_key").unwrap(),
             "existing_value"
         );
-        // SessionRouter-added fields should be present.
         assert!(result.metadata.contains_key("session_id"));
         assert!(result.metadata.contains_key("from"));
         assert!(result.metadata.contains_key("to"));
         assert!(result.metadata.contains_key("channel"));
         assert!(result.metadata.contains_key("account_id"));
+    }
+
+    #[tokio::test]
+    async fn test_processed_msg_fallback_from_ctx_raw_webhook() {
+        let router = make_router();
+        let webhook = feishu_dm_webhook("ou_user_a", "oc_agent_b");
+        let mut ctx = MessageContext::default();
+        ctx.metadata
+            .insert("_raw_webhook".to_string(), webhook.to_string());
+        let processed = serde_json::json!({
+            "content": "{\"text\":\"hello\"}",
+            "metadata": {}
+        });
+        let result = router.process(&ctx, &processed).await.unwrap();
+        assert_eq!(result.metadata.get("from").unwrap(), "ou_user_a");
+        assert_eq!(result.metadata.get("to").unwrap(), "oc_agent_b");
+        assert_eq!(result.metadata.get("channel").unwrap(), "feishu");
+        assert_eq!(result.metadata.get("account_id").unwrap(), "tenant_abc");
+        assert_session_id_format(result.metadata.get("session_id").unwrap(), "oc_agent_b");
+        assert_eq!(result.content, "{\"text\":\"hello\"}");
+    }
+
+    /// ProcessedMessage input: routing fields from ctx.metadata["_raw_webhook"].
+    #[tokio::test]
+    async fn test_processed_msg_extracts_thread_id_from_raw_webhook() {
+        let router = make_router();
+        let webhook = serde_json::json!({
+            "sender": {
+                "sender_id": { "open_id": "ou_thread_user" }
+            },
+            "message": {
+                "chat_id": "oc_thread_chat",
+                "chat_type": "p2p",
+                "message_id": "om_thread_001",
+                "message_type": "text",
+                "content": "{\"text\":\"original\"}",
+                "create_time": "1777229589621",
+                "thread_id": "ot_thread_xyz"
+            },
+            "channel": "feishu",
+            "tenant_key": "tenant_thread"
+        });
+        let mut ctx = MessageContext::default();
+        ctx.metadata
+            .insert("_raw_webhook".to_string(), webhook.to_string());
+        let processed = serde_json::json!({
+            "content": "{\"text\":\"rewritten\"}",
+            "metadata": {}
+        });
+        let result = router.process(&ctx, &processed).await.unwrap();
+        assert_eq!(result.metadata.get("from").unwrap(), "ou_thread_user");
+        assert_eq!(result.metadata.get("to").unwrap(), "oc_thread_chat");
+        assert_eq!(result.metadata.get("channel").unwrap(), "feishu");
+        assert_eq!(result.metadata.get("account_id").unwrap(), "tenant_thread");
+        assert!(result
+            .metadata
+            .get("session_id")
+            .unwrap()
+            .starts_with("oc_thread_chat_"));
+        assert_eq!(result.content, "{\"text\":\"original\"}");
+    }
+
+    #[tokio::test]
+    async fn test_processed_msg_without_raw_webhook_errors() {
+        let router = make_router();
+        let processed = serde_json::json!({
+            "content": "{\"text\":\"hi\"}",
+            "metadata": {}
+        });
+        let ctx = MessageContext::default();
+        let err = router.process(&ctx, &processed).await;
+        assert!(err.is_err(), "should fail without raw webhook");
     }
 }

--- a/src/permission/approval_flow/tests.rs
+++ b/src/permission/approval_flow/tests.rs
@@ -15,6 +15,7 @@ fn test_session_manager() -> Arc<SessionManager> {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
     };
     Arc::new(SessionManager::new(
         &config,

--- a/src/slash/handlers_tests.rs
+++ b/src/slash/handlers_tests.rs
@@ -92,6 +92,7 @@ async fn test_clear_handler_handle_returns_reply() {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: DmScope::default(),
+        ..Default::default()
     };
     let sm = Arc::new(SessionManager::new(
         &gc,
@@ -255,6 +256,7 @@ fn make_workdir_session_manager() -> std::sync::Arc<SessionManager> {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: DmScope::default(),
+        ..Default::default()
     };
     Arc::new(SessionManager::new(
         &gc,

--- a/src/slash/handlers_tests_new.rs
+++ b/src/slash/handlers_tests_new.rs
@@ -29,6 +29,7 @@ fn make_workdir_session_manager() -> std::sync::Arc<SessionManager> {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: DmScope::default(),
+        ..Default::default()
     };
     Arc::new(SessionManager::new(
         &gc,

--- a/src/slash/handlers_tests_system.rs
+++ b/src/slash/handlers_tests_system.rs
@@ -19,6 +19,7 @@ fn make_sm() -> Arc<SessionManager> {
         rate_limit_per_minute: 0,
         max_message_size: 0,
         dm_scope: DmScope::default(),
+        ..Default::default()
     };
     Arc::new(SessionManager::new(
         &gc,

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -70,6 +70,7 @@ mod tests {
             rate_limit_per_minute: 100,
             max_message_size: 65536,
             dm_scope: crate::gateway::DmScope::PerChannelPeer,
+            ..Default::default()
         };
         let session_manager = Arc::new(SessionManager::new(
             &cfg,

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -37,6 +37,7 @@ fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/tools/builtin/sessions_steer_kill_tests.rs
+++ b/src/tools/builtin/sessions_steer_kill_tests.rs
@@ -26,6 +26,7 @@ fn test_gateway_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -244,6 +244,7 @@ mod tests {
                 rate_limit_per_minute: 100,
                 max_message_size: 1024,
                 dm_scope: crate::gateway::DmScope::default(),
+                ..Default::default()
             },
             None,
             None,

--- a/src/tools/builtin/skill_tool_tests.rs
+++ b/src/tools/builtin/skill_tool_tests.rs
@@ -34,6 +34,7 @@ mod tests {
                 rate_limit_per_minute: 100,
                 max_message_size: 1024,
                 dm_scope: crate::gateway::DmScope::default(),
+                ..Default::default()
             },
             None,
             None,
@@ -124,6 +125,7 @@ mod tests {
                 rate_limit_per_minute: 100,
                 max_message_size: 1024,
                 dm_scope: crate::gateway::DmScope::default(),
+                ..Default::default()
             },
             None,
             Some(tmp.path().to_path_buf()),

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -151,6 +151,7 @@ pub(crate) fn make_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/tests/im_inbound_e2e_tests.rs
+++ b/tests/im_inbound_e2e_tests.rs
@@ -25,6 +25,7 @@ fn test_session_manager() -> Arc<SessionManager> {
             rate_limit_per_minute: 100,
             max_message_size: 65536,
             dm_scope: DmScope::PerChannelPeer,
+            ..Default::default()
         },
         None,
         None,
@@ -52,7 +53,7 @@ fn load_raw_fixture(filename: &str) -> serde_json::Value {
 #[tokio::test]
 async fn test_p2p_dm_full_chain() {
     let mgr = test_session_manager();
-    let registry = ProcessorRegistry::new(mgr);
+    let registry = ProcessorRegistry::new(mgr, None);
     let raw = load_raw_fixture("im-message-receive_v1-no-event-id-2026-04-26T18-53-09-967Z.json");
 
     let result = registry
@@ -85,7 +86,7 @@ async fn test_p2p_dm_full_chain() {
 #[tokio::test]
 async fn test_group_chat_rejected() {
     let mgr = test_session_manager();
-    let registry = ProcessorRegistry::new(mgr);
+    let registry = ProcessorRegistry::new(mgr, None);
     let raw = load_raw_fixture("im-group-chat-message.json");
 
     let result = registry.process_inbound(&raw).await;

--- a/tests/integration_llm_busy.rs
+++ b/tests/integration_llm_busy.rs
@@ -103,6 +103,7 @@ fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/tests/integration_pending_messages.rs
+++ b/tests/integration_pending_messages.rs
@@ -30,6 +30,7 @@ fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 

--- a/tests/integration_shutdown_checkpoint.rs
+++ b/tests/integration_shutdown_checkpoint.rs
@@ -33,6 +33,7 @@ fn test_config() -> GatewayConfig {
         rate_limit_per_minute: 100,
         max_message_size: 1024,
         dm_scope: DmScope::default(),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Add `RawLogProcessor` (priority 10) to the inbound processor chain in `im/processor`. This processor logs raw inbound webhook payloads to disk for audit and debugging purposes.

## Changes

- **New file** `src/im/processor/raw_log_processor.rs`: Implements `MessageProcessor` trait with `RawLogProcessor` struct
  - Reads from `ctx.metadata["_raw_webhook"]` (saved by `process_inbound` before chain runs)
  - Writes JSON log files named `{platform}_{timestamp_ms}_{message_id}.json`
  - `RawLogConfig { enabled, dir, retention_days }` — disabled by default
  - Fail-open: log write errors don't block message processing
  - Expired log cleanup on initialization

- **Modified** `src/im/processor/mod.rs`:
  - `ProcessorRegistry::new()` accepts `Option<RawLogConfig>`; registers `RawLogProcessor` always (enabled=false when None)
  - `process_inbound()` saves raw webhook JSON to `ctx.metadata["_raw_webhook"]` before chain runs

- **Modified** `src/im/processor/session_router.rs`:
  - Added `get_webhook_raw()` fallback to recover original webhook JSON when upstream processor serializes `ProcessedMessage`
  - Extractors (`extract_from`, `extract_to`, etc.) now support both webhook and ProcessedMessage input layouts

- **Modified** `src/gateway/mod.rs`:
  - `GatewayConfig` gains `raw_log_dir: Option<PathBuf>` field with `Default` impl

- **Test fixes**: Updated `GatewayConfig` construction in 20+ test files to use `..Default::default()`

## Testing

- All existing tests pass (`cargo test`)
- New unit tests for `RawLogProcessor` cover: disabled passthrough, enabled write, fail-open, expired log cleanup
- New `SessionRouter` test for ProcessedMessage fallback path

Source: issue #954
Type: feat
