### PR TITLE
docs(design): fix session restore responsibility attribution

### DIFF
--- a/docs/design/session/session-lifecycle.md
+++ b/docs/design/session/session-lifecycle.md
@@ -140,7 +140,7 @@ SessionManager 需要持久化
 
 - **Daemon**：启动时初始化 SqliteStorage、SessionConfigProvider、Sweeper。
 - **SessionManager**：session 创建/切换时通过 CheckpointManager 触发持久化。
-- **Gateway**：访问 session 时检查 status，若为 archived 则触发 restore 流程并发送通知。
+- **Gateway**：通过 SessionManager 的返回结果获知 session 是否由归档恢复，如是则向用户发送「正在恢复会话...」通知。
 
 ### 下游
 


### PR DESCRIPTION
## 修改内容

修复 session-lifecycle.md 中 Archived session 恢复责任归属矛盾。

**改前**：模块关系/上游章节称 Gateway 检查 status 并触发 restore，与同文档数据流章节、session/README、gateway/README、gateway/inbound-flow 均矛盾（其余四处一致指向 SessionManager 负责恢复）。

**改后**：Gateway 通过 SessionManager 的返回结果获知 session 是否由归档恢复，如是则发送通知。恢复由 SessionManager 内部完成。

## 改动文件

- `docs/design/session/session-lifecycle.md` — 模块关系/上游章节 1 行修正

## 代码对照发现

| 差异 | 判定 |
|------|------|
| 恢复通知发送主体：代码中 SessionManager 绕过 Gateway 直接调用 adapter.send_message() | 文档更好 |
| Gateway 无法获知 session 是否恢复：resolve() 返回 String，无恢复标志 | 文档更好 |
| Gateway::route_message() 跳过 find_or_create() 的 channel override | 代码有 bug（独立问题） |

Source: user
Type: docs
