### PR TITLE
refactor(ddt): merge-base for finished, allow comment on unrecorded files, empty commit in check

### DIFF
--- a/scripts/design-doc-tracker/README.md
+++ b/scripts/design-doc-tracker/README.md
@@ -11,18 +11,22 @@
 - `<path>` 可以是单个 `.md` 文件或目录
   - **文件模式**：仅处理该文件
   - **目录模式**：递归处理目录下所有 `.md` 文件（原有行为）
-- 在非 `master` 分支上执行时，自动使用 `master` 分支最近一次 commit 作为基准，并输出 warning
+- 始终使用 `git merge-base HEAD origin/master` 的分叉点 commit 作为记录值，与当前所在分支无关
+- 如果 `origin/master` 不存在或 merge-base 失败，报错返回 rc=1
 
 ### `python3 ddt.py comment <path> <text>`
 
-为已记录的 design doc 设置备注。`<path>` 为相对于项目根的文件路径。
+为 design doc 设置备注。`<path>` 为相对于项目根的文件路径。
 
-- 文件必须已有记录（先执行 `finished`）
+- 如果文件已有记录，仅覆盖 comment（行为不变）
+- 如果文件无记录，自动创建新记录，commit 留空，comment 设为指定文本
+- `<text>` 可以为空字符串
 
 ### `python3 ddt.py check`
 
 扫描项目中 `docs/design/` 目录下的 `.md` 文件，报告自上次确认以来发生变更的文档。
 
+- 记录中 commit 为空的文件视为 changed，直接输出
 - 输出格式：`path` 或 `path\tcomment`（有备注时）
 
 ## 记录文件

--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -5,15 +5,15 @@ Design Doc Tracker (ddt) – track which design docs have been implemented.
 Commands
 --------
 - ``finished <path>``
-    Record that every ``.md`` file under *<path>* matches current HEAD.
+    Record that every ``.md`` file under *<path>* matches the merge-base
+    of HEAD and origin/master.
     *<path>* can be a directory (recursively) or a single ``.md`` file.
-    On non-master branches, uses the latest master commit as fallback.
     Clears any existing comment for matched files.
 
 - ``comment <path> <text>``
-    Override the comment for a specific design doc file.  The file must
-    already have a record (use ``finished`` first).  ``<path>`` is relative
-    to the repo root.
+    Override the comment for a specific design doc file.  If the file already
+    has a record the comment is updated; otherwise a new record is created
+    with an empty commit.  ``<path>`` is relative to the repo root.
 
 - ``check``
     Scan ``docs/design/`` for ``.md`` files and report any that have
