### PR TITLE
docs(design): split system_prompt README into sub-feature docs

### DIFF
--- a/docs/design/system_prompt/README.md
+++ b/docs/design/system_prompt/README.md
@@ -1,127 +1,63 @@
-# System Prompt 模块
+# System Prompt
 
 ## 概述
 
-System Prompt 是每次 API 调用时发送给 LLM 的固定前缀，承载 agent 的身份定义、能力边界和运行上下文。
+System Prompt 是每次 API 调用时发送给 LLM 的固定前缀，承载 agent 的身份定义、能力边界和运行上下文，由静态层、动态层、追加区三个独立分区组成，静态层与动态层之间通过边界标记分隔。
 
 ## 架构
 
-System Prompt 由多个 Section 组成，分为静态层、动态层和追加区三层，静态层与动态层之间通过边界标记分隔。追加区是独立分区，持久化在会话状态中，位于 system prompt 末尾。
+System Prompt 按内容生命周期分为三个内容分区和一个边界标记：
 
-### 静态层
+```
+Session 创建 / 恢复 / Compaction
+  →
+  System Prompt Builder
+       │
+       ├── Bootstrap Loader ── bootstrap 文件（AGENTS.md / SOUL.md 等）
+       ├── ToolRegistry ── 工具分组索引
+       ├── DiskSkillRegistry ── skill 清单
+       └── MEMORY.md ── 长期记忆（MemorySection 来源）
+       │
+       ▼
+  ╔════════════════════════╗
+  ║  静态层（session 持久）  ║  ← 走 Section 级缓存
+  ╠════════════════════════╣
+  ║  __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__      ║  ← cache adapter 的切分点
+  ╠════════════════════════╣
+  ║  动态层（每请求即时构建）  ║  ← 不参与前缀缓存
+  ╠════════════════════════╣
+  ║  追加区（/system 管理）  ║  ← 独立分区，持久化
+  ╚════════════════════════╝
+       │
+       ▼
+  Cache Adapter → LLM API
+```
 
-Session 创建时组装，写入 ConversationSession 运行时字段，在 session 生命周期内保持不变（除非触发缓存失效重建）。
+子功能文档：
 
