### PR TITLE
refactor: SessionRouter 改为计算 session_key 而非调 find_or_create

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -323,50 +323,85 @@ impl Gateway {
 
     /// Route an incoming message to the appropriate agent.
     ///
-    /// Reads `session_id` from `message.metadata`. Returns `MissingSessionId`
-    /// if absent. Validates the session exists in the active sessions table
-    /// before forwarding to the registered IM plugin.
-    pub async fn route_message(
+    /// Supports two metadata formats for session resolution:
+    /// 1. New path: `session_key` → call `SessionManager::resolve()` to get session_id
+    /// 2. Old path: `session_id` → validate directly in active sessions table
+    ///
+    /// If both are missing, sends a user-visible error via the plugin and
+    /// returns `NoRoutingKey`.
+    /// Forward a resolved message to the IM plugin for the given channel.
+    async fn forward_to_plugin(
         &self,
         channel: &str,
-        message: Message,
-        _account_id: Option<&str>,
+        message: &Message,
+        session_id: &str,
     ) -> Result<(), GatewayError> {
-        // Read session_id from metadata (written there by SessionRouter).
-        let session_id = message
-            .metadata
-            .get("session_id")
-            .ok_or(GatewayError::MissingSessionId)?;
-
-        // Verify session exists in the active sessions table.
         if !self.session_manager.has_session(session_id).await {
             return Err(GatewayError::MissingSessionId);
         }
-
-        // Find the IM plugin registered for this channel.
         let plugin = self
             .get_plugin(channel)
             .await
             .ok_or(GatewayError::UnknownChannel(channel.to_string()))?;
-
-        // Validate message size.
         if message.content.len() > self.config.max_message_size {
             return Err(GatewayError::MessageTooLarge);
         }
-
-        // Resolve thread_id from the session checkpoint.
         let thread_id = self.session_manager.get_thread_id(session_id).await;
-
-        // Build a text RenderedOutput and forward to the plugin.
         let output = RenderedOutput {
             msg_type: "text".into(),
-            payload: json!({"content": {"text": message.content}}),
+            payload: json!({"content": {"text": &message.content}}),
         };
         plugin
             .send(&output, &message.to, thread_id.as_deref())
-            .await?;
+            .await
+            .map_err(|e| GatewayError::AdapterError(e.to_string()))
+    }
 
-        Ok(())
+    /// Send a best-effort user-visible error via the plugin.
+    async fn send_user_error(&self, channel: &str, message: &Message) {
+        if let Some(plugin) = self.get_plugin(channel).await {
+            let err_output = RenderedOutput {
+                msg_type: "text".into(),
+                payload: json!({
+                    "content": {
+                        "text":
+                            "\u{26A0}\u{FE0F} \u{4F1A}\u{8BDD}\u{8DEF}\u{7531}\
+                            \u{5931}\u{8D25}\u{FF0C}\u{8BF7}\u{91CD}\u{8BD5}"
+                    }
+                }),
+            };
+            let _ = plugin.send(&err_output, &message.to, None).await;
+        }
+    }
+
+    pub async fn route_message(
+        &self,
+        channel: &str,
+        message: Message,
+        account_id: Option<&str>,
+    ) -> Result<(), GatewayError> {
+        // --- New path: session_key → SessionManager::resolve() ---
+        if let Some(session_key) = message.metadata.get("session_key") {
+            if !session_key.is_empty() {
+                let session_id = self
+                    .session_manager
+                    .resolve(session_key, channel, &message, account_id)
+                    .await
+                    .map_err(|e| GatewayError::AdapterError(e.to_string()))?;
+                return self.forward_to_plugin(channel, &message, &session_id).await;
+            }
+        }
+
+        // --- Fallback: session_id (old path, backward compatible) ---
+        if let Some(session_id) = message.metadata.get("session_id") {
+            if !session_id.is_empty() {
+                return self.forward_to_plugin(channel, &message, session_id).await;
+            }
+        }
+
+        // --- No key fallback: both missing/empty ---
+        self.send_user_error(channel, &message).await;
+        Err(GatewayError::NoRoutingKey)
     }
 
     /// Get active sessions for an agent (proxied to SessionManager).
@@ -391,6 +426,9 @@ pub enum GatewayError {
 
     #[error("Missing session ID in message metadata")]
     MissingSessionId,
+
+    #[error("No routing key: both session_key and session_id missing from metadata")]
+    NoRoutingKey,
 
     #[error("Outbound error: {0}")]
     OutboundError(String),

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -313,13 +313,13 @@ async fn test_session_not_duplicated() {
 }
 
 #[tokio::test]
-async fn test_route_message_no_session_id_returns_missing_session_id() {
-    // When a message arrives WITHOUT session_id in metadata,
-    // Gateway::route_message should return MissingSessionId.
+async fn test_route_message_no_session_id_returns_no_routing_key() {
+    // When a message arrives WITHOUT session_key or session_id in metadata,
+    // Gateway::route_message should return NoRoutingKey.
     let (gw, _sm) = setup(make_config(), "mock").await;
     let msg_without_session = make_message("agent-1", "hello");
     let result = gw.route_message("mock", msg_without_session, None).await;
-    assert!(matches!(result, Err(GatewayError::MissingSessionId)));
+    assert!(matches!(result, Err(GatewayError::NoRoutingKey)));
 }
 
 #[tokio::test]
@@ -348,6 +348,9 @@ fn test_gateway_error_display() {
         .to_string()
         .contains("e"));
     assert!(GatewayError::RateLimitExceeded.to_string().contains("Rate"));
+    assert!(GatewayError::NoRoutingKey
+        .to_string()
+        .contains("No routing key"));
 }
 
 // ── Session isolation tests ─────────────────────────────────────────────────

--- a/src/im/processor/mod.rs
+++ b/src/im/processor/mod.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::gateway::SessionManager;
 pub use cleaner::FeishuMessageCleaner;
 pub use raw_log_processor::{RawLogConfig, RawLogProcessor};
 use serde_json::Value;
@@ -123,7 +122,7 @@ impl ProcessorRegistry {
     /// - [`SessionRouter`] (inbound, priority 20) — resolves session IDs
     /// - [`FeishuMessageCleaner`] (inbound, priority 30)
     /// - [`FeishuMessageCleaner`] (inbound, priority 30)
-    pub fn new(session_manager: Arc<SessionManager>, raw_log_config: Option<RawLogConfig>) -> Self {
+    pub fn new(dm_scope: crate::gateway::DmScope, raw_log_config: Option<RawLogConfig>) -> Self {
         let mut registry = Self::default();
         match raw_log_config {
             Some(config) => {
@@ -140,7 +139,7 @@ impl ProcessorRegistry {
                 registry.register(p);
             }
         }
-        registry.register(SessionRouter::new(session_manager));
+        registry.register(SessionRouter::new(dm_scope));
         registry.register(FeishuMessageCleaner);
         registry
     }
@@ -251,25 +250,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    use crate::session::bootstrap::BootstrapMode;
-    use crate::session::persistence::ReasoningLevel;
-
-    fn test_session_manager() -> Arc<SessionManager> {
-        Arc::new(SessionManager::new(
-            &crate::gateway::GatewayConfig {
-                name: "test".to_string(),
-                rate_limit_per_minute: 100,
-                max_message_size: 65536,
-                dm_scope: crate::gateway::DmScope::PerChannelPeer,
-                ..Default::default()
-            },
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ))
-    }
-
     /// A no-op inbound processor that records how many times it was called
     /// and at what priority.
     struct SpyProcessor {
@@ -357,8 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_registry_default_has_all_processors() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr, None);
+        let registry = ProcessorRegistry::new(crate::gateway::DmScope::PerChannelPeer, None);
         // FeishuMessageCleaner (inbound, prio 30)
         assert!(!registry.inbound.is_empty());
     }
@@ -414,8 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_inbound_chain_simple_text() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr, None);
+        let registry = ProcessorRegistry::new(crate::gateway::DmScope::PerChannelPeer, None);
         let raw =
             load_raw_fixture("im-message-receive_v1-no-event-id-2026-04-26T18-53-09-967Z.json");
         let expected = load_expected_fixture("expected/01_text_simple.json");
@@ -426,8 +404,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_inbound_chain_post_lists() {
-        let mgr = test_session_manager();
-        let registry = ProcessorRegistry::new(mgr, None);
+        let registry = ProcessorRegistry::new(crate::gateway::DmScope::PerChannelPeer, None);
         let raw =
             load_raw_fixture("im-message-receive_v1-no-event-id-2026-04-27T02-58-21-195Z.json");
         let expected = load_expected_fixture("expected/03_post_lists.json");

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -1,27 +1,27 @@
-//! SessionRouter — inbound MessageProcessor that resolves session IDs.
+//! SessionRouter — inbound MessageProcessor that computes session keys.
 //!
-//! Extracts feishu routing fields (`account_id`, `from`, `to`, `channel`)
-//! directly from the raw feishu webhook JSON, then calls
-//! [`SessionManager::find_or_create`][crate::gateway::SessionManager::find_or_create]
-//! and attaches the resulting `session_id` to the message metadata.
+//! Extracts routing fields (`account_id`, `from`, `to`, `channel`)
+//! directly from the raw webhook JSON, then computes a deterministic
+//! `session_key` via [`DmScope::compute_session_key`] and writes it
+//! to the message metadata.
 //!
 //! Runs at priority 20, before [`FeishuMessageCleaner`] (priority 30).
 
 use super::{MessageContext, MessageProcessor, ProcessError, ProcessPhase, ProcessedMessage};
-use crate::gateway::{Message, SessionManager};
+use crate::gateway::{DmScope, Message};
 use async_trait::async_trait;
 use serde_json::Value;
 
-/// SessionRouter — resolves and attaches a session_id to the message pipeline.
+/// SessionRouter — computes and attaches a session_key to the message pipeline.
 #[derive(Debug, Clone)]
 pub struct SessionRouter {
-    manager: std::sync::Arc<SessionManager>,
+    dm_scope: DmScope,
 }
 
 impl SessionRouter {
-    /// Create a new SessionRouter backed by the given SessionManager.
-    pub fn new(manager: std::sync::Arc<SessionManager>) -> Self {
-        Self { manager }
+    /// Create a new SessionRouter with the given [`DmScope`].
+    pub fn new(dm_scope: DmScope) -> Self {
+        Self { dm_scope }
     }
 
     /// Extract feishu sender open_id from the raw webhook.
@@ -120,39 +120,33 @@ impl SessionRouter {
             })
             .unwrap_or_default()
     }
+}
 
-    /// Build a [`Message`] from webhook + extracted routing fields.
-    fn build_message(
-        webhook: &Value,
-        raw: &Value,
+impl SessionRouter {
+    /// Compute a deterministic session key from routing fields,
+    /// returning an empty string on missing fields.
+    fn compute_key(
+        &self,
         from: &str,
         to: &str,
         channel: &str,
+        account_id: Option<&str>,
         thread_id: Option<String>,
-    ) -> Message {
-        let content = Self::extract_msg_content(webhook, raw);
-        let id = webhook
-            .get("message")
-            .and_then(|m| m.get("message_id"))
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .unwrap_or_else(|| "unknown".to_string());
-        let timestamp = webhook
-            .get("message")
-            .and_then(|m| m.get("create_time"))
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse::<i64>().ok())
-            .unwrap_or_else(|| chrono::Utc::now().timestamp());
-        Message {
-            id,
+    ) -> String {
+        if from.is_empty() || to.is_empty() {
+            return String::new();
+        }
+        let msg = Message {
+            id: String::new(),
             from: from.to_string(),
             to: to.to_string(),
-            content,
+            content: String::new(),
             channel: channel.to_string(),
-            timestamp,
+            timestamp: 0,
             metadata: std::collections::HashMap::new(),
             thread_id,
-        }
+        };
+        self.dm_scope.compute_session_key(channel, &msg, account_id)
     }
 }
 
@@ -186,19 +180,13 @@ impl MessageProcessor for SessionRouter {
             return Err(ProcessError::SessionNotSupportedForChannel(channel));
         }
 
-        let from = Self::extract_from(&webhook)?;
-        let to = Self::extract_to(&webhook)?;
+        let from = Self::extract_from(&webhook).unwrap_or_default();
+        let to = Self::extract_to(&webhook).unwrap_or_default();
         let channel = Self::extract_channel(&webhook);
         let account_id = Self::extract_account_id(&webhook);
         let thread_id = Self::extract_thread_id(&webhook);
 
-        let msg = Self::build_message(&webhook, raw, &from, &to, &channel, thread_id);
-
-        let session_id = self
-            .manager
-            .find_or_create(&channel, &msg, account_id.as_deref())
-            .await
-            .map_err(|e| ProcessError::ProcessingFailed(e.to_string()))?;
+        let session_key = self.compute_key(&from, &to, &channel, account_id.as_deref(), thread_id);
 
         let mut metadata = ctx.metadata.clone();
         let acc_id = account_id.unwrap_or_else(|| "default".to_string());
@@ -206,12 +194,11 @@ impl MessageProcessor for SessionRouter {
         metadata.insert("from".to_string(), from);
         metadata.insert("to".to_string(), to);
         metadata.insert("channel".to_string(), channel);
-        metadata.insert("session_id".to_string(), session_id);
+        metadata.insert("session_key".to_string(), session_key);
 
-        Ok(ProcessedMessage {
-            content: msg.content,
-            metadata,
-        })
+        let content = Self::extract_msg_content(&webhook, raw);
+
+        Ok(ProcessedMessage { content, metadata })
     }
 }
 
@@ -222,43 +209,10 @@ impl MessageProcessor for SessionRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::gateway::{DmScope, GatewayConfig};
-    use crate::session::bootstrap::BootstrapMode;
-    use crate::session::persistence::ReasoningLevel;
-    use std::sync::Arc;
-
-    fn test_config() -> GatewayConfig {
-        GatewayConfig {
-            name: "test".to_string(),
-            rate_limit_per_minute: 100,
-            max_message_size: 65536,
-            dm_scope: DmScope::PerAccountChannelPeer,
-            ..Default::default()
-        }
-    }
+    use crate::gateway::DmScope;
 
     fn make_router() -> SessionRouter {
-        let mgr = Arc::new(SessionManager::new(
-            &test_config(),
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        SessionRouter::new(mgr)
-    }
-
-    fn assert_session_id_format(sid: &str, agent_id: &str) {
-        assert!(
-            sid.starts_with(&format!("{agent_id}_")),
-            "bad format: {sid}"
-        );
-        let hex = sid.rsplitn(2, '_').next().unwrap();
-        assert_eq!(hex.len(), 8, "hex part wrong: {hex}");
-        assert!(
-            hex.chars().all(|c| c.is_ascii_hexdigit()),
-            "hex part non-hex: {hex}"
-        );
+        SessionRouter::new(DmScope::PerAccountChannelPeer)
     }
 
     /// Minimal feishu DM webhook fixture.
@@ -299,32 +253,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_private_chat_creates_session() {
+    async fn test_private_chat_computes_session_key() {
         let router = make_router();
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
         let result = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
-        let sid = result.metadata.get("session_id").unwrap();
-        assert_session_id_format(sid, "oc_agent_b");
+        let key = result.metadata.get("session_key").unwrap();
+        assert!(!key.is_empty(), "session_key should not be empty");
+        // PerAccountChannelPeer: acc:channel:from:to
+        assert!(key.contains("ou_user_a"), "key should contain from: {key}");
+        assert!(key.contains("oc_agent_b"), "key should contain to: {key}");
     }
 
     #[tokio::test]
-    async fn test_existing_session_not_duplicated() {
+    async fn test_deterministic_session_key() {
         let router = make_router();
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
         let r1 = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
-        let id1 = r1.metadata.get("session_id").unwrap().clone();
+        let key1 = r1.metadata.get("session_key").unwrap().clone();
         let r2 = router
             .process(&MessageContext::default(), &raw)
             .await
             .unwrap();
-        let id2 = r2.metadata.get("session_id").unwrap().clone();
-        assert_eq!(id1, id2, "session should not be duplicated");
+        let key2 = r2.metadata.get("session_key").unwrap().clone();
+        assert_eq!(key1, key2, "same input must produce same session_key");
     }
 
     #[tokio::test]
@@ -342,26 +299,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_account_id_passed_to_find_or_create() {
-        let cfg = GatewayConfig {
-            dm_scope: DmScope::PerAccountChannelPeer,
-            ..test_config()
-        };
-        let mgr = Arc::new(SessionManager::new(
-            &cfg,
-            None,
-            None,
-            BootstrapMode::Full,
-            ReasoningLevel::default(),
-        ));
-        let router = SessionRouter::new(mgr);
+    async fn test_dm_scope_affects_session_key() {
+        let r1 = SessionRouter::new(DmScope::PerChannelPeer);
+        let r2 = SessionRouter::new(DmScope::PerAccountChannelPeer);
         let raw = feishu_dm_webhook("ou_user_a", "oc_agent_b");
-        let result = router
+        let k1 = r1
             .process(&MessageContext::default(), &raw)
             .await
-            .unwrap();
-        let sid = result.metadata.get("session_id").unwrap();
-        assert_session_id_format(sid, "oc_agent_b");
+            .unwrap()
+            .metadata
+            .get("session_key")
+            .unwrap()
+            .clone();
+        let k2 = r2
+            .process(&MessageContext::default(), &raw)
+            .await
+            .unwrap()
+            .metadata
+            .get("session_key")
+            .unwrap()
+            .clone();
+        assert_ne!(k1, k2, "different DmScope should produce different keys");
     }
 
     #[tokio::test]
@@ -376,7 +334,7 @@ mod tests {
             result.metadata.get("existing_key").unwrap(),
             "existing_value"
         );
-        assert!(result.metadata.contains_key("session_id"));
+        assert!(result.metadata.contains_key("session_key"));
         assert!(result.metadata.contains_key("from"));
         assert!(result.metadata.contains_key("to"));
         assert!(result.metadata.contains_key("channel"));
@@ -399,7 +357,10 @@ mod tests {
         assert_eq!(result.metadata.get("to").unwrap(), "oc_agent_b");
         assert_eq!(result.metadata.get("channel").unwrap(), "feishu");
         assert_eq!(result.metadata.get("account_id").unwrap(), "tenant_abc");
-        assert_session_id_format(result.metadata.get("session_id").unwrap(), "oc_agent_b");
+        let key = result.metadata.get("session_key").unwrap();
+        assert!(!key.is_empty());
+        assert!(key.contains("ou_user_a"));
+        assert!(key.contains("oc_agent_b"));
         assert_eq!(result.content, "{\"text\":\"hello\"}");
     }
 
@@ -435,23 +396,26 @@ mod tests {
         assert_eq!(result.metadata.get("to").unwrap(), "oc_thread_chat");
         assert_eq!(result.metadata.get("channel").unwrap(), "feishu");
         assert_eq!(result.metadata.get("account_id").unwrap(), "tenant_thread");
-        assert!(result
-            .metadata
-            .get("session_id")
-            .unwrap()
-            .starts_with("oc_thread_chat_"));
+        let key = result.metadata.get("session_key").unwrap();
+        assert!(!key.is_empty());
+        assert!(key.contains("ou_thread_user"));
+        assert!(key.contains("oc_thread_chat"));
         assert_eq!(result.content, "{\"text\":\"original\"}");
     }
 
     #[tokio::test]
-    async fn test_processed_msg_without_raw_webhook_errors() {
+    async fn test_missing_fields_yields_empty_session_key() {
         let router = make_router();
-        let processed = serde_json::json!({
-            "content": "{\"text\":\"hi\"}",
-            "metadata": {}
-        });
-        let ctx = MessageContext::default();
-        let err = router.process(&ctx, &processed).await;
-        assert!(err.is_err(), "should fail without raw webhook");
+        // A minimal payload with no sender/message fields.
+        let raw = serde_json::json!({});
+        let result = router
+            .process(&MessageContext::default(), &raw)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.metadata.get("session_key").unwrap(),
+            "",
+            "missing fields should yield empty session_key"
+        );
     }
 }


### PR DESCRIPTION
SessionRouter 改为计算 session_key 而非调 find_or_create 创建 session

- SessionRouter 不再持有 Arc<SessionManager>，改为持有 DmScope
- process() 计算确定性 session_key 写入 metadata（替代 session_id）
- Gateway route_message() 支持 session_key/session_id 双路径过渡
- 无 key 兜底：两者都缺失时回复用户错误提示

Source: issue #947
Type: refactor
