### PR TITLE
fix(ddt): finished clears comment, add separate comment command

### DIFF
--- a/scripts/design-doc-tracker/README.md
+++ b/scripts/design-doc-tracker/README.md
@@ -4,13 +4,18 @@
 
 ## 用法
 
-### `python3 ddt.py finished <dir> [--comment TEXT]`
+### `python3 ddt.py finished <dir>`
 
-将 `<dir>` 下所有 `.md` 文件的当前 git commit 记录为已确认状态。
+将 `<dir>` 下所有 `.md` 文件的当前 git commit 记录为已确认状态，并清空备注。
 
 - **必须在 `master` 分支上执行**
 - `<dir>` 必须存在且包含至少一个 `.md` 文件
-- `--comment TEXT` 为该目录下所有文件设置备注（省略时保留已有备注，新文件默认为空）
+
+### `python3 ddt.py comment <path> <text>`
+
+为已记录的 design doc 设置备注。`<path>` 为相对于项目根的文件路径。
+
+- 文件必须已有记录（先执行 `finished`）
 
 ### `python3 ddt.py check`
 

--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -4,12 +4,15 @@ Design Doc Tracker (ddt) – track which design docs have been implemented.
 
 Commands
 --------
-- ``finished <dir> [--comment TEXT]``
+- ``finished <dir>``
     Record that every ``.md`` file under *<dir>* matches current HEAD.
     Must be on the ``master`` branch.  *<dir>* must exist and contain at
-    least one ``.md`` file.  ``--comment`` sets a comment for all files
-    under *<dir>* (default: empty string, preserves existing comment on
-    update when omitted).
+    least one ``.md`` file.  Clears any existing comment for matched files.
+
+- ``comment <path> <text>``
+    Override the comment for a specific design doc file.  The file must
+    already have a record (use ``finished`` first).  ``<path>`` is relative
+    to the repo root.
 
 - ``check``
     Scan ``docs/design/`` for ``.md`` files and report any that have
@@ -20,13 +23,15 @@ records.json lives alongside this script.
 
 from __future__ import annotations
 
