### PR TITLE
fix: 两阶段合并逻辑在某维度无规则时误入 default_deny

### DIFF
--- a/docs/design/permission/README.md
+++ b/docs/design/permission/README.md
@@ -47,6 +47,7 @@ Agent 维度规则    User 维度规则
 - **Agent 规则**仅匹配 Agent ID，定义 Agent 自身的能力边界
 - **User+Agent 规则**同时匹配 User ID 和 Agent ID，实现细粒度交集控制
 - 两套规则在同一引擎中求值，双方都必须 Allow 操作才放行
+- **某维度无规则时的语义**：当某一维度没有匹配规则时，该维度视为无限制，由另一维度自主决定。例如 Agent 维度返回 Allow 但 User 维度无 UserAndAgent 规则（返回 None），则整体结果为 Allow——即“无用户规则”不等同于“无用户许可”，而是“无用户限制”。同理，Agent 维度无规则时，由 User 维度决定。
 
 Owner（User ID = `"owner"`）在引擎层面短路：当 caller 的 User ID 为 Owner 时，跳过所有 User 维度规则，仅评估 Agent 维度。
 

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -185,6 +185,12 @@ impl PermissionEngine {
             ) => PermissionResponse::Allowed {
                 token: generate_token(),
             },
+            (Some(PermissionResponse::Allowed { .. }), None) => PermissionResponse::Allowed {
+                token: generate_token(),
+            },
+            (None, Some(PermissionResponse::Allowed { .. })) => PermissionResponse::Allowed {
+                token: generate_token(),
+            },
             _ => self.default_deny(request.body(), &rules.defaults, "no matching rule"),
         };
         info!(

--- a/src/permission/engine/engine_two_phase_tests.rs
+++ b/src/permission/engine/engine_two_phase_tests.rs
@@ -139,7 +139,7 @@ fn test_two_phase_agent_deny_user_allow() {
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
-/// Agent Allow + User no match → Denied (non-owner)
+/// Agent Allow + User no match → Allowed (agent rule decides when no user rule exists)
 #[test]
 fn test_two_phase_agent_allow_user_no_match() {
     let rules = vec![
@@ -160,9 +160,9 @@ fn test_two_phase_agent_allow_user_no_match() {
         // No UserAndAgent rule for alice+test-agent
     ];
     let engine = make_ruleset(Effect::Deny, rules);
-    // Agent Allow + User None → Denied (intersection model: both must Allow)
+    // Agent Allow + User None → Allowed (no user restriction, agent decides)
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    assert!(matches!(resp, PermissionResponse::Denied { .. }));
+    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 
 /// Two phases both have no match → Denied (default policy)
@@ -248,7 +248,7 @@ fn test_two_phase_owner_agent_no_match() {
     assert!(matches!(resp, PermissionResponse::Denied { .. }));
 }
 
-/// Non-owner behavior not affected by Owner shortcut (User Allow alone is not enough)
+/// Non-owner behavior not affected by Owner shortcut (User Allow alone is sufficient when no AgentOnly rule exists)
 #[test]
 fn test_two_phase_non_owner_needs_both_phases() {
     // Only UserAndAgent Allow rule, no AgentOnly rule
@@ -269,15 +269,15 @@ fn test_two_phase_non_owner_needs_both_phases() {
         priority: 5,
     }];
     let engine = make_ruleset(Effect::Deny, rules);
-    // Alice is not owner, Agent phase has no match, User phase Allow is not enough alone
+    // Alice is not owner, Agent phase has no match, User phase Allow → Allowed (no agent restriction)
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    // Agent None + User Allow → Denied (intersection model: both must Allow)
-    assert!(matches!(resp, PermissionResponse::Denied { .. }));
+    // Agent None + User Allow → Allowed (no agent restriction, user decides)
+    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 // ---------------------------------------------------------------------------
 // Extra deny subjects tests
 // ---------------------------------------------------------------------------
-/// extra_deny_subjects = None → Agent Allow + User no match → Denied (intersection model)
+/// extra_deny_subjects = None → Agent Allow + User no match → Allowed (no user restriction)
 #[test]
 fn test_extra_deny_subjects_empty() {
     let rules = vec![Rule {
@@ -295,9 +295,9 @@ fn test_extra_deny_subjects_empty() {
         priority: 10,
     }];
     let engine = make_ruleset(Effect::Deny, rules);
-    // Only AgentOnly Allow rule, no UserAndAgent rule → intersection model → Denied
+    // Only AgentOnly Allow rule, no UserAndAgent rule → Allowed (no user restriction)
     let resp = engine.evaluate(file_request("test-agent", "/data/file.txt", "alice"), None);
-    assert!(matches!(resp, PermissionResponse::Denied { .. }));
+    assert!(matches!(resp, PermissionResponse::Allowed { .. }));
 }
 
 /// extra_deny_subjects has a matching subject → overrides result to Denied

--- a/tests/integration_permission_tests.rs
+++ b/tests/integration_permission_tests.rs
@@ -275,7 +275,6 @@ async fn test_permission_engine_reload_updates_rules() {
     let mut engine = PermissionEngine::new_with_default_data_root(initial_rules);
 
     // Initial: should allow
-    let tmpdir = TempDir::new().unwrap();
     let test_file = tmpdir.path().join("file.txt");
     let test_file_str = test_file.to_str().unwrap().to_string();
     let response = engine.evaluate(
@@ -312,6 +311,94 @@ async fn test_permission_engine_reload_updates_rules() {
 // Integration Test: Permission Engine Template Resolution
 // Ensures templates are properly resolved during rule expansion
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Regression: Bare request with AgentOnly rules should return Allowed
+// Verifies Step 1.1 fix: (Some(Allowed), None) no longer falls to default_deny
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_bare_request_agent_only_rules_return_allowed() {
+    // Build a ruleset with ONLY AgentOnly rules (no UserAndAgent rules)
+    let rules = RuleSetBuilder::new()
+        .rule(
+            RuleBuilder::new()
+                .name("agent-read-file")
+                .subject_glob("*")
+                .allow()
+                .action(Action::File {
+                    operation: "read".to_string(),
+                    paths: vec!["/home/**".to_string()],
+                })
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("agent-exec-git")
+                .subject_glob("*")
+                .allow()
+                .action(Action::Command {
+                    command: "git".to_string(),
+                    args: CommandArgs::Allowed {
+                        allowed: vec!["status".to_string(), "log".to_string()],
+                    },
+                })
+                .build()
+                .unwrap(),
+        )
+        .default_file(Effect::Deny)
+        .default_command(Effect::Deny)
+        .build()
+        .unwrap();
+
+    let engine = PermissionEngine::new_with_default_data_root(rules);
+
+    // Bare file read — agent allows, no user rules → should be Allowed
+    let response = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::FileOp {
+            agent: "test-agent".to_string(),
+            path: "/home/admin/file.txt".to_string(),
+            op: "read".to_string(),
+        }),
+        None,
+    );
+    assert!(
+        matches!(response, PermissionResponse::Allowed { .. }),
+        "Bare request with only AgentOnly rules should return Allowed, got: {:?}",
+        response
+    );
+
+    // Bare git status — agent allows, no user rules → should be Allowed
+    let response = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "git".to_string(),
+            args: vec!["status".to_string()],
+        }),
+        None,
+    );
+    assert!(
+        matches!(response, PermissionResponse::Allowed { .. }),
+        "Bare request with only AgentOnly rules should return Allowed, got: {:?}",
+        response
+    );
+
+    // Bare exec rm — no matching agent rule → should be Denied (default_deny)
+    let response = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::CommandExec {
+            agent: "test-agent".to_string(),
+            cmd: "rm".to_string(),
+            args: vec!["-rf".to_string()],
+        }),
+        None,
+    );
+    assert!(
+        matches!(response, PermissionResponse::Denied { .. }),
+        "Bare request with no matching rule should return Denied, got: {:?}",
+        response
+    );
+}
 
 #[tokio::test]
 async fn test_permission_engine_template_resolution() {


### PR DESCRIPTION
fix: 两阶段合并逻辑在某维度无规则时误入 default_deny

当 agent phase 返回 Allowed 但 user phase 返回 None（无 UserAndAgent 规则）时，原逻辑走入 catch-all 的 default_deny 分支，错误地拒绝了请求。

修改 merge 逻辑新增 `(Some(Allowed), None)` 和 `(None, Some(Allowed))` 两个 arm，使无规则维度视为无限制，由另一维度自主决定。

变更内容：
- `engine_eval.rs`: 新增两个 match arm
- `engine_two_phase_tests.rs`: 更新 3 个测试的断言和注释
- `integration_permission_tests.rs`: 新增 Bare 请求 + AgentOnly 规则的回归测试；修复 `test_permission_engine_reload_updates_rules` 中 tmpdir 覆盖导致路径不匹配的 bug
- `docs/design/permission/README.md`: 补充某维度无规则的语义说明

Source: CI
Type: fix
