### PR TITLE
feat: 添加 Cache Break 两阶段检测机制

### DIFF
--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -72,6 +72,20 @@ impl SessionMessageHandler {
                 if let Some(cs) = session_manager.get_conversation_session(session_id).await {
                     let mut cs_write = cs.write().await;
                     cs_write.append_response(unified);
+                    // Cache break detection (must run before accumulate_usage
+                    // so that last_cache_read_tokens still holds the previous value).
+                    if let Some(info) =
+                        cs_write.detect_cache_break_for_usage(stream_result.usage.cache_read_tokens)
+                    {
+                        tracing::warn!(
+                            session_id,
+                            previous = info.previous_cache_read,
+                            current = info.current_cache_read,
+                            drop = info.drop_tokens,
+                            ratio = info.drop_ratio,
+                            "Cache break detected"
+                        );
+                    }
                     cs_write.accumulate_usage(&stream_result.usage);
                 }
                 let text = stream_result

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -249,6 +249,17 @@ impl ConversationSession {
         self.streaming_sink.as_ref()
     }
 
+    /// Detects a cache break between the previous and current
+    /// `cache_read_tokens`, then updates the tracked last value.
+    ///
+    /// Delegates to [`RunningStats::detect_cache_break_and_update`].
+    pub fn detect_cache_break_for_usage(
+        &mut self,
+        current_cache_read: Option<u32>,
+    ) -> Option<crate::llm::stats::CacheBreakInfo> {
+        self.stats.detect_cache_break_and_update(current_cache_read)
+    }
+
     /// Accumulates a single API call's usage into the session stats.
     pub fn accumulate_usage(&mut self, usage: &UnifiedUsage) {
         self.stats.accumulate(usage);

--- a/src/llm/stats.rs
+++ b/src/llm/stats.rs
@@ -6,6 +6,57 @@
 
 use super::types::UnifiedUsage;
 
+/// Information about a detected cache break between two consecutive calls.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheBreakInfo {
+    /// Previous call's `cache_read_tokens` value.
+    pub previous_cache_read: u32,
+    /// Current call's `cache_read_tokens` value.
+    pub current_cache_read: u32,
+    /// Absolute drop in cache-read tokens.
+    pub drop_tokens: u32,
+    /// Ratio of the drop relative to the previous value (0.0–1.0).
+    pub drop_ratio: f64,
+}
+
+/// Detects a cache break between two consecutive cache-read token counts.
+///
+/// Returns `Some(CacheBreakInfo)` when:
+/// - `current` is less than `previous` by more than 5%
+///   (`current < previous * 0.95`) **and** the absolute drop exceeds
+///   2 000 tokens.
+///
+/// Returns `None` when either input is `None`, the current value is
+/// greater than or equal to the previous value, or the drop does not
+/// meet the thresholds.
+pub fn detect_cache_break(previous: Option<u32>, current: Option<u32>) -> Option<CacheBreakInfo> {
+    let prev = previous?;
+    let curr = current?;
+
+    if curr >= prev {
+        return None;
+    }
+
+    let drop_tokens = prev - curr;
+    let threshold_tokens = 2000u32;
+
+    if drop_tokens <= threshold_tokens {
+        return None;
+    }
+
+    let drop_ratio = drop_tokens as f64 / prev as f64;
+    if drop_ratio <= 0.05 {
+        return None;
+    }
+
+    Some(CacheBreakInfo {
+        previous_cache_read: prev,
+        current_cache_read: curr,
+        drop_tokens,
+        drop_ratio,
+    })
+}
+
 /// Accumulated token usage statistics across multiple LLM API calls.
 ///
 /// All fields use `u64` to avoid overflow in long sessions that may
@@ -24,6 +75,10 @@ pub struct RunningStats {
     pub total_cache_write_tokens: u64,
     /// Number of API calls accumulated.
     pub request_count: u64,
+    /// `cache_read_tokens` from the most recent API call.
+    ///
+    /// `None` before any calls have been accumulated.
+    pub last_cache_read_tokens: Option<u32>,
 }
 
 impl RunningStats {
@@ -36,7 +91,22 @@ impl RunningStats {
             total_cache_read_tokens: 0,
             total_cache_write_tokens: 0,
             request_count: 0,
+            last_cache_read_tokens: None,
         }
+    }
+
+    /// Detects a cache break using the previous and current
+    /// `cache_read_tokens` values, then updates the tracked last value.
+    ///
+    /// Call this **before** `accumulate()` so that `last_cache_read_tokens`
+    /// still holds the previous call's value when the comparison is made.
+    pub fn detect_cache_break_and_update(
+        &mut self,
+        current_cache_read: Option<u32>,
+    ) -> Option<CacheBreakInfo> {
+        let info = detect_cache_break(self.last_cache_read_tokens, current_cache_read);
+        self.last_cache_read_tokens = current_cache_read;
+        info
     }
 
     /// Accumulates a single API call's usage into the running totals.
@@ -80,6 +150,12 @@ impl RunningStats {
     /// for readability at call sites.
     pub fn total_cache_saved(&self) -> u64 {
         self.total_cache_read_tokens
+    }
+
+    /// Returns the `cache_read_tokens` from the most recent API call,
+    /// or `None` if no calls have been accumulated yet.
+    pub fn last_cache_read_tokens(&self) -> Option<u32> {
+        self.last_cache_read_tokens
     }
 }
 
@@ -190,5 +266,168 @@ mod tests {
     fn test_default_trait() {
         let stats = RunningStats::default();
         assert_eq!(stats.request_count, 0);
+    }
+
+    // ── detect_cache_break unit tests ──────────────────────────────
+
+    #[test]
+    fn detect_cache_break_returns_none_when_both_none() {
+        assert!(detect_cache_break(None, None).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_prev_none() {
+        assert!(detect_cache_break(None, Some(10000)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_curr_none() {
+        assert!(detect_cache_break(Some(10000), None).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_curr_equals_prev() {
+        assert!(detect_cache_break(Some(10000), Some(10000)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_curr_greater_than_prev() {
+        assert!(detect_cache_break(Some(8000), Some(10000)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_drop_exactly_2000() {
+        // 10000 -> 8000: drop = 2000, ratio = 20%, drop_tokens <= 2000
+        assert!(detect_cache_break(Some(10000), Some(8000)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_drop_below_2000() {
+        // 10000 -> 8500: drop = 1500
+        assert!(detect_cache_break(Some(10000), Some(8500)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_ratio_le_5_percent() {
+        // 100000 -> 94000: drop = 6000, ratio = 6%, but drop > 2000
+        // Actually 6000/100000 = 0.06 > 0.05, so this WOULD be a break.
+        // Need ratio <= 5%: 100000 -> 95500: drop = 4500, ratio = 4.5%
+        assert!(detect_cache_break(Some(100000), Some(95500)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_none_when_ratio_exactly_5_percent() {
+        // 100000 -> 95000: drop = 5000, ratio = 5.0%, drop > 2000
+        // ratio <= 0.05 (equal), so returns None
+        assert!(detect_cache_break(Some(100000), Some(95000)).is_none());
+    }
+
+    #[test]
+    fn detect_cache_break_returns_some_when_both_thresholds_met() {
+        // 100000 -> 90000: drop = 10000, ratio = 10%
+        let info = detect_cache_break(Some(100000), Some(90000)).unwrap();
+        assert_eq!(info.previous_cache_read, 100000);
+        assert_eq!(info.current_cache_read, 90000);
+        assert_eq!(info.drop_tokens, 10000);
+        assert!((info.drop_ratio - 0.10).abs() < 1e-10);
+    }
+
+    #[test]
+    fn detect_cache_break_large_drop() {
+        // 50000 -> 30000: drop = 20000, ratio = 40%
+        let info = detect_cache_break(Some(50000), Some(30000)).unwrap();
+        assert_eq!(info.drop_tokens, 20000);
+        assert!((info.drop_ratio - 0.40).abs() < 1e-10);
+    }
+
+    // ── RunningStats.last_cache_read_tokens integration tests ───────
+
+    #[test]
+    fn last_cache_read_tokens_none_before_any_accumulate() {
+        let stats = RunningStats::new();
+        assert_eq!(stats.last_cache_read_tokens, None);
+    }
+
+    #[test]
+    fn last_cache_read_tokens_set_by_detect_cache_break_and_update() {
+        let mut stats = RunningStats::new();
+        // First call: detect_cache_break_and_update sets the field
+        stats.detect_cache_break_and_update(Some(3000));
+        assert_eq!(stats.last_cache_read_tokens, Some(3000));
+    }
+
+    #[test]
+    fn last_cache_read_tokens_tracks_latest_value_via_detect() {
+        let mut stats = RunningStats::new();
+        stats.detect_cache_break_and_update(Some(3000));
+        assert_eq!(stats.last_cache_read_tokens, Some(3000));
+
+        stats.detect_cache_break_and_update(Some(5000));
+        assert_eq!(stats.last_cache_read_tokens, Some(5000));
+
+        stats.detect_cache_break_and_update(Some(2000));
+        assert_eq!(stats.last_cache_read_tokens, Some(2000));
+    }
+
+    #[test]
+    fn last_cache_read_tokens_none_when_cache_read_none() {
+        let mut stats = RunningStats::new();
+        stats.accumulate(&make_usage(100, 50, Some(150), None, None));
+        // cache_read_tokens is None in UnifiedUsage, accumulate sets it to 0,
+        // but last_cache_read_tokens is NOT updated by accumulate — it's a
+        // separate tracking field only updated via detect_cache_break_and_update.
+        assert_eq!(stats.last_cache_read_tokens, None);
+    }
+
+    #[test]
+    fn detect_cache_break_and_update_returns_none_first_call() {
+        let mut stats = RunningStats::new();
+        let result = stats.detect_cache_break_and_update(Some(10000));
+        assert!(result.is_none());
+        assert_eq!(stats.last_cache_read_tokens, Some(10000));
+    }
+
+    #[test]
+    fn detect_cache_break_and_update_returns_none_when_no_break() {
+        let mut stats = RunningStats::new();
+        stats.detect_cache_break_and_update(Some(10000));
+        // Small drop: 10000 -> 9900, drop = 100 <= 2000
+        let result = stats.detect_cache_break_and_update(Some(9900));
+        assert!(result.is_none());
+        assert_eq!(stats.last_cache_read_tokens, Some(9900));
+    }
+
+    #[test]
+    fn detect_cache_break_and_update_returns_some_on_break() {
+        let mut stats = RunningStats::new();
+        stats.detect_cache_break_and_update(Some(100000));
+        // Big drop: 100000 -> 90000, drop = 10000, ratio = 10%
+        let result = stats.detect_cache_break_and_update(Some(90000));
+        let info = result.unwrap();
+        assert_eq!(info.previous_cache_read, 100000);
+        assert_eq!(info.current_cache_read, 90000);
+        assert_eq!(info.drop_tokens, 10000);
+        // After update, last_cache_read_tokens should be the new value
+        assert_eq!(stats.last_cache_read_tokens, Some(90000));
+    }
+
+    #[test]
+    fn detect_cache_break_and_update_chain() {
+        let mut stats = RunningStats::new();
+        stats.detect_cache_break_and_update(Some(50000));
+        assert_eq!(stats.last_cache_read_tokens, Some(50000));
+
+        // 50000 -> 49000: drop 1000 <= 2000
+        let r1 = stats.detect_cache_break_and_update(Some(49000));
+        assert!(r1.is_none());
+        assert_eq!(stats.last_cache_read_tokens, Some(49000));
+
+        // 49000 -> 45000: drop 4000, ratio = 4000/49000 ≈ 8.16% > 5%
+        let r2 = stats.detect_cache_break_and_update(Some(45000));
+        let info = r2.unwrap();
+        assert_eq!(info.previous_cache_read, 49000);
+        assert_eq!(info.current_cache_read, 45000);
+        assert_eq!(info.drop_tokens, 4000);
+        assert_eq!(stats.last_cache_read_tokens, Some(45000));
     }
 }


### PR DESCRIPTION
## 变更概述

为 LLM 会话增强层添加 Cache Break 两阶段检测机制（简化版，不做 fingerprint 归因）。

### 核心变更

- `RunningStats` 新增 `last_cache_read_tokens: Option<u32>` 字段，追踪上一轮 cache_read_tokens
- 新增 `CacheBreakInfo` 结构体和 `detect_cache_break` 自由函数，阈值：降幅 > 5% 且绝对下降 > 2000 tokens
- `RunningStats::detect_cache_break_and_update` 封装检测+更新逻辑，一次调用完成两步操作
- `ConversationSession::detect_cache_break_for_usage` 委托方法
- `clear_busy_and_send` 中 `accumulate_usage` 前插入检测，break 时 `tracing::warn!` 输出事件

### 测试

- 28 个 stats 模块测试全部通过（11 个 detect_cache_break 单元测试 + 4 个 last_cache_read_tokens 集成测试 + 4 个 detect_cache_break_and_update 测试 + 9 个原有测试）
- 全量 lib 测试 1953 passed, 1 pre-existing failure（config wizard 临时目录问题，与本次变更无关）

Source: issue #970
Type: feat
