### PR TITLE
feat: 验证 ToolsSection 在 system prompt 静态层被前缀缓存覆盖

### DIFF
--- a/src/llm/cache_adapter/mod.rs
+++ b/src/llm/cache_adapter/mod.rs
@@ -41,6 +41,11 @@ impl CacheAdapter for NoopCacheAdapter {
 /// Generates structured [`SystemBlock`] entries from `system_static` and
 /// `system_dynamic`, marking static blocks with `cache: true` so that the
 /// Anthropic protocol layer can emit `cache_control: {"type": "ephemeral"}`.
+///
+/// Tool definitions (ToolsSection) are part of `system_static` and
+/// therefore automatically covered by prefix caching through this adapter.
+/// When tools are embedded in the system prompt text, no separate
+/// `cache_control` annotation on the `tools` API parameter is needed.
 pub struct AnthropicCacheAdapter;
 
 impl CacheAdapter for AnthropicCacheAdapter {
@@ -211,5 +216,30 @@ mod tests {
     #[test]
     fn kimi_adapter_name() {
         assert_eq!(KimiCacheAdapter.name(), "kimi");
+    }
+
+    #[test]
+    fn anthropic_adapter_tools_section_in_static() {
+        let mut req = make_request();
+        req.system_static = Some(
+            "## RoleSection\n\n\
+                You are a helpful assistant.\n\n\
+                ## ToolsSection\n\n\
+                ### file_system\n\
+                - `read` (dangerous: low)\n\
+                - `write` (dangerous: medium)\n\n\
+                ### code\n\
+                - `edit` (dangerous: medium)\n"
+                .to_owned(),
+        );
+        AnthropicCacheAdapter.apply(&mut req);
+
+        let blocks = req.system_blocks.as_ref().unwrap();
+        // Split by "\n\n" produces 3 non-empty blocks: RoleSection,
+        // ToolsSection header, and ToolsSection content.
+        assert!(blocks.len() >= 2);
+        for block in blocks {
+            assert!(block.cache, "block should be cached: {:?}", block.text);
+        }
     }
 }

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -379,6 +379,45 @@ fn test_messages_cache_control_empty_messages() {
     assert!(messages.is_empty());
 }
 
+/// Verify that ToolsSection content in `system_blocks` produces `cache_control`
+/// in the Anthropic request body, confirming the prefix-cache path covers tool
+/// definitions embedded in the static layer.
+#[test]
+fn test_build_request_tools_section_cache_control() {
+    use crate::llm::types::SystemBlock;
+
+    let proto = AnthropicProtocol::new();
+    let mut request = make_request();
+    // Simulate a system prompt with role section followed by ToolsSection content
+    let system_static = "Role: You are a helpful assistant.";
+    let tools_section = "\n\n## Tools\n\n- web_search: search the web\n- read: read files";
+    let full_static = format!("{system_static}{tools_section}");
+    request.system_blocks = Some(vec![SystemBlock {
+        text: full_static,
+        cache: true,
+    }]);
+    let body = proto.build_request(&request).unwrap();
+
+    let system = body.get("system").unwrap().as_array().unwrap();
+    assert_eq!(system.len(), 1);
+    let block = &system[0];
+    assert_eq!(block.get("type").unwrap(), "text");
+    assert!(
+        block
+            .get("text")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .contains("web_search"),
+        "system block should contain ToolsSection content"
+    );
+    assert_eq!(
+        block.get("cache_control").unwrap(),
+        &serde_json::json!({ "type": "ephemeral" }),
+        "ToolsSection block must have cache_control when cache=true"
+    );
+}
+
 #[test]
 fn test_messages_cache_control_with_system_blocks() {
     use crate::llm::types::SystemBlock;


### PR DESCRIPTION
验证工具 Schema 文本（ToolsSection）作为 system prompt 静态层的一部分，经 AnthropicCacheAdapter 处理后正确标记 cache: true，并在 Anthropic 请求中输出 cache_control。

- 新增 cache_adapter UT 验证 ToolsSection 内容通过 adapter 后标记 cache: true
- 新增 protocol/anthropic UT 验证 build_request 输出包含 cache_control
- 补充 AnthropicCacheAdapter 文档注释说明 ToolsSection 缓存策略

Source: issue #969
Type: feat
