### PR TITLE
chore: blacklist README.md and fix sort order in ddt check

### DIFF
--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -83,12 +83,37 @@ def _save_records(records: List[Dict[str, str]]) -> None:
         f.write("\n")
 
 
+# Paths excluded from check output (relative to REPO_ROOT)
+BLACKLIST = frozenset({
+    "docs/design/README.md",
+})
+
+
+def _sort_key(p: Path) -> list:
+    """Sort key: subdirectories before index files at each level.
+
+    Splits the path into segments and lowercases each one for
+    case-insensitive comparison.  Directory segments (which precede a
+    ``/`` in the original string) naturally sort before file-name
+    segments at the same depth, so
+    ``docs/design/agent/README.md`` sorts before
+    ``docs/design/README.md``.
+    """
+    return [part.lower() for part in p.relative_to(REPO_ROOT).parts]
+
+
 def _collect_md_files(directory: Path) -> List[Path]:
-    """Recursively collect .md files, return relative-to-REPO_ROOT paths."""
+    """Recursively collect .md files, return relative-to-REPO_ROOT paths.
+
+    Results are sorted with subdirectory contents before index files
+    at each level, and BLACKLIST entries are excluded.
+    """
     result: List[Path] = []
-    for p in sorted(directory.rglob("*.md")):
+    for p in sorted(directory.rglob("*.md"), key=_sort_key):
         if p.is_file():
             rel = str(p.relative_to(REPO_ROOT))
+            if rel in BLACKLIST:
+                continue
             result.append(Path(rel))
     return result
 


### PR DESCRIPTION
ddt 工具两项改进：

1. 将 `docs/design/README.md` 加入 blacklist，`check`/`finished`/`comment` 均不再输出此文件
2. 排序逻辑改为子目录内容优先于各级索引文件（如 `agent/` 下的文件排在 `agent/README.md` 前面）

Source: user
Type: chore
