### PR TITLE
docs(design): add platform plugin code file layout to IM Adapter + clarify ContentNormalizer delegation

### DIFF
--- a/docs/design/im_adapter/README.md
+++ b/docs/design/im_adapter/README.md
@@ -10,14 +10,31 @@ IM Adapter 模块提供跨消息渠道的插件化适配框架。每个消息渠
 
 IM Adapter 模块不包含业务逻辑，由三层组成：
 
-- **插件接口层**：定义 IMPlugin trait，统一插件契约。每个消息渠道实现此 trait，提供入站解析、格式渲染、消息发送、生命周期管理四组方法。terminal 渠道的实现位于 [CLI 模块](../cli/README.md)，不在此目录。
+- **插件接口层**：定义 IMPlugin trait，统一插件契约。每个消息渠道实现此 trait，提供入站解析、格式渲染、消息发送、生命周期管理、平台清洗五组方法。terminal 渠道的实现位于 [CLI 模块](../cli/README.md)，不在此目录。
 - **通用渲染能力**：代码块语法高亮和流式增量渲染是跨平台通用机制，作为 IMPlugin trait 的默认实现提供。各平台插件自动继承，按需覆盖平台差异化部分。
-- **平台插件**：每个消息渠道的数据和渲染实现。IM 渠道（飞书、Discord 等）的插件放在 `platforms/` 子目录下。每个插件内部包含——Adapter（webhook 解析、token 管理、API 调用）和 Renderer（ContentBlock[] → 平台原生格式）。terminal 渠道的实现位于 CLI 模块。
+- **平台插件**：每个消息渠道的数据和渲染实现。IM 渠道（飞书、Discord 等）的插件放在 `platforms/` 子目录下。terminal 渠道的实现位于 CLI 模块。
 
 模块运行时注册表由 Gateway 维护：
 
 - **Plugin Registry**：platform → IMPlugin 的映射。Gateway 通过 platform 字段选择插件。
 - **插件注册机制**：Gateway 启动时自动扫描 `platforms/` 目录，发现所有实现了 IMPlugin trait 的插件并加载。不在 `platforms/` 下的插件（如 CLI 模块的 terminal）通过显式注册加入 Plugin Registry。用户可通过配置文件控制各平台的启用/禁用。新增 IM 平台 = 新增目录 + 实现 trait，Gateway 代码和配置均无需改动。
+
+平台插件为自包含模块，内部结构统一：
+
+```
+platforms/<平台名>/
+├── mod.rs         — 插件注册，impl IMPlugin trait
+├── adapter.rs     — 入站：webhook 解析 → NormalizedMessage
+│                  — 出站：API 调用发送消息
+│                  — token 管理与刷新
+├── renderer.rs    — ContentBlock[] + DSL → 平台原生格式
+├── cleaner.rs     — 平台消息清洗（@ 语法、mention 等），实现 clean_content() 回调
+└── tools/         — 平台工具注册
+    ├── mod.rs     — register_tools() 入口
+    └── ...        — 各工具分组文件
+```
+
+各文件职责单一、无循环依赖。新增平台时按此布局创建目录即可。
 
 ### 对外工具
 
@@ -37,6 +54,8 @@ im_adapter/
 每个消息渠道插件实现统一接口，包含以下方法分组：
 
 **入站**：解析 webhook payload 为 NormalizedMessage。消息过滤（空内容、非文本消息）在解析阶段完成——Adapter 对不支持的消息类型不产 NormalizedMessage。
+
+**清洗**：`clean_content(raw: &str) -> String`，接收平台原生文本，移除平台专属标记（飞书 @ 语法、Discord mention 等），产出清洗后的纯文本。由 Processor Chain 的 ContentNormalizer 调用。各平台按需实现，不需要的平台空实现透传。
 
 **渲染**：接收 ContentBlock[] 和 DSL 解析结果，按平台能力选择输出格式（纯文本或富格式）。渲染是纯数据转换，无副作用。
 

--- a/docs/design/im_adapter/platforms/feishu.md
+++ b/docs/design/im_adapter/platforms/feishu.md
@@ -71,6 +71,32 @@ interactive 元素注入
 
 按钮指令由 Processor Chain 的 DslParser 解析后传入 Renderer。按钮渲染规则：首个按钮为 primary 样式，后续按钮为 default 样式，所有按钮平铺在单个 action 元素中。
 
+### 代码文件
+
+飞书插件代码位于 `src/im_adapter/platforms/feishu/`，各文件职责如下：
+
+```
+platforms/feishu/
+├── mod.rs         — FeishuPlugin 结构体， impl IMPlugin trait
+├── adapter.rs     — 入站：飞书 webhook 解析 → NormalizedMessage
+│                  — 出站：按 msg_type 选择发送路径（text 消息 / card 消息）
+│                  — token 管理与自动刷新
+├── renderer.rs    — ContentBlock[] + DSL → 飞书卡片 JSON / 飞书文本
+│                  — 输出类型决策（text vs card）
+│                  — markdown → 飞书元素映射（标题/粗体/代码块/列表/引用/链接/分割线）
+│                  — header 提取 + body 渲染
+│                  — DSL 按钮注入
+├── cleaner.rs     — 飞书平台消息清洗，实现 clean_content()
+│                  — 移除 @ 提及语法
+│                  — 移除 `<at>xxx</at>` 等飞书专属标记
+│                  — ContentNormalizer 调用此回调完成平台残留清洗
+└── tools/         — 飞书工具注册
+    ├── mod.rs     — register_tools() 入口，注册所有飞书工具分组
+    └── ...        — 各工具分组实现文件（im/calendar/task/bitable/doc/drive/sheet）
+```
+
+新增飞书工具分组时，在 `tools/` 下新增文件并注册。
+
 ## 数据流
 
 ### 入站路径
