### PR TITLE
feat: CLI admin 模块 stub 实现补全

### DIFF
--- a/docs/design/cli/admin.md
+++ b/docs/design/cli/admin.md
@@ -38,7 +38,7 @@ handler 函数
 
 run 命令启动 daemon 进程，读取配置目录、初始化所有组件后进入消息循环。stop 命令读取 PID 文件，向 daemon 进程发送终止信号，清理 PID 文件。
 
-config 命令管理配置文件。setup 子命令启动交互式配置向导（详见 [LLM Provider 配置向导](../llm/provider-config-wizard.md)），引导用户选择 Provider、输入凭据、发现模型并写入配置。validate 子命令校验配置文件格式。
+config 命令管理配置文件。setup 子命令启动交互式配置向导（详见 [LLM Provider 配置向导](../llm/provider-config-wizard.md)），引导用户选择 Provider、输入凭据、发现模型并写入配置。validate 子命令校验配置文件格式。list 子命令列出 `~/.closeclaw/` 目录下的所有配置文件（models.json、channels.json、gateway.json、plugins.json、system.json、credentials.json），显示文件路径、版本号和最后修改时间。
 
 rule 命令管理权限规则。check 子命令校验单条规则语法，list 子命令列出已有规则。
 
@@ -58,6 +58,7 @@ closeclaw <command> [args]
 │   ├── stop：读 PID 文件 → kill 进程 → 清理 PID 文件
 │   ├── config setup：交互式向导 → 拉取模型列表 → 用户选择 → 写入配置
 │   ├── config validate：读文件 → 校验格式 → 输出结果
+│   ├── config list：扫描配置目录 → 列出配置文件 → 输出列表
 │   └── rule check/list：读规则文件 → 校验/列表 → 输出结果
 │
 └─ daemon RPC

