### PR TITLE
docs(design): add daemon shutdown design doc

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,7 +7,7 @@
 | [agent](agent/README.md) | Agent 配置档案（目录式、注册清单、permissions 独立）、spawn 协调与权限沿链路继承 |
 | [cli](cli/README.md) | 命令行接口模块：CLI Chat（terminal 渠道的 IMPlugin 实现）和 CLI Admin（daemon 管理命令） |
 | [config](config/README.md) | CloseClaw 运行时配置管理：多文件拆分、ConfigManager 统一读写、备份回退、凭据分离、Agent 注册清单与多级加载、热重载 |
-| [daemon](daemon/README.md) | 进程入口和组件胶水层：系统启动时按依赖关系初始化所有组件、后台任务 spawn、优雅关闭 |
+| [daemon](daemon/README.md) | 进程入口和组件胶水层：五阶段启动、后台管理、graceful/forceful 双模关闭 |
 | [gateway](gateway/README.md) | 消息路由中枢：管理 IM 插件、调度 Processor Chain、路由决策（slash vs normal）、选择平台插件完成出站渲染与发送 |
 | [llm](llm/README.md) | 统一多供应商 LLM 调用与模型发现：五层分离架构、Provider/Protocol/Interpreter 分层、内容块归一化、缓存适配、Provider 配置向导 |
 | [mode](mode/README.md) | Session 运行模式管理：Plan Mode（规划/执行分离、双路径、审批栅栏）和 Auto Mode（连续自主执行），通过工具过滤和权限边界约束 agent 行为 |

--- a/docs/design/daemon/README.md
+++ b/docs/design/daemon/README.md
@@ -22,6 +22,12 @@ Daemon 启动分为五个阶段，按依赖顺序依次初始化：
 
 Daemon 持有 SessionManager 和 Gateway 的引用，作为二者的所有者管理其生命周期。
 
+### 子功能
+
+| 文档 | 简述 |
+|------|------|
+| [shutdown.md](shutdown.md) | 关闭全流程：ShutdownHandle 协调器、graceful/forceful 双模、阶段化执行、recovery 衔接、用户可见进度通知 |
+
 ## 数据流
 
 ### 启动路径
@@ -55,31 +61,21 @@ Daemon 启动
 
 ### 关闭路径
 
-Daemon 收到关闭信号后分阶段执行。不做 session 粒度的停止操作——全部委托 SessionManager 统一处理。SessionManager 负责遍历 session 树、按正确顺序停止、处理超时和脏标记。
+Daemon 关闭由 ShutdownHandle 统一协调，分阶段执行。详见 [shutdown.md](shutdown.md)。
+
+高层概览：
 
 ```
-SIGTERM（首次）
-  →
-Daemon graceful 关闭
-  ├── 1. 停止接收新消息（IM Adapters 关闭入站接收）
-  ├── 2. 关闭所有活跃 Session
-  │     委托 SessionManager 以 graceful 模式关闭，含超时参数
-  │     Daemon 不感知 session 树结构和停止顺序
-  ├── 3. 停止后台任务（ArchiveSweeper、Skill Watcher）
-  ├── 4. 持久化所有活跃 Session（CheckpointManager 最终 flush）
-  ├── 5. 关闭消息通道出站（IM Adapters 停止发送、Gateway 清理注册表）
-  ├── 6. 关闭 Storage 连接
-  └── 退出进程（如有 session 超时未完成则标记 dirty，下次启动告警）
-
-SIGTERM（重复）或 SIGINT
-  →
-Daemon forceful 关闭
-  ├── 1. 停止接收新消息
-  ├── 2. 委托 SessionManager 以 forceful 模式关闭所有 Session
-  ├── 3. 停止后台任务
-  ├── 4-6. 同 graceful 路径
-  └── 退出进程
+信号到达
+  → ShutdownHandle 判定模式（Graceful / Forceful）
+  → 关闭入站接收 + Drain 已有消息
+  → Session 停止（委托 SessionManager，graceful 模式等工具完成、LLM 流结束再停；forceful 模式立即 kill）
+  → 停止后台任务
+  → 最终持久化 + 关闭出站 + 关闭存储
+  → 退出
 ```
+
+Graceful 模式由用户掌控节奏：接收进度通知，可随时升级为 forceful。Forceful 不做等待，依赖 recovery 在下次启动时恢复未完成操作。
 
 ## 模块关系
 

