### PR TITLE
feat(ddt): add comment field to design doc tracker

### DIFF
--- a/scripts/design-doc-tracker/README.md
+++ b/scripts/design-doc-tracker/README.md
@@ -4,16 +4,19 @@
 
 ## 用法
 
-### `python3 ddt.py finished <dir>`
+### `python3 ddt.py finished <dir> [--comment TEXT]`
 
 将 `<dir>` 下所有 `.md` 文件的当前 git commit 记录为已确认状态。
 
 - **必须在 `master` 分支上执行**
 - `<dir>` 必须存在且包含至少一个 `.md` 文件
+- `--comment TEXT` 为该目录下所有文件设置备注（省略时保留已有备注，新文件默认为空）
 
 ### `python3 ddt.py check`
 
 扫描项目中 `docs/design/` 目录下的 `.md` 文件，报告自上次确认以来发生变更的文档。
+
+- 输出格式：`path` 或 `path\tcomment`（有备注时）
 
 ## 记录文件
 

--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -4,10 +4,12 @@ Design Doc Tracker (ddt) – track which design docs have been implemented.
 
 Commands
 --------
-- ``finished <dir>``
+- ``finished <dir> [--comment TEXT]``
     Record that every ``.md`` file under *<dir>* matches current HEAD.
     Must be on the ``master`` branch.  *<dir>* must exist and contain at
-    least one ``.md`` file.
+    least one ``.md`` file.  ``--comment`` sets a comment for all files
+    under *<dir>* (default: empty string, preserves existing comment on
+    update when omitted).
 
 - ``check``
     Scan ``docs/design/`` for ``.md`` files and report any that have
@@ -128,11 +130,19 @@ def cmd_finished(args: argparse.Namespace) -> int:
 
     for rel_path in md_files:
         key = str(rel_path)
+        # Preserve existing comment when --comment is not provided
+        if args.comment is not None:
+            comment = args.comment
+        elif key in existing:
+            comment = records[existing[key]].get("comment", "")
+        else:
+            comment = ""
         entry: Dict[str, str] = {
             "path": key,
             "commit": commit,
             "commit_time": commit_time,
             "confirmed_time": confirmed_time,
+            "comment": comment,
         }
         if key in existing:
             records[existing[key]] = entry
@@ -168,7 +178,12 @@ def cmd_check(args: argparse.Namespace) -> int:
             changed.append(key)
 
     for p in changed:
-        print(p)
+        rec = record_map.get(p, {})
+        comment = rec.get("comment", "")
+        if comment:
+            print(f"{p}\t{comment}")
+        else:
+            print(p)
 
     return 0
 
@@ -184,6 +199,9 @@ def main() -> int:
 
     p_finished = sub.add_parser("finished", help="Mark design doc(s) as implemented")
     p_finished.add_argument("dir", help="Directory (relative to repo root) to record")
+    p_finished.add_argument(
+        "--comment", default=None, help="Comment to attach to all files under <dir>"
+    )
 
     sub.add_parser("check", help="Check for changed design docs since last confirmation")
 

--- a/scripts/design-doc-tracker/ddt_test.py
+++ b/scripts/design-doc-tracker/ddt_test.py
@@ -54,6 +54,7 @@ ddt.DESIGN_DOC_DIR = Path(_FAKE_REPO) / "docs" / "design"
 
 def _make_args(**kwargs) -> argparse.Namespace:
     """Build a minimal Namespace for cmd_finished / cmd_check."""
+    kwargs.setdefault("comment", None)
     return argparse.Namespace(**kwargs)
 
 
@@ -262,6 +263,7 @@ class TestCmdFinished(unittest.TestCase):
         # All records share the same commit
         for r in records:
             self.assertEqual(r["commit"], "deadbeef")
+            self.assertEqual(r["comment"], "")
 
     def test_idempotent_record_update(self):
         """Running finished twice updates (not duplicates) records."""
