### PR TITLE
docs(design): add cache-adapter to system_prompt data flow and module relations

### DIFF
--- a/docs/design/system_prompt/README.md
+++ b/docs/design/system_prompt/README.md
@@ -122,6 +122,8 @@ API 请求到达
   →
   拼接：静态层 + 边界标记 + 动态层 + AppendSection
   →
+  cache adapter 以边界标记为切分点注入缓存控制参数
+  →
   发送 LLM 请求
 ```
 
@@ -149,6 +151,7 @@ Archived session 被访问
 - **ToolRegistry**：提供 ToolsSection 的分组索引。
 - **DiskSkillRegistry**：按 agent 过滤并提供 skill 列表数据，读取磁盘 skill 并合并内置 SkillRegistry 的 skill，按优先级排序。
 - **Slash 模块**：`/system` 指令操作 AppendSection，详细设计见 [slash/system-append](docs/design/slash/system-append.md)。
+- **Cache Adapter**：以边界标记为切分点，对静态层注入缓存控制参数。system prompt 组装完成后经 cache adapter 处理再进入 LLM client。
 
 ### 无关
 


### PR DESCRIPTION
设计文档：system_prompt/README.md（跨模块一致性修正）

## 变更
- `docs/design/system_prompt/README.md`
  - 请求数据流补充 cache adapter 处理步骤（拼接完成 → cache adapter → LLM 请求）
  - 模块关系下游新增 Cache Adapter 条目

## 附带修改
- 无

## 代码对照发现
Step 3 发现 5 条代码与设计文档差异（全部以文档为准），已记入 CODE-GAPS.md：
- P0：Priority prompt 三级覆盖机制（`PromptOverrides`）运行时可替换静态层
- P1：Bootstrap 文件合并为单 Section / HashMap 文件顺序不确定
- P2：ToolsSection 不缓存 / HeartbeatSection 死代码

Source: user
Type: docs
