### PR TITLE
fix: SkillListingSection 从 section cache 中移除，修复 CI 测试时序竞争

### DIFF
--- a/src/system_prompt/sections.rs
+++ b/src/system_prompt/sections.rs
@@ -38,10 +38,7 @@ impl Section {
     pub fn is_cacheable(&self) -> bool {
         matches!(
             self,
-            Section::RoleSection(_)
-                | Section::MemorySection(_)
-                | Section::HeartbeatSection(_)
-                | Section::SkillListingSection(_)
+            Section::RoleSection(_) | Section::MemorySection(_) | Section::HeartbeatSection(_)
         )
     }
 
@@ -323,7 +320,7 @@ mod tests {
     #[test]
     fn test_skill_listing_section_is_cacheable() {
         let s = Section::SkillListingSection("some skills".to_string());
-        assert!(s.is_cacheable());
+        assert!(!s.is_cacheable());
     }
 
     #[test]


### PR DESCRIPTION
修复 SkillListingSection 缓存污染导致 CI 测试失败的问题。

CI 并行运行时，SECTION_CACHE 被其他测试写入的 SkillListingSection 结果污染，
导致 `test_build_from_workspace_skill_listing_injected` 读到脏缓存。

从 `is_cacheable()` 中移除 `SkillListingSection`，使其每次重新渲染，
与 PR #986 修复 ToolsSection 的模式一致。

Source: CI run 27497607994
Type: fix