-静态层由两部分组成：bootstrap 文件作为独立 Section，系统生成三个 Section。
-
-Bootstrap 文件按文件名格式化渲染，每文件以 `## 文件名` 为标题，作为独立 Section 注入 system prompt 前缀。按 Minimal/Full 两种模式选择文件集合：
-
-| 文件 | Minimal | Full |
-|------|---------|------|
-| AGENTS.md | ✅ | ✅ |
-| SOUL.md | ✅ | ✅ |
-| IDENTITY.md | ✅ | ✅ |
-| USER.md | ✅ | ✅ |
-| TOOLS.md | ✅ | ✅ |
-| BOOTSTRAP.md | ❌ | ✅ |
-| MEMORY.md | ❌ | ✅ |
-| HEARTBEAT.md | ❌ | ❌ |
-
-HEARTBEAT.md 不属于 bootstrap 集合——它是 cron 触发时由 agent 按需读取的动态上下文，不注入 system prompt。
-
-加载后的 bootstrap 文件内容按文件名格式化渲染（每文件以 `## 文件名` 为标题），作为独立 Section 注入 system prompt 前缀。Bootstrap 文件不存在时跳过，不报错。
-
-系统生成的 Section：
-
-| Section | 内容 | 来源 |
-|---------|------|------|
-| ToolsSection | 所有可用工具的分组索引（名称 + 危险度标记 + 常用工具的行为描述） | ToolRegistry |
-| SkillListingSection | 可用 skill 的摘要清单（名称 + 描述 + 触发条件） | DiskSkillRegistry |
-| MemorySection | 跨 session 的长期记忆 | MEMORY.md |
-
-单个 Section 组装失败时跳过该 Section，其余继续。
-
-ToolsSection 按分组聚合输出，常用工具注入完整行为描述，延迟工具仅注入名称和危险度标记。一级索引有总长度上限，超出时截断。ToolsSection 的实际内容从 ToolRegistry 生成。
-
-SkillListingSection 从 DiskSkillRegistry 获取 skill 数据，按 agent 过滤可见 skill，渲染为摘要清单。若 skill 列表为空，不添加此 Section。listing 内容作为 Section 进入 system prompt，而非 session transcript 中的独立消息。
-
-### 动态层
-
-每次 API 请求时注入，不进持久化存储，不改变 session 的 system prompt。
-
-| Section | 内容 | 来源 |
-|---------|------|------|
-| ChannelContext | 当前消息来源（chat_name、sender_id、timestamp） | 入站消息元数据 |
-| WorkingDirectory | 当前 session 的工作目录路径 | ConversationSession 运行时字段 |
-| GitStatus | 从 workdir 路径派生的 git 分支和变更状态（非 git 仓库时不注入） | session/working-directory 模块 |
-
-动态层内容的约束：同一 session 内多次 API 调用间，动态层内容应尽量不变，确保 KV cache 前缀命中。每轮必然变化的信息（如后台任务状态）不放在 system prompt 中，改用消息驱动推送（task 完成 → 注入 user 消息 → LLM 下轮看到）。每轮递增的计数器（如 turn_count）通过 API metadata 字段传递。
-
-### 追加区
-
-AppendSection 是 system prompt 末尾的独立分区，持久化在会话状态中，不受上下文压缩影响。与 AGENTS.md 等静态层 Section 无优先级冲突——二者是独立分区。
-
-由 `/system` 指令增删管理：
-- `/system add <内容>`：追加文本（多次叠加，会话恢复时保留）
-- `/system clear`：清空追加内容
-- `/system list`：查看当前追加列表
-
-详细设计见 [slash/system-append](docs/design/slash/system-append.md)。
-
-### 边界标记
-
-静态层和动态层之间通过 `STATIC_LAYER_END` 标记分隔。该标记是 cache adapter 的程序输入——cache adapter 以标记为切分点，标记之前的内容作为可缓存前缀（在支持前缀缓存的 provider 上标记 `cache_control`），标记之后的内容每次请求重新计算，不参与前缀缓存。追加区位于动态层之后、对话历史之前。
-
-### 缓存策略
-
-静态层内容走 session 级 Section 缓存。文件型 Section 基于 mtime 校验：文件未变更时命中缓存，避免重复读取和字符串拼接。工具和 skill 内容通过显式缓存失效触发重建。
-
-此缓存节省本地文件读取和字符串拼接开销，与 API 侧的 KV Cache 是独立的两层优化。API KV Cache 通过 cache adapter 层实现——静态层和动态层通过边界标记分离后，cache adapter 在静态层上标记缓存控制参数，使支持前缀缓存的 provider（Anthropic、Kimi）复用静态前缀的 KV cache，仅对动态层和新增消息计费。对于仅支持完全匹配缓存的 provider，通过精简静态层总 token 量来降低每次请求的成本。
-
-缓存失效触发：
-- 文件变更（bootstrap 或 MEMORY.md）→ 对应 Section 缓存失效，下次请求重建
-- `/clear` 命令 → 所有静态层缓存失效
-- Skill 文件变更 → 文件监听器使 SkillListingSection 缓存失效，下次 session 创建、archive 恢复或 compaction 发生时从 registry 获取最新 listing
-- 工具定义变更 → 从 ToolRegistry 重新生成 ToolsSection
-- Session 恢复 → 强制重建全部静态层，确保内容与最新文件一致
-- Compaction → 触发 system prompt 重建回调，强制重建全部静态层，确保继续对话时角色定义、工具列表、skill 清单和长期记忆均为最新版本
-
-### 默认 Prompt
-
-当所有 Section 渲染结果为空时，使用默认 prompt："You are CloseClaw, a helpful AI assistant."。
-
-### 无 Workspace 的 Session
-
-当 session 没有对应 workspace 目录时，不加载 bootstrap 文件，静态层仅包含 ToolsSection 和 SkillListingSection。
+| 文档 | 内容 |
+|------|------|
+| [static-layer.md](static-layer.md) | 静态层：bootstrap 文件、系统生成的 Section、Section 级缓存与失效规则 |
+| [dynamic-layer.md](dynamic-layer.md) | 动态层：每请求即时注入的 ChannelContext / WorkingDirectory / GitStatus，KV Cache 稳定性约束 |
+| [kv-cache.md](kv-cache.md) | 边界标记 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 的位置和语义，作为 cache adapter 的切分合约 |
+| [appends.md](appends.md) | 追加区：`/system` 指令管理的独立分区，持久化不受压缩影响 |
 
 ## 数据流
 
