### PR TITLE
feat(ddt): finished supports single file + master fallback

### DIFF
--- a/scripts/design-doc-tracker/README.md
+++ b/scripts/design-doc-tracker/README.md
@@ -4,12 +4,14 @@
 
 ## 用法
 
-### `python3 ddt.py finished <dir>`
+### `python3 ddt.py finished <path>`
 
-将 `<dir>` 下所有 `.md` 文件的当前 git commit 记录为已确认状态，并清空备注。
+将 `<path>` 指向的 `.md` 文件（或目录下所有 `.md` 文件）的当前 git commit 记录为已确认状态，并清空备注。
 
-- **必须在 `master` 分支上执行**
-- `<dir>` 必须存在且包含至少一个 `.md` 文件
+- `<path>` 可以是单个 `.md` 文件或目录
+  - **文件模式**：仅处理该文件
+  - **目录模式**：递归处理目录下所有 `.md` 文件（原有行为）
+- 在非 `master` 分支上执行时，自动使用 `master` 分支最近一次 commit 作为基准，并输出 warning
 
 ### `python3 ddt.py comment <path> <text>`
 

--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -4,10 +4,11 @@ Design Doc Tracker (ddt) – track which design docs have been implemented.
 
 Commands
 --------
-- ``finished <dir>``
-    Record that every ``.md`` file under *<dir>* matches current HEAD.
-    Must be on the ``master`` branch.  *<dir>* must exist and contain at
-    least one ``.md`` file.  Clears any existing comment for matched files.
+- ``finished <path>``
+    Record that every ``.md`` file under *<path>* matches current HEAD.
+    *<path>* can be a directory (recursively) or a single ``.md`` file.
+    On non-master branches, uses the latest master commit as fallback.
+    Clears any existing comment for matched files.
 
 - ``comment <path> <text>``
     Override the comment for a specific design doc file.  The file must
@@ -70,6 +71,14 @@ def _commit_committer_date(ref: str = "HEAD") -> str:
     return r.stdout.strip()
 
 
+def _master_commit() -> str | None:
+    """Return the latest commit on master, or None if master doesn't exist."""
+    r = _run(["git", "log", "master", "--format=%H", "-1"])
+    if r.returncode != 0 or not r.stdout.strip():
+        return None
+    return r.stdout.strip()
+
+
 def _load_records() -> List[Dict[str, str]]:
     if RECORDS_FILE.exists():
         with open(RECORDS_FILE, "r", encoding="utf-8") as f:
@@ -102,31 +111,47 @@ def _now_iso() -> str:
 
 
 def cmd_finished(args: SimpleNamespace) -> int:
-    dir_path = REPO_ROOT / args.dir
+    target = REPO_ROOT / args.dir
 
-    # 1. branch must be master
+    # 1. resolve target: file or directory
+    md_files: List[Path] = []
+    if target.is_file():
+        # single file: must be .md
+        if target.suffix != ".md":
+            print(f"Error: '{args.dir}' is not a .md file", file=sys.stderr)
+            return 1
+        rel = str(target.relative_to(REPO_ROOT))
+        md_files = [Path(rel)]
+    elif target.is_dir():
+        md_files = _collect_md_files(target)
+        if not md_files:
+            print("no .md files found")
+            return 0
+    else:
+        # path doesn't exist
+        if target.suffix == ".md":
+            print(f"Error: file '{args.dir}' does not exist", file=sys.stderr)
+        else:
+            print(f"Error: directory '{args.dir}' does not exist", file=sys.stderr)
+        return 1
+
+    # 2. branch handling: fallback on non-master
     branch = _current_branch()
-    if branch != "master":
-        print(f"Error: must be on master branch, currently on '{branch}'", file=sys.stderr)
-        return 1
-
-    # 2. directory must exist and be a directory
-    if not dir_path.exists():
-        print(f"Error: directory '{args.dir}' does not exist", file=sys.stderr)
-        return 1
-    if not dir_path.is_dir():
-        print(f"Error: '{args.dir}' is not a directory", file=sys.stderr)
-        return 1
-
-    # 3. collect .md files
-    md_files = _collect_md_files(dir_path)
-    if not md_files:
-        print("no .md files found")
-        return 0
-
-    # 4. build records
     commit = _head_commit()
-    commit_time = _commit_committer_date()
+    if branch != "master":
+        fallback = _master_commit()
+        if fallback is None:
+            print("Error: not on master and no master branch found", file=sys.stderr)
+            return 1
+        commit = fallback
+        print(
+            f"Warning: not on master branch (on '{branch}'), "
+            f"using fallback commit {commit}",
+            file=sys.stderr,
+        )
+
+    # 3. build records
+    commit_time = _commit_committer_date(commit)
     confirmed_time = _now_iso()
 
     records = _load_records()
@@ -208,10 +233,10 @@ def main() -> int:
 
 
 @main.command(name="finished")
