### PR TITLE
docs(design): refine archived session and mapping table relationship design

### DIFF
--- a/docs/design/session/README.md
+++ b/docs/design/session/README.md
@@ -59,10 +59,14 @@ Gateway / SessionManager  ← session 生命周期协调者
   - session_key 是路由查找键，不直接等于 session_id。同一 key 下可以有多个 session（`/new` 指令创建新 session 后覆盖映射）
 
   **key_registry 生命周期**：
-  - 启动时：SessionManager 扫描所有 status=active 的 session，按会话路由键分组，取各 key 下最新 session_id 写入映射表。archived session 不加载
-  - 运行时：查映射表获取已有 session；命中则直接使用，未命中则通过会话路由字段查询 SQLite（联合索引保证性能）——查到 archived 则恢复并注册，查不到则创建新 session 并注册
+  - 启动时：SessionManager 扫描所有 status=active 的 session，按会话路由键分组，取各 key 下最新 session_id 写入映射表。archived session 不加载。同时执行数据一致性校验（详见 [session-lifecycle.md](session-lifecycle.md) 数据一致性校验节）
+  - 运行时：查映射表获取已有 session
+    - 命中 → 校验 session status 仍为 active。若 status 已变为 archived（如被 Sweeper 归档），从映射表移除该条目 → 走未命中回退路径
+    - 未命中 → 通过会话路由字段查询 SQLite → 查到 archived 则取 last_message_at 最新的一条恢复并注册 → 查不到则创建新 session 并注册
+    - 创建新 session 前，做一次 SQLite 双重确认：该 key 下是否已有 active session（防御性检查，正常不应发生）。若有 → 直接注册已有 session（自愈），不再创建新的
   - 创建新 session 后覆盖映射。`/new` 指令同理
   - 映射表为纯内存数据结构，不单独持久化——重建依赖 SessionCheckpoint 中的会话路由键字段
+  - SessionManager 对每个 agent_id 串行处理请求，确保同一 key 的 lookup、恢复、创建操作不会并发竞态
   - **CheckpointManager**：协调 SessionCheckpoint 的读写缓存和持久化。需要持久化时调用 PersistenceService。
   - **SqliteStorage**：生产级持久化后端。SQLite 存元数据，JSONL 文件存 transcript。
   - **ArchiveSweeper**：定时后台任务，扫描 idle session 并归档，扫描过期 archive 并清理。
@@ -87,11 +91,13 @@ Gateway / SessionManager  ← session 生命周期协调者
 ```
 用户消息到达 Gateway
   → Gateway 提取 metadata 中的会话路由信息
-  → SessionManager 查找或创建 session
+  → SessionManager 查找或创建 session（per agent_id 串行）
     → 查映射表
-    → 命中 active session → 返回已有 session
+    → 命中 → 校验 session status 仍为 active
+      → 是 active → 返回已有 session
+      → 非 active → 从映射表移除该条目 → 走未命中路径
     → 未命中 → 通过会话路由字段查询 SQLite
-      → 查到 archived session → 触发恢复
+      → 查到一条或多条 archived session → 取 last_message_at 最新的一条
         → transcript 移回活跃区
         → status 更新为 active
         → 返回 SessionCheckpoint
@@ -99,10 +105,12 @@ Gateway / SessionManager  ← session 生命周期协调者
         → 注册到映射表
         → 执行状态初始为 Idle
         → Gateway 通知用户 → 返回恢复后的 session
-      → 查不到 → 创建新 session → 注册到映射表
-        → 构建 system prompt（注入 bootstrap、工具列表、skill 列表）
-        → 初始化执行状态（Idle）
-        → 首次持久化（写入 checkpoint 和 transcript）
+      → 查不到 archived → 双重确认该 key 下无 active session
+        → 若有 → 注册已有 session 到映射表（自愈，不创建新 session）
+        → 若无 → 创建新 session → 注册到映射表
+          → 构建 system prompt（注入 bootstrap、工具列表、skill 列表）
+          → 初始化执行状态（Idle）
+          → 首次持久化（写入 checkpoint 和 transcript）
 ```
 
 ### Session 运行时
@@ -121,7 +129,7 @@ Gateway / SessionManager  ← session 生命周期协调者
 
 工具调用：
   ConversationSession 注册工具进程句柄
-     → Tool 状态设为 Running(Foreground) 或 Running(Background)
+     → Tool 状态设为 Running(Foreground) 或 Running(Background)（创建后先进入 Pending 瞬态，进程 fork 后转为 Running）
      → 前台：session 阻塞等待完成 → 完成 → 注销句柄
      → 后台：session 不阻塞，进程句柄保留 → 完成时结果注入消息队列
 
@@ -156,7 +164,7 @@ ConversationSession 更新内存中的追加条目列表
 
 两种结束路径：
 - **主动结束**：用户关闭会话或 `/stop`，SessionManager 移除运行时引用，CheckpointManager 最终保存。
