### PR TITLE
fix: bump MSRV from 1.75 to 1.80 to resolve CI clippy incompatible_msrv errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["CloseClaw Team"]
 description = "Lightweight, rule-driven multi-agent execution framework"
 license = "MIT"
 repository = "https://github.com/jpxthu/CloseClaw"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [features]
 fake-llm = []


### PR DESCRIPTION
Bump `rust-version` in Cargo.toml from 1.75 to 1.80. The project uses `std::sync::LazyLock` which stabilized in Rust 1.80.0, causing 50 `incompatible_msrv` clippy errors on CI master builds.

Source: CI
Type: fix
