### PR TITLE
feat: add prompt template support for sub-agent spawning

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,7 @@
 pub mod communication;
 pub mod config;
 pub mod process;
+pub mod prompt_template;
 pub mod registry;
 pub mod spawn;
 pub mod state;
@@ -61,3 +62,7 @@ mod tests {
 #[cfg(test)]
 #[path = "spawn_tests.rs"]
 mod spawn_tests;
+
+#[cfg(test)]
+#[path = "prompt_template_tests.rs"]
+mod prompt_template_tests;

--- a/src/agent/prompt_template.rs
+++ b/src/agent/prompt_template.rs
@@ -1,0 +1,75 @@
+//! Prompt template definitions for sub-agent spawning.
+//!
+//! Provides predefined prompt prefixes that constrain sub-agent behavior modes
+//! (read-only research vs. validation/audit). Injected into the sub-agent's
+//! first message when spawning via `sessions_spawn`.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Built-in prompt templates for sub-agent behavior modes.
+///
+/// Each variant carries a pre-defined prompt prefix that is prepended to
+/// the task description when spawning a sub-agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PromptTemplate {
+    /// Read-only research mode: constrains the sub-agent to investigation
+    /// and analysis without modifying any files.
+    Explore,
+    /// Validation/audit mode: constrains the sub-agent to perform item-by-item
+    /// verification and report differences in structured output.
+    Validation,
+}
+
+/// Error returned when parsing an invalid prompt template string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidPromptTemplate;
+
+impl fmt::Display for InvalidPromptTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid prompt template: expected \"explore\" or \"validation\""
+        )
+    }
+}
+
+impl std::error::Error for InvalidPromptTemplate {}
+
+impl FromStr for PromptTemplate {
+    type Err = InvalidPromptTemplate;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "explore" => Ok(PromptTemplate::Explore),
+            "validation" => Ok(PromptTemplate::Validation),
+            _ => Err(InvalidPromptTemplate),
+        }
+    }
+}
+
+impl PromptTemplate {
+    /// Returns the prompt prefix text for this template.
+    ///
+    /// The prefix is prepended to the task description when spawning a sub-agent
+    /// with this template.
+    pub fn prefix(&self) -> &'static str {
+        match self {
+            PromptTemplate::Explore => {
+                "You are in READ-ONLY RESEARCH mode. You MUST NOT modify any \
+                 files, create new files, delete files, or execute commands that \
+                 alter system state. Your sole purpose is to investigate, analyze, \
+                 and report findings. Provide your analysis in a structured report \
+                 format."
+            }
+            PromptTemplate::Validation => {
+                "You are in VALIDATION/AUDIT mode. Your task is to perform \
+                 item-by-item verification against the given criteria. For each \
+                 item: state whether it passes or fails, provide the expected \
+                 value, the actual value, and a brief explanation of any \
+                 discrepancy. Output your findings as a structured checklist \
+                 with clear PASS/FAIL status for every item."
+            }
+        }
+    }
+}

--- a/src/agent/prompt_template_tests.rs
+++ b/src/agent/prompt_template_tests.rs
@@ -1,0 +1,42 @@
+use std::str::FromStr;
+
+use super::prompt_template::PromptTemplate;
+
+#[test]
+fn test_parse_explore() {
+    let template = PromptTemplate::from_str("explore").unwrap();
+    assert_eq!(template, PromptTemplate::Explore);
+}
+
+#[test]
+fn test_parse_validation() {
+    let template = PromptTemplate::from_str("validation").unwrap();
+    assert_eq!(template, PromptTemplate::Validation);
+}
+
+#[test]
+fn test_parse_invalid() {
+    let result = PromptTemplate::from_str("invalid");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_explore_prefix_non_empty() {
+    let template = PromptTemplate::Explore;
+    let prefix = template.prefix();
+    assert!(!prefix.is_empty());
+}
+
+#[test]
+fn test_validation_prefix_non_empty() {
+    let template = PromptTemplate::Validation;
+    let prefix = template.prefix();
+    assert!(!prefix.is_empty());
+}
+
+#[test]
+fn test_prefixes_differ() {
+    let explore_prefix = PromptTemplate::Explore.prefix();
+    let validation_prefix = PromptTemplate::Validation.prefix();
+    assert_ne!(explore_prefix, validation_prefix);
+}

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -1,5 +1,6 @@
 //! Built-in sessions_spawn tool — creates child sessions for sub-agents.
 
+use crate::agent::prompt_template::PromptTemplate;
 use crate::agent::spawn::SpawnController;
 use crate::config::ConfigManager;
 use crate::gateway::session_manager::{SessionManager, SpawnMode};
@@ -32,6 +33,7 @@ struct SpawnArgs {
     mode_str: String,
     fork: bool,
     allowed_tools: Option<Vec<String>>,
+    prompt_template: Option<PromptTemplate>,
 }
 
 impl SessionsSpawnTool {
@@ -83,6 +85,12 @@ impl SessionsSpawnTool {
                     .collect::<Vec<String>>()
             })
             .filter(|v| !v.is_empty());
+        let prompt_template = args
+            .get("promptTemplate")
+            .and_then(|v| v.as_str())
+            .map(|s| s.parse::<PromptTemplate>())
+            .transpose()
+            .map_err(|e| ToolCallError::InvalidArgs(e.to_string()))?;
         Ok(SpawnArgs {
             task: task.to_string(),
             agent_id,
@@ -92,6 +100,7 @@ impl SessionsSpawnTool {
             mode_str: mode_str.to_string(),
             fork,
             allowed_tools,
+            prompt_template,
         })
     }
 
@@ -241,6 +250,11 @@ impl Tool for SessionsSpawnTool {
                         "type": "string"
                     },
                     "description": tools_desc
+                },
+                "promptTemplate": {
+                    "type": "string",
+                    "enum": ["explore", "validation"],
+                    "description": "Built-in prompt template to prepend to the task. 'explore' constrains read-only research; 'validation' enforces structured audit output."
                 }
             },
             "required": ["task"]
@@ -273,12 +287,17 @@ impl Tool for SessionsSpawnTool {
             .get_session_depth(parent_session_id)
             .await
             .unwrap_or(0);
+        // Prepend prompt template prefix to task if specified
+        let effective_task = match spawn_args.prompt_template {
+            Some(tpl) => format!("{}\n\n{}", tpl.prefix(), spawn_args.task),
+            None => spawn_args.task.clone(),
+        };
         let child_session_id = self
             .create_child(
                 &config,
                 parent_session_id,
                 parent_depth,
-                &spawn_args.task,
+                &effective_task,
                 spawn_args.light_context,
                 spawn_args.workspace.as_deref(),
                 spawn_args.mode,


### PR DESCRIPTION
feat: add prompt template support for sub-agent spawning

Implement built-in prompt templates (explore/validation) that constrain
sub-agent behavior when spawning via sessions_spawn.

- **explore** template: enforces read-only research mode — sub-agent must not modify files
- **validation** template: enforces structured audit output with PASS/FAIL checklist

Changes:
- Add `PromptTemplate` enum with `Explore`/`Validation` variants in `src/agent/prompt_template.rs`
- Implement `FromStr` for string-based template parsing (`"explore"` / `"validation"`)
- Add `prefix()` method returning predefined prompt text
- Extend `sessions_spawn` tool with optional `promptTemplate` parameter
- Prepend template prefix to task when spawning child sessions
- Add comprehensive unit tests for parsing and prefix behavior

Source: user
Type: feat
