### PR TITLE
feat: Anthropic Protocol messages 尾部添加 cache_control 标记

### DIFF
--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -57,6 +57,48 @@ fn build_message(msg: &InternalMessage) -> serde_json::Value {
     })
 }
 
+/// Mark the last message with `cache_control` for Anthropic prefix caching.
+///
+/// The API allows mixing string and content-blocks content formats within
+/// the messages array, so only the final message is converted.
+fn mark_last_message_cache_control(messages: &mut [serde_json::Value]) {
+    if let Some(last_msg) = messages.last_mut() {
+        if let Some(content) = last_msg.get("content").and_then(|c| c.as_str()) {
+            let text = content.to_string();
+            last_msg.as_object_mut().unwrap().insert(
+                "content".to_string(),
+                serde_json::json!([{
+                    "type": "text",
+                    "text": text,
+                    "cache_control": { "type": "ephemeral" }
+                }]),
+            );
+        }
+    }
+}
+
+/// Build the Anthropic `system` array from system blocks.
+///
+/// Each block with `cache=true` gets a `cache_control` marker.
+fn build_system_array(blocks: &[crate::llm::types::SystemBlock]) -> Vec<serde_json::Value> {
+    blocks
+        .iter()
+        .map(|b| {
+            let mut obj = serde_json::json!({
+                "type": "text",
+                "text": b.text,
+            });
+            if b.cache {
+                obj.as_object_mut().unwrap().insert(
+                    "cache_control".to_string(),
+                    serde_json::json!({ "type": "ephemeral" }),
+                );
+            }
+            obj
+        })
+        .collect()
+}
+
 #[async_trait]
 impl ChatProtocol for AnthropicProtocol {
     fn protocol_id(&self) -> &ProtocolId {
@@ -75,9 +117,14 @@ impl ChatProtocol for AnthropicProtocol {
             );
         }
 
+        let mut messages: Vec<serde_json::Value> =
+            request.messages.iter().map(build_message).collect();
+
+        mark_last_message_cache_control(&mut messages);
+
         let mut body = serde_json::json!({
             "model": request.model,
-            "messages": request.messages.iter().map(build_message).collect::<Vec<_>>(),
+            "messages": messages,
         });
 
         if let Some(max_tokens) = request.max_tokens {
@@ -94,26 +141,9 @@ impl ChatProtocol for AnthropicProtocol {
             );
         }
 
-        // System blocks: if present, serialize as Anthropic's system array format.
-        // Each block with cache=true gets a cache_control marker.
         if let Some(ref blocks) = request.system_blocks {
             if !blocks.is_empty() {
-                let system_array: Vec<serde_json::Value> = blocks
-                    .iter()
-                    .map(|b| {
-                        let mut obj = serde_json::json!({
-                            "type": "text",
-                            "text": b.text,
-                        });
-                        if b.cache {
-                            obj.as_object_mut().unwrap().insert(
-                                "cache_control".to_string(),
-                                serde_json::json!({ "type": "ephemeral" }),
-                            );
-                        }
-                        obj
-                    })
-                    .collect();
+                let system_array = build_system_array(blocks);
                 body.as_object_mut()
                     .unwrap()
                     .insert("system".to_string(), serde_json::json!(system_array));

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -301,3 +301,115 @@ fn test_build_request_high_reasoning_level_no_injection() {
     assert!(body.get("reasoning_effort").is_none());
     assert!(body.get("reasoning_level").is_none());
 }
+
+// ── messages cache_control tests ──────────────────────────────────────────
+
+#[test]
+fn test_messages_cache_control_single_message() {
+    let proto = AnthropicProtocol::new();
+    let request = make_request(); // single "Hello" message
+    let body = proto.build_request(&request).unwrap();
+
+    let messages = body.get("messages").unwrap().as_array().unwrap();
+    assert_eq!(messages.len(), 1);
+
+    // Content should be a content blocks array with cache_control
+    let content = messages[0].get("content").unwrap().as_array().unwrap();
+    assert_eq!(content.len(), 1);
+    assert_eq!(content[0].get("type").unwrap(), "text");
+    assert_eq!(content[0].get("text").unwrap(), "Hello");
+    assert_eq!(
+        content[0].get("cache_control").unwrap(),
+        &serde_json::json!({ "type": "ephemeral" })
+    );
+}
+
+#[test]
+fn test_messages_cache_control_multiple_messages() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.messages = vec![
+        InternalMessage {
+            role: "user".to_string(),
+            content: "Hi".to_string(),
+        },
+        InternalMessage {
+            role: "assistant".to_string(),
+            content: "Hey!".to_string(),
+        },
+        InternalMessage {
+            role: "user".to_string(),
+            content: "What's up?".to_string(),
+        },
+    ];
+    let body = proto.build_request(&request).unwrap();
+
+    let messages = body.get("messages").unwrap().as_array().unwrap();
+    assert_eq!(messages.len(), 3);
+
+    // First two messages should keep string content
+    assert!(messages[0].get("content").unwrap().is_string());
+    assert_eq!(messages[0].get("content").unwrap().as_str().unwrap(), "Hi");
+    assert!(messages[1].get("content").unwrap().is_string());
+    assert_eq!(
+        messages[1].get("content").unwrap().as_str().unwrap(),
+        "Hey!"
+    );
+
+    // Last message should be content blocks with cache_control
+    let last_content = messages[2].get("content").unwrap().as_array().unwrap();
+    assert_eq!(last_content.len(), 1);
+    assert_eq!(last_content[0].get("type").unwrap(), "text");
+    assert_eq!(last_content[0].get("text").unwrap(), "What's up?");
+    assert_eq!(
+        last_content[0].get("cache_control").unwrap(),
+        &serde_json::json!({ "type": "ephemeral" })
+    );
+}
+
+#[test]
+fn test_messages_cache_control_empty_messages() {
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.messages = vec![];
+    let body = proto.build_request(&request).unwrap();
+
+    // Empty messages should produce an empty array with no cache_control added
+    let messages = body.get("messages").unwrap().as_array().unwrap();
+    assert!(messages.is_empty());
+}
+
+#[test]
+fn test_messages_cache_control_with_system_blocks() {
+    use crate::llm::types::SystemBlock;
+
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    request.messages = vec![InternalMessage {
+        role: "user".to_string(),
+        content: "Hello".to_string(),
+    }];
+    request.system_blocks = Some(vec![SystemBlock {
+        text: "System prompt".to_string(),
+        cache: true,
+    }]);
+    let body = proto.build_request(&request).unwrap();
+
+    // System should have cache_control
+    let system = body.get("system").unwrap().as_array().unwrap();
+    assert_eq!(system.len(), 1);
+    assert_eq!(
+        system[0].get("cache_control").unwrap(),
+        &serde_json::json!({ "type": "ephemeral" })
+    );
+
+    // Messages should also have cache_control on the last message
+    let messages = body.get("messages").unwrap().as_array().unwrap();
+    assert_eq!(messages.len(), 1);
+    let content = messages[0].get("content").unwrap().as_array().unwrap();
+    assert_eq!(content.len(), 1);
+    assert_eq!(
+        content[0].get("cache_control").unwrap(),
+        &serde_json::json!({ "type": "ephemeral" })
+    );
+}


### PR DESCRIPTION
## 概述

在 `AnthropicProtocol::build_request` 中，构建 messages 数组后，若非空，将最后一条消息的 content 从纯文本字符串转为 content blocks 数组格式并添加 `cache_control: { type: ephemeral }`，以支持 Anthropic 服务端前缀缓存。

前 N-1 条消息保持原有字符串 content 格式不变，Anthropic API 允许同一请求中混合使用两种 content 格式。

## 改动

- `src/llm/protocol/anthropic.rs`：新增 `mark_last_message_cache_control` 函数，在 `build_request` 中调用
- `src/llm/protocol/anthropic_tests.rs`：新增 4 个测试用例覆盖单条/多条/空 messages + system 共存场景

Source: issue #968
Type: feat