### PR TITLE
feat: 从 system prompt 动态层移出 turn_count + 固化 ChannelContext timestamp

### DIFF
--- a/src/gateway/priority_prompt_tests.rs
+++ b/src/gateway/priority_prompt_tests.rs
@@ -24,7 +24,7 @@ fn test_priority_override_wins_over_agent_and_custom() {
         custom_prompt: Some("custom prompt".into()),
     };
     let meta = make_meta("u", "ch", 0);
-    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let dynamic = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     assert!(full.contains("override prompt"));
@@ -41,7 +41,7 @@ fn test_priority_agent_wins_over_custom() {
         custom_prompt: Some("custom prompt".into()),
     };
     let meta = make_meta("u", "ch", 0);
-    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let dynamic = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     assert!(full.contains("agent prompt"));
@@ -57,7 +57,7 @@ fn test_priority_custom_fallback() {
         custom_prompt: Some("custom prompt".into()),
     };
     let meta = make_meta("u", "ch", 0);
-    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let dynamic = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     assert!(full.contains("custom prompt"));
@@ -72,7 +72,7 @@ fn test_priority_override_mutual_exclusivity() {
         custom_prompt: Some("custom ignored".into()),
     };
     let meta = make_meta("u", "ch", 0);
-    let dynamic = build_dynamic_sections(0, &meta, None, &[]);
+    let dynamic = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     // Only override prompt appears
@@ -93,7 +93,7 @@ fn test_priority_hit_only_appends_append_section() {
         custom_prompt: None,
     };
     let meta = make_meta("alice", "telegram", 1700000000);