--- a/docs/design/daemon/shutdown.md
+++ b/docs/design/daemon/shutdown.md
@@ -1,0 +1,148 @@
+# Daemon 关闭
+
+## 概述
+
+Daemon 关闭流程在收到操作系统信号后触发，由 ShutdownHandle 统一协调，按 Phase 0（信号接收与模式判定）+ Phase 1–7（停止流程）有序关闭所有组件。支持 graceful（优雅等待）和 forceful（强制终止）两种模式，用户可在 graceful 期间随时升级为 forceful。关闭过程中保证数据不丢失——未完成的操作通过 recovery 机制在下次启动时恢复。
+
+## 架构
+
+### ShutdownHandle
+
+ShutdownHandle 是关闭流程的中央协调器，在 Daemon 启动时创建，持有以下核心状态：
+
+- **关闭门控标志**：关闭开始后置为拒绝状态，所有处理组件在开始处理新操作前检查，若已关闭则拒绝
+- **活跃操作计数**：原子计数器。处理组件处理工作前递增，完成后递减
+- **drain 等待**：阻塞等待活跃操作计数降至零或超时返回。用于等待 in-flight 消息处理完毕
+- **drain 状态查询**：查询当前活跃操作计数和剩余等待项
+
+注册活跃操作计数的组件：
+
+| 组件 | 递增时机 | 递减时机 |
+|------|---------|---------|
+| Gateway 消息处理循环 | 消息出队开始处理 | 响应发送完成 |
+| 异步工具执行 | 工具进程创建 | 进程退出 |
+| 子 session 处理 | 子 session 创建 | 子 session 结果注入父 session |
+
+ShutdownHandle 不管理后台任务（ArchiveSweeper、Skill Watcher 等）——这些有自己的停止接口，不属于活跃操作计数范畴。
+
+### 双模关闭
+
+| 模式 | 触发条件 | 核心行为 |
+|------|---------|---------|
+| Graceful | 首次 SIGTERM | 等 LLM 流结束、等工具执行完，用户可见进度，可随时升级 |
+| Forceful | 重复 SIGTERM 或 SIGINT | 立即 kill 工具进程和 LLM 请求，依赖 recovery 恢复 |
+
+### 升级路径
+
+任一情况下触发 graceful → forceful 升级：
+- 收到第二次 SIGTERM 或 SIGINT
+- 用户通过进度通知选择"强制关闭"
+
+升级后：已有序停止的 session 直接持久化，未停止的切换为 forceful 模式继续。
+
+### Session 停止策略
+
+Daemon 不感知 session 树结构和停止顺序——全部委托 SessionManager 统一处理。SessionManager 构建 session 父子树，叶子→根顺序、并发停止同级 session。
+
+Graceful 模式下单 session 的停止行为（详见 [session-execution.md](../session/session-execution.md)）：
+
+| Session 当前状态 | 行为 |
+|-----------------|------|
+| LLM 流式输出中 | 等待流结束。结束后 assistant 消息若含工具调用请求，将工具调用写入待完成操作记录并持久化会话检查点，不执行工具。下次启动由恢复机制注入工具失败结果，LLM 自行决策 |
+| 工具执行中 | 等待工具完成。完成后工具结果写入对话记录、清除待完成操作记录、持久化会话检查点。不触发新一轮 LLM turn——下次用户消息自然衔接 |
+| Idle | 直接持久化 |
+
+Daemon 不依赖 session 停止流程的硬超时自动升级——工具执行时间不可预测。Daemon 可从 SessionManager 查询当前停止进度，汇总为进度通知展示给用户，由用户决定继续等待还是升级为 forceful。
+
+## 数据流
+
+### 关闭全流程
+
+```
+信号到达
+  ↓
+Phase 0：信号接收 & 模式判定
+  ├── SIGTERM（首次）→ Graceful 模式
+  ├── SIGTERM（重复）/ SIGINT → Forceful 模式
+  └── 关闭门控标志置为拒绝状态（组件拒绝新操作）
+  ↓
+Phase 1：入站停摆 + Drain
+  ├── IM Adapters 关闭入站（websocket 断开、webhook 退订）
+  └── 调用 drain 等待 in-flight 消息处理完毕
+      超时 → 记录剩余活跃操作计数，继续
+  ↓
+Phase 2：Session 停止
+  委托 SessionManager 统一关闭所有 session：
+  ├── 构建 session 父子树
+  ├── 叶子→根顺序，同级并发停止
+  ├── Graceful：按 session 当前状态分别处理（见架构节）
+  └── Forceful：立即终止工具进程和 LLM 请求
+  ↓
+Phase 3：后台任务停止
+  ├── ArchiveSweeper：取消定时器，给当前扫描短 grace period 后强制停止
+  ├── Skill Watcher：取消
+  └── Config Hot Reload：取消
+  ↓
+Phase 4：最终持久化
+  └── 通过 SessionManager 执行最终落盘（确保 Phase 2 中所有状态持久化）
+  ↓
+Phase 5：出站关闭
+  ├── IM Adapters 关闭出站连接
+  └── Gateway 清理路由表、processor 注册表
+  ↓
+Phase 6：存储关闭
+  └── 关闭存储连接，释放文件句柄
+  ↓
+Phase 7：退出
+  ├── 异常 session → 日志告警
+  └── 进程退出
+```
+
+### 用户进度通知
+
+Graceful 关闭期间，向用户发送实时状态，收集各组件状态汇总输出：
+
+```
+⏳ 正在优雅关闭...
+
+活跃 Session：
+  • session-1 — LLM 流式输出中，已等待 3s
+  • session-2 — 工具执行中：make build 编译任务，已运行 12s
+  • session-3 — 已就绪
+
+[继续等待] [强制关闭]
+```
+
+用户可选择等待或升级为 forceful。通知在 Session 停止阶段开始时发送，有状态变化时更新（session 完成、新 session 开始停止等）。
+
+### Recovery 衔接
+
+关闭流程与 [session-recovery.md](../session/session-recovery.md) 的衔接点：
+
+**Graceful 关闭后重启**：
+- LLM 流结束后工具调用未执行：会话检查点中已写入待完成操作记录。重启时恢复机制扫描到待完成操作非空 → 标记为异常 → 注入恢复通知（系统消息，列出未完成任务摘要）和工具失败结果到对话流 → LLM 自行决策重试
+- 工具执行完毕、未做新一轮 LLM：工具结果已写入对话记录，待完成操作已清除。会话检查点干净，下次用户消息触发 LLM turn 时 LLM 自然看到此前工具结果继续处理
+
+**Forceful 关闭后重启**：
+- 工具被终止：会话检查点中待完成操作记录残留。重启时恢复机制扫描到待完成操作非空 → 标记为异常 → 注入恢复通知和工具失败结果到对话流 → LLM 自行决策。工具副作用不可控（编译到一半等），这是用户选择 forceful 时已知的代价
+
+## 模块关系
+
+### 上游
+
+- **操作系统**：通过信号（SIGTERM、SIGINT）触发关闭
+- **用户**：通过进度通知选择升级为 forceful
+
+### 下游
+
+- **ShutdownHandle**：Daemon 创建并持有，调用门控设置、drain 等待、状态查询
+- **SessionManager**：委托统一关闭所有 session（含最终持久化），传入模式参数
+- **IM Adapters**：关闭入站/出站连接
+- **Gateway**：清理路由表和注册表
+- **SqliteStorage**：关闭存储连接
+- **后台任务**（ArchiveSweeper、Skill Watcher、Config Hot Reload）：逐一停止
+
+### 无关
+
+- **LLM Provider**（无调用关系）：关闭流程通过 SessionManager 间接影响 LLM 请求，不直接调用 Provider
+- **Processor Chain**（无调用关系）：处理器链由 Gateway 管理，关闭时随 Gateway 清理


### PR DESCRIPTION
设计文档：daemon/README.md（关闭路径更新 + 子功能索引）+ daemon/shutdown.md（新建）

## 新增文件
- `docs/design/daemon/shutdown.md` — Daemon 关闭全流程设计：ShutdownHandle 协调器、graceful/forceful 双模、7 阶段执行、recovery 衔接、用户可见进度通知

## 修改文件
- `docs/design/daemon/README.md` — 关闭路径从详细 ASCII 图改为高层概述 + 引用 shutdown.md；架构节新增子功能目录索引
- `docs/design/README.md` — daemon 简述更新为反映新设计

## 代码对照发现
Shutdown 相关 11 条差异（P0-P2），全数为设计文档正确、代码待实现——这是设计先行的正常状态。核心链路：ShutdownHandle 注入组件 + 双模信号处理 + SessionManager.shutdown_all(mode) + 用户进度通知。

既存 README 预存差异 9 条，非本次引入，已有 CODE-GAPS 对应条目。

Source: user
Type: docs
