### PR TITLE
feat: 打通 Cache Adapter 调用链路 + 解析 STATIC_LAYER_END 边界标记

### DIFF
--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -9,7 +9,9 @@
 
 use super::Gateway;
 use crate::gateway::session_manager::SessionManager;
-use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::gateway::system_prompt_inject::{
+    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
+};
 use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
 use crate::llm::session::ChatSession;
@@ -246,6 +248,11 @@ impl SessionMessageHandler {
             &dynamic_sections,
             overrides.as_ref(),
         );
+
+        // ── Split static/dynamic for cache adapter (reserved) ──────────
+        // Issue #965: pre-split the prompt here; #967 will wire the
+        // results into InternalRequest for the non-streaming path.
+        let (_system_static, _system_dynamic) = split_static_dynamic(&full_prompt);
 
         // ── Build ChatRequest with system + user messages ───────────────
         let mut messages = vec![];

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -1,5 +1,7 @@
 use super::session_handler::MessageMetadata;
-use super::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use super::system_prompt_inject::{
+    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
+};
 use super::*;
 use crate::llm::client::UnifiedChatClient;
 use crate::llm::fallback::FallbackClient;
@@ -410,6 +412,69 @@ fn test_workdir_path_no_config_dir_exposure() {
     assert_eq!(sanitized, "~/my-agent/u123/");
     assert!(!sanitized.contains(".closeclaw"));
     assert!(!sanitized.contains("/home/alice"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// split_static_dynamic Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// split_static_dynamic: content before marker → static, after → dynamic.
+#[test]
+fn test_split_static_dynamic_with_marker() {
+    let input = "Be helpful.
+<!-- STATIC_LAYER_END -->
+You are a coding assistant.";
+    let (s, d) = split_static_dynamic(input);
+    assert_eq!(s.as_deref(), Some("Be helpful."));
+    assert_eq!(d.as_deref(), Some("You are a coding assistant."));
+}
+
+/// split_static_dynamic: no marker → entire prompt goes to static.
+#[test]
+fn test_split_static_dynamic_no_marker() {
+    let input = "You are a helpful assistant.";
+    let (s, d) = split_static_dynamic(input);
+    assert_eq!(s.as_deref(), Some("You are a helpful assistant."));
+    assert_eq!(d, None);
+}
+
+/// split_static_dynamic: empty string → (None, None).
+#[test]
+fn test_split_static_dynamic_empty() {
+    let (s, d) = split_static_dynamic("");
+    assert_eq!(s, None);
+    assert_eq!(d, None);
+}
+
+/// split_static_dynamic: marker at the very start → static is None, dynamic is the rest.
+#[test]
+fn test_split_static_dynamic_marker_at_start() {
+    let input = "<!-- STATIC_LAYER_END -->\nSome dynamic content.";
+    let (s, d) = split_static_dynamic(input);
+    assert_eq!(s, None, "static should be None when marker is at the start");
+    assert_eq!(d.as_deref(), Some("Some dynamic content."));
+}
+
+/// split_static_dynamic: marker at the very end → dynamic is None, static is the rest.
+#[test]
+fn test_split_static_dynamic_marker_at_end() {
+    let input = "Static content.\n<!-- STATIC_LAYER_END -->";
+    let (s, d) = split_static_dynamic(input);
+    assert_eq!(s.as_deref(), Some("Static content."));
+    assert_eq!(d, None, "dynamic should be None when marker is at the end");
+}
+
+/// split_static_dynamic: multiple markers → only the first one is used as the split point.
+#[test]
+fn test_split_static_dynamic_multiple_markers() {
+    let input = "First part.\n<!-- STATIC_LAYER_END -->\nMiddle.\n<!-- STATIC_LAYER_END -->\nLast.";
+    let (s, d) = split_static_dynamic(input);
+    assert_eq!(s.as_deref(), Some("First part."));
+    // Dynamic should contain everything after the first marker, including the second marker
+    assert_eq!(
+        d.as_deref(),
+        Some("Middle.\n<!-- STATIC_LAYER_END -->\nLast.")
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -13,7 +13,9 @@ use tokio_util::sync::CancellationToken;
 use super::session_handler::{MessageMetadata, SessionMessageHandler};
 use crate::gateway::outbound::StreamResult;
 use crate::gateway::session_manager::SessionManager;
-use crate::gateway::system_prompt_inject::{build_dynamic_sections, build_full_system_prompt};
+use crate::gateway::system_prompt_inject::{
+    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
+};
 use crate::gateway::Gateway;
 use crate::im::IMPlugin;
 use crate::llm::client::UnifiedChatClient;
@@ -86,6 +88,8 @@ impl SessionMessageHandler {
             overrides.as_ref(),
         );
 
+        let (system_static, system_dynamic) = split_static_dynamic(&full_prompt);
+
         let mut messages = vec![];
         if !full_prompt.is_empty() {
             messages.push(ChatMessage {
@@ -111,10 +115,10 @@ impl SessionMessageHandler {
             max_tokens: None,
             stream: true,
             extra_body: Default::default(),
-            system_static: None,
-            system_dynamic: None,
+            system_static,
+            system_dynamic,
             system_blocks: None,
-            session_id: None,
+            session_id: Some(session_id.to_string()),
             reasoning_level,
         };
 

--- a/src/gateway/system_prompt_inject.rs
+++ b/src/gateway/system_prompt_inject.rs
@@ -62,6 +62,41 @@ pub(crate) fn build_dynamic_sections(
     sections
 }
 
+/// Split a full system prompt into static and dynamic parts.
+///
+/// Uses the `<!-- STATIC_LAYER_END -->` boundary marker as the split point:
+///
+/// - Content **before** the first marker → `Some(static)` (trailing whitespace trimmed)
+/// - Content **after** the first marker → `Some(dynamic)` (leading whitespace trimmed)
+/// - No marker → `(Some(full_prompt.to_owned()), None)`
+/// - Empty string → `(None, None)`
+pub(crate) fn split_static_dynamic(full_prompt: &str) -> (Option<String>, Option<String>) {
+    if full_prompt.is_empty() {
+        return (None, None);
+    }
+
+    let marker = "<!-- STATIC_LAYER_END -->";
+    match full_prompt.find(marker) {
+        Some(pos) => {
+            let static_part = full_prompt[..pos].trim_end().to_owned();
+            let dynamic_part = full_prompt[pos + marker.len()..].trim_start().to_owned();
+
+            let s = if static_part.is_empty() {
+                None
+            } else {
+                Some(static_part)
+            };
+            let d = if dynamic_part.is_empty() {
+                None
+            } else {
+                Some(dynamic_part)
+            };
+            (s, d)
+        }
+        None => (Some(full_prompt.to_owned()), None),
+    }
+}
+
 /// Compose a full system prompt from static layer + dynamic sections.
 ///
 /// Inserts `<!-- STATIC_LAYER_END -->` between static and dynamic layers.


### PR DESCRIPTION
打通 Cache Adapter 调用链路，新增 split_static_dynamic 函数解析 STATIC_LAYER_END 边界标记，流式路径 InternalRequest 正确填充 system_static/system_dynamic/session_id。

Source: issue #965
Type: feat