@@ -55,25 +55,15 @@ def _run(cmd: List[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _current_branch() -> str:
-    r = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-    return r.stdout.strip()
-
-
-def _head_commit() -> str:
-    r = _run(["git", "rev-parse", "HEAD"])
-    return r.stdout.strip()
-
-
 def _commit_committer_date(ref: str = "HEAD") -> str:
     """Return ISO-8601 committer date for *ref*."""
     r = _run(["git", "log", "-1", "--format=%cI", ref])
     return r.stdout.strip()
 
 
-def _master_commit() -> str | None:
-    """Return the latest commit on master, or None if master doesn't exist."""
-    r = _run(["git", "log", "master", "--format=%H", "-1"])
+def _merge_base_commit() -> str | None:
+    """Return the merge-base of HEAD and origin/master, or None on failure."""
+    r = _run(["git", "merge-base", "HEAD", "origin/master"])
     if r.returncode != 0 or not r.stdout.strip():
         return None
     return r.stdout.strip()
@@ -135,20 +125,15 @@ def cmd_finished(args: SimpleNamespace) -> int:
             print(f"Error: directory '{args.dir}' does not exist", file=sys.stderr)
         return 1
 
-    # 2. branch handling: fallback on non-master
-    branch = _current_branch()
-    commit = _head_commit()
-    if branch != "master":
-        fallback = _master_commit()
-        if fallback is None:
-            print("Error: not on master and no master branch found", file=sys.stderr)
-            return 1
-        commit = fallback
+    # 2. get commit via merge-base
+    commit = _merge_base_commit()
+    if commit is None:
         print(
-            f"Warning: not on master branch (on '{branch}'), "
-            f"using fallback commit {commit}",
+            "Error: git merge-base HEAD origin/master failed. "
+            "Ensure origin/master exists.",
             file=sys.stderr,
         )
+        return 1
 
     # 3. build records
     commit_time = _commit_committer_date(commit)
@@ -177,7 +162,11 @@ def cmd_finished(args: SimpleNamespace) -> int:
 
 
 def cmd_comment(args: SimpleNamespace) -> int:
-    """Override the comment for a single design doc file."""
+    """Override the comment for a single design doc file.
+
+    If the file already has a record, only the comment is overwritten.
+    If no record exists yet, a new record is created with an empty commit.
+    """
     records = _load_records()
     for rec in records:
         if rec["path"] == args.path:
@@ -185,8 +174,19 @@ def cmd_comment(args: SimpleNamespace) -> int:
             _save_records(records)
             print(f"Updated comment for '{args.path}'")
             return 0
-    print(f"Error: no record for '{args.path}'. Run 'finished' first.", file=sys.stderr)
-    return 1
+    # No existing record — create a new one with empty commit fields
+    records.append(
+        {
+            "path": args.path,
+            "commit": "",
+            "commit_time": "",
+            "confirmed_time": _now_iso(),
+            "comment": args.text,
+        }
+    )
+    _save_records(records)
+    print(f"Created record for '{args.path}'")
+    return 0
 
 
 def cmd_check(args: SimpleNamespace) -> int:
@@ -205,6 +205,10 @@ def cmd_check(args: SimpleNamespace) -> int:
         rec = record_map.get(key)
         if rec is None:
             # no record → treat as changed
+            changed.append(key)
+            continue
+        if rec["commit"] == "":
+            # empty commit → treat as changed
             changed.append(key)
             continue
         # git diff --quiet exits 1 if there are changes

--- a/scripts/design-doc-tracker/ddt_test.py
+++ b/scripts/design-doc-tracker/ddt_test.py
@@ -174,12 +174,9 @@ class TestCmdFinished(unittest.TestCase):
         ddt.RECORDS_FILE = self._orig_records
         shutil.rmtree(self._tmpdir)
 
-    def _patch_branch(self, branch: str):
-        """Return a patcher that makes _current_branch return *branch*."""
-        return mock.patch.object(ddt, "_current_branch", return_value=branch)
-
-    def _patch_head(self, commit: str = "aaaa1111"):
-        return mock.patch.object(ddt, "_head_commit", return_value=commit)
+    def _patch_merge_base(self, commit: str | None = "aaaa1111"):
+        """Return a patcher that makes _merge_base_commit return *commit* (or None)."""
+        return mock.patch.object(ddt, "_merge_base_commit", return_value=commit)
 
     def _patch_commit_date(self, dt: str = "2025-01-01T00:00:00+00:00"):
         return mock.patch.object(ddt, "_commit_committer_date", return_value=dt)
@@ -187,18 +184,10 @@ class TestCmdFinished(unittest.TestCase):
     def _patch_now(self, iso: str = "2025-06-12T00:00:00+08:00"):
         return mock.patch.object(ddt, "_now_iso", return_value=iso)
 
-    def test_not_on_master(self):
-        """Should error (rc=1) when not on master branch."""
-        args = _make_args(dir="docs/design")
-        with self._patch_branch("feature/foo"):
-            rc = ddt.cmd_finished(args)
-        self.assertEqual(rc, 1)
-
     def test_directory_not_exist(self):
         """Should error when target directory doesn't exist."""
         args = _make_args(dir="nonexistent")
-        with self._patch_branch("master"):
-            rc = ddt.cmd_finished(args)
+        rc = ddt.cmd_finished(args)
         self.assertEqual(rc, 1)
 
     def test_non_md_file_rejected(self):
@@ -206,11 +195,56 @@ class TestCmdFinished(unittest.TestCase):
         target = self._fake_repo / "not_a_dir.txt"
         target.write_text("hi")
         args = _make_args(dir="not_a_dir.txt")
-        with self._patch_branch("master"):
-            rc = ddt.cmd_finished(args)
+        rc = ddt.cmd_finished(args)
         self.assertEqual(rc, 1)
 
-    # -- single file tests (Step 1.4) -----------------------------------
+    # -- merge-base tests ---------------------------------------------------
+
+    def test_merge_base_success(self):
+        """Happy path: merge-base returns a commit, records it."""
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stdout = sys.stdout
+        sys.stdout = buf = io.StringIO()
+        try:
+            with self._patch_merge_base("merge001"), \
+                 self._patch_commit_date("2025-03-01T00:00:00+00:00"), \
+                 self._patch_now("2025-06-12T00:00:00+08:00"):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        self.assertIn("1 file(s)", buf.getvalue())
+
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["commit"], "merge001")
+        self.assertEqual(records[0]["comment"], "")
+
+    def test_merge_base_failure(self):
+        """Should error (rc=1) when merge-base fails."""
+        # Create directory so it passes the existence check
+        design_dir = self._fake_repo / "docs" / "design"
+        design_dir.mkdir(parents=True)
+        (design_dir / "auth.md").write_text("# Auth")
+        args = _make_args(dir="docs/design")
+        import io, sys
+        old_stderr = sys.stderr
+        sys.stderr = buf = io.StringIO()
+        try:
+            with self._patch_merge_base(None):
+                rc = ddt.cmd_finished(args)
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("merge-base", buf.getvalue())
+
+    # -- single file tests ---------------------------------------------------
 
     def test_single_md_file_happy_path(self):
         """Passing a .md file path should record only that file."""
@@ -224,8 +258,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("cafe0001"), \
+            with self._patch_merge_base("cafe0001"), \
                  self._patch_commit_date("2025-03-01T00:00:00+00:00"), \
                  self._patch_now("2025-06-12T00:00:00+08:00"):
                 rc = ddt.cmd_finished(args)
@@ -250,8 +283,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stderr = sys.stderr
         sys.stderr = buf = io.StringIO()
         try:
-            with self._patch_branch("master"):
-                rc = ddt.cmd_finished(args)
+            rc = ddt.cmd_finished(args)
         finally:
             sys.stderr = old_stderr
         self.assertEqual(rc, 1)
@@ -264,8 +296,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stderr = sys.stderr
         sys.stderr = buf = io.StringIO()
         try:
-            with self._patch_branch("master"):
-                rc = ddt.cmd_finished(args)
+            rc = ddt.cmd_finished(args)
         finally:
             sys.stderr = old_stderr
         self.assertEqual(rc, 1)
@@ -283,8 +314,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("dir0001"), \
+            with self._patch_merge_base("dir0001"), \
                  self._patch_commit_date("2025-04-01T00:00:00+00:00"), \
                  self._patch_now("2025-06-12T00:00:00+08:00"):
                 rc = ddt.cmd_finished(args)
@@ -300,70 +330,6 @@ class TestCmdFinished(unittest.TestCase):
         self.assertIn("docs/design/auth.md", paths)
         self.assertIn("docs/design/db.md", paths)
 
-    def test_master_fallback_non_master_branch(self):
-        """On non-master branch, should use fallback master commit + warning."""
-        design_dir = self._fake_repo / "docs" / "design"
-        design_dir.mkdir(parents=True)
-        (design_dir / "auth.md").write_text("# Auth")
-
-        args = _make_args(dir="docs/design")
-        import io, sys
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
-        sys.stdout = stdout_buf = io.StringIO()
-        sys.stderr = stderr_buf = io.StringIO()
-        try:
-            with self._patch_branch("feature/foo"), \
-                 mock.patch.object(ddt, "_master_commit", return_value="fallback1234"), \
-                 self._patch_commit_date("2025-05-01T00:00:00+00:00"), \
-                 self._patch_now("2025-06-12T00:00:00+08:00"):
-                rc = ddt.cmd_finished(args)
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
-
-        self.assertEqual(rc, 0)
-        # Warning should mention the branch and fallback commit
-        warning = stderr_buf.getvalue()
-        self.assertIn("feature/foo", warning)
-        self.assertIn("fallback1234", warning)
-        self.assertIn("Warning", warning)
-
-        # Record should use fallback commit
-        records = _read_json(ddt.RECORDS_FILE)
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]["commit"], "fallback1234")
-
-    def test_master_branch_normal(self):
-        """On master branch, behavior should be unchanged (no warning)."""
-        design_dir = self._fake_repo / "docs" / "design"
-        design_dir.mkdir(parents=True)
-        (design_dir / "auth.md").write_text("# Auth")
-
-        args = _make_args(dir="docs/design")
-        import io, sys
-        old_stdout = sys.stdout
-        old_stderr = sys.stderr
-        sys.stdout = stdout_buf = io.StringIO()
-        sys.stderr = stderr_buf = io.StringIO()
-        try:
-            with self._patch_branch("master"), \
-                 self._patch_head("master001"), \
-                 self._patch_commit_date("2025-06-01T00:00:00+00:00"), \
-                 self._patch_now("2025-06-12T00:00:00+08:00"):
-                rc = ddt.cmd_finished(args)
-        finally:
-            sys.stdout = old_stdout
-            sys.stderr = old_stderr
-
-        self.assertEqual(rc, 0)
-        # No warning on stderr
-        self.assertEqual(stderr_buf.getvalue(), "")
-
-        records = _read_json(ddt.RECORDS_FILE)
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]["commit"], "master001")
-
     def test_empty_directory_no_md(self):
         """Directory exists but has no .md files → rc=0, prints hint."""
         empty_dir = self._fake_repo / "empty_dir"