-- **自动归档**：Sweeper 检测 idle 超时 → 检查无未完成操作 → 标记为 archived（更新 SQLite status + 记录归档时间）→ transcript 移入 archived_sessions/ → 通知 SessionManager 从映射表移除此 session_key。
+- **自动归档**：Sweeper 检测 idle 超时 → 检查无未完成操作 → 标记为 archived（更新 SQLite status + 记录归档时间）→ transcript 移入 archived_sessions/。Sweeper 不通知 SessionManager——映射表在下次 lookup 命中时通过 status 校验感知到归档，自行移除已失效条目。
 - **自动清理**：Sweeper 检测 archived 超过 purge TTL → 删除元数据 + transcript 文件。
 
 ### 重启恢复

--- a/docs/design/session/session-execution.md
+++ b/docs/design/session/session-execution.md
@@ -65,7 +65,7 @@ Session 的整体状态由三维组合判定：
 
 - **斜杠指令**（`/stop`）：用户在 session 内输入，停当前 session。支持 `--cascade`（级联子 session）和 `--force`（强制终止）标记，可组合使用
 - **父 session 停止**：父 session 被停时，对子 session 采用相同的停止模式（graceful 或 forceful）
-- **系统关闭**：由 Daemon 触发，调用 SessionManager 统一关闭所有活跃 session。SessionManager 内部负责 session 树遍历和停止顺序，Daemon 只传模式参数和超时。所有 session 关闭完毕后，未在超时内完成的 session 标记为 dirty——下次启动时检测并告警
+- **系统关闭**：由 Daemon 触发，调用 SessionManager 统一关闭所有活跃 session。SessionManager 内部负责 session 树遍历和停止顺序，Daemon 只传模式参数和超时。所有 session 关闭完毕后，未在超时内完成的 session 留有未清除的 pending_operations——下次启动时由恢复扫描检测为 dirty 并注入恢复通知
 
 ### 后台结果注入
 

--- a/docs/design/session/session-lifecycle.md
+++ b/docs/design/session/session-lifecycle.md
@@ -67,7 +67,9 @@ SQLite 访问通过线程池包装为异步调用，保证不阻塞运行时。
 
 **ArchiveSweeper** 是 daemon 启动时 spawn 的后台任务，负责两个定时操作：
 
-1. **Archive**：扫描 status=active 且 last_message_at 超过 idleMinutes 且 **pending_operations 为空** 的 session → 调用 archive，transcript 移入 archived_sessions/，**通知 SessionManager 从映射表移除此 session_key**。
+1. **Archive**：扫描 status=active 且 last_message_at 超过 idleMinutes 且 **pending_operations 为空** 的 session → 调用 archive，transcript 移入 archived_sessions/。
+
+归档后 Sweeper 不与 SessionManager 通信——映射表同步由 SessionManager 在下次 lookup 时通过 status 校验被动完成（详见 [README.md](README.md) key_registry 自愈逻辑）。
 2. **Purge**：扫描 status=archived 且 archived_at 超过 purgeAfterMinutes 的 session → 调用 purge，彻底删除。
 
 **调度策略**：启动后延迟一个完整 interval 再执行首次扫描；Unix 系统上将 Sweeper 进程优先级降低，减少对业务逻辑的 CPU 影响。
@@ -104,15 +106,16 @@ Sweeper 定时触发
         → 执行归档
           → 更新 session 状态为 archived，记录归档时间
           → transcript 从活跃区移至归档区
-          → 通知 SessionManager：从映射表移除此 session_key
 ```
+
+归档完成后不通知 SessionManager。SessionManager 在下次 lookup 命中该 key 时，通过 status 校验发现 session 已归档，自行从映射表移除并走未命中回退路径。
 
 ### Archived → Active 恢复
 
 ```
 入站消息到达，映射表未命中
   → SessionManager 通过会话路由字段查询 SQLite
-  → 查到 archived session → 触发恢复
+  → 查到一条或多条 archived session → 取 last_message_at 最新的一条
     → transcript 从归档区移回活跃区
     → session 状态更新为 active，清除归档时间
     → 返回 SessionCheckpoint
@@ -121,9 +124,14 @@ Sweeper 定时触发
   → 注册到映射表
 ```
 
+多条 archived session 匹配同一 key 时，取 last_message_at 最大的那条——最近活跃的 session 承载最新上下文，对用户最有价值。未命中最新的 session 不会被恢复，随 purgeAfterMinutes 到期后由 Sweeper 清理。
+
 ### 恢复时重建策略
 
-恢复时 SqliteStorage 只负责数据层（文件移回 + 数据库状态更新），返回 SessionCheckpoint。SessionManager 拿到 checkpoint 后用其数据重建 ConversationSession 运行时对象，并重新走注入流程以保证 system prompt 内容最新。同时向 Gateway 返回恢复标志，Gateway 向用户发送「正在恢复会话...」通知。
+上列流程中各组件的职责划分：
+- **SqliteStorage**：数据层（文件移回 + 数据库状态更新），输出 SessionCheckpoint
+- **SessionManager**：运行时层（重建 ConversationSession + 触发注入 + 注册映射表），向 Gateway 返回恢复标志
+- **Gateway**：用户通知（发送「正在恢复会话…」消息）
 
 ### Archived → Purge 清理
 
@@ -147,19 +155,29 @@ SessionManager 需要持久化
     → 写入完整 transcript 到文件
 ```
 