-import argparse
 import json
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List
+
+import click
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = Path(
@@ -81,7 +86,6 @@ def _save_records(records: List[Dict[str, str]]) -> None:
 
 def _collect_md_files(directory: Path) -> List[Path]:
     """Recursively collect .md files, return relative-to-REPO_ROOT paths."""
-    base = str(REPO_ROOT) + "/"
     result: List[Path] = []
     for p in sorted(directory.rglob("*.md")):
         if p.is_file():
@@ -97,7 +101,7 @@ def _now_iso() -> str:
 # ── sub-commands ─────────────────────────────────────────────────────────
 
 
-def cmd_finished(args: argparse.Namespace) -> int:
+def cmd_finished(args: SimpleNamespace) -> int:
     dir_path = REPO_ROOT / args.dir
 
     # 1. branch must be master
@@ -130,19 +134,12 @@ def cmd_finished(args: argparse.Namespace) -> int:
 
     for rel_path in md_files:
         key = str(rel_path)
-        # Preserve existing comment when --comment is not provided
-        if args.comment is not None:
-            comment = args.comment
-        elif key in existing:
-            comment = records[existing[key]].get("comment", "")
-        else:
-            comment = ""
         entry: Dict[str, str] = {
             "path": key,
             "commit": commit,
             "commit_time": commit_time,
             "confirmed_time": confirmed_time,
-            "comment": comment,
+            "comment": "",
         }
         if key in existing:
             records[existing[key]] = entry
@@ -154,7 +151,20 @@ def cmd_finished(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_check(args: argparse.Namespace) -> int:
+def cmd_comment(args: SimpleNamespace) -> int:
+    """Override the comment for a single design doc file."""
+    records = _load_records()
+    for rec in records:
+        if rec["path"] == args.path:
+            rec["comment"] = args.text
+            _save_records(records)
+            print(f"Updated comment for '{args.path}'")
+            return 0
+    print(f"Error: no record for '{args.path}'. Run 'finished' first.", file=sys.stderr)
+    return 1
+
+
+def cmd_check(args: SimpleNamespace) -> int:
     records = _load_records()
     record_map: Dict[str, Dict[str, str]] = {r["path"]: r for r in records}
 
@@ -191,32 +201,31 @@ def cmd_check(args: argparse.Namespace) -> int:
 # ── main ─────────────────────────────────────────────────────────────────
 
 
+@click.group()
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Design Doc Tracker – track implementation status of design docs."
-    )
-    sub = parser.add_subparsers(dest="command")
+    """Design Doc Tracker – 跟踪设计文档的实现状态。"""
+    return 0
 
-    p_finished = sub.add_parser("finished", help="Mark design doc(s) as implemented")
-    p_finished.add_argument("dir", help="Directory (relative to repo root) to record")
-    p_finished.add_argument(
-        "--comment", default=None, help="Comment to attach to all files under <dir>"
-    )
 
-    sub.add_parser("check", help="Check for changed design docs since last confirmation")
+@main.command(name="finished")
+@click.argument("dir")
+def finished_cmd(dir: str) -> int:
+    """标记设计文档已实现。DIR 为仓库根目录下的目录路径。"""
+    return cmd_finished(SimpleNamespace(dir=dir))
 
-    args = parser.parse_args()
-    if args.command is None:
-        parser.print_help()
-        return 1
 
-    if args.command == "finished":
-        return cmd_finished(args)
-    elif args.command == "check":
-        return cmd_check(args)
-    else:
-        parser.print_help()
-        return 1
+@main.command(name="comment")
+@click.argument("path")
+@click.argument("text")
+def comment_cmd(path: str, text: str) -> int:
+    """为已记录的设计文档设置/覆盖评论。PATH 为文件路径，TEXT 为评论内容。"""
+    return cmd_comment(SimpleNamespace(path=path, text=text))
+
+
+@main.command(name="check")
+def check_cmd() -> int:
+    """扫描设计文档目录，报告有变更的文件。"""
+    return cmd_check(SimpleNamespace())
 
 
 if __name__ == "__main__":

--- a/scripts/design-doc-tracker/ddt_test.py
+++ b/scripts/design-doc-tracker/ddt_test.py
@@ -53,8 +53,7 @@ ddt.DESIGN_DOC_DIR = Path(_FAKE_REPO) / "docs" / "design"
 
 
 def _make_args(**kwargs) -> argparse.Namespace:
-    """Build a minimal Namespace for cmd_finished / cmd_check."""
-    kwargs.setdefault("comment", None)
+    """Build a minimal Namespace for cmd_finished / cmd_check / cmd_comment."""
     return argparse.Namespace(**kwargs)
 
 
@@ -303,14 +302,15 @@ class TestCmdFinished(unittest.TestCase):
         self.assertEqual(records[0]["comment"], "")
 
 
-    def test_finished_with_comment(self):
-        """--comment sets comment on every record."""
+    def test_finished_clears_comment(self):
+        """Re-running finished on a file with a comment clears it to ''."""
         design_dir = self._fake_repo / "docs" / "design"
         design_dir.mkdir(parents=True)
         (design_dir / "auth.md").write_text("# Auth")
-        (design_dir / "db.md").write_text("# DB")
 
-        args = _make_args(dir="docs/design", comment="hello world")
+        # First run – set up record, then add a comment
+        args_finished = _make_args(dir="docs/design")
+        args_comment = _make_args(path="docs/design/auth.md", text="original comment")
         import io, sys
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
@@ -319,59 +319,16 @@ class TestCmdFinished(unittest.TestCase):
                  self._patch_head("c1"), \
                  self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
                  self._patch_now("2025-01-01T00:00:00+08:00"):
-                rc = ddt.cmd_finished(args)
+                ddt.cmd_finished(args_finished)
+            ddt.cmd_comment(args_comment)
         finally:
             sys.stdout = old_stdout
 
-        self.assertEqual(rc, 0)
+        # Verify comment was set
         records = _read_json(ddt.RECORDS_FILE)
-        self.assertEqual(len(records), 2)
-        for r in records:
-            self.assertEqual(r["comment"], "hello world")
+        self.assertEqual(records[0]["comment"], "original comment")
 
-    def test_finished_without_comment_default_empty(self):
-        """Without --comment, new records have comment=''"""
-        design_dir = self._fake_repo / "docs" / "design"
-        design_dir.mkdir(parents=True)
-        (design_dir / "auth.md").write_text("# Auth")
-
-        args = _make_args(dir="docs/design")
-        import io, sys
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c1"), \
-                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
-                 self._patch_now("2025-01-01T00:00:00+08:00"):
-                ddt.cmd_finished(args)
-        finally:
-            sys.stdout = old_stdout
-
-        records = _read_json(ddt.RECORDS_FILE)
-        self.assertEqual(records[0]["comment"], "")
-
-    def test_finished_preserves_existing_comment(self):
-        """Re-running finished without --comment preserves existing comment."""
-        design_dir = self._fake_repo / "docs" / "design"
-        design_dir.mkdir(parents=True)
-        (design_dir / "auth.md").write_text("# Auth")
-
-        # First run with a comment
-        args1 = _make_args(dir="docs/design", comment="original")
-        import io, sys
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c1"), \
-                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
-                 self._patch_now("2025-01-01T00:00:00+08:00"):
-                ddt.cmd_finished(args1)
-        finally:
-            sys.stdout = old_stdout
-
-        # Second run without --comment
+        # Second run – finished clears comment
         args2 = _make_args(dir="docs/design")
         sys.stdout = io.StringIO()
         try:
@@ -385,43 +342,68 @@ class TestCmdFinished(unittest.TestCase):
 
         records = _read_json(ddt.RECORDS_FILE)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]["comment"], "original")