@@ -374,8 +340,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
         try:
-            with self._patch_branch("master"):
-                rc = ddt.cmd_finished(args)
+            rc = ddt.cmd_finished(args)
         finally:
             sys.stdout = old_stdout
 
@@ -383,7 +348,7 @@ class TestCmdFinished(unittest.TestCase):
         self.assertIn("no .md files found", buf.getvalue())
 
     def test_normal_record_files(self):
-        """Happy path: master branch, dir has .md files, records created."""
+        """Happy path: dir has .md files, records created from merge-base."""
         design_dir = self._fake_repo / "docs" / "design"
         design_dir.mkdir(parents=True)
         (design_dir / "auth.md").write_text("# Auth")
@@ -395,8 +360,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = buf = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("deadbeef"), \
+            with self._patch_merge_base("deadbeef"), \
                  self._patch_commit_date("2025-01-01T12:00:00+00:00"), \
                  self._patch_now("2025-06-12T12:00:00+08:00"):
                 rc = ddt.cmd_finished(args)
@@ -430,8 +394,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("v1"), \
+            with self._patch_merge_base("v1"), \
                  self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
                  self._patch_now("2025-01-01T00:00:00+08:00"):
                 ddt.cmd_finished(args)
@@ -441,8 +404,7 @@ class TestCmdFinished(unittest.TestCase):
         # Second run with different commit
         sys.stdout = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("v2"), \
