### PR TITLE
docs(design): remove /clear from slash design doc

### DIFF
--- a/docs/design/slash/README.md
+++ b/docs/design/slash/README.md
@@ -45,7 +45,6 @@ Dispatcher 不持有 Session 引用——Handler 返回 SlashResult 后，由 Ga
 | WorkdirHandler | cd, pwd, git | Reply / Exec | ❌ |
 | ExecHandler | exec | Exec / Reply | ❌ |
 | HelpHandler | help | Reply | ✅ |
-| ClearHandler | clear | Reply | ✅ |
 
 ### 子功能目录
 


### PR DESCRIPTION
## 修改内容
- `docs/design/slash/README.md` — 从 Handler 清单中删除 ClearHandler 行

## 修改理由
`/clear`（清除 transcript 保留设置）与 `/new`（创建新 session）功能重叠。owner 决策删除 `/clear` 指令，设计文档先行修正。

## 代码对照发现
本次改动为设计文档修正。代码中 ClearHandler 仍存在，属待清理代码债。
无新增代码-文档差异。

Source: user
Type: docs