+        self.assertEqual(records[0]["comment"], "")
         self.assertEqual(records[0]["commit"], "c2")
 
-    def test_finished_overrides_comment(self):
-        """finished --comment "new" overrides existing comment."""
-        design_dir = self._fake_repo / "docs" / "design"
-        design_dir.mkdir(parents=True)
-        (design_dir / "auth.md").write_text("# Auth")
 
-        # First run with a comment
-        args1 = _make_args(dir="docs/design", comment="old")
-        import io, sys
-        old_stdout = sys.stdout
-        sys.stdout = io.StringIO()
-        try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c1"), \
-                 self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
-                 self._patch_now("2025-01-01T00:00:00+08:00"):
-                ddt.cmd_finished(args1)
-        finally:
-            sys.stdout = old_stdout
+# ---------------------------------------------------------------------------
+# Tests – cmd_comment
+# ---------------------------------------------------------------------------
 
-        # Second run with a different comment
-        args2 = _make_args(dir="docs/design", comment="new")
-        sys.stdout = io.StringIO()
-        try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c2"), \
-                 self._patch_commit_date("2025-02-01T00:00:00+00:00"), \
-                 self._patch_now("2025-02-01T00:00:00+08:00"):
-                ddt.cmd_finished(args2)
-        finally:
-            sys.stdout = old_stdout
 
+class TestCmdComment(unittest.TestCase):
+    """Tests for cmd_comment."""
+
+    def setUp(self):
+        self._orig_repo = ddt.REPO_ROOT
+        self._orig_records = ddt.RECORDS_FILE
+        self._tmpdir = tempfile.mkdtemp(prefix="ddt_comment_")
+        self._fake_repo = Path(self._tmpdir) / "repo"
+        self._fake_repo.mkdir()
+        ddt.REPO_ROOT = self._fake_repo
+        ddt.RECORDS_FILE = self._fake_repo / "records.json"
+
+    def tearDown(self):
+        ddt.REPO_ROOT = self._orig_repo
+        ddt.RECORDS_FILE = self._orig_records
+        shutil.rmtree(self._tmpdir)
+
+    def test_comment_success(self):
+        """Existing record → comment command updates it successfully."""
+        _write_json(
+            ddt.RECORDS_FILE,
+            [{"path": "docs/design/auth.md", "commit": "aaa111", "comment": ""}],
+        )
+        args = _make_args(path="docs/design/auth.md", text="needs review")
+        rc = ddt.cmd_comment(args)
+        self.assertEqual(rc, 0)
         records = _read_json(ddt.RECORDS_FILE)
-        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["comment"], "needs review")
+
+    def test_comment_no_record(self):
+        """No existing record → error (rc=1)."""
+        _write_json(ddt.RECORDS_FILE, [])
+        args = _make_args(path="docs/design/nonexistent.md", text="hello")
+        import io, sys
+        old_stderr = sys.stderr
+        sys.stderr = buf = io.StringIO()
+        try:
+            rc = ddt.cmd_comment(args)
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("no record", buf.getvalue())
+
+    def test_comment_overwrites_existing(self):
+        """Existing comment → overwritten with new value."""
+        _write_json(
+            ddt.RECORDS_FILE,
+            [{"path": "docs/design/auth.md", "commit": "aaa111", "comment": "old"}],
+        )
+        args = _make_args(path="docs/design/auth.md", text="new")
+        rc = ddt.cmd_comment(args)
+        self.assertEqual(rc, 0)
+        records = _read_json(ddt.RECORDS_FILE)
         self.assertEqual(records[0]["comment"], "new")
 
 


### PR DESCRIPTION
修正 comment 功能的设计：

- `finished <dir>`：清空 comment（不再接受 `--comment`）
- 新增 `comment <path> <text>`：为已记录的 design doc 单独设置/覆盖 comment
- `check`：有 comment 时输出 `path\tcomment`

同时需要先 revert PR #1032 的错误实现。

Source: user
Type: fix