+            with self._patch_merge_base("v2"), \
                  self._patch_commit_date("2025-02-01T00:00:00+00:00"), \
                  self._patch_now("2025-02-01T00:00:00+08:00"):
                 ddt.cmd_finished(args)
@@ -454,7 +416,6 @@ class TestCmdFinished(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["commit"], "v2")
         self.assertEqual(records[0]["comment"], "")
-
 
     def test_finished_clears_comment(self):
         """Re-running finished on a file with a comment clears it to ''."""
@@ -469,8 +430,7 @@ class TestCmdFinished(unittest.TestCase):
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c1"), \
+            with self._patch_merge_base("c1"), \
                  self._patch_commit_date("2025-01-01T00:00:00+00:00"), \
                  self._patch_now("2025-01-01T00:00:00+08:00"):
                 ddt.cmd_finished(args_finished)
@@ -486,8 +446,7 @@ class TestCmdFinished(unittest.TestCase):
         args2 = _make_args(dir="docs/design")
         sys.stdout = io.StringIO()
         try:
-            with self._patch_branch("master"), \
-                 self._patch_head("c2"), \
+            with self._patch_merge_base("c2"), \
                  self._patch_commit_date("2025-02-01T00:00:00+00:00"), \
                  self._patch_now("2025-02-01T00:00:00+08:00"):
                 ddt.cmd_finished(args2)
@@ -534,19 +493,41 @@ class TestCmdComment(unittest.TestCase):
         records = _read_json(ddt.RECORDS_FILE)
         self.assertEqual(records[0]["comment"], "needs review")
 
-    def test_comment_no_record(self):
-        """No existing record → error (rc=1)."""
+    def test_comment_creates_record_for_unrecorded_file(self):
+        """No existing record → creates a new record with empty commit."""
         _write_json(ddt.RECORDS_FILE, [])
-        args = _make_args(path="docs/design/nonexistent.md", text="hello")
-        import io, sys
-        old_stderr = sys.stderr
-        sys.stderr = buf = io.StringIO()
-        try:
-            rc = ddt.cmd_comment(args)
-        finally:
-            sys.stderr = old_stderr
-        self.assertEqual(rc, 1)
-        self.assertIn("no record", buf.getvalue())
+        args = _make_args(path="docs/design/new.md", text="first comment")
+        rc = ddt.cmd_comment(args)
+        self.assertEqual(rc, 0)
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["path"], "docs/design/new.md")
+        self.assertEqual(records[0]["commit"], "")
+        self.assertEqual(records[0]["commit_time"], "")
+        self.assertEqual(records[0]["comment"], "first comment")
+        self.assertNotEqual(records[0]["confirmed_time"], "")
+
+    def test_comment_empty_string(self):
+        """Empty string comment should be written successfully."""
+        _write_json(
+            ddt.RECORDS_FILE,
+            [{"path": "docs/design/auth.md", "commit": "aaa111", "comment": "old"}],
+        )
+        args = _make_args(path="docs/design/auth.md", text="")
+        rc = ddt.cmd_comment(args)
+        self.assertEqual(rc, 0)
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(records[0]["comment"], "")
+
+    def test_comment_unrecorded_keeps_empty_commit(self):
+        """Creating a record via comment should have empty commit."""
+        _write_json(ddt.RECORDS_FILE, [])
+        args = _make_args(path="docs/design/brand_new.md", text="needs review")
+        rc = ddt.cmd_comment(args)
+        self.assertEqual(rc, 0)
+        records = _read_json(ddt.RECORDS_FILE)
+        self.assertEqual(records[0]["commit"], "")
+        self.assertEqual(records[0]["comment"], "needs review")
 
     def test_comment_overwrites_existing(self):
         """Existing comment → overwritten with new value."""
