### PR TITLE
fix: use thread ID in test temp dir to fix parallel test race

### DIFF
--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -207,7 +207,7 @@ mod write_wizard_config_tests {
     /// Helper: create a temporary directory and return its path.
     fn with_temp_dir(f: impl FnOnce(std::path::PathBuf)) {
         let tmp = std::env::temp_dir();
-        let dir = tmp.join(format!("closeclaw_test_{}", std::process::id()));
+        let dir = tmp.join(format!("closeclaw_test_{:?}", std::thread::current().id()));
         std::fs::create_dir_all(&dir).unwrap();
         f(dir.clone());
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
修复 config_wizard 测试竞态问题。

with_temp_dir 使用 std::process::id() 生成临时目录名，同一 cargo test 进程内所有测试线程共享 PID，导致 write_wizard_config 并行测试共享同一目录。一个测试的 remove_dir_all 清理了目录，另一个测试读文件时出现 NotFound 错误。

改为 std::thread::current().id()，每个测试线程使用独立临时目录，消除竞态。

Source: issue #998
Type: fix