-### 构建（Session 创建时）
+### 构建（创建 / 恢复 / 压缩后）
 
-```
-SessionManager 创建新 session
-  →
-  builder 通过 Bootstrap Loader 按模式加载 bootstrap 文件
-  ToolRegistry 生成工具分组索引
-  DiskSkillRegistry 提供 skill 列表数据
-  读取 MEMORY.md（命中缓存则跳过）
-  →
-  组装静态层：bootstrap 文件 + ToolsSection + SkillListingSection + MemorySection
-  →
-  写入 ConversationSession 的 system prompt 字段（运行时字段，不进 SessionCheckpoint）
-```
+静态层在 session 创建、archive 恢复或 compaction 完成时由 System Prompt Builder 从 bootstrap 文件和系统 Section 组装而成，构建结果写入 ConversationSession 运行时字段。完整构建流程见 [static-layer.md](static-layer.md) 数据流。
 
-### 请求（每次 API 调用时）
+### 请求（每次 API 调用）
 
 ```
 API 请求到达
   →
-  从 ConversationSession 取出静态层（System Prompt Builder 构建的缓存结果）
-  ConversationSession 构建动态层：ChannelContext + WorkingDirectory + GitStatus
-    ChannelContext 由 Gateway 以入站上下文结构体传入，不依赖原始 payload
-  ConversationSession 从自身运行时字段读取 AppendSection
+  ConversationSession 取出静态层（构建时缓存的完整结果）
+  ConversationSession 即时构建动态层（ChannelContext + WorkingDirectory + GitStatus）
+  ConversationSession 从运行时字段读取追加条目
   →
-  拼接：静态层 + 边界标记 + 动态层 + AppendSection（由 ConversationSession 完成）
+  拼接：静态层 + __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__ + 动态层 + 追加区
   →
   cache adapter 以边界标记为切分点注入缓存控制参数
   →
@@ -145,17 +81,17 @@ Archived session 被访问
 ### 上游
 
 - **SessionManager**：在 session 创建和恢复时触发 system prompt 构建。
+- **Slash 模块**：`/system` 指令向 Session 写入 system_appends，system prompt 在每次 API 请求时从 Session 读取并拼入追加区。详细交互见 [slash/system-append](docs/design/slash/system-append.md)。
 
 ### 下游
 
 - **Bootstrap Loader**：提供 bootstrap 文件内容，按 Minimal/Full 模式加载。
 - **ToolRegistry**：提供 ToolsSection 的分组索引。
-- **DiskSkillRegistry**：按 agent 过滤并提供 skill 列表数据，按优先级排序。
-- **Slash 模块**：`/system` 指令操作 AppendSection，详细设计见 [slash/system-append](docs/design/slash/system-append.md)。
-- **Cache Adapter**：以边界标记为切分点，对静态层注入缓存控制参数。system prompt 组装完成后经 cache adapter 处理再进入 LLM client。
+- **DiskSkillRegistry**：按 agent 过滤并提供 skill 列表数据。
+- **Cache Adapter**：以边界标记为切分点，对静态层注入缓存控制参数。详见 [llm/cache-adapter](docs/design/llm/cache-adapter.md)。
 
 ### 无关
 
-- **LLM Provider**（无调用关系）：system prompt 构建完成后通过 ConversationSession 传递给 LLM provider，构建流程本身不调用 provider。
-- **Compaction 模块**（间接关联）：compaction 完成后通过回调触发 system prompt 重建，确保 Section 内容与最新文件一致。system prompt 本身不参与对话消息的压缩逻辑。
-- **Permission 模块**（无调用关系）：权限检查在 Gateway 层，发生在 system prompt 构建之前。
+- **LLM Provider**：构建流程本身不调用 provider，构建完成后通过 ConversationSession 传递。
+- **Compaction 模块**：压缩完成后通过回调触发重建，但 system prompt 不参与消息压缩逻辑。
+- **Permission 模块**：权限检查在 Gateway 层，发生在 system prompt 构建之前。

--- a/docs/design/system_prompt/appends.md
+++ b/docs/design/system_prompt/appends.md
@@ -1,0 +1,62 @@
+# 追加区
+
+## 概述
+
+追加区是 System Prompt 末尾的独立分区，持久化在会话状态中，不受上下文压缩影响，通过 `/system` 指令增删管理。
+
+## 架构
+
+AppendSection 位于 system prompt 末尾，与静态层 Section 无优先级冲突——二者是独立分区。
+
+由 `/system` 指令管理：
+- `/system add <内容>`：追加文本（多次叠加，会话恢复时保留）
+- `/system clear`：清空追加内容
+- `/system list`：查看当前追加列表
+
+详细设计见 [slash/system-append](docs/design/slash/system-append.md)。
+
+追加区持久化在 SessionCheckpoint 中，不受上下文压缩影响。会话恢复时从 checkpoint 重建，之前的追加内容完整保留。`/system clear` 触发持久化更新。
+
+## 数据流
+
+### 追加
+
+```
+/system add <内容>
+  ↓
+Gateway 调用 ConversationSession.add_system_append()
+  ↓
+ConversationSession 更新内存中的追加条目列表
+  ↓
+CheckpointManager.save() 将 system_appends 写入 SessionCheckpoint
+  ↓
+下一次 API 调用时，ConversationSession 读取自身追加条目并拼入 AppendSection
+```
+
+### 清空
+
+```
+/system clear
+  ↓
+Gateway 调用 ConversationSession.clear_system_appends()
+  ↓
+ConversationSession 清空内存中的追加条目列表 + 触发静态层缓存全部失效
+  ↓
+CheckpointManager.save() 持久化空列表
+```
+
+## 模块关系
+
+### 上游
+
+- **Slash 模块**：`/system` 指令触发追加区的增删操作。详细交互见 [slash/system-append](docs/design/slash/system-append.md)。
+
+### 下游
+
+- **ConversationSession**：每次 API 调用时从自身运行时字段读取追加条目并拼入 System Prompt 末尾。
+- **SessionCheckpoint**：`system_appends` 字段随 session 持久化，恢复时重建。
+
+### 无关
+
+- **静态层**：追加区与静态层是独立分区，互不覆盖。`/system clear` 会同时清空静态层缓存以触发重建，但两者内容相互独立。
+- **Compaction 模块**：追加区内容不参与对话压缩，压缩不影响追加条目。

--- a/docs/design/system_prompt/dynamic-layer.md
+++ b/docs/design/system_prompt/dynamic-layer.md
@@ -1,0 +1,51 @@
+# 动态层
+
+## 概述
+
+动态层是每次 API 请求时即时注入的 System Prompt 后缀，不进持久化存储，不改变 session 的固定 system prompt。
+
+## 架构
+
+动态层由三个 Section 组成，每次 API 请求时由 ConversationSession 直接构建（不走 System Prompt Builder）：
+
+| Section | 内容 | 来源 |
+|---------|------|------|
+| ChannelContext | 当前消息来源（chat_name、sender_id、timestamp） | 入站消息元数据 |
+| WorkingDirectory | 当前 session 的工作目录路径 | ConversationSession 运行时字段 |
+| GitStatus | 从 workdir 路径派生的 git 分支和变更状态（非 git 仓库时不注入） | session/working-directory 模块 |
+
+动态层位于静态层和追加区之间，通过边界标记与静态层分隔。
+
+ChannelContext 由 Gateway 以入站上下文结构体传入，不依赖原始 payload。WorkingDirectory 和 GitStatus 由 ConversationSession 从自身运行时字段读取。
+
+### KV Cache 稳定性约束
+
+同一 session 内多次 API 调用间，动态层内容应尽量不变——虽然 cache adapter 不对动态层标记显式缓存控制参数（边界标记之后的内容不参与显式前缀缓存），但支持服务端自动前缀缓存的 provider 仍可因稳定前缀获得更高命中率。每轮必然变化的信息不放在 system prompt 中，改用消息驱动推送——后台任务完成时注入 user 消息，LLM 下轮看到。每轮递增的计数器通过 API metadata 字段传递。
+
+## 数据流
+
+```
+API 请求到达
+  →
+  ConversationSession 从自身运行时字段读取 WorkingDirectory + GitStatus
+  Gateway 提供入站上下文（platform、chat_name、sender_id、timestamp）
+  →
+  即时组装动态层：ChannelContext + WorkingDirectory + GitStatus
+  →
+  拼接到 system prompt（静态层 + 边界标记 + 动态层）
+```
+
+## 模块关系
+
+### 上游
+
+- **Gateway**：每次 API 请求时提供 ChannelContext 所需的入站消息元数据。
+
+### 下游
+
+- **Cache Adapter**：动态层位于边界标记之后，不参与前缀缓存。cache adapter 对动态层内容透传不做修改。
+
+### 无关
+
+- **System Prompt Builder**：动态层不走 Builder 构建路径，由 ConversationSession 直接组装。
+- **SessionCheckpoint**：动态层不持久化，恢复 session 时不恢复动态层。

--- a/docs/design/system_prompt/kv-cache.md
+++ b/docs/design/system_prompt/kv-cache.md
@@ -1,0 +1,48 @@
+# 边界标记与前缀缓存
+
+## 概述
+
+边界标记是 System Prompt 静态层和动态层之间的分隔锚点，同时作为 cache adapter 的程序输入——cache adapter 以其为切分点，对静态前缀注入缓存控制参数，为动态后缀和消息历史透传不做标记。
+
+## 架构
+
+### 边界标记
+
+静态层和动态层之间通过 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 标记分隔。标记的位置在 System Prompt 组装完成后的最终文本中，静态层之后、动态层之前。
+
+标记是 cache adapter 的程序输入，而非仅供人类阅读的装饰文本——cache adapter 以标记为切分点，标记之前的内容作为可缓存前缀（cache adapter 对其标记显式缓存控制参数），标记之后的内容每次请求重新计算，不参与显式前缀缓存（但服务端自动前缀缓存的 provider 仍可因稳定前缀获益）。追加区位于动态层之后、对话历史之前。
+
+### 前缀缓存
+
+API 侧 KV Cache 通过 cache adapter 层实现。静态层和动态层通过边界标记分离后，cache adapter 在静态层上标记缓存控制参数，使支持前缀缓存的 provider 复用静态前缀的 KV cache，仅对动态层和新增消息计费。
+
+对于仅支持完全匹配缓存的 provider，通过精简静态层总 token 量来降低每次请求的成本。
+
+不同 provider 的缓存策略不同（显式前缀缓存 vs 服务端自动前缀缓存 vs 完全匹配缓存），具体适配逻辑由 llm/cache-adapter 定义，system prompt 模块只负责提供边界标记作为合约。
+
+## 数据流
+
+```
+System Prompt 组装完成（静态层 + 边界标记 + 动态层 + 追加区）
+  →
+  cache adapter 读取边界标记位置
+    → 标记之前：静态前缀（注入 cache_control 参数）
+    → 标记之后：动态后缀 + 追加区（透传）
+  →
+  发送 LLM 请求
+```
+
+## 模块关系
+
+### 上游
+
+- **System Prompt 构建流程**：静态层构建完成后、动态层之前插入边界标记。
+
+### 下游
+
+- **Cache Adapter**：以边界标记为切分点，对静态层注入缓存控制参数。详见 [llm/cache-adapter](docs/design/llm/cache-adapter.md)。
+
+### 无关
+
+- **Compaction 模块**：边界标记不参与对话消息压缩。压缩后触发 system prompt 重建，静态层重建时边界标记随之重新定位。
+- **追加区**：追加区位于动态层之后、边界标记之后，不参与前缀缓存。

--- a/docs/design/system_prompt/static-layer.md
+++ b/docs/design/system_prompt/static-layer.md
@@ -1,0 +1,93 @@
+# 静态层
+
+## 概述
+
+静态层是 System Prompt 中在 session 生命周期内保持不变的部分，在 session 创建、archive 恢复、compaction 完成时构建，写入 ConversationSession 运行时字段，除非触发缓存失效重建否则内容不变。
+
+## 架构
+
+静态层由两部分组成：bootstrap 文件作为独立 Section，以及三个系统生成的 Section。
+
+### Bootstrap 文件加载
+
+Bootstrap 文件按文件名格式化渲染，每文件以 `## 文件名` 为标题，作为独立 Section 注入 system prompt 前缀。按 Minimal / Full 两种模式选择文件集合：
+
+| 文件 | Minimal | Full |
+|------|---------|------|
+| AGENTS.md | ✅ | ✅ |
+| SOUL.md | ✅ | ✅ |
+| IDENTITY.md | ✅ | ✅ |
+| USER.md | ✅ | ✅ |
+| TOOLS.md | ✅ | ✅ |
+| BOOTSTRAP.md | ❌ | ✅ |
+| MEMORY.md | ❌ | ❌ |
+| HEARTBEAT.md | ❌ | ❌ |
+
+HEARTBEAT.md 不属于 bootstrap 集合——它是 cron 触发时由 agent 按需读取的动态上下文，不注入 system prompt。Bootstrap 文件不存在时跳过，不报错。
+
+### 系统生成的 Section
+
+| Section | 内容 | 来源 |
+|---------|------|------|
+| ToolsSection | 所有可用工具的分组索引（名称 + 危险度标记 + 常用工具的行为描述） | ToolRegistry |
+| SkillListingSection | 可用 skill 的摘要清单（名称 + 描述 + 触发条件） | DiskSkillRegistry |
+| MemorySection | 跨 session 的长期记忆 | MEMORY.md |
+
+单个 Section 组装失败时跳过该 Section，其余继续。
+
+ToolsSection 按分组聚合输出，常用工具注入完整行为描述，延迟工具仅注入名称和危险度标记。一级索引有总长度上限，超出时截断。ToolsSection 的实际内容从 ToolRegistry 生成。
+
+SkillListingSection 从 DiskSkillRegistry 获取 skill 数据，按 agent 过滤可见 skill，渲染为摘要清单。若 skill 列表为空，不添加此 Section。listing 内容作为 Section 进入 system prompt，而非 session transcript 中的独立消息。
+
+### Section 级缓存
+
+静态层内容走 session 级 Section 缓存。文件型 Section 基于 mtime 校验——文件未变更时命中缓存，避免重复读取和字符串拼接。工具和 skill 内容通过显式缓存失效触发重建。
+
+此缓存节省本地文件读取和字符串拼接开销，与 API 侧的 KV Cache 是独立的两层优化。
+
+缓存失效触发：
+- 文件变更（bootstrap 或 MEMORY.md）→ 对应 Section 缓存失效，下次请求重建
+- `/clear` 命令 → 所有静态层缓存失效
+- `/system clear` → 清空追加区的同时触发静态层缓存全部失效
+- Skill 文件变更 → 文件监听器使 SkillListingSection 缓存失效，下次注入触发时从 registry 获取最新 listing
+- 工具定义变更 → 从 ToolRegistry 重新生成 ToolsSection
+- Session 恢复 → 强制重建全部静态层，确保内容与最新文件一致
+- Compaction → 触发 system prompt 重建回调，强制重建全部静态层
+
+### 兜底与变体
+
+当所有 Section 渲染结果为空时，使用默认 prompt："You are CloseClaw, a helpful AI assistant."。
+
+当 session 没有对应 workspace 目录时，不加载 bootstrap 文件，静态层仅包含 ToolsSection 和 SkillListingSection。
+
+## 数据流
+
+```
+SessionManager 创建新 session / 恢复 archive / compaction 完成
+  →
+  builder 通过 Bootstrap Loader 按模式加载 bootstrap 文件
+  ToolRegistry 生成工具分组索引
+  DiskSkillRegistry 提供 skill 列表数据
+  读取 MEMORY.md（命中缓存则跳过）
+  →
+  组装静态层：bootstrap 文件 + ToolsSection + SkillListingSection + MemorySection
+  →
+  写入 ConversationSession 的 system prompt 字段（运行时字段，不进 SessionCheckpoint）
+```
+
+## 模块关系
+
+### 上游
+
+- **SessionManager**：在 session 创建、archive 恢复、compaction 完成时触发静态层构建。
+
+### 下游
+
+- **Bootstrap Loader**：提供 bootstrap 文件内容，按 Minimal/Full 模式加载。
+- **ToolRegistry**：提供 ToolsSection 的分组索引。
+- **DiskSkillRegistry**：按 agent 过滤并提供 skill 列表数据。
+
+### 无关
+
+- **LLM Provider**：静态层构建完成后通过 ConversationSession 传递给 LLM provider，构建流程本身不调用 provider。
+- **Compaction 模块**：compaction 完成后通过回调触发重建，静态层本身不参与对话消息的压缩逻辑。