@@ -770,6 +751,88 @@ class TestCmdCheck(unittest.TestCase):
         lines = [l for l in buf.getvalue().strip().splitlines()]
         self.assertEqual(len(lines), 1)
         self.assertEqual(lines[0], "docs/design/auth.md")
+
+    def test_empty_commit_treated_as_changed(self):
+        """Record with empty commit → treated as changed (no git diff run)."""
+        self._create_design_docs(["auth.md"])
+        self._write_records(
+            [{"path": "docs/design/auth.md", "commit": "", "comment": ""}]
+        )
+        args = _make_args()
+
+        # _run should NOT be called since empty commit skips git diff
+        with mock.patch.object(ddt, "_run") as mock_run:
+            import io, sys
+            old_stdout = sys.stdout
+            sys.stdout = buf = io.StringIO()
+            try:
+                rc = ddt.cmd_check(args)
+            finally:
+                sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        mock_run.assert_not_called()
+        self.assertIn("docs/design/auth.md", buf.getvalue())
+
+    def test_empty_commit_with_comment_output(self):
+        """Record with empty commit + comment → output 'path\tcomment'."""
+        self._create_design_docs(["auth.md"])
+        self._write_records(
+            [{"path": "docs/design/auth.md", "commit": "", "comment": "needs implementation"}]
+        )
+        args = _make_args()
+
+        with mock.patch.object(ddt, "_run") as mock_run:
+            import io, sys
+            old_stdout = sys.stdout
+            sys.stdout = buf = io.StringIO()
+            try:
+                rc = ddt.cmd_check(args)
+            finally:
+                sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        mock_run.assert_not_called()
+        lines = [l for l in buf.getvalue().strip().splitlines()]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], "docs/design/auth.md\tneeds implementation")
+
+    def test_empty_commit_mixed_with_normal(self):
+        """Mix of empty-commit and normal-commit records."""
+        self._create_design_docs(["new.md", "ok.md", "old.md"])
+        self._write_records([
+            {"path": "docs/design/new.md", "commit": "", "comment": ""},
+            {"path": "docs/design/ok.md", "commit": "aaa111", "comment": ""},
+            {"path": "docs/design/old.md", "commit": "bbb222", "comment": "stale"},
+        ])
+        args = _make_args()
+
+        def fake_run(cmd, **kwargs):
+            if "ok.md" in str(cmd):
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr=""
+            )
+
+        with mock.patch.object(ddt, "_run", side_effect=fake_run):
+            import io, sys
+            old_stdout = sys.stdout
+            sys.stdout = buf = io.StringIO()
+            try:
+                rc = ddt.cmd_check(args)
+            finally:
+                sys.stdout = old_stdout
+
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        lines = [l.strip() for l in output.strip().splitlines()]
+        # new.md (empty commit) and old.md (changed) should be reported; ok.md should not
+        self.assertEqual(len(lines), 2)
+        self.assertIn("docs/design/new.md", lines)
+        self.assertIn("docs/design/old.md\tstale", lines)
+        self.assertNotIn("docs/design/ok.md", output)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
重构 ddt 三个子命令逻辑：

- **finished**：始终使用 `git merge-base HEAD origin/master` 的分叉点 commit 作为记录值，不再依赖分支判断
- **comment**：支持对无记录文件创建新记录（commit 留空），不再要求先执行 finished
- **check**：记录中 commit 为空时视为 changed，直接输出，跳过 git diff

同步更新 README 文档和单元测试，新增 merge-base 失败、无记录文件 comment、空 commit check 等测试用例。

Source: issue #1037
Type: refactor
