### PR TITLE
docs(design): clarify daemon startup phases and step dependencies

### DIFF
--- a/docs/design/daemon/README.md
+++ b/docs/design/daemon/README.md
@@ -12,6 +12,12 @@ Daemon 启动分为五个阶段，按依赖顺序依次初始化：
 基础设施 → 能力注册 → 运行时组件 → 消息通道 → 后台任务
 ```
 
+- **基础设施**：Config 加载（含 .env + openclaw.json 迁移）、Storage 初始化、SessionConfigProvider 初始化
+- **能力注册**：AgentRegistry、Permission Engine、Agent Config 扫描、Tools Registry + DiskSkillRegistry
+- **运行时组件**：Session Manager、System Prompt 构建、Renderer / Plugin 注册
+- **消息通道**：IM Adapters、Gateway（含 SlashDispatcher + ApprovalFlow 注入）
+- **后台任务**：ArchiveSweeper、Skill Watcher、Config Hot Reload
+
 初始化完成后进入消息循环，由 Gateway 接管所有消息处理。
 
 Daemon 持有 SessionManager 和 Gateway 的引用，作为二者的所有者管理其生命周期。
@@ -24,20 +30,26 @@ Daemon 持有 SessionManager 和 Gateway 的引用，作为二者的所有者管
 进程启动
   →
 Daemon 启动
-  ├── 1. Config 加载（多文件合并、凭据分离）
+  ──── 基础设施 ────
+  ├── 1. Config 加载（多文件合并、凭据分离、.env 加载、openclaw.json 迁移）
   ├── 2. Storage 初始化（SqliteStorage）
-  ├── 3. SessionConfigProvider 初始化（读取 config/session.json，提供 per-agent 的 idle/purge 阈值）
-  ├── 4. Permission Engine 初始化（加载规则 + 默认策略）
-  ├── 5. Agent Config 扫描（两级优先级扫描 + 字段合并 → 注册表）
-  ├── 6. Tools Registry + DiskSkillRegistry（注册所有工具和 skill）
-  ├── 7. Session Manager 创建（注入 storage、agent config、tool/skill registry）
-  ├── 8. System Prompt Builder 创建（由 Session Manager 持有引用）
-  ├── 9. Processor Registry（注册入站/出站处理器，按 priority 排序）
-  ├── 10. Renderer Set（各平台 Renderer 注册）
+  ├── 3. SessionConfigProvider 初始化（读取 session_config.json，提供 per-agent 的 idle/purge 阈值）
+  ──── 能力注册 ────
+  ├── 4. AgentRegistry 初始化
+  ├── 5. Permission Engine 初始化（加载全局默认策略，Agent 维度规则延迟加载）
+  ├── 6. Agent Config 扫描（两级优先级扫描 + 字段合并 → 注册表）
+  ├── 7. Tools Registry + DiskSkillRegistry（各模块 register_tools() 注册工具定义，SpawnController 注入；扫描五层 skill 目录）
+  ──── 运行时组件 ────
+  ├── 8. Session Manager 创建（注入 storage、agent config、tool/skill registry）
+  ├── 9. System Prompt 构建（SessionManager 内部调用构建函数，持有 PromptOverrides，初始为 None）
+  ├── 10. Renderer / Plugin 注册（各平台 Renderer 与 Adapter 封装为 Plugin 并注册）
+  ──── 消息通道 ────
   ├── 11. IM Adapters（各平台 Adapter 创建，注入对应 Renderer）
-  ├── 12. Gateway 创建（注入 adapters、processor registry、renderers、session manager、permission）
+  ├── 12. Gateway 创建（注入 adapters、processor registry、renderers、session manager、permission；安装 SlashDispatcher；注入 ApprovalFlow）
+  ──── 后台任务 ────
   ├── 13. ArchiveSweeper spawn（独立后台任务，定时扫描 idle session 归档 + 过期 archive 清理，详见 session 文档）
   ├── 14. Skill Watcher spawn（独立后台任务，监听 skill 文件变更）
+  ├── 15. Config Hot Reload spawn（监听配置文件变更，触发增量/全量重载）
   └── 进入消息循环
 ```
 
