### PR TITLE
fix: ContentNormalizer 非飞书格式消息退化为纯文本标准化

### DIFF
--- a/src/processor_chain/content_normalizer.rs
+++ b/src/processor_chain/content_normalizer.rs
@@ -381,34 +381,40 @@ impl MessageProcessor for ContentNormalizer {
         ctx: &MessageContext,
     ) -> Result<Option<ProcessedMessage>, ProcessError> {
         // Step 1: Parse feishu webhook content.
-        let raw: FeishuMessage = serde_json::from_str(&ctx.content).map_err(|e| {
-            ProcessError::invalid_message(format!("failed to parse feishu message: {e}"))
-        })?;
+        let (content, metadata) = match serde_json::from_str::<FeishuMessage>(&ctx.content) {
+            Ok(raw) => {
+                let content = match raw.msg_type.as_str() {
+                    "text" => {
+                        let text = raw.text.as_ref().ok_or_else(|| {
+                            ProcessError::invalid_message("text message missing text field")
+                        })?;
+                        text.text.clone()
+                    }
+                    "post" => {
+                        let content_json = raw.content.as_ref().ok_or_else(|| {
+                            ProcessError::invalid_message("post message missing content field")
+                        })?;
+                        let content_str = content_json.to_string();
+                        post_to_markdown(&content_str)
+                    }
+                    _ => return Ok(None),
+                };
 
-        let content = match raw.msg_type.as_str() {
-            "text" => {
-                let text = raw.text.as_ref().ok_or_else(|| {
-                    ProcessError::invalid_message("text message missing text field")
-                })?;
-                text.text.clone()
+                // Extract feishu_thread_id: prefer thread_id > root_id > parent_id
+                let feishu_thread_id = raw.thread_id.or(raw.root_id).or(raw.parent_id);
+
+                let mut metadata = serde_json::Map::new();
+                if let Some(tid) = feishu_thread_id {
+                    metadata.insert("feishu_thread_id".to_string(), serde_json::json!(tid));
+                }
+
+                (content, metadata)
             }
-            "post" => {
-                let content_json = raw.content.as_ref().ok_or_else(|| {
-                    ProcessError::invalid_message("post message missing content field")
-                })?;
-                let content_str = content_json.to_string();
-                post_to_markdown(&content_str)
+            Err(_) => {
+                // Not valid Feishu JSON — treat ctx.content as plain text
+                (ctx.content.clone(), serde_json::Map::new())
             }
-            _ => return Ok(None),
         };
-
-        // Extract feishu_thread_id: prefer thread_id > root_id > parent_id
-        let feishu_thread_id = raw.thread_id.or(raw.root_id).or(raw.parent_id);
-
-        let mut metadata = serde_json::Map::new();
-        if let Some(tid) = feishu_thread_id {
-            metadata.insert("feishu_thread_id".to_string(), serde_json::json!(tid));
-        }
 
         // Step 2–5: Markdown normalization
         let mut normalized = content;

--- a/src/processor_chain/content_normalizer_tests.rs
+++ b/src/processor_chain/content_normalizer_tests.rs
@@ -426,3 +426,43 @@ fn test_add_code_block_normal_text_unchanged() {
     let out = add_code_block_language_hint(input);
     assert_eq!(out, "just some plain text");
 }
+
+// --- Plain text / invalid JSON inputs (non-Feishu format) ---
+
+#[tokio::test]
+async fn test_process_plain_text_normalized() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_123".to_string(),
+        content: "hello\n\n\n\nworld  ".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "om_plain_1".to_string(),
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap();
+    assert!(result.is_some());
+    let out = result.unwrap();
+    // Empty lines compressed (4 consecutive → 1 gap), trailing whitespace trimmed
+    assert_eq!(out.content, "hello\n\nworld");
+    // No feishu_thread_id for plain text
+    assert!(out.metadata.get("feishu_thread_id").is_none());
+}
+
+#[tokio::test]
+async fn test_process_invalid_json_normalized() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_123".to_string(),
+        content: "{invalid json".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "om_invalid_1".to_string(),
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap();
+    assert!(result.is_some());
+    let out = result.unwrap();
+    assert_eq!(out.content, "{invalid json");
+    assert!(out.metadata.get("feishu_thread_id").is_none());
+}


### PR DESCRIPTION
ContentNormalizer 的 process() 方法在收到非飞书格式消息（纯文本、无效 JSON）时，原来直接返回 ProcessError::invalid_message 导致消息丢弃。

修改为：JSON 解析失败时将 ctx.content 视为纯文本，走 4 步标准化流程（normalize_empty_lines → trim_trailing_whitespace → normalize_urls → add_code_block_language_hint），不设置 feishu_thread_id metadata，正常返回 ProcessedMessage。

Source: issue #973
Type: fix