### PR DESCRIPTION
设计文档：system_prompt/README.md（索引+架构概览）+ 4 个子功能文档

## 新增文件
- `docs/design/system_prompt/static-layer.md` — 静态层：bootstrap 文件、系统生成的 Section、Section 级缓存与失效规则
- `docs/design/system_prompt/dynamic-layer.md` — 动态层：每请求即时注入、KV Cache 稳定性约束
- `docs/design/system_prompt/kv-cache.md` — 边界标记 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 与 prefix caching 合约
- `docs/design/system_prompt/appends.md` — 追加区：/system 指令管理、持久化

## 修改文件
- `docs/design/system_prompt/README.md` — 瘦身为模块架构概览 + 子功能目录索引

## 附带修改
- 边界标记从 `STATIC_LAYER_END` 改为 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__`（追随 Claude Code 标准）
- MEMORY.md 从 bootstrap 文件表移除（仅通过 MemorySection 访问，消除双重注入）
- Slash 模块关系方向修正（上游而非下游）
- `/system clear` 缓存失效条件补入 static-layer.md

## 代码对照发现
10 条差异，全部判定「文档更好」——不改设计文档，代码侧需建 issue 修正：
- Bootstrap 文件合并为单 Section（应每文件独立）
- MEMORY.md 残留 Full 模式 bootstrap 列表
- ToolsSection 未参与 Section 级缓存
- SessionState 空 Section 每请求注入
- `/system clear` 未触发静态层缓存失效
- HeartbeatSection / build_system_prompt append 死代码
- Section 组装顺序与文档不符
- Priority Prompt Override 整体待移除
- 双路径 system prompt 注入残留
- 边界标记格式

Source: user
Type: docs
