### PR TITLE
feat: implement model parameter in sessions_spawn and project-level agents.json loading

### DIFF
--- a/plan/2026-06-14-21-33-design-doc-agent-config.md
+++ b/plan/2026-06-14-21-33-design-doc-agent-config.md
@@ -1,0 +1,144 @@
+# Plan: Agent Config - model 参数 + 项目级 agents.json
+
+> ⚠️ **状态管理规范**：所有情况下都应尽可能避免全局变量，详见 `skills/avoid-global-state/SKILL.md`。
+
+## 来源
+design-doc: docs/design/agent/agent-config.md
+
+## 项目路径
+/home/admin/code/closeclaw
+
+## 目的
+修复 design doc `agent-config.md` 中发现的 2 个 gap：
+1. `sessions_spawn` 工具 schema 声明了 `model` 参数但从未解析和应用（设计文档要求的模型优先级链第一层是死代码）
+2. 项目级 `agents.json` 注册清单未加载（设计文档要求加载用户级 + 项目级两份清单并取 ID 并集）
+
+## 思路
+
+### Gap 1 - model 参数
+设计文档定义的模型解析优先级：`显式 model 参数 > 父 agent.subagents.model > 目标 agent.model > 系统默认`
+
+当前代码（`src/gateway/session_manager/spawn.rs:152`）只实现了 `目标 agent.model > 系统默认`。需要：
+- 在 `SpawnArgs` 中新增 `model` 字段，在 `parse_args()` 中解析
+- 在 `create_child()` 和 `create_child_session()` 中传递 `model` 参数
+- 在 `create_child_session` 中实现完整优先级链：显式 model 参数 > 父 agent 的 `subagents.model` > 目标 agent 的 `model` > 系统默认
+
+### Gap 2 - 项目级 agents.json
+当前 `agent_loader.rs:34` 只从 `self.config_dir.join("agents.json")`（用户级）加载注册清单。需要：
+- 额外从 `<repo>/.closeclaw/agents.json`（项目级）加载注册清单
+- 两份清单取 ID 并集（同 ID 项目覆盖用户，注释掉的 ID 跳过）
+- 复用已有的 `AgentDirectoryProvider` 做后续的 per-agent config 加载（已支持两级目录）
+
+开发必读：
+- **必须**阅读 CONTRIBUTING.md `CONTRIBUTING.md`
+- **必须**阅读项目 design doc `docs/design/agent/agent-config.md`
+
+### Step 1.1：SpawnArgs 新增 model 字段
+修改 `src/tools/builtin/sessions_spawn.rs`：
+- `SpawnArgs` 结构体新增 `model: Option<String>` 字段
+- `parse_args()` 中解析 `"model"` 参数：`args.get("model").and_then(|v| v.as_str()).map(String::from)`
+- `Ok(SpawnArgs { ... })` 中包含 `model` 字段
+
+验收：`cargo check` 通过，SpawnArgs 包含 model 字段，parse_args 正确解析。
+
+### Step 1.2：传递 model 参数到 create_child_session
+修改 `src/tools/builtin/sessions_spawn.rs`：
+- `create_child()` 方法签名新增 `model: Option<&str>` 参数
+- `call()` 中将 `spawn_args.model.as_deref()` 传递给 `create_child()`
+
+修改 `src/gateway/session_manager/spawn.rs`：
+- `create_child_session()` 方法签名新增 `model: Option<&str>` 参数
+- 在模型解析处实现完整优先级链：
+  ```rust
+  let model = model_override  // 显式 model 参数
+      .or(config.subagents.model.clone())  // 父 agent.subagents.model
+      .or(config.model.clone())  // 目标 agent.model
+      .unwrap_or_else(|| "default".to_string());  // 系统默认
+  ```
+
+验收：`cargo check` 通过，model 参数从 tool call 传递到 session 创建。
+
+### Step 1.3：项目级 agents.json 注册清单加载
+修改 `src/config/agent_loader.rs`：
+- `load_agents()` 方法签名新增 `repo_root: Option<&Path>` 参数（如已有则确认传递）
+- 在加载用户级 `agents.json` 后，额外加载 `<repo>/.closeclaw/agents.json`（如存在）
+- 解析两份清单，取 ID 并集（`HashSet` 合并）
+- 将合并后的 ID 列表传递给 `AgentDirectoryProvider`
+- 注意：`reload_agents()` 也需要传递 `repo_root`（可能需要从 ConfigManager 获取）
+
+验收：`cargo check` 通过，两份 agents.json 都被加载，ID 取并集。
+
+### Step 1.4：UT 编写
+修改/新增测试文件：
+- `sessions_spawn` model 参数解析测试：验证 model 字段正确解析（有值/无值/缺失）
+- `create_child_session` 模型优先级测试：验证 4 层优先级链
+- `agent_loader` 项目级 agents.json 测试：验证 ID 并集合并逻辑
+
+验收：`cargo test` 通过，覆盖所有新增代码逻辑分支。
+
+### Step 1.5：修复模型优先级链 — 父 agent.subagents.model 未正确使用（E2 review 发现）
+
+**问题**：Step 1.2 实现的优先级链中 `config.subagents.model` 使用的是**目标 agent** 的配置，但设计文档要求是**父 agent** 的 `subagents.model`。
+
+修改 `src/tools/builtin/sessions_spawn.rs`：
+- `call()` 中，在获取 `parent_session_id` 和 `config`（目标 agent）之后，查找父 agent 的配置：
+  ```rust
+  let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
+  let parent_subagents_model = parent_agent_id
+      .as_ref()
+      .and_then(|id| self.config_manager.agent(id))
+      .and_then(|c| c.subagents.model.clone());
+  ```
+- `create_child()` 方法签名新增 `parent_subagents_model: Option<&str>` 参数
+- 将 `parent_subagents_model.as_deref()` 传递给 `create_child()`
+
+修改 `src/gateway/session_manager/spawn.rs`：
+- `create_child_session()` 方法签名新增 `parent_subagents_model: Option<&str>` 参数
+- 修正模型优先级链：
+  ```rust
+  let model = model_override                          // 1. 显式 model 参数
+      .map(String::from)
+      .or(parent_subagents_model.map(String::from))   // 2. 父 agent.subagents.model
+      .or(config.model.clone())                        // 3. 目标 agent.model
+      .unwrap_or_else(|| "default".to_string());       // 4. 系统默认
+  ```
+- 删除 `config.subagents.model` 相关代码（该字段应由父 agent 侧消费，非目标 agent 侧）
+
+修改测试文件：适配新签名，更新测试用例验证正确的优先级链。
+
+验收：`cargo check` 通过，优先级链与设计文档一致。
+
+### Step 1.6：修复 repo_root 未赋值 — reload_agents() 热重载丢失项目级配置（E2 review 发现）
+
+**问题**：`ConfigManager.repo_root` 初始化为 `None` 且无处赋值，`reload_agents()` 读取 `self.repo_root` 始终为 `None`。
+
+修改 `src/config/agent_loader.rs`：
+- 在 `load_agents()` 方法开头，将 `repo_root` 参数保存到 `self.repo_root`：
+  ```rust
+  // Persist repo_root for reload_agents()
+  if repo_root.is_some() {
+      *self.repo_root_slot() = repo_root.map(Path::to_path_buf);
+  }
+  ```
+  或者直接在 `load_agents()` 开头赋值：
+  ```rust
+  self.repo_root = repo_root.map(|p| p.to_path_buf());
+  ```
+
+验收：`cargo check` 通过，首次 `load_agents(repo_root)` 后 `self.repo_root` 被正确赋值，`reload_agents()` 能加载项目级 agents.json。
+
+## 变更文件清单
+
+| 文件 | 变更类型 | 说明 |
+|------|---------|------|
+| `src/tools/builtin/sessions_spawn.rs` | 修改 | SpawnArgs 新增 model，传递到 create_child |
+| `src/gateway/session_manager/spawn.rs` | 修改 | create_child_session 新增 model 参数，实现优先级链 |
+| `src/config/agent_loader.rs` | 修改 | 加载项目级 agents.json，ID 并集 |
+| 测试文件 | 新增/修改 | 覆盖新增逻辑 |
+
+## 约束
+- 文件行数 ≤ 500（含测试）
+- 单行宽度 ≤ 100 字符
+- 函数体 ≤ 50 行
+- 函数参数 ≤ 6
+- 模块嵌套 ≤ 3 层

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -28,49 +28,47 @@ fn strip_jsonc_comments(content: &str) -> String {
 }
 
 impl ConfigManager {
-    /// Load agent registration list and resolve agent configurations
-    /// from two-level directories (user + project).
-    pub fn load_agents(&self, repo_root: Option<&Path>) -> Result<(), ConfigLoadError> {
-        let agents_json_path = self.config_dir.join("agents.json");
-        if !agents_json_path.exists() {
-            return Ok(());
+    /// Load an agents.json file and return parsed agent IDs.
+    pub(crate) fn load_agents_json(&self, path: &Path) -> Result<Vec<String>, ConfigLoadError> {
+        if !path.exists() {
+            return Ok(Vec::new());
         }
-
-        let raw = fs::read_to_string(&agents_json_path).map_err(|e| ConfigLoadError::IoError {
-            path: agents_json_path.clone(),
+        let raw = fs::read_to_string(path).map_err(|e| ConfigLoadError::IoError {
+            path: path.to_path_buf(),
             error: e.to_string(),
         })?;
         let cleaned = strip_jsonc_comments(&raw);
-        let agents_cfg: AgentsConfig =
+        let cfg: AgentsConfig =
             serde_json::from_str(&cleaned).map_err(|e| ConfigLoadError::ParseError {
-                path: agents_json_path.clone(),
+                path: path.to_path_buf(),
                 error: e.to_string(),
             })?;
+        Ok(cfg.agents)
+    }
 
-        let user_agents_dir = self
-            .config_dir
-            .parent()
-            .unwrap_or(&self.config_dir)
-            .join("agents");
-        let project_agents_dir = repo_root.map(|r| r.join(".closeclaw").join("agents"));
+    /// Merge agent IDs from user and project lists (union).
+    pub(crate) fn merge_agent_ids(user: &[String], project: &[String]) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut merged = Vec::new();
+        for id in user.iter().chain(project.iter()) {
+            if seen.insert(id.clone()) {
+                merged.push(id.clone());
+            }
+        }
+        merged
+    }
 
-        let provider = AgentDirectoryProvider::new(
-            agents_cfg.agents.clone(),
-            user_agents_dir,
-            project_agents_dir,
-        )
-        .map_err(|e| ConfigLoadError::ValidationError {
-            path: agents_json_path.clone(),
-            message: e.to_string(),
-        })?;
-
-        // Validate parent_id references against registry
-        let registry_ids: HashSet<&str> = agents_cfg.agents.iter().map(String::as_str).collect();
+    /// Validate parent_id references against the merged registry.
+    fn validate_parent_ids(
+        provider: &AgentDirectoryProvider,
+        registry_ids: &HashSet<&str>,
+        json_path: &Path,
+    ) -> Result<(), ConfigLoadError> {
         for (id, entry) in provider.entries() {
             if let Some(ref parent_id) = entry.parent_id {
                 if !registry_ids.contains(parent_id.as_str()) {
                     return Err(ConfigLoadError::ValidationError {
-                        path: agents_json_path,
+                        path: json_path.to_path_buf(),
                         message: format!(
                             "Agent '{}' references unregistered parent '{}'",
                             id, parent_id
@@ -79,17 +77,20 @@ impl ConfigManager {
                 }
             }
         }
+        Ok(())
+    }
 
-        *self.agents.write().expect("RwLock for agents was poisoned") = provider.entries().clone();
-
-        // Sync agent permissions
+    /// Sync agent permissions from provider into ConfigManager cache.
+    fn sync_permissions(
+        &self,
+        ids: &[String],
+        provider_perms: &HashMap<String, crate::agent::config::AgentPermissions>,
+    ) {
         let mut perms_map = self.agent_permissions.write().expect("RwLock poisoned");
-        let provider_perms = provider.permissions();
-        for id in &agents_cfg.agents {
+        for id in ids {
             if let Some(p) = provider_perms.get(id) {
                 perms_map.insert(id.clone(), p.clone());
             } else {
-                // Registered agent missing permissions.json → synthesize full-deny baseline
                 perms_map.insert(
                     id.clone(),
                     crate::agent::config::AgentPermissions {
@@ -100,15 +101,58 @@ impl ConfigManager {
                 );
             }
         }
-        drop(perms_map);
+    }
+
+    /// Load agent registration list and resolve agent configurations
+    /// from two-level directories (user + project).
+    pub fn load_agents(&self, repo_root: Option<&Path>) -> Result<(), ConfigLoadError> {
+        // Persist repo_root so reload_agents() can load project-level config
+        if repo_root.is_some() {
+            *self.repo_root.write().expect("RwLock poisoned") = repo_root.map(Path::to_path_buf);
+        }
+
+        let agents_json_path = self.config_dir.join("agents.json");
+        let user_ids = self.load_agents_json(&agents_json_path)?;
+
+        let project_ids = if let Some(repo) = repo_root {
+            let path = repo.join(".closeclaw").join("agents.json");
+            self.load_agents_json(&path)?
+        } else {
+            Vec::new()
+        };
+
+        let merged_ids = Self::merge_agent_ids(&user_ids, &project_ids);
+        if merged_ids.is_empty() {
+            return Ok(());
+        }
+
+        let user_agents_dir = self
+            .config_dir
+            .parent()
+            .unwrap_or(&self.config_dir)
+            .join("agents");
+        let project_agents_dir = repo_root.map(|r| r.join(".closeclaw").join("agents"));
+
+        let provider =
+            AgentDirectoryProvider::new(merged_ids.clone(), user_agents_dir, project_agents_dir)
+                .map_err(|e| ConfigLoadError::ValidationError {
+                    path: agents_json_path.clone(),
+                    message: e.to_string(),
+                })?;
+
+        let registry_ids: HashSet<&str> = merged_ids.iter().map(String::as_str).collect();
+        Self::validate_parent_ids(&provider, &registry_ids, &agents_json_path)?;
+
+        *self.agents.write().expect("RwLock for agents was poisoned") = provider.entries().clone();
+        self.sync_permissions(&merged_ids, provider.permissions());
 
         Ok(())
     }
 
-    /// Hot-reload: re-scan agents/ directory and update agents + agent_permissions caches.
-    /// Called when agents.json or any agents/<id>/*.json file changes on disk.
+    /// Hot-reload: re-scan agents/ directory and update caches.
     pub fn reload_agents(&self) -> Result<(), ConfigLoadError> {
-        self.load_agents(None)?;
+        let repo_root = self.repo_root.read().expect("RwLock poisoned").clone();
+        self.load_agents(repo_root.as_deref())?;
         info!("Agent configs reloaded");
         Ok(())
     }

--- a/src/config/agent_loader_tests.rs
+++ b/src/config/agent_loader_tests.rs
@@ -1,0 +1,255 @@
+//! Unit tests for `agent_loader.rs` — agent registration list loading
+//! and ID union merge logic.
+//!
+//! Covers:
+//! - `load_agents_json`: parsing user/project agents.json
+//! - `merge_agent_ids`: union of two ID lists
+//! - `load_agents`: project-level agents.json loading
+//!
+//! Tests use tempdirs to simulate user and project config layouts.
+//!
+//! `ConfigManager` is created with `config_dir = <tmp>/config/`.
+//! `load_agents_json` reads `<config_dir>/agents.json`, so
+//! agents.json goes into `<tmp>/config/agents.json`.
+//! `load_agents` derives `user_agents_dir = <config_dir>/../agents`,
+//! i.e. `<tmp>/agents/`.
+
+use std::fs;
+use std::path::Path;
+
+use crate::config::ConfigManager;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Write an agents.json file with the given IDs.
+fn write_agents_json(dir: &Path, ids: &[&str]) {
+    let content = serde_json::json!({ "agents": ids });
+    let json_str = serde_json::to_string_pretty(&content).unwrap();
+    fs::write(dir.join("agents.json"), json_str).unwrap();
+}
+
+/// Create a minimal `config.json` for an agent so
+/// `AgentDirectoryProvider` can resolve it.
+fn create_agent_config(agents_dir: &Path, id: &str) {
+    let agent_dir = agents_dir.join(id);
+    fs::create_dir_all(&agent_dir).unwrap();
+    let config = serde_json::json!({
+        "id": id,
+        "name": id,
+    });
+    fs::write(
+        agent_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Build a `ConfigManager` with `config_dir = <base>/config/`.
+/// The agents directory is `<base>/agents/`.
+fn make_config_manager(base: &Path) -> ConfigManager {
+    let config_dir = base.join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    ConfigManager::new(config_dir).expect("ConfigManager::new should succeed")
+}
+
+// ===========================================================================
+// merge_agent_ids tests
+// ===========================================================================
+
+/// Verify that `merge_agent_ids` produces a union of two lists
+/// with first-wins deduplication.
+#[test]
+fn test_merge_agent_ids_union() {
+    let user = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+    let project = vec!["beta".to_string(), "delta".to_string(), "alpha".to_string()];
+
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+
+    assert_eq!(merged.len(), 4, "should have 4 unique IDs");
+    assert_eq!(merged[0], "alpha");
+    assert_eq!(merged[1], "beta");
+    assert_eq!(merged[2], "gamma");
+    assert_eq!(merged[3], "delta");
+}
+
+/// When project list is empty, merged result equals user list.
+#[test]
+fn test_merge_agent_ids_empty_project() {
+    let user = vec!["a".to_string(), "b".to_string()];
+    let project: Vec<String> = vec![];
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+    assert_eq!(merged, vec!["a", "b"]);
+}
+
+/// When both lists are empty, result is empty.
+#[test]
+fn test_merge_agent_ids_both_empty() {
+    let user: Vec<String> = vec![];
+    let project: Vec<String> = vec![];
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+    assert!(merged.is_empty());
+}
+
+// ===========================================================================
+// load_agents_json tests
+// ===========================================================================
+
+/// Loading a non-existent agents.json should return an empty list.
+#[test]
+fn test_load_agents_json_nonexistent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cm = make_config_manager(tmp.path());
+    let result = cm.load_agents_json(&tmp.path().join("nonexistent.json"));
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}
+
+/// Loading a valid agents.json should parse the IDs correctly.
+#[test]
+fn test_load_agents_json_valid() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    write_agents_json(&config_dir, &["orchestrator", "coder"]);
+    let cm = make_config_manager(tmp.path());
+    let ids = cm
+        .load_agents_json(&config_dir.join("agents.json"))
+        .unwrap();
+    assert_eq!(ids, vec!["orchestrator", "coder"]);
+}
+
+/// Loading a JSONC agents.json with comments should strip comments
+/// and parse correctly.
+#[test]
+fn test_load_agents_json_with_comments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    // Comments come first, then real entries (avoids trailing comma)
+    let json = r#"{
+  "agents": [
+    // "commented-out-agent",
+    "a",
+    "c"
+  ]
+}"#;
+    fs::write(config_dir.join("agents.json"), json).unwrap();
+    let cm = make_config_manager(tmp.path());
+    let ids = cm
+        .load_agents_json(&config_dir.join("agents.json"))
+        .unwrap();
+    assert_eq!(ids, vec!["a", "c"]);
+}
+
+// ===========================================================================
+// load_agents — project-level agents.json integration
+// ===========================================================================
+
+/// When both user and project agents.json exist, their IDs should
+/// be merged (union).
+#[test]
+fn test_load_agents_merges_user_and_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cm = make_config_manager(tmp.path());
+
+    // agents.json goes into config_dir, agents go into sibling agents dir
+    let config_dir = tmp.path().join("config");
+    let agents_dir = tmp.path().join("agents");
+
+    write_agents_json(&config_dir, &["agent-1", "agent-2"]);
+    create_agent_config(&agents_dir, "agent-1");
+    create_agent_config(&agents_dir, "agent-2");
+
+    // Fake repo root with project-level agents.json
+    let repo_dir = tempfile::tempdir().unwrap();
+    let project_closeclaw = repo_dir.path().join(".closeclaw");
+    fs::create_dir_all(&project_closeclaw).unwrap();
+    write_agents_json(&project_closeclaw, &["agent-2", "agent-3"]);
+    let project_agents = project_closeclaw.join("agents");
+    create_agent_config(&project_agents, "agent-2");
+    create_agent_config(&project_agents, "agent-3");
+
+    cm.load_agents(Some(repo_dir.path()))
+        .expect("load_agents should succeed");
+
+    let agents = cm.agents();
+    let mut ids: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+    ids.sort();
+    assert!(
+        ids.contains(&"agent-1"),
+        "user-level agent-1 should be present"
+    );
+    assert!(ids.contains(&"agent-2"), "agent-2 should be present");
+    assert!(
+        ids.contains(&"agent-3"),
+        "project-level agent-3 should be present"
+    );
+    assert_eq!(ids.len(), 3, "should have exactly 3 unique agents");
+}
+
+/// When repo_root is None, only user-level agents.json is loaded.
+#[test]
+fn test_load_agents_no_project_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cm = make_config_manager(tmp.path());
+    let config_dir = tmp.path().join("config");
+    let agents_dir = tmp.path().join("agents");
+
+    write_agents_json(&config_dir, &["user-agent"]);
+    create_agent_config(&agents_dir, "user-agent");
+
+    cm.load_agents(None).expect("load_agents should succeed");
+
+    let agents = cm.agents();
+    let ids: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+    assert_eq!(ids, vec!["user-agent"]);
+}
+
+/// When project-level agents.json does not exist, only user-level
+/// is loaded (no error).
+#[test]
+fn test_load_agents_project_json_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cm = make_config_manager(tmp.path());
+    let config_dir = tmp.path().join("config");
+    let agents_dir = tmp.path().join("agents");
+
+    write_agents_json(&config_dir, &["only-user"]);
+    create_agent_config(&agents_dir, "only-user");
+
+    let repo_dir = tempfile::tempdir().unwrap();
+
+    cm.load_agents(Some(repo_dir.path()))
+        .expect("load_agents should succeed even without project json");
+
+    let agents = cm.agents();
+    let ids: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+    assert_eq!(ids, vec!["only-user"]);
+}
+
+/// Reload should re-read agents from disk.
+#[test]
+fn test_reload_agents_reloads() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cm = make_config_manager(tmp.path());
+    let config_dir = tmp.path().join("config");
+    let agents_dir = tmp.path().join("agents");
+
+    write_agents_json(&config_dir, &["a"]);
+    create_agent_config(&agents_dir, "a");
+
+    cm.load_agents(None).unwrap();
+    assert!(cm.agents().contains_key("a"));
+
+    // Add a new agent
+    write_agents_json(&config_dir, &["a", "b"]);
+    create_agent_config(&agents_dir, "b");
+    cm.reload_agents().unwrap();
+
+    let agents = cm.agents();
+    let mut ids: Vec<&str> = agents.keys().map(|s| s.as_str()).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["a", "b"]);
+}

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -194,12 +194,10 @@ pub struct ConfigInfo {
 // ---------------------------------------------------------------------------
 
 /// Unified configuration management entry point.
-///
 /// Provides atomic write, backup integration, and unified access to all
 /// JSON config files under the config/ directory.
 ///
 /// # Design
-///
 /// Each configuration section (models, channels, gateway, etc.) is stored
 /// as a separate JSON file. ConfigManager loads all sections into memory
 /// and provides:
@@ -220,6 +218,8 @@ pub struct ConfigManager {
     pub(crate) agents: RwLock<HashMap<String, super::agents::ResolvedAgentConfig>>,
     /// Per-agent raw permissions (loaded from permissions.json).
     pub(crate) agent_permissions: RwLock<HashMap<String, AgentPermissions>>,
+    /// Optional project root for loading project-level agents.json.
+    pub(crate) repo_root: RwLock<Option<PathBuf>>,
 }
 
 impl ConfigManager {
@@ -237,6 +237,7 @@ impl ConfigManager {
             credentials_provider: RwLock::new(CredentialsProvider::default()),
             agents: RwLock::new(HashMap::new()),
             agent_permissions: RwLock::new(HashMap::new()),
+            repo_root: RwLock::new(None),
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,8 @@
 //! Implements ConfigProvider trait for extensible config management.
 
 pub mod agent_loader;
+#[cfg(test)]
+mod agent_loader_tests;
 pub mod agents;
 pub mod backup;
 pub mod manager;

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -394,6 +394,8 @@ mod bug904_tests;
 #[cfg(test)]
 mod flush_tests;
 #[cfg(test)]
+mod model_priority_tests;
+#[cfg(test)]
 mod rebuild_tests;
 #[cfg(test)]
 mod resolve_tests;

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -92,6 +92,8 @@ async fn test_try_push_announce_run_mode() {
             SpawnMode::Run,
             false,
             None,
+            None,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -136,6 +138,8 @@ async fn test_try_push_announce_session_mode_noop() {
             None,
             SpawnMode::Session,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -257,6 +261,8 @@ async fn test_thinking_blocks_excluded() {
             None,
             SpawnMode::Run,
             false,
+            None,
+            None,
             None,
         )
         .await

--- a/src/gateway/session_manager/model_priority_tests.rs
+++ b/src/gateway/session_manager/model_priority_tests.rs
@@ -1,0 +1,241 @@
+//! Tests for the model priority chain in `create_child_session`.
+//!
+//! Verifies the 4-layer priority:
+//!   explicit model param > parent agent.subagents.model
+//!   > target agent.model > system default
+//!
+//! These are separated from `spawn_tests.rs` to keep both files
+//! under the 500-line file-size limit.
+
+use super::spawn::SpawnMode;
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::SessionManager;
+use crate::agent::config::SubagentsConfig;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::session::bootstrap::BootstrapMode;
+use serial_test::serial;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::llm::session::ConversationSession;
+
+fn test_resolved_config(
+    id: &str,
+    model: Option<&str>,
+    workspace: Option<PathBuf>,
+) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: model.map(String::from),
+        workspace,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        source: ConfigSource::Merged,
+    }
+}
+
+async fn register_parent_session(mgr: &SessionManager, parent_id: &str, workdir: PathBuf) {
+    let cs = ConversationSession::new(parent_id.to_string(), "test-model".to_string(), workdir);
+    let arc = Arc::new(RwLock::new(cs));
+    let mut conv = mgr.conversation_sessions.write().await;
+    conv.insert(parent_id.to_string(), arc);
+}
+
+/// Verify the model chosen on the ConversationSession matches the
+/// expected value.
+async fn assert_child_model(mgr: &SessionManager, child_id: &str, expected_model: &str) {
+    let cs = mgr
+        .get_conversation_session(child_id)
+        .await
+        .expect("child ConversationSession should exist");
+    let guard = cs.read().await;
+    let actual = guard.model();
+    assert_eq!(
+        actual, expected_model,
+        "child model mismatch: expected '{}', got '{}'",
+        expected_model, actual
+    );
+}
+
+// ── 1. Explicit model_override wins over everything ────────────────────────
+
+/// When `model_override` is `Some("override-model")`, it should be
+/// used regardless of config values or parent_subagents_model.
+#[tokio::test]
+#[serial]
+async fn test_model_priority_explicit_override_wins() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("target-a", Some("target-model"), None);
+
+    register_parent_session(&mgr, "p1", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "p1",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            Some("override-model"),   // model_override
+            Some("parent-sub-model"), // parent_subagents_model
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert_child_model(&mgr, &child_id, "override-model").await;
+}
+
+// ── 2. Parent subagents.model wins over target agent.model ────────────────
+
+/// When `model_override` is `None` but `parent_subagents_model` is set,
+/// the parent's choice should win over the target agent's model.
+#[tokio::test]
+#[serial]
+async fn test_model_priority_parent_subagents_wins() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("target-b", Some("target-model"), None);
+
+    register_parent_session(&mgr, "p2", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "p2",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,                    // model_override
+            Some("parent-override"), // parent_subagents_model
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert_child_model(&mgr, &child_id, "parent-override").await;
+}
+
+// ── 3. Target agent.model used when no override/subagents.model ───────────
+
+/// When neither `model_override` nor `parent_subagents_model` is set,
+/// the target agent's own `model` field should be used.
+#[tokio::test]
+#[serial]
+async fn test_model_priority_target_agent_model() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("target-c", Some("my-custom-model"), None);
+
+    register_parent_session(&mgr, "p3", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "p3",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None, // model_override
+            None, // parent_subagents_model
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert_child_model(&mgr, &child_id, "my-custom-model").await;
+}
+
+// ── 4. System default used when nothing else is set ───────────────────────
+
+/// When `model_override`, `parent_subagents_model`, and `config.model`
+/// are all `None`, the system default `"default"` should be used.
+#[tokio::test]
+#[serial]
+async fn test_model_priority_system_default() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("target-d", None, None);
+
+    register_parent_session(&mgr, "p4", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "p4",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None, // model_override
+            None, // parent_subagents_model
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert_child_model(&mgr, &child_id, "default").await;
+}
+
+// ── 5. Parent subagents.model beats target model when no override ─────────
+
+/// When `model_override` is `None` but `parent_subagents_model` is set,
+/// it should take priority over the target agent's `model`.
+#[tokio::test]
+#[serial]
+async fn test_model_priority_parent_subagents_beats_target() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("target-e", Some("target-model"), None);
+
+    register_parent_session(&mgr, "p5", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "p5",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,                       // model_override
+            Some("subagents-override"), // parent_subagents_model
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // parent_subagents_model should win over target model
+    assert_child_model(&mgr, &child_id, "subagents-override").await;
+}

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -84,6 +84,8 @@ impl SessionManager {
         mode: SpawnMode,
         fork: bool,
         allowed_tools: Option<Vec<String>>,
+        model_override: Option<&str>,
+        parent_subagents_model: Option<&str>,
     ) -> Result<String, String> {
         // Apply tool whitelist override: when allowed_tools is provided,
         // replace the config's tools list so the child session only has
@@ -149,9 +151,12 @@ impl SessionManager {
         drop(tool_registry_guard);
 
         // 5. Create ConversationSession
-        let model = config
-            .model
-            .clone()
+        // Model priority: explicit model param > parent agent.subagents.model
+        // > target agent.model > system default
+        let model = model_override
+            .map(String::from)
+            .or(parent_subagents_model.map(String::from))
+            .or(config.model.clone())
             .unwrap_or_else(|| "default".to_string());
 
         // 5a. Wire child into parent's cancel-token tree (Step 1.5).

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -75,6 +75,8 @@ async fn test_create_child_session_basic() {
             SpawnMode::Run,
             false,
             None,
+            None,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -129,6 +131,8 @@ async fn test_create_child_session_workspace_fallback() {
             SpawnMode::Session,
             false,
             None,
+            None,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -148,6 +152,8 @@ async fn test_create_child_session_workspace_fallback() {
             Some(other.path().to_str().unwrap()),
             SpawnMode::Run,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -184,6 +190,8 @@ async fn test_create_child_session_registers_child_info() {
             None,
             SpawnMode::Session,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -223,6 +231,8 @@ async fn test_steer_child_injects_pending_message() {
             None,
             SpawnMode::Session,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -274,6 +284,8 @@ async fn test_kill_child_removes_from_all_tables() {
             None,
             SpawnMode::Session,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -336,6 +348,8 @@ async fn test_validate_child_ownership_returns_none_for_run_mode() {
             SpawnMode::Run,
             false,
             None,
+            None,
+            None,
         )
         .await
         .expect("create_child_session should succeed");
@@ -371,6 +385,8 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
             None,
             SpawnMode::Session,
             false,
+            None,
+            None,
             None,
         )
         .await
@@ -426,6 +442,8 @@ async fn test_create_child_session_allowed_tools_override() {
             SpawnMode::Run,
             false,
             Some(allowed),
+            None,
+            None,
         )
         .await
         .expect("create_child_session with allowed_tools should succeed");
@@ -458,6 +476,8 @@ async fn test_create_child_session_no_allowed_tools_preserves_config() {
             None,
             SpawnMode::Run,
             false,
+            None,
+            None,
             None,
         )
         .await

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -177,6 +177,8 @@ pub(super) async fn spawn_n_run_children(
                 SpawnMode::Run,
                 false,
                 None,
+                None,
+                None,
             )
             .await
             .expect("create_child_session should succeed");

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -24,7 +24,7 @@ pub struct SessionsSpawnTool {
 }
 
 /// Parsed arguments for a `sessions_spawn` tool call.
-struct SpawnArgs {
+pub(crate) struct SpawnArgs {
     task: String,
     agent_id: Option<String>,
     light_context: bool,
@@ -34,6 +34,7 @@ struct SpawnArgs {
     fork: bool,
     allowed_tools: Option<Vec<String>>,
     prompt_template: Option<PromptTemplate>,
+    pub(crate) model: Option<String>,
 }
 
 impl SessionsSpawnTool {
@@ -53,7 +54,7 @@ impl SessionsSpawnTool {
     }
 
     /// Parse the raw JSON arguments into typed [`SpawnArgs`].
-    fn parse_args(args: &Value) -> Result<SpawnArgs, ToolCallError> {
+    pub(crate) fn parse_args(args: &Value) -> Result<SpawnArgs, ToolCallError> {
         let task = args
             .get("task")
             .and_then(|v| v.as_str())
@@ -91,6 +92,7 @@ impl SessionsSpawnTool {
             .map(|s| s.parse::<PromptTemplate>())
             .transpose()
             .map_err(|e| ToolCallError::InvalidArgs(e.to_string()))?;
+        let model = args.get("model").and_then(|v| v.as_str()).map(String::from);
         Ok(SpawnArgs {
             task: task.to_string(),
             agent_id,
@@ -101,6 +103,7 @@ impl SessionsSpawnTool {
             fork,
             allowed_tools,
             prompt_template,
+            model,
         })
     }
 
@@ -155,6 +158,8 @@ impl SessionsSpawnTool {
         mode: SpawnMode,
         fork: bool,
         allowed_tools: Option<Vec<String>>,
+        model: Option<&str>,
+        parent_subagents_model: Option<&str>,
     ) -> Result<String, ToolCallError> {
         self.session_manager
             .create_child_session(
@@ -167,6 +172,8 @@ impl SessionsSpawnTool {
                 mode,
                 fork,
                 allowed_tools,
+                model,
+                parent_subagents_model,
             )
             .await
             .map_err(|e| {
@@ -282,6 +289,13 @@ impl Tool for SessionsSpawnTool {
             })?;
         self.validate_spawn_permissions(&config, parent_session_id)
             .await?;
+        // Look up the parent agent's subagents.model config
+        // (used as priority level 2 in the model priority chain).
+        let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
+        let parent_subagents_model = parent_agent_id
+            .as_ref()
+            .and_then(|id| self.config_manager.agent(id))
+            .and_then(|c| c.subagents.model.clone());
         let parent_depth = self
             .session_manager
             .get_session_depth(parent_session_id)
@@ -303,6 +317,8 @@ impl Tool for SessionsSpawnTool {
                 spawn_args.mode,
                 spawn_args.fork,
                 spawn_args.allowed_tools,
+                spawn_args.model.as_deref(),
+                parent_subagents_model.as_deref(),
             )
             .await?;
         Ok(ToolResult {

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -213,3 +213,85 @@ async fn test_sessions_spawn_missing_task_error_with_allowed_tools() {
         other => panic!("expected InvalidArgs, got {:?}", other),
     }
 }
+
+// ===========================================================================
+// Model parameter parsing tests (Step 1.4)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// 6. test_sessions_spawn_model_param_parsed
+// ---------------------------------------------------------------------------
+
+/// When `model` is present in the JSON args, `parse_args` should extract
+/// it as `Some(String)` in `SpawnArgs.model`.
+#[test]
+fn test_sessions_spawn_model_param_parsed() {
+    let args = json!({
+        "task": "do work",
+        "model": "deepseek/deepseek-chat"
+    });
+    let spawn_args = crate::tools::builtin::sessions_spawn::SessionsSpawnTool::parse_args(&args)
+        .expect("parse_args should succeed");
+    assert_eq!(
+        spawn_args.model.as_deref(),
+        Some("deepseek/deepseek-chat"),
+        "model should be parsed from args"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. test_sessions_spawn_model_param_absent
+// ---------------------------------------------------------------------------
+
+/// When `model` is absent from the JSON args, `parse_args` should set
+/// `SpawnArgs.model` to `None`.
+#[test]
+fn test_sessions_spawn_model_param_absent() {
+    let args = json!({"task": "do work"});
+    let spawn_args = crate::tools::builtin::sessions_spawn::SessionsSpawnTool::parse_args(&args)
+        .expect("parse_args should succeed");
+    assert!(
+        spawn_args.model.is_none(),
+        "model should be None when not provided"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. test_sessions_spawn_model_param_empty_string
+// ---------------------------------------------------------------------------
+
+/// When `model` is present but empty string, `parse_args` should set
+/// `SpawnArgs.model` to `Some("")` (empty string is still a value).
+#[test]
+fn test_sessions_spawn_model_param_empty_string() {
+    let args = json!({"task": "do work", "model": ""});
+    let spawn_args = crate::tools::builtin::sessions_spawn::SessionsSpawnTool::parse_args(&args)
+        .expect("parse_args should succeed");
+    assert_eq!(
+        spawn_args.model.as_deref(),
+        Some(""),
+        "model should be Some(\"\") when set to empty string"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 9. test_sessions_spawn_model_param_schema
+// ---------------------------------------------------------------------------
+
+/// The input schema should declare `model` as a string property.
+#[test]
+fn test_sessions_spawn_model_param_schema() {
+    let tool = make_tool();
+    let schema = tool.input_schema();
+    let model_prop = schema["properties"]["model"]
+        .as_object()
+        .expect("model should be an object in properties");
+    assert_eq!(model_prop["type"], "string");
+    assert!(
+        model_prop["description"]
+            .as_str()
+            .unwrap()
+            .contains("Override"),
+        "description should mention override"
+    );
+}

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -194,6 +194,8 @@ impl Tool for SkillTool {
                         SpawnMode::Run,
                         false, // fork (parent history inheritance)
                         allowed_tools,
+                        None, // model_override
+                        None, // parent_subagents_model
                     )
                     .await
                     .map_err(|e| {


### PR DESCRIPTION
feat: implement model parameter in sessions_spawn and project-level agents.json loading

Two gaps identified in design doc agent-config.md:

1. **model 参数解析**: `sessions_spawn` 工具 schema 声明了 `model` 参数但从未解析。实现完整优先级链：显式 model 参数 > 父 agent.subagents.model > 目标 agent.model > 系统默认。

2. **项目级 agents.json**: 仅加载用户级注册清单。增加从 `<repo>/.closeclaw/agents.json` 加载项目级清单，两份清单取 ID 并集（同 ID 项目覆盖用户）。

Source: user
Type: feat