@@ -97,7 +123,7 @@ Gateway 选择飞书插件
 发送到目标 (chat_id, thread_id?)
 ```
 
-## 对外工具
+### 对外工具
 
 飞书插件通过 IM Adapter 模块的工具注册入口注册以下工具分组到 ToolRegistry：
 

--- a/docs/design/processor_chain/inbound-chain.md
+++ b/docs/design/processor_chain/inbound-chain.md
@@ -29,12 +29,12 @@ Processor 链（按 priority 升序执行，纯变换）
   │     → 原始消息写入日志，透传
   │
   ├── SessionRouter（priority 20）
-  │     → 从 (platform, sender_id, peer_id, account_id) 计算 session_key
+  │     → 从 (platform, sender_id, peer_id, account_id, agent_id) 计算 session_key
   │     → session_key 写入 metadata
   │     → 不创建 session、不查 SessionManager
   │
   └── ContentNormalizer（priority 30）
-        → 清洗平台残留元数据（飞书 at 语法、Discord mention 等）
+        → 平台清洗：调用 IMPlugin.clean_content()，委托对应平台插件移除专属标记
         → 富文本展开为标准 markdown
         → 标准化格式：压缩连续空行、去行尾空格、裸 URL 补全 https:// 前缀
   ↓
@@ -45,8 +45,9 @@ ProcessedMessage → Gateway 路由
 
 SessionRouter 计算 session_key 的方式：
 
-- `session_key = hash(platform, sender_id, peer_id, account_id)`
+- `session_key = hash(platform, sender_id, peer_id, account_id, agent_id)`
 - `account_id` 由 `sender_id` 通过身份映射得到，是 CloseClaw 本地的账号标识。一个 CloseClaw 账号可绑定多个平台的 sender_id
+- `agent_id` 参与哈希，用于区分同一 CloseClaw 实例上运行的不同 agent 的 session
 - `thread_id` 不参与——仅用于出站时 Gateway 定向回复到正确的话题线
 
 session_key 是一个确定性哈希值，相同的输入永远产相同的 key。但 session_key 不直接等于 session_id——它只是一个查找键。
@@ -71,7 +72,7 @@ SessionRouter 不区分私聊和群聊。会话粒度由 Adapter 通过 peer_id 
 ```
 IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, account_id, content }
   → RawLogProcessor：记录原始内容到日志 → 透传
-    → SessionRouter：计算 session_key = hash(platform, sender_id, peer_id, account_id) → 写入 metadata.session_key
+    → SessionRouter：计算 session_key = hash(platform, sender_id, peer_id, account_id, agent_id) → 写入 metadata.session_key
       → ContentNormalizer：清洗平台残留 → 标准化 markdown 格式
         → ProcessedMessage { content, metadata { session_key } }
           → Gateway
@@ -84,6 +85,8 @@ IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, 
 - ContentNormalizer 异常时内容不变（丢回原文），消息继续流转
 - 所有异常均记录日志，用于后续问题定位和改进
 
+**平台清洗委托**：ContentNormalizer 的"平台残留清洗"不包含任何平台专属逻辑。清洗行为委托给 IMPlugin trait 的 `clean_content()` 回调——ContentNormalizer 调用消息来源平台的插件方法，各平台插件实现自己的清洗逻辑（飞书处理 @ 语法，Discord 处理 mention，不支持的平台空实现透传）。ContentNormalizer 自身只执行平台无关的标准化（富文本展开、空行压缩、去尾空格、URL 补全）。
+
 ## 模块关系
 
 - **上游**：IM Adapter（各平台提供适配器，产 NormalizedMessage）
@@ -91,5 +94,5 @@ IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, 
 - **链内**：
   - RawLogProcessor — 审计日志（副作用），不改内容
   - SessionRouter — 计算 session_key（纯哈希计算），写 metadata
-  - ContentNormalizer — 内容清洗 + 格式标准化（纯文本变换）
+  - ContentNormalizer — 格式标准化（平台无关）+ 委托 IMPlugin 清洗平台残留
 - **无关**：出站 Processor 链（独立链路，与入站互不干扰）


### PR DESCRIPTION
设计文档：im_adapter/README.md + platforms/feishu.md（补充平台插件代码文件布局）+ processor_chain/inbound-chain.md（明确 ContentNormalizer 委托机制 + session_key 纳入 agent_id）

## 修改文件
- `docs/design/im_adapter/README.md` — 新增平台插件代码文件布局模板、IMPlugin trait 补 clean_content() 清洗方法
- `docs/design/im_adapter/platforms/feishu.md` — 新增"代码文件"小节 + "对外工具"降级为架构子节
- `docs/design/processor_chain/inbound-chain.md` — ContentNormalizer 委托 IMPlugin.clean_content()、session_key 纳入 agent_id（5维）

## 修补的 gap
- CODE-GAPS.md 二、设计文档 Gap：飞书插件代码分散在三个目录（新增平台布局规范 + 飞书文件职责）

## 代码对照发现
  - IMPlugin trait 缺 clean_content()/init()/shutdown() → 已在 CODE-GAPS IM Adapter 节记录
  - platforms/ 目录不存在 → 已在 CODE-GAPS IM Adapter 节记录
  - NormalizedMessage 缺 message_type/media_refs/quoted_message → 已在 CODE-GAPS IM Adapter 节记录
  - ContentNormalizer 硬编码飞书解析非委托 → 已在 CODE-GAPS Processor Chain 节记录
  - session_key 无 hash 无 agent_id → 已在 CODE-GAPS Session 节记录
  - 两套并行 Processor Chain → 已在 CODE-GAPS Processor Chain 节记录
  （全部为已知 gap，本次修改未引入新差异）

Source: user
Type: docs