-    let dynamic = build_dynamic_sections(5, &meta, None, &["extra instruction".into()]);
+    let dynamic = build_dynamic_sections(&meta, None, &["extra instruction".into()], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     // Override prompt is the base
@@ -107,7 +107,7 @@ fn test_priority_hit_only_appends_append_section() {
         "ChannelContext should not appear on priority hit"
     );
     assert!(
-        !full.contains("turn_count: 5"),
+        !full.contains("pending_tasks:"),
         "SessionState should not appear on priority hit"
     );
     assert!(
@@ -124,14 +124,14 @@ fn test_priority_hit_multiple_appends() {
         ..Default::default()
     };
     let meta = make_meta("u", "ch", 0);
-    let dynamic = build_dynamic_sections(0, &meta, None, &["first".into(), "second".into()]);
+    let dynamic = build_dynamic_sections(&meta, None, &["first".into(), "second".into()], None);
     let full = build_full_system_prompt(Some("static"), &dynamic, Some(&overrides));
 
     assert!(full.contains("agent prompt"));
     assert!(full.contains("first"));
     assert!(full.contains("second"));
     assert!(!full.contains("sender_id"));
-    assert!(!full.contains("turn_count"));
+    assert!(!full.contains("pending_tasks:"));
 }
 
 /// Test (d): When no override matches, normal behavior is preserved.
@@ -139,7 +139,7 @@ fn test_priority_hit_multiple_appends() {
 fn test_priority_no_hit_normal_behavior() {
     let overrides = PromptOverrides::default(); // all None
     let meta = make_meta("bob", "feishu", 1700000000);
-    let dynamic = build_dynamic_sections(3, &meta, None, &[]);
+    let dynamic = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("static prompt"), &dynamic, Some(&overrides));
 
     // Static prompt is preserved
@@ -148,14 +148,14 @@ fn test_priority_no_hit_normal_behavior() {
     assert!(full.contains("<!-- STATIC_LAYER_END -->"));
     // Dynamic layers injected
     assert!(full.contains("sender_id: bob"));
-    assert!(full.contains("turn_count: 3"));
+    assert!(full.contains("pending_tasks:"));
 }
 
 /// Test (e): None overrides behaves identically to normal path.
 #[test]
 fn test_priority_none_overrides_normal_behavior() {
     let meta = make_meta("carol", "ch", 1700000000);
-    let dynamic = build_dynamic_sections(2, &meta, None, &["appendix".into()]);
+    let dynamic = build_dynamic_sections(&meta, None, &["appendix".into()], None);
     let full_none = build_full_system_prompt(Some("static"), &dynamic, None);
     let full_default =
         build_full_system_prompt(Some("static"), &dynamic, Some(&PromptOverrides::default()));
@@ -165,6 +165,6 @@ fn test_priority_none_overrides_normal_behavior() {
     // Both contain static + dynamic
     assert!(full_none.contains("static"));
     assert!(full_none.contains("sender_id: carol"));
-    assert!(full_none.contains("turn_count: 2"));
+    assert!(full_none.contains("pending_tasks:"));
     assert!(full_none.contains("appendix"));
 }

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -220,25 +220,26 @@ impl SessionMessageHandler {
         session_id: &str,
     ) -> Result<UnifiedResponse, crate::llm::LLMError> {
         // ── Static layer ───────────────────────────────────────────────
-        let (static_prompt_opt, turn_count, workdir_path, system_appends) =
+        let (static_prompt_opt, session_timestamp, _turn_count, workdir_path, system_appends) =
             if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                 let cs_read = cs.read().await;
                 (
                     cs_read.system_prompt().map(|s| s.to_string()),
+                    Some(cs_read.session_created_at()),
                     cs_read.turn_count(),
                     cs_read.workdir().to_string_lossy().into_owned(),
                     cs_read.system_appends().to_vec(),
                 )
             } else {
-                (None, 0, String::new(), Vec::new())
+                (None, None, 0, String::new(), Vec::new())
             };
 
         // ── Dynamic sections ───────────────────────────────────────────
         let dynamic_sections = build_dynamic_sections(
-            turn_count,
             meta,
             Some(workdir_path.as_str()),
             &system_appends,
+            session_timestamp,
         );
 
         // ── Compose full prompt ─────────────────────────────────────────

--- a/src/gateway/session_handler_dynamic_tests.rs
+++ b/src/gateway/session_handler_dynamic_tests.rs
@@ -173,7 +173,7 @@ fn make_meta(sender: &str, channel: &str, ts: i64) -> MessageMetadata {
 #[test]
 fn test_build_dynamic_sections_channel_context() {
     let meta = make_meta("user_42", "feishu", 1700000000);
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
 
     // Find ChannelContext section
     let cc = sections
@@ -187,31 +187,67 @@ fn test_build_dynamic_sections_channel_context() {
     assert!(rendered.contains("timestamp:"));
 }
 
-/// build_dynamic_sections always includes SessionState with correct turn_count.
+/// session_timestamp parameter overrides meta.timestamp in ChannelContext.
+#[test]
+fn test_build_dynamic_sections_session_timestamp_override() {
+    let meta = make_meta("user_42", "feishu", 1700000000);
+    let session_ts: i64 = 1700000042;
+    let sections = build_dynamic_sections(&meta, None, &[], Some(session_ts));
+    let cc = sections
+        .iter()
+        .find(|s: &&Section| s.name() == "channel_context")
+        .unwrap();
+    let rendered = cc.render();
+    // The timestamp should be derived from session_ts, not meta.timestamp
+    let expected_dt = chrono::DateTime::from_timestamp(session_ts, 0).unwrap();
+    assert!(
+        rendered.contains(&expected_dt.to_rfc3339()),
+        "ChannelContext timestamp should use session_timestamp when provided"
+    );
+}
+
+/// When session_timestamp is None, ChannelContext falls back to meta.timestamp.
+#[test]
+fn test_build_dynamic_sections_session_timestamp_fallback() {
+    let meta = make_meta("user_42", "feishu", 1700000000);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
+    let cc = sections
+        .iter()
+        .find(|s: &&Section| s.name() == "channel_context")
+        .unwrap();
+    let rendered = cc.render();
+    // The timestamp should be derived from meta.timestamp
+    let expected_dt = chrono::DateTime::from_timestamp(meta.timestamp, 0).unwrap();
+    assert!(
+        rendered.contains(&expected_dt.to_rfc3339()),
+        "ChannelContext timestamp should fallback to meta.timestamp when session_timestamp is None"
+    );
+}
+
+/// build_dynamic_sections always includes SessionState with correct pending_tasks.
 #[test]
 fn test_build_dynamic_sections_session_state() {
     let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(7, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
 
     let ss = sections
         .iter()
         .find(|s: &&Section| s.name() == "session_state");
     assert!(ss.is_some(), "SessionState should always be present");
     let rendered = ss.unwrap().render();
-    assert!(rendered.contains("turn_count: 7"));
     assert!(rendered.contains("pending_tasks:"));
 }
 
-/// SessionState with zero turn_count.
+/// SessionState with empty pending_tasks.
 #[test]
-fn test_build_dynamic_sections_turn_count_zero() {
+fn test_build_dynamic_sections_empty_pending_tasks() {
     let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     let ss = sections
         .iter()
         .find(|s: &&Section| s.name() == "session_state")
         .unwrap();
-    assert!(ss.render().contains("turn_count: 0"));
+    assert!(ss.render().contains("pending_tasks:"));
 }
 
 /// AppendSection reflects the per-session system_appends slice:
@@ -222,7 +258,7 @@ fn test_build_dynamic_sections_append_section() {
     let meta = make_meta("u", "ch", 0);
 
     // Part 1: empty slice → no AppendSection
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     assert!(
         !sections.iter().any(|s| s.name() == "append"),
         "AppendSection absent when system_appends is empty"
@@ -233,7 +269,7 @@ fn test_build_dynamic_sections_append_section() {
         "first extra instruction".to_string(),
         "second extra instruction".to_string(),
     ];
-    let sections2 = build_dynamic_sections(0, &meta, None, &items);
+    let sections2 = build_dynamic_sections(&meta, None, &items, None);
     let last = sections2.last().expect("sections should be non-empty");
     assert_eq!(
         last.name(),
@@ -257,7 +293,7 @@ fn test_build_dynamic_sections_append_section() {
 #[test]
 fn test_build_full_system_prompt_composition() {
     let meta = make_meta("alice", "telegram", 1700000000);
-    let sections = build_dynamic_sections(3, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(Some("You are helpful."), &sections, None);
 
     // Contains static layer
@@ -267,21 +303,21 @@ fn test_build_full_system_prompt_composition() {
     // Contains dynamic ChannelContext
     assert!(full.contains("sender_id: alice"));
     // Contains dynamic SessionState
-    assert!(full.contains("turn_count: 3"));
+    assert!(full.contains("pending_tasks:"));
 }
 
 /// build_full_system_prompt with no static prompt uses only dynamic sections.
 #[test]
 fn test_build_full_system_prompt_no_static() {
     let meta = make_meta("bob", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     let full = build_full_system_prompt(None, &sections, None);
 
     // No boundary marker when no static prompt
     assert!(!full.contains("<!-- STATIC_LAYER_END -->"));
     // Still contains dynamic content
     assert!(full.contains("sender_id: bob"));
-    assert!(full.contains("turn_count: 0"));
+    assert!(full.contains("pending_tasks:"));
 }
 
 /// build_full_system_prompt with static but empty dynamic sections.
@@ -290,7 +326,7 @@ fn test_build_full_system_prompt_empty_dynamic() {
     // Pass empty system_appends so dynamic sections are only ChannelContext + SessionState
     let meta = make_meta("", "", 0);
     // build_dynamic_sections always returns ChannelContext + SessionState (at minimum)
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     // These two sections always render to non-empty strings, so dynamic is never truly empty.
     // But we verify the composition still works.
     let full = build_full_system_prompt(Some("static"), &sections, None);
@@ -334,7 +370,7 @@ async fn test_handle_message_backward_compat() {
 #[test]
 fn test_build_dynamic_sections_no_global_workdir() {
     let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta, None, &[]);
+    let sections = build_dynamic_sections(&meta, None, &[], None);
     // Without a workdir_path parameter, no GitStatus section should appear
     let has_git = sections.iter().any(|s| s.name() == "git_status");
     assert!(!has_git, "GitStatus should not appear without workdir_path");
@@ -345,7 +381,7 @@ fn test_build_dynamic_sections_no_global_workdir() {
 #[test]
 fn test_build_dynamic_sections_working_directory() {
     let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta, Some("/tmp/test"), &[]);
+    let sections = build_dynamic_sections(&meta, Some("/tmp/test"), &[], None);
     let wd = sections.iter().find(|s| s.name() == "working_directory");
     assert!(
         wd.is_some(),
@@ -361,7 +397,7 @@ fn test_build_dynamic_sections_git_status_with_path() {
     let meta = make_meta("u", "ch", 0);
     // Use CARGO_MANIFEST_DIR which is a git repo
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let sections = build_dynamic_sections(0, &meta, Some(manifest_dir), &[]);
+    let sections = build_dynamic_sections(&meta, Some(manifest_dir), &[], None);
     let has_wd = sections.iter().any(|s| s.name() == "working_directory");
     let has_git = sections.iter().any(|s| s.name() == "git_status");
     assert!(has_wd, "WorkingDirectory should be present");
@@ -372,7 +408,7 @@ fn test_build_dynamic_sections_git_status_with_path() {
 #[test]
 fn test_build_dynamic_sections_no_git_for_non_repo() {
     let meta = make_meta("u", "ch", 0);
-    let sections = build_dynamic_sections(0, &meta, Some("/tmp"), &[]);
+    let sections = build_dynamic_sections(&meta, Some("/tmp"), &[], None);
     let has_wd = sections.iter().any(|s| s.name() == "working_directory");
     let has_git = sections.iter().any(|s| s.name() == "git_status");
     assert!(has_wd, "WorkingDirectory should be present");
@@ -385,7 +421,7 @@ fn test_working_directory_render_sanitization() {
     let meta = make_meta("u", "ch", 0);
     // Use a path that contains workspaces/ to test sanitization
     let fake_workdir = "/home/user/.closeclaw/workspaces/agent1/user1/";
-    let sections = build_dynamic_sections(0, &meta, Some(fake_workdir), &[]);
+    let sections = build_dynamic_sections(&meta, Some(fake_workdir), &[], None);
     let wd = sections
         .iter()
         .find(|s| s.name() == "working_directory")

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -55,31 +55,39 @@ impl SessionMessageHandler {
         gateway: &Arc<Gateway>,
         plugin: &Arc<dyn IMPlugin>,
     ) -> Result<StreamResult, LLMError> {
-        let (static_prompt_opt, turn_count, workdir_path, system_appends, reasoning_level) =
-            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                let cs_read = cs.read().await;
-                (
-                    cs_read.system_prompt().map(|s| s.to_string()),
-                    cs_read.turn_count(),
-                    cs_read.workdir().to_string_lossy().into_owned(),
-                    cs_read.system_appends().to_vec(),
-                    cs_read.reasoning_level().clone(),
-                )
-            } else {
-                (
-                    None,
-                    0,
-                    String::new(),
-                    Vec::new(),
-                    ReasoningLevel::default(),
-                )
-            };
+        let (
+            static_prompt_opt,
+            session_timestamp,
+            turn_count,
+            workdir_path,
+            system_appends,
+            reasoning_level,
+        ) = if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+            let cs_read = cs.read().await;
+            (
+                cs_read.system_prompt().map(|s| s.to_string()),
+                Some(cs_read.session_created_at()),
+                cs_read.turn_count(),
+                cs_read.workdir().to_string_lossy().into_owned(),
+                cs_read.system_appends().to_vec(),
+                cs_read.reasoning_level().clone(),
+            )
+        } else {
+            (
+                None,
+                None,
+                0,
+                String::new(),
+                Vec::new(),
+                ReasoningLevel::default(),
+            )
+        };
 
         let dynamic_sections = build_dynamic_sections(
-            turn_count,
             meta,
             Some(workdir_path.as_str()),
             &system_appends,
+            session_timestamp,
         );
         let overrides = session_manager.get_prompt_overrides().await;
         let full_prompt = build_full_system_prompt(
@@ -120,6 +128,7 @@ impl SessionMessageHandler {
             system_blocks: None,
             session_id: Some(session_id.to_string()),
             reasoning_level,
+            turn_count: Some(turn_count),
         };
 
         // Get streaming sink from session (CLI/websocket consumers).

--- a/src/gateway/system_prompt_inject.rs
+++ b/src/gateway/system_prompt_inject.rs
@@ -21,23 +21,24 @@ use crate::system_prompt::workdir;
 /// the end of the section list, formatted as a `[N] 内容` numbered
 /// list in insertion order.
 pub(crate) fn build_dynamic_sections(
-    turn_count: u32,
     meta: &MessageMetadata,
     workdir_path: Option<&str>,
     system_appends: &[String],
+    session_timestamp: Option<i64>,
 ) -> Vec<Section> {
     let mut sections: Vec<Section> = Vec::new();
 
     sections.push(Section::ChannelContext {
         chat_name: meta.channel.clone(),
         sender_id: meta.sender_id.clone(),
-        timestamp: chrono::DateTime::from_timestamp(meta.timestamp, 0)
+        timestamp: session_timestamp
+            .and_then(|ts| chrono::DateTime::from_timestamp(ts, 0))
+            .or_else(|| chrono::DateTime::from_timestamp(meta.timestamp, 0))
             .map(|dt| dt.to_rfc3339())
             .unwrap_or_default(),
     });
 
     sections.push(Section::SessionState {
-        turn_count,
         pending_tasks: vec![],
     });
 

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -112,6 +112,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            turn_count: None,
         };
         let result = provider.send(request, serde_json::Value::Null).await;
         assert!(result.is_err());

--- a/src/llm/cache_adapter/mod.rs
+++ b/src/llm/cache_adapter/mod.rs
@@ -123,6 +123,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         }
     }
 

--- a/src/llm/client_test.rs
+++ b/src/llm/client_test.rs
@@ -211,6 +211,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/deepseek/tests.rs
+++ b/src/llm/deepseek/tests.rs
@@ -29,6 +29,7 @@ fn make_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/fake/fake_tests.rs
+++ b/src/llm/fake/fake_tests.rs
@@ -20,6 +20,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/fallback.rs
+++ b/src/llm/fallback.rs
@@ -108,6 +108,7 @@ impl FallbackClient {
             system_blocks: None,
             session_id: None,
             reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            turn_count: None,
         }
     }
 

--- a/src/llm/glm/tests/mock_extra.rs
+++ b/src/llm/glm/tests/mock_extra.rs
@@ -22,6 +22,7 @@ fn internal_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/glm/tests/mock_integration.rs
+++ b/src/llm/glm/tests/mock_integration.rs
@@ -22,6 +22,7 @@ fn internal_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/legacy/legacy_provider_tests.rs
+++ b/src/llm/legacy/legacy_provider_tests.rs
@@ -36,6 +36,7 @@ fn make_internal_request(content: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/legacy/legacy_session.rs
+++ b/src/llm/legacy/legacy_session.rs
@@ -168,6 +168,7 @@ impl ChatSession for LegacySessionAdapter {
             system_blocks: None,
             session_id: None,
             reasoning_level: self.reasoning_level,
+            turn_count: None,
         }
     }
 

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -98,6 +98,7 @@ fn create_internal_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: Default::default(),
+        turn_count: None,
     }
 }
 
@@ -255,6 +256,7 @@ fn create_streaming_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: Default::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -324,6 +324,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let response = provider
@@ -368,6 +369,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let result = provider.send(request, serde_json::json!({})).await;
@@ -404,6 +406,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let result = provider.send(request, serde_json::json!({})).await;
@@ -444,6 +447,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let mut stream = provider

--- a/src/llm/plugin.rs
+++ b/src/llm/plugin.rs
@@ -224,6 +224,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         }
     }
 

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -22,6 +22,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -18,6 +18,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 // ── build_request tests ───────────────────────────────────────────────────

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -24,6 +24,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -189,6 +189,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: InternalRequest = serde_json::from_str(&json).unwrap();
@@ -226,6 +227,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: InternalRequest = serde_json::from_str(&json).unwrap();
@@ -250,6 +252,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: ReasoningLevel::default(),
+            turn_count: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("extra_body"));

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -99,6 +99,10 @@ pub struct ConversationSession {
     pub(crate) tool_states: Arc<RwLock<HashMap<String, ToolExecState>>>,
     /// Per-child session states. See [`super::session_state`].
     pub(crate) child_states: Arc<RwLock<HashMap<String, ChildSessionState>>>,
+    /// When this session was created (Unix timestamp, seconds).
+    /// Used by `build_dynamic_sections` as the ChannelContext timestamp
+    /// so that system-prompt KV-cache prefix stays stable across turns.
+    created_at: i64,
     /// Tool process kill handles. See [`super::session_handles`].
     pub(crate) tool_handles: Arc<RwLock<HashMap<String, Arc<dyn KillHandle>>>>,
     /// Spawned child sessions. See [`super::session_handles`].
@@ -131,6 +135,7 @@ impl ConversationSession {
             reasoning_level: ReasoningLevel::default(),
             workdir,
             stats: RunningStats::new(),
+            created_at: Utc::now().timestamp(),
             streaming_sink: None,
             stream_enabled: false,
             announce_queue: Vec::new(),
@@ -172,6 +177,11 @@ impl ConversationSession {
     pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
         self.system_prompt = Some(prompt.into());
         self
+    }
+
+    /// Returns the Unix timestamp (seconds) when this session was created.
+    pub fn session_created_at(&self) -> i64 {
+        self.created_at
     }
 
     /// Sets the reasoning level.
@@ -364,6 +374,7 @@ impl std::fmt::Debug for ConversationSession {
             .field("pending_messages", &self.pending_messages)
             .field("reasoning_level", &self.reasoning_level)
             .field("workdir", &self.workdir)
+            .field("created_at", &self.created_at)
             .field("stats", &self.stats)
             .field(
                 "streaming_sink",

--- a/src/llm/session/session_chat.rs
+++ b/src/llm/session/session_chat.rs
@@ -185,6 +185,7 @@ impl ChatSession for ConversationSession {
             system_blocks: None,
             session_id: None,
             reasoning_level: self.reasoning_level,
+            turn_count: None,
         }
     }
 

--- a/src/llm/stub.rs
+++ b/src/llm/stub.rs
@@ -161,6 +161,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let response = provider
@@ -193,6 +194,7 @@ mod tests {
             system_blocks: None,
             session_id: None,
             reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            turn_count: None,
         };
 
         let response = provider

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -356,6 +356,10 @@ pub struct InternalRequest {
     /// Skipped during serialization to avoid leaking to API payloads.
     #[serde(skip)]
     pub reasoning_level: ReasoningLevel,
+    /// Current turn count within the session, used for API metadata.
+    /// Skipped during serialization when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_count: Option<u32>,
 }
 
 fn default_temperature() -> f32 {

--- a/src/llm/volcengine/tests.rs
+++ b/src/llm/volcengine/tests.rs
@@ -30,6 +30,7 @@ fn make_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -250,7 +250,6 @@ mod tests {
     fn test_dynamic_sections_not_cached() {
         reset_sections();
         let sections = vec![Section::SessionState {
-            turn_count: 1,
             pending_tasks: vec![],
         }];
         let result1 = build_system_prompt(sections.clone(), None);

--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -26,7 +26,6 @@ pub enum Section {
         timestamp: String,
     },
     SessionState {
-        turn_count: u32,
         pending_tasks: Vec<String>,
     },
     AppendSection(String),
@@ -62,7 +61,7 @@ impl Section {
             Section::WorkingDirectory(_) => "working_directory",
         }
     }
-    fn format_session_state(&self, turn_count: u32, pending_tasks: &[String]) -> String {
+    fn format_session_state(&self, pending_tasks: &[String]) -> String {
         let tasks_str = if pending_tasks.is_empty() {
             "  (none)".to_string()
         } else {
@@ -74,8 +73,8 @@ impl Section {
                 .join("\n")
         };
         format!(
-            "## Session State\n- turn_count: {}\n- pending_tasks:\n{}\n",
-            turn_count, tasks_str
+            "## Session State\n- pending_tasks:\n{}\n",
+            tasks_str
         )
     }
 
@@ -112,9 +111,8 @@ impl Section {
                 )
             }
             Section::SessionState {
-                turn_count,
                 pending_tasks,
-            } => self.format_session_state(*turn_count, pending_tasks),
+            } => self.format_session_state(pending_tasks),
             Section::AppendSection(content) => {
                 format!("## Append\n{}\n", content)
             }
@@ -275,11 +273,9 @@ mod tests {
     #[test]
     fn test_section_render_session_state() {
         let s = Section::SessionState {
-            turn_count: 5,
             pending_tasks: vec!["task1".to_string(), "task2".to_string()],
         };
         let rendered = s.render();
-        assert!(rendered.contains("turn_count: 5"));
         assert!(rendered.contains("task1"));
         assert!(!s.is_cacheable());
     }
@@ -467,7 +463,6 @@ mod tests {
     #[test]
     fn test_session_state_name() {
         let s = Section::SessionState {
-            turn_count: 1,
             pending_tasks: vec![],
         };
         assert_eq!(s.name(), "session_state");


### PR DESCRIPTION
移除 system prompt 动态层的 turn_count，改为通过 InternalRequest metadata 传递；固化 ChannelContext timestamp 为 session 创建时间，提升 KV cache 前缀稳定性。

Source: issue #966
Type: feat
