### PR TITLE
fix: 补全 minimax 集成测试 InternalRequest turn_count 字段

### DIFF
--- a/tests/minimax_mock_tests.rs
+++ b/tests/minimax_mock_tests.rs
@@ -28,6 +28,7 @@ fn internal_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: closeclaw::session::persistence::ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 

--- a/tests/minimax_stream_mock_tests.rs
+++ b/tests/minimax_stream_mock_tests.rs
@@ -28,6 +28,7 @@ fn streaming_request(model: &str) -> InternalRequest {
         system_blocks: None,
         session_id: None,
         reasoning_level: closeclaw::session::persistence::ReasoningLevel::default(),
+        turn_count: None,
     }
 }
 


### PR DESCRIPTION
补全 minimax 集成测试中 InternalRequest 缺失的 turn_count 字段，修复 cargo test --tests 编译失败。

- tests/minimax_mock_tests.rs: 在 internal_request() 的 reasoning_level 之后添加 turn_count: None
- tests/minimax_stream_mock_tests.rs: 在 streaming_request() 的 reasoning_level 之后添加 turn_count: None

Source: issue #991
Type: fix