+### 数据一致性校验
+
+SessionManager 在启动时和定期维护中执行 SQLite 与文件系统的双向一致性校验：
+
+**SQLite → 文件系统**：SQLite 中有记录但 transcript 文件不存在 → 视为损坏。删除 SQLite 记录，不注册到映射表。不尝试恢复一个没有 transcript 的 session。
+
+**文件系统 → SQLite**：transcript 文件存在但 SQLite 无对应记录 → 视为孤儿文件。删除文件，不尝试从文件反推元数据（文件不包含 status、路由字段等关键信息）。
+
+**定期维护**：启动时执行一次完整扫描，之后以可配置的间隔（默认每小时）执行增量扫描。扫描优先级低于业务逻辑，不阻塞正常请求处理。
+
 ## 模块关系
 
 ### 上游
 
-- **Daemon**：启动时初始化 SqliteStorage、SessionConfigProvider、Sweeper。
-- **SessionManager**：session 创建/切换时通过 CheckpointManager 触发持久化；Sweeper 归档后通知 SessionManager 移除映射条目。
+- **Daemon**：启动时初始化 SqliteStorage、SessionConfigProvider、Sweeper。数据一致性校验由 SessionManager 在其初始化过程中自动执行。
+- **SessionManager**：session 创建/切换时通过 CheckpointManager 触发持久化。
 - **Gateway**：通过 SessionManager 的返回结果获知 session 是否由归档恢复，如是则向用户发送「正在恢复会话...」通知。
 
 ### 下游
 
 - **SqliteStorage**（PersistenceService trait 的实现）：SQLite + 文件系统读写。
 - **SessionConfigProvider**：读取 `config/session.json`，提供 per-agent 配置。
-- **SessionManager（映射表）**：Sweeper 归档后通知 SessionManager 从映射表移除条目。
+- **SessionManager（映射表）**：映射表不单独持久化——重建依赖 SessionCheckpoint 中的会话路由键字段。Sweeper 归档后不通知映射表，SessionManager 在下次 lookup 时通过 status 校验自行移除已归档的映射条目。
 
 ### 无关
 

--- a/docs/design/session/session-recovery.md
+++ b/docs/design/session/session-recovery.md
@@ -31,8 +31,13 @@ Daemon 启动
     → 扫描每个 active session 的 checkpoint
       → pending_operations 非空 → 标记为 dirty
       → pending_operations 为空 → 正常（无需处理）
+    → 防御性扫描：遍历 status=archived 的 session
+      → pending_operations 非空 → 先恢复为 active，再注入恢复通知
+      → pending_operations 为空 → 跳过
     → 对每个 dirty session 立即注入恢复通知
 ```
+
+防御性扫描极少命中（Sweeper 归档前检查 pending_operations 为空），但覆盖崩溃发生在归档过程中的极端窗口：status 已改为 archived 但 transcript 尚未完成迁移的状态下，残留的未完成操作仍能被发现和恢复。
 
 恢复通知在启动时立即注入，不等待入站消息。原因：自动化流程（定时任务、webhook 触发）没有 IM 入站消息来激活它们。
 
@@ -117,6 +122,8 @@ SessionManager 启动扫描
   → 扫描 checkpoint.pending_operations
     → 非空 → 标记 dirty，构造恢复通知
     → 为空 → 跳过
+  → 遍历 status=archived 的 session（防御性）
+    → pending_operations 非空 → 恢复为 active → 标记 dirty
   → 对 dirty session：
     → 注入 system 恢复通知（列出未完成操作摘要）
     → 对每个未完成的工具调用：注入 tool_result 失败反馈


### PR DESCRIPTION
设计文档：session 模块 - Archived session 与映射表关系设计细化

## 修改文件
- `docs/design/session/README.md` — 映射表自愈校验（lookup 命中时验证 status）、双重确认（创建前查 SQLite）、per-agent_id 串行处理
- `docs/design/session/session-lifecycle.md` — 被动同步（Sweeper 归档后不通知 SessionManager）、多 archived 选择规则（last_message_at DESC）、数据一致性校验（启动+定期双向扫描）
- `docs/design/session/session-recovery.md` — 防御性 archived dirty session 扫描
- `docs/design/session/session-execution.md` — 措辞修正（"标记为 dirty"→"留有未清除的 pending_operations"）

## 代码对照发现
- 路由命中时不校验 checkpoint status（缺自愈逻辑）
- CheckpointManager::archive() 实际销毁数据（应只归档不删除）
- SessionManager 绕过 Gateway 直接发送恢复通知（架构违例）

Source: user
Type: docs