-@click.argument("dir")
-def finished_cmd(dir: str) -> int:
-    """标记设计文档已实现。DIR 为仓库根目录下的目录路径。"""
-    return cmd_finished(SimpleNamespace(dir=dir))
+@click.argument("path")
+def finished_cmd(path: str) -> int:
+    """标记设计文档已实现。PATH 为仓库根目录下的文件或目录路径（支持单个 .md 文件或整个目录）。"""
+    return cmd_finished(SimpleNamespace(dir=path))
 
 
 @main.command(name="comment")

--- a/scripts/design-doc-tracker/ddt_test.py
+++ b/scripts/design-doc-tracker/ddt_test.py
@@ -201,14 +201,168 @@ class TestCmdFinished(unittest.TestCase):
             rc = ddt.cmd_finished(args)
         self.assertEqual(rc, 1)
 
-    def test_directory_is_file(self):
-        """Should error when target is a file, not a directory."""
-        target = self._fake_repo / "not_a_dir.md"
+    def test_non_md_file_rejected(self):
+        """Should error when target is a non-.md file."""
+        target = self._fake_repo / "not_a_dir.txt"
         target.write_text("hi")
-        args = _make_args(dir="not_a_dir.md")
+        args = _make_args(dir="not_a_dir.txt")
         with self._patch_branch("master"):
             rc = ddt.cmd_finished(args)
         self.assertEqual(rc, 1)
+
+    # -- single file tests (Step 1.4) -----------------------------------
+
+    def test_single_md_file_happy_path(self):
+        """Passing a .md file path should record only that file."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+        (design_dir / "db.md").write_text("# DB")
+
+        args = _make_args(dir="docs/design/auth.md")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = buf = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("cafe0001"), \
+                 self._patch_commit_date("2025-03-01T00:00:00+00:00"), \
+                 self._patch_now("2025-06-12T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        self.assertIn("1 file(s)", output)
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["path"], "docs/design/auth.md")
+        self.assertEqual(records[0]["commit"], "cafe0001")
+
+    def test_single_non_md_file_error(self):
+        """Passing a non-.md file should error."""
+        target = self._fake_repo / "readme.txt"
+        target.write_text("hello")
+        args = _make_args(dir="readme.txt")
+        import io, sys
+        old_stderr = sys.stderr
+        sys.stderr = buf = io.StringIO()
+        try:
+            with self._patch_branch("master"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("not a .md file", buf.getvalue())
+
+    def test_single_md_file_not_exist_error(self):
+        """Passing a non-existent .md path should error."""
+        args = _make_args(dir="docs/design/missing.md")
+        import io, sys
+        old_stderr = sys.stderr
+        sys.stderr = buf = io.StringIO()
+        try:
+            with self._patch_branch("master"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("does not exist", buf.getvalue())
+
+    def test_directory_behavior_unchanged(self):
+        """Directory path should still work as before (recursive)."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+        (design_dir / "db.md").write_text("# DB")
+
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = buf = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("dir0001"), \
+                 self._patch_commit_date("2025-04-01T00:00:00+00:00"), \
+                 self._patch_now("2025-06-12T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        self.assertIn("2 file(s)", buf.getvalue())
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 2)
+        paths = {r["path"] for r in records}
+        self.assertIn("docs/design/auth.md", paths)
+        self.assertIn("docs/design/db.md", paths)
+
+    def test_master_fallback_non_master_branch(self):
+        """On non-master branch, should use fallback master commit + warning."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = stdout_buf = io.StringIO()
+        sys.stderr = stderr_buf = io.StringIO()
+        try:
+            with self._patch_branch("feature/foo"), \
+                 mock.patch.object(ddt, "_master_commit", return_value="fallback1234"), \
+                 self._patch_commit_date("2025-05-01T00:00:00+00:00"), \
+                 self._patch_now("2025-06-12T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+        self.assertEqual(rc, 0)
+        # Warning should mention the branch and fallback commit
+        warning = stderr_buf.getvalue()
+        self.assertIn("feature/foo", warning)
+        self.assertIn("fallback1234", warning)
+        self.assertIn("Warning", warning)
+
+        # Record should use fallback commit
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["commit"], "fallback1234")
+
+    def test_master_branch_normal(self):
+        """On master branch, behavior should be unchanged (no warning)."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stdout = sys.stdout
+        old_stderr = sys.stderr
+        sys.stdout = stdout_buf = io.StringIO()
+        sys.stderr = stderr_buf = io.StringIO()
+        try:
+            with self._patch_branch("master"), \
+                 self._patch_head("master001"), \
+                 self._patch_commit_date("2025-06-01T00:00:00+00:00"), \
+                 self._patch_now("2025-06-12T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+        self.assertEqual(rc, 0)
+        # No warning on stderr
+        self.assertEqual(stderr_buf.getvalue(), "")
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["commit"], "master001")
 
     def test_empty_directory_no_md(self):
         """Directory exists but has no .md files → rc=0, prints hint."""


### PR DESCRIPTION
feat(ddt): finished supports single file + master fallback

- `ddt finished <path>` 支持单个 .md 文件路径，只确认该文件
- `ddt finished <dir>` 保持向后兼容，行为不变
- 非 master 分支时自动 fallback 到最近 master commit，输出 warning
- 补充测试用例，更新 README 文档

Source: issue #1034
Type: feat
