### PR TITLE
fix: ToolsSection 从 section cache 移除，修复 CI 测试竞争

### DIFF
--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -39,7 +39,6 @@ impl Section {
         matches!(
             self,
             Section::RoleSection(_)
-                | Section::ToolsSection(_)
                 | Section::MemorySection(_)
                 | Section::HeartbeatSection(_)
                 | Section::SkillListingSection(_)
@@ -418,7 +417,7 @@ mod tests {
     #[test]
     fn test_tools_section() {
         let s = Section::ToolsSection("tool_a\ntool_b".to_string());
-        assert!(s.is_cacheable());
+        assert!(!s.is_cacheable());
         assert_eq!(s.name(), "tools");
         let rendered = s.render();
         assert!(rendered.starts_with("## Tools\n"));


### PR DESCRIPTION
修复 `test_find_or_create_with_tool_registry` 在 CI 环境下持续失败的问题。

根因：ToolsSection 被标记为 cacheable，在 CI 并行测试时序下，SECTION_CACHE 被其他测试污染，导致系统 prompt 缺失工具名称。

修复：从 `is_cacheable()` 中移除 `ToolsSection`，使其每次重新渲染。

Source: CI