--- a/src/handlers/handlers_tests.rs
+++ b/src/handlers/handlers_tests.rs
@@ -1,0 +1,362 @@
+use super::*;
+use closeclaw::permission::Effect;
+
+// -----------------------------------------------------------------
+// config validate tests
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn test_config_validate_valid_agents_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("agents.json");
+    std::fs::write(&file, r#"{"agents":["orchestrator","coder"]}"#).unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "valid agents config should pass: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_valid_models_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("models.json");
+    std::fs::write(
+        &file,
+        r#"{"providers":{"p":{"baseUrl":"https://api.example.com","models":[{"id":"m1"}]}}}"#,
+    )
+    .unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(
+        result.is_ok(),
+        "valid models config should pass: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_file_not_found() {
+    let result = handle_config(ConfigAction::Validate {
+        file: "/tmp/nonexistent_closeclaw_test_config.json".to_string(),
+    })
+    .await;
+    assert!(result.is_err(), "missing file should return error");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("not found"),
+        "error should mention not found: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_invalid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("bad.json");
+    std::fs::write(&file, "not valid json {{{").unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(result.is_err(), "invalid JSON should fail validation");
+}
+
+#[tokio::test]
+async fn test_config_validate_unrecognized_format() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("unknown.json");
+    std::fs::write(&file, r#"{"foo":"bar"}"#).unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(result.is_err(), "unrecognized format should fail");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("Unrecognized") || msg.contains("validation failed"),
+        "error should indicate unrecognized format: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_agents_with_duplicate_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("agents.json");
+    std::fs::write(&file, r#"{"agents":["agent1","agent1"]}"#).unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(result.is_err(), "duplicate agent id should fail");
+}
+
+#[tokio::test]
+async fn test_config_validate_models_with_invalid_base_url() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join("models.json");
+    std::fs::write(
+        &file,
+        r#"{"providers":{"p":{"baseUrl":"ftp://bad","models":[{"id":"m1"}]}}}"#,
+    )
+    .unwrap();
+    let result = handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await;
+    assert!(result.is_err(), "invalid base_url should fail");
+}
+
+// -----------------------------------------------------------------
+// config list tests
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn test_config_list_empty_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Create the expected structure: tmp/.closeclaw/
+    let config_dir = tmp.path().join(".closeclaw");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    // Temporarily override HOME so handle_config uses our dir
+    let orig_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    let result = handle_config(ConfigAction::List).await;
+    if let Some(h) = orig_home {
+        std::env::set_var("HOME", h);
+    }
+    // Should succeed and find no configs
+    assert!(
+        result.is_ok(),
+        "empty config list should succeed: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_config_list_no_config_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    // No .closeclaw directory
+    let orig_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    let result = handle_config(ConfigAction::List).await;
+    if let Some(h) = orig_home {
+        std::env::set_var("HOME", h);
+    }
+    // Should succeed gracefully (prints message, returns Ok)
+    assert!(
+        result.is_ok(),
+        "missing config dir should not error: {:?}",
+        result
+    );
+}
+
+// -----------------------------------------------------------------
+// parse_rule_input tests
+// -----------------------------------------------------------------
+
+#[test]
+fn test_parse_rule_input_json() {
+    let json = r#"{
+        "name": "test-rule",
+        "subject": {"agent": "coder"},
+        "effect": "allow",
+        "actions": [{"type": "all"}]
+    }"#;
+    let rule = parse_rule_input(json).unwrap();
+    assert_eq!(rule.name, "test-rule");
+    assert_eq!(rule.effect, Effect::Allow);
+    assert!(!rule.actions.is_empty());
+}
+
+#[test]
+fn test_parse_rule_input_yaml() {
+    let yaml = r#"name: yaml-rule
+subject:
+  agent: orchestrator
+effect: deny
+actions:
+  - type: all"#;
+    let rule = parse_rule_input(yaml).unwrap();
+    assert_eq!(rule.name, "yaml-rule");
+    assert_eq!(rule.effect, Effect::Deny);
+}
+
+#[test]
+fn test_parse_rule_input_invalid() {
+    let result = parse_rule_input("neither json nor yaml {{{");
+    assert!(result.is_err(), "invalid input should fail parse");
+}
+
+// -----------------------------------------------------------------
+// handle_rule_check tests
+// -----------------------------------------------------------------
+
+#[test]
+fn test_handle_rule_check_valid() {
+    let json = r#"{
+        "name": "check-test",
+        "subject": {"agent": "agent1"},
+        "effect": "allow",
+        "actions": [{"type": "all"}]
+    }"#;
+    let result = handle_rule_check(json);
+    assert!(result.is_ok(), "valid rule should pass check: {:?}", result);
+}
+
+#[test]
+fn test_handle_rule_check_empty_name() {
+    let json = r#"{
+        "name": "",
+        "subject": {"agent": "agent1"},
+        "effect": "allow",
+        "actions": [{"type": "all"}]
+    }"#;
+    let result = handle_rule_check(json);
+    assert!(result.is_err(), "empty name should fail validation");
+}
+
+#[test]
+fn test_handle_rule_check_empty_subject_agent() {
+    let json = r#"{
+        "name": "bad-subject",
+        "subject": {"agent": ""},
+        "effect": "allow",
+        "actions": [{"type": "all"}]
+    }"#;
+    let result = handle_rule_check(json);
+    assert!(result.is_err(), "empty subject agent should fail");
+}
+
+#[test]
+fn test_handle_rule_check_no_actions_no_template() {
+    let json = r#"{
+        "name": "no-actions",
+        "subject": {"agent": "agent1"},
+        "effect": "allow"
+    }"#;
+    let result = handle_rule_check(json);
+    assert!(result.is_err(), "missing actions and template should fail");
+}
+
+#[test]
+fn test_handle_rule_check_invalid_json() {
+    let result = handle_rule_check("not a rule");
+    assert!(result.is_err(), "invalid input should fail");
+}
+
+// -----------------------------------------------------------------
+// handle_rule_list tests
+// -----------------------------------------------------------------
+
+#[test]
+fn test_handle_rule_list_empty_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rules_dir = tmp.path().join(".closeclaw").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    let orig_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    let result = handle_rule_list();
+    if let Some(h) = orig_home {
+        std::env::set_var("HOME", h);
+    }
+    assert!(
+        result.is_ok(),
+        "empty rules dir should succeed: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_handle_rule_list_with_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rules_dir = tmp.path().join(".closeclaw").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    // Create some rule files
+    std::fs::write(rules_dir.join("allow.json"), "{}").unwrap();
+    std::fs::write(rules_dir.join("deny.yaml"), "{}").unwrap();
+    std::fs::write(rules_dir.join("readme.txt"), "skip").unwrap(); // not a rule file
+    let orig_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    let result = handle_rule_list();
+    if let Some(h) = orig_home {
+        std::env::set_var("HOME", h);
+    }
+    assert!(
+        result.is_ok(),
+        "rules list with files should succeed: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_handle_rule_list_no_rules_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    // No .closeclaw/rules directory
+    let orig_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    let result = handle_rule_list();
+    if let Some(h) = orig_home {
+        std::env::set_var("HOME", h);
+    }
+    assert!(
+        result.is_ok(),
+        "missing rules dir should not error: {:?}",
+        result
+    );
+}
+
+// -----------------------------------------------------------------
+// legacy tests migrated from mod.rs
+// -----------------------------------------------------------------
+
+use crate::Cli;
+use clap::CommandFactory;
+
+#[test]
+fn test_pid() {
+    assert!(pid_file_path().to_str().unwrap().contains(".closeclaw"));
+}
+
+#[test]
+fn test_stop_f() {
+    let m = Cli::command()
+        .try_get_matches_from(["c", "stop", "-f"])
+        .unwrap();
+    assert!(m.subcommand().unwrap().1.get_flag("force"));
+}
+
+#[test]
+fn test_mask_key_short() {
+    // Keys <= 8 chars are fully masked
+    assert_eq!(mask_key("abc"), "****");
+    assert_eq!(mask_key("12345678"), "****");
+}
+
+#[test]
+fn test_mask_key_long() {
+    // Keys > 8 chars show first 4 and last 4
+    assert_eq!(mask_key("abcdefghij"), "abcd....ghij");
+    assert_eq!(mask_key("minimax-key-001"), "mini....-001");
+    assert_eq!(mask_key("sk-1234567890abcdef"), "sk-1....cdef");
+}
+
+#[test]
+fn test_env_write_uses_raw_key() {
+    // Verify the format string used in handle_config_setup writes raw key (not masked)
+    let k = "MINIMAX";
+    let v = "my-secret-key-123";
+    let line = format!("{}={}\n", k, v);
+    assert!(line.starts_with("MINIMAX=my-secret-key-123"));
+    assert!(!line.contains("****"));
+    assert!(!line.contains("...."));
+    // Also verify the key portion does NOT contain mask pattern
+    let written = format!("{}={}", k, v);
+    assert!(written.contains("my-secret-key-123"));
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,334 @@
+//! CLI command handlers.
+
+use anyhow::Result;
+use closeclaw::cli::args::*;
+use closeclaw::config::agents::{validate_agents_config, AgentsConfig};
+use closeclaw::config::providers::models::ModelsConfigData;
+use closeclaw::config::{ConfigManager, ConfigProvider};
+use closeclaw::permission::rules::validation::validate_rule;
+use closeclaw::permission::{Defaults, PermissionEngine, Rule, RuleSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[allow(dead_code)] // pub API for masking secrets in CLI output (covered by tests)
+pub fn mask_key(key: &str) -> String {
+    if key.len() <= 8 {
+        "****".to_string()
+    } else {
+        format!("{}....{}", &key[..4], &key[key.len() - 4..])
+    }
+}
+
+pub fn pid_file_path() -> PathBuf {
+    let home = std::env::var("HOME").expect("HOME not set");
+    PathBuf::from(home).join(".closeclaw").join("daemon.pid")
+}
+
+pub async fn handle_agent(action: AgentAction, user_id: &str) -> Result<()> {
+    let _owner = user_id; // reserved for permission checks
+    match action {
+        AgentAction::List => {
+            println!("Agents:\n  (no agents running)");
+        }
+        AgentAction::Create { name, model } => {
+            let m = model.unwrap_or_else(|| "minimax/MiniMax-M2.7".to_string());
+            println!("Creating agent '{}' with model '{}'", name, m);
+        }
+        AgentAction::Info { name } => {
+            println!("Agent info for '{}':\n  (not implemented)", name);
+        }
+    }
+    Ok(())
+}
+
+/// Validate agents config content (JSON value with `agents` key).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not an agents config.
+fn validate_agents_config_content(val: &serde_json::Value) -> Result<bool> {
+    if val.get("agents").is_none() {
+        return Ok(false);
+    }
+    match serde_json::from_value::<AgentsConfig>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = validate_agents_config(&config) {
+                anyhow::bail!("agents config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("agents config parse error: {}", e),
+    }
+}
+
+/// Validate models config content (JSON value with `providers` or `mode` key).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not a models config.
+fn validate_models_config_content(val: &serde_json::Value) -> Result<bool> {
+    if val.get("providers").is_none() && val.get("mode").is_none() {
+        return Ok(false);
+    }
+    match serde_json::from_value::<ModelsConfigData>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = config.validate() {
+                anyhow::bail!("models config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("models config parse error: {}", e),
+    }
+}
+
+/// Validate config file content by detecting its type and running the appropriate validator.
+fn validate_config_content(content: &str) -> Result<()> {
+    let val: serde_json::Value =
+        serde_json::from_str(content).map_err(|e| anyhow::anyhow!("JSON parse error: {}", e))?;
+
+    match validate_agents_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    match validate_models_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    anyhow::bail!("Unrecognized config format: file is not a valid models.json or agents.json");
+}
+
+pub async fn handle_config(action: ConfigAction) -> Result<()> {
+    match action {
+        ConfigAction::Validate { file } => {
+            let path = std::path::Path::new(&file);
+            if !path.exists() {
+                anyhow::bail!("Config file not found: {}", file);
+            }
+            let content = std::fs::read_to_string(path)?;
+            validate_config_content(&content)?;
+        }
+        ConfigAction::List => {
+            let config_dir = dirs::home_dir()
+                .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+                .join(".closeclaw");
+            if !config_dir.exists() {
+                println!("Config directory not found at {}", config_dir.display());
+                return Ok(());
+            }
+            let manager = ConfigManager::new(config_dir.clone())?;
+            let configs = manager.list_configs();
+            if configs.is_empty() {
+                println!("No config files found in {}", config_dir.display());
+            } else {
+                println!("Config files ({}):", configs.len());
+                for info in &configs {
+                    let version = if info.version.is_empty() {
+                        String::from("(no version)")
+                    } else {
+                        info.version.clone()
+                    };
+                    let modified = info
+                        .last_modified
+                        .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+                        .unwrap_or_else(|| "(unknown)".to_string());
+                    println!("  {} v{} [{}]", info.path, version, modified);
+                }
+            }
+        }
+        ConfigAction::Setup { yes } => {
+            handle_config_setup(yes).await?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_rule(action: RuleAction, user_id: &str) -> Result<()> {
+    let _owner = user_id; // reserved for permission checks
+    match action {
+        RuleAction::Check { rule } => {
+            handle_rule_check(&rule)?;
+        }
+        RuleAction::List => {
+            handle_rule_list()?;
+        }
+    }
+    Ok(())
+}
+
+/// Parse a rule string (JSON or YAML) into a Rule struct.
+fn parse_rule_input(input: &str) -> Result<Rule> {
+    // Try JSON first
+    if let Ok(rule) = serde_json::from_str::<Rule>(input) {
+        return Ok(rule);
+    }
+    // Fall back to YAML
+    let rule: Rule = serde_yaml::from_str(input)
+        .map_err(|e| anyhow::anyhow!("Failed to parse rule as JSON or YAML: {}", e))?;
+    Ok(rule)
+}
+
+/// Validate a single rule string and print the result.
+fn handle_rule_check(rule: &str) -> Result<()> {
+    let parsed = parse_rule_input(rule)?;
+    let errors = validate_rule(&parsed);
+    if errors.is_empty() {
+        println!("Rule '{}' is valid", parsed.name);
+    } else {
+        for err in &errors {
+            println!("ERROR: {}", err);
+        }
+        anyhow::bail!("Rule validation failed for '{}'", parsed.name);
+    }
+    Ok(())
+}
+
+/// List rule files from ~/.closeclaw/rules/ directory.
+fn handle_rule_list() -> Result<()> {
+    let rules_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+        .join(".closeclaw")
+        .join("rules");
+    if !rules_dir.exists() {
+        println!("No rules directory found at {}", rules_dir.display());
+        return Ok(());
+    }
+    let mut rule_files: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(&rules_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext == "json" || ext == "yaml" || ext == "yml" {
+                rule_files.push(
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("?")
+                        .to_string(),
+                );
+            }
+        }
+    }
+    rule_files.sort();
+    if rule_files.is_empty() {
+        println!("No rule files found in {}", rules_dir.display());
+    } else {
+        println!("Rules ({} files):", rule_files.len());
+        for f in &rule_files {
+            println!("  {}", f);
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_skill(action: SkillAction, user_id: &str) -> Result<()> {
+    let _owner = user_id; // reserved for permission checks
+    use closeclaw::skills::{builtin_skills_with_engine, init_disk_skills, ScanConfig};
+    match action {
+        SkillAction::List => {
+            let rs = RuleSet {
+                rules: vec![],
+                defaults: Defaults::default(),
+                template_includes: vec![],
+                agent_creators: std::collections::HashMap::new(),
+            };
+            let eng = Arc::new(PermissionEngine::new_with_default_data_root(rs));
+            let config = ScanConfig::default();
+            let disk_reg = init_disk_skills(&config);
+            if disk_reg.is_empty() {
+                println!("Installed skills (bundled):");
+            } else {
+                println!("Installed skills (disk):");
+                for name in disk_reg.list() {
+                    println!("  {} [disk]", name);
+                }
+                println!("Installed skills (bundled):");
+            }
+            for s in builtin_skills_with_engine(eng).iter() {
+                println!(
+                    "  {} v{} [bundled]",
+                    s.manifest().name,
+                    s.manifest().version
+                );
+            }
+        }
+        SkillAction::Install { name } => {
+            println!("Installing skill: {}", name);
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_stop(force: bool) -> Result<()> {
+    let p = pid_file_path();
+    let pid: u32 = if p.exists() {
+        std::fs::read_to_string(&p)?
+            .trim()
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid PID"))?
+    } else {
+        anyhow::bail!("PID file not found at {}.", p.display())
+    };
+    if pid == std::process::id() {
+        anyhow::bail!("Refusing to kill self.");
+    }
+    let sig = if force { "KILL" } else { "TERM" };
+    match std::process::Command::new("kill")
+        .arg(format!("-{}", sig))
+        .arg(pid.to_string())
+        .output()
+    {
+        Ok(o) if o.status.success() => {
+            let _ = std::fs::remove_file(&p);
+            println!("Daemon (PID {}) stopped ({}).", pid, sig);
+        }
+        Ok(o) => {
+            anyhow::bail!("kill returned {}", o.status);
+        }
+        Err(e) => {
+            anyhow::bail!("Failed to kill: {}", e);
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_config_setup(skip: bool) -> Result<()> {
+    use closeclaw::cli::config_wizard;
+
+    println!("\n=== CloseClaw Setup Wizard ===\n");
+
+    let output = match config_wizard::run_wizard().await {
+        Ok(Some(output)) => output,
+        Ok(None) => {
+            println!("Wizard cancelled.");
+            return Ok(());
+        }
+        Err(e) => anyhow::bail!("Wizard error: {}", e),
+    };
+
+    // If skip (yes mode), skip the confirm step and write config directly.
+    if !skip {
+        use dialoguer::Confirm;
+        let confirmed = tokio::task::spawn_blocking(|| {
+            Confirm::new()
+                .with_prompt("Write config now?")
+                .default(true)
+                .interact()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Confirm task failed: {}", e))??;
+        if !confirmed {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    config_wizard::write_wizard_config(&output)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod handlers_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ use clap::{Parser, Subcommand};
 use closeclaw::cli::args::*;
 use std::path::PathBuf;
 
+/// Fixed owner identity for CLI invocations.
+/// CLI 渠道调用者默认为 Owner，不走 Permission 引擎。
+const CLI_OWNER_ID: &str = "owner";
+
 #[derive(Parser)]
 #[command(name = "closeclaw", version = env!("CARGO_PKG_VERSION"))]
 pub(crate) struct Cli {
@@ -46,10 +50,10 @@ async fn main() -> anyhow::Result<()> {
     closeclaw::init();
     let cli = Cli::parse();
     match cli.command {
-        Commands::Agent { action } => handle_agent(action).await?,
+        Commands::Agent { action } => handle_agent(action, CLI_OWNER_ID).await?,
         Commands::Config { action } => handle_config(action).await?,
-        Commands::Rule { action } => handle_rule(action).await?,
-        Commands::Skill { action } => handle_skill(action).await?,
+        Commands::Rule { action } => handle_rule(action, CLI_OWNER_ID).await?,
+        Commands::Skill { action } => handle_skill(action, CLI_OWNER_ID).await?,
         Commands::Run { config_dir } => {
             let config_dir: PathBuf = if config_dir.is_empty() {
                 dirs::home_dir()


### PR DESCRIPTION
## 变更内容

补全 CLI Admin 模块中 config validate、rule check/list、config list 的 stub 实现，使其与 design doc (`docs/design/cli/admin.md`) 一致。

### 具体变更

- **config validate**：读取指定配置文件，自动识别 models/agents 类型并调用对应校验器
- **rule check**：解析单条规则 JSON/YAML，调用 `validate_rule()` 校验语法
- **rule list**：读取 `~/.closeclaw/rules/` 目录，列出所有规则文件
- **config list**：使用 `ConfigManager::list_configs()` 列出配置文件
- **Owner 身份固定**：CLI 调用者默认 `user_id` 为 `"owner"`，传入 handler 函数
- **UT 覆盖**：新增 20 个单元测试覆盖正常+异常路径
- **design doc 同步**：补充 `list` 子命令描述及数据流条目

### 结构变更

- `src/handlers.rs` 拆分为 `src/handlers/mod.rs`（335行）+ `src/handlers/handlers_tests.rs`（289行）
- `handle_config` 中 `validate_config_content()` 提取为独立函数并进一步拆分
- 历史遗留 UT 迁移至独立测试文件

Source: user
Type: feat