@@ -298,6 +300,129 @@ class TestCmdFinished(unittest.TestCase):
         # Should still be exactly 1 record (updated, not duplicated)
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["commit"], "v2")
+        self.assertEqual(records[0]["comment"], "")
+
+
+    def test_finished_with_comment(self):
+        """--comment sets comment on every record."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+        (design_dir / "db.md").write_text("# DB")
+
+        args = _make_args(dir="docs/design", comment="hello world")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c1"), \
+                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
+                 self._patch_now("2025-01-01T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 2)
+        for r in records:
+            self.assertEqual(r["comment"], "hello world")
+
+    def test_finished_without_comment_default_empty(self):
+        """Without --comment, new records have comment=''"""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c1"), \
+                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
+                 self._patch_now("2025-01-01T00:00:00+08:00"):
+                ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(records[0]["comment"], "")
+
+    def test_finished_preserves_existing_comment(self):
+        """Re-running finished without --comment preserves existing comment."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        # First run with a comment
+        args1 = _make_args(dir="docs/design", comment="original")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c1"), \
+                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
+                 self._patch_now("2025-01-01T00:00:00+08:00"):
+                ddt.cmd_finished(args1)
+        finally:
+            sys.stdout = old_stdout
+
+        # Second run without --comment
+        args2 = _make_args(dir="docs/design")
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c2"), \
+                 self._patch_commit_date("2025-02-01T00:00:00+00:00"), \
+                 self._patch_now("2025-02-01T00:00:00+08:00"):
+                ddt.cmd_finished(args2)
+        finally:
+            sys.stdout = old_stdout
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["comment"], "original")
+        self.assertEqual(records[0]["commit"], "c2")
+
+    def test_finished_overrides_comment(self):
+        """finished --comment "new" overrides existing comment."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        # First run with a comment
+        args1 = _make_args(dir="docs/design", comment="old")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c1"), \
+                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
+                 self._patch_now("2025-01-01T00:00:00+08:00"):
+                ddt.cmd_finished(args1)
+        finally:
+            sys.stdout = old_stdout
+
+        # Second run with a different comment
+        args2 = _make_args(dir="docs/design", comment="new")
+        sys.stdout = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("c2"), \
+                 self._patch_commit_date("2025-02-01T00:00:00+00:00"), \
+                 self._patch_now("2025-02-01T00:00:00+08:00"):
+                ddt.cmd_finished(args2)
+        finally:
+            sys.stdout = old_stdout
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["comment"], "new")
 
 
 # ---------------------------------------------------------------------------
@@ -459,6 +584,56 @@ class TestCmdCheck(unittest.TestCase):
         self.assertEqual(len(lines), 2)
         self.assertIn("docs/design/new.md", lines)  # no record → changed
         self.assertIn("docs/design/old.md", lines)  # recorded but changed
+
+    def test_check_output_with_comment(self):
+        """Changed file with comment → output is 'path\tcomment'."""
+        self._create_design_docs(["auth.md"])
+        self._write_records(
+            [{"path": "docs/design/auth.md", "commit": "aaa111", "comment": "important doc"}]
+        )
+        args = _make_args()
+
+        with mock.patch.object(ddt, "_run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=""
+            )
+            import io, sys
+            old_stdout = sys.stdout
+            sys.stdout = buf = io.StringIO()
+            try:
+                rc = ddt.cmd_check(args)
+            finally:
+                sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        lines = [l for l in buf.getvalue().strip().splitlines()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], "docs/design/auth.md\timportant doc")
+
+    def test_check_output_no_comment(self):
+        """Changed file without comment → output is just path."""
+        self._create_design_docs(["auth.md"])
+        self._write_records(
+            [{"path": "docs/design/auth.md", "commit": "aaa111", "comment": ""}]
+        )
+        args = _make_args()
+
+        with mock.patch.object(ddt, "_run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr=""
+            )
+            import io, sys
+            old_stdout = sys.stdout
+            sys.stdout = buf = io.StringIO()
+            try:
+                rc = ddt.cmd_check(args)
+            finally:
+                sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        lines = [l for l in buf.getvalue().strip().splitlines()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], "docs/design/auth.md")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
为 design-doc-tracker 添加 comment 字段支持。

- `finished` 新增 `--comment TEXT` 参数，为目录下所有文件设置备注
- `check` 输出格式变为 `path\tcomment`（有备注时）
- `records.json` 每条记录增加 `comment` 字段
- 测试从 21 个增至 27 个

Source: user
Type: feat
