### PR TITLE
fix: test-audit 仅扫描测试文件，排除生产代码

### DIFF
--- a/scripts/test-audit.sh
+++ b/scripts/test-audit.sh
@@ -154,7 +154,7 @@ for i in "${!LABELS[@]}"; do
   pattern="${PATTERNS[$i]}"
 
   # 构建 find 命令参数
-  FIND_ARGS=("$SRC_DIR" "$TEST_DIR" -name '*.rs' -type f)
+  FIND_ARGS=("$SRC_DIR" "$TEST_DIR" -type f \( -name '*_tests.rs' -o -path '*/tests/*' -o -name 'tests.rs' \))
   if [[ -n "$TARGET_FILTER" ]]; then
     FIND_ARGS+=(-path "*${TARGET_FILTER}*")
   fi


### PR DESCRIPTION
fix: test-audit 仅扫描测试文件，排除生产代码

## 变更内容
将 `scripts/test-audit.sh` 的扫描范围从所有 `.rs` 文件缩小为测试文件：
- `*_tests.rs` 结尾的文件
- 路径中包含 `/tests/` 的文件
- `tests.rs` 文件

消除生产代码中 `env::set_var`、`create_dir_all` 等合法用法的误报。

违规数从 290 降至 224。

Source: issue #1005
Type: fix