@@ -81,25 +93,28 @@ Daemon forceful 关闭
 |------|------|
 | Config | 启动时加载，传入各组件 |
 | Storage | 启动时初始化 SqliteStorage |
-| SessionConfigProvider | 启动时加载 config/session.json，提供给 ArchiveSweeper 和 Session Manager |
+| SessionConfigProvider | 启动时加载 session_config.json，提供给 ArchiveSweeper 和 Session Manager |
 | Permission Engine | 启动时加载权限规则 |
 | Agent Config | 启动时扫描合并 agent 配置 |
 | Tools Registry | 启动时注册所有工具 |
 | Skills Registry | 启动时注册所有 skill |
 | Session Manager | 启动时创建并注入依赖，Daemon 持有其所有权 |
-| System Prompt Builder | 由 Session Manager 持有 |
-| Processor Registry | 启动时注册处理器 |
+| System Prompt | SessionManager 内部调用 build_full_system_prompt() 构建，持有 PromptOverrides（初始 None） |
+| Processor Registry | 由 Gateway 内部管理，Daemon 不直接创建 |
 | Renderer Set | 启动时注册各平台 Renderer |
 | IM Adapters | 启动时创建各平台适配器 |
 | Gateway | 启动时创建并注入依赖，Daemon 持有其所有权 |
-| ArchiveSweeper | 启动时 spawn 后台任务（依赖 Storage + SessionConfigProvider，行为由 session 模块定义） |
+| ArchiveSweeper | 启动时 spawn 后台任务（依赖 Storage + SessionConfigProvider，详见 Session 设计文档） |
+| AgentRegistry | 启动时创建 agent 注册表，Daemon 持有其所有权 |
+| ApprovalFlow | 启动时创建并注入 Gateway，Daemon 持有其所有权 |
+| SpawnController | 启动时创建并注入 ToolRegistry，校验 Agent spawn 权限 |
+| Config Hot Reload | 启动时 spawn 后台任务，监听配置文件变更并触发重载 |
 | Skill Watcher | 启动时 spawn 后台任务 |
 
 ### 无关
 
 - **LLM Provider**（无调用关系）：Daemon 不调用 LLM
 - **Processor Chain**（无调用关系）：处理器链由 Gateway 调度，Daemon 不直接参与
-- **Slash Command**（无调用关系）：斜杠指令由 Gateway 拦截分派
 - **Renderer**（无调用关系）：渲染由 Gateway 选择和调度
 
 


### PR DESCRIPTION
设计文档：daemon/README.md（启动流程阶段划分 + 步骤完善）

## 修改内容
- 启动路径添加五阶段分组标签（基础设施/能力注册/运行时组件/消息通道/后台任务）
- 架构节展开各阶段组件列表
- 启动步骤重新编排（14→15）：新增 AgentRegistry、.env 加载、openclaw.json 迁移、Config Hot Reload、SpawnController、ApprovalFlow
- 修正 System Prompt 描述（移除不存在的 Builder 类型，反映 PromptOverrides 模式）
- 移除 Processor Registry 启动步骤（实际由 Gateway 内部管理）
- Slash Command 从"无关"改为受管理（SlashDispatcher 由 Daemon 创建注入）
- 下游表补全：AgentRegistry、ApprovalFlow、SpawnController、Config Hot Reload
- 修正代码模块名引用 + session_config.json 路径

## 新增文件
（无，仅修改现有文件）

## 附带修改
（无）

## 代码对照发现
- 关闭路径与设计文档差距大 → 记录为代码 gap
- ArchiveSweeper 启动时序提前 → 两可，记录
- Skill 目录层数（文档说五层，代码两层）→ 记录为 gap
- 其余详见 CODE-GAPS.md

Source: user
Type: docs
