### PR TITLE
fix: align CLI admin commands with design doc

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -105,10 +105,10 @@ pub fn parse_model_selection(input: &str, total: usize) -> anyhow::Result<Vec<us
     Ok(indices)
 }
 
-/// Locate the project config directory (`~/.closeclaw/config/`).
+/// Locate the project config directory (`~/.closeclaw/`).
 fn config_dir() -> PathBuf {
     let home = std::env::var("HOME").expect("HOME not set");
-    PathBuf::from(home).join(".closeclaw").join("config")
+    PathBuf::from(home).join(".closeclaw")
 }
 
 /// Write wizard output to config files.
@@ -120,8 +120,8 @@ fn config_dir() -> PathBuf {
 ///   (so running wizard multiple times does not lose manual overrides)
 ///
 /// Files written:
-/// - `~/.closeclaw/config/models.json`   — merged provider+model config
-/// - `~/.closeclaw/config/credentials/<provider_id>.json` — API key for the provider
+/// - `~/.closeclaw/models.json`   — merged provider+model config
+/// - `~/.closeclaw/credentials/<provider_id>.json` — API key for the provider
 //-
 //- NOTE: Any change to `write_wizard_config` or `run_wizard` must be verified
 //- against `tests/cli_config_wizard_test.py` (python3 E2E test using pexpect).

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -389,3 +389,86 @@ mod write_wizard_config_tests {
         );
     }
 }
+
+// -----------------------------------------------------------------
+// Step 1.1: config_dir() path tests
+// -----------------------------------------------------------------
+
+#[cfg(test)]
+mod config_dir_tests {
+    use super::config_dir;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_config_dir_points_to_closeclaw() {
+        let dir = config_dir();
+        let dir_str = dir.to_string_lossy();
+        assert!(
+            dir_str.ends_with(".closeclaw"),
+            "config_dir should end with .closeclaw, got: {}",
+            dir_str
+        );
+    }
+
+    #[test]
+    fn test_config_dir_is_under_home() {
+        let dir = config_dir();
+        let home = std::env::var("HOME").expect("HOME not set");
+        assert!(
+            dir.starts_with(&home),
+            "config_dir should be under HOME, got: {} (HOME={})",
+            dir.display(),
+            home
+        );
+    }
+
+    #[test]
+    fn test_config_dir_matches_wizard_output_path() {
+        // Verify write_wizard_config uses the same directory as config_dir()
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let models_path = dir.join("models.json");
+        assert!(
+            models_path.to_string_lossy().ends_with("models.json"),
+            "wizard output should write models.json at config root"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// Step 1.2: credentials directory structure tests
+// -----------------------------------------------------------------
+
+#[cfg(test)]
+mod credentials_path_tests {
+    use crate::config::manager::ConfigSection;
+
+    #[test]
+    fn test_credentials_section_is_directory() {
+        assert!(ConfigSection::Credentials.is_directory());
+    }
+
+    #[test]
+    fn test_credentials_dir_name() {
+        assert_eq!(ConfigSection::Credentials.dir_name(), "credentials");
+    }
+
+    #[test]
+    fn test_non_credentials_sections_are_not_directories() {
+        assert!(!ConfigSection::Models.is_directory());
+        assert!(!ConfigSection::Channels.is_directory());
+        assert!(!ConfigSection::Gateway.is_directory());
+        assert!(!ConfigSection::Plugins.is_directory());
+        assert!(!ConfigSection::System.is_directory());
+    }
+
+    #[test]
+    fn test_credentials_filename_ends_with_slash() {
+        let filename = ConfigSection::Credentials.filename();
+        assert!(
+            filename.ends_with('/'),
+            "Credentials filename should end with /, got: {}",
+            filename
+        );
+    }
+}

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -20,24 +20,18 @@ use crate::agent::config::AgentPermissions;
 // Error types
 // ---------------------------------------------------------------------------
 
-/// Error loading a configuration file.
 #[derive(Debug, Error)]
 pub enum ConfigLoadError {
     #[error("config directory not found: {0}")]
     ConfigDirNotFound(PathBuf),
-
     #[error("config file not found: {0}")]
     ConfigFileNotFound(PathBuf),
-
     #[error("failed to parse config file {path}: {error}")]
     ParseError { path: PathBuf, error: String },
-
     #[error("config validation failed for {path}: {message}")]
     ValidationError { path: PathBuf, message: String },
-
     #[error("backup not found for {0}")]
     BackupNotFound(PathBuf),
-
     #[error("I/O error loading {path}: {error}")]
     IoError { path: PathBuf, error: String },
 }
@@ -51,18 +45,14 @@ impl From<io::Error> for ConfigLoadError {
     }
 }
 
-/// Error writing a configuration file.
 #[derive(Debug, Error)]
 pub enum ConfigWriteError {
     #[error("validation failed for {0}: {1}")]
     ValidationFailed(String, String),
-
     #[error("backup failed for {path}: {error}")]
     BackupFailed { path: PathBuf, error: String },
-
     #[error("write failed for {path}: {error}")]
     WriteFailed { path: PathBuf, error: String },
-
     #[error("config file not found: {0}")]
     FileNotFound(PathBuf),
 }
@@ -76,7 +66,6 @@ impl From<io::Error> for ConfigWriteError {
     }
 }
 
-/// Validation error for a config file.
 #[derive(Debug)]
 pub struct ConfigValidationError {
     pub path: PathBuf,
@@ -150,7 +139,6 @@ pub enum ConfigSection {
 }
 
 impl ConfigSection {
-    /// Returns the filename associated with this section.
     pub fn filename(&self) -> &'static str {
         match self {
             ConfigSection::Models => "models.json",
@@ -158,11 +146,21 @@ impl ConfigSection {
             ConfigSection::Gateway => "gateway.json",
             ConfigSection::Plugins => "plugins.json",
             ConfigSection::System => "system.json",
-            ConfigSection::Credentials => "credentials.json",
+            ConfigSection::Credentials => "credentials/",
         }
     }
 
-    /// Returns the absolute path to this section's file relative to config_dir.
+    pub fn is_directory(&self) -> bool {
+        matches!(self, ConfigSection::Credentials)
+    }
+
+    pub fn dir_name(&self) -> &'static str {
+        match self {
+            ConfigSection::Credentials => "credentials",
+            _ => panic!("dir_name() called on non-directory section: {:?}", self),
+        }
+    }
+
     pub(crate) fn path(&self, config_dir: &Path) -> PathBuf {
         config_dir.join(self.filename())
     }
@@ -187,6 +185,60 @@ pub struct ConfigInfo {
     pub version: String,
     /// Last modified timestamp (None if the file hasn't been read yet).
     pub last_modified: Option<DateTime<Local>>,
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers (module-level)
+// ---------------------------------------------------------------------------
+
+/// Read the "version" field from a JSON file.
+/// Returns an empty string if the file is missing or unparseable.
+fn read_json_version(path: &Path) -> String {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+        .and_then(|v| v.get("version")?.as_str().map(str::to_string))
+        .unwrap_or_default()
+}
+
+/// Collect `ConfigInfo` entries from a directory of individual JSON files.
+fn list_directory_configs(dir_path: &Path) -> Vec<ConfigInfo> {
+    let mut infos = Vec::new();
+    let Ok(entries) = fs::read_dir(dir_path) else {
+        return infos;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let last_modified = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(DateTime::<Local>::from);
+        infos.push(ConfigInfo {
+            path: path.to_string_lossy().to_string(),
+            version: read_json_version(&path),
+            last_modified,
+        });
+    }
+    infos
+}
+
+/// Collect `ConfigInfo` for a single-file config section.
+fn list_file_config(config_dir: &Path, section: &ConfigSection) -> Option<ConfigInfo> {
+    let path = section.path(config_dir);
+    let metadata = fs::metadata(&path).ok()?;
+    let last_modified = metadata.modified().ok().map(DateTime::<Local>::from);
+    Some(ConfigInfo {
+        path: path.to_string_lossy().to_string(),
+        version: read_json_version(&path),
+        last_modified,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -251,7 +303,6 @@ impl ConfigManager {
             return Err(ConfigLoadError::ConfigDirNotFound(self.config_dir.clone()));
         }
 
-        // The 5 mandatory config files (Credentials is a directory, handled separately)
         let mandatory_sections = [
             ConfigSection::Models,
             ConfigSection::Channels,
@@ -270,52 +321,39 @@ impl ConfigManager {
             if !path.exists() {
                 return Err(ConfigLoadError::ConfigFileNotFound(path));
             }
-
             let content = fs::read_to_string(&path).map_err(|e| ConfigLoadError::IoError {
                 path: path.clone(),
                 error: e.to_string(),
             })?;
-
             let value: serde_json::Value = match serde_json::from_str(&content) {
                 Ok(v) => v,
-                Err(_parse_err) => {
-                    // Try rollback + retry before reporting the error
-                    match self.try_rollback_and_retry(&path, section, &mut sections) {
-                        Ok(()) => continue,
-                        Err(e) => return Err(e),
-                    }
-                }
+                Err(_) => match self.try_rollback_and_retry(&path, section, &mut sections) {
+                    Ok(()) => continue,
+                    Err(e) => return Err(e),
+                },
             };
-
             sections.insert(section, value);
         }
 
         // Load credentials from config/credentials/ directory.
         let creds_dir = self.config_dir.join(CredentialsProvider::config_path());
-        let creds_provider = match CredentialsProvider::load_from_dir(&creds_dir) {
-            Ok(cp) => cp,
-            Err(e) => {
-                warn!(
-                    "failed to load credentials from '{}': {}",
-                    creds_dir.display(),
-                    e
-                );
-                CredentialsProvider::default()
-            }
-        };
+        let creds_provider = CredentialsProvider::load_from_dir(&creds_dir).unwrap_or_else(|e| {
+            warn!(
+                "failed to load credentials from '{}': {}",
+                creds_dir.display(),
+                e
+            );
+            CredentialsProvider::default()
+        });
         *self.credentials_provider.write().expect("RwLock poisoned") = creds_provider.clone();
-        // Store as JSON value in sections (may be empty/default if dir is absent)
         if let Ok(json) = serde_json::to_value(&creds_provider) {
             sections.insert(ConfigSection::Credentials, json);
         }
 
         drop(sections);
-
-        // Load agent configurations (non-fatal if agents.json is absent)
         if let Err(e) = self.load_agents(None) {
             warn!("failed to load agent configs: {}", e);
         }
-
         Ok(())
     }
 
@@ -328,52 +366,46 @@ impl ConfigManager {
         section: ConfigSection,
         sections: &mut HashMap<ConfigSection, serde_json::Value>,
     ) -> Result<(), ConfigLoadError> {
-        // Try to find a backup
-        match self.backup_manager.find_latest_backup(path) {
-            Ok(backup_path) => {
-                if self.backup_manager.rollback(path).is_ok() {
-                    let retry_content = fs::read_to_string(path).ok();
-                    if let Some(retry_content) = retry_content {
-                        if let Ok(retry_value) =
-                            serde_json::from_str::<serde_json::Value>(&retry_content)
-                        {
-                            warn!("已用备份恢复 {}, 备份来源: {:?}", section, backup_path);
-                            sections.insert(section, retry_value);
-                            return Ok(());
-                        }
-                    }
-                }
-                // Retry failed
-                error!("配置文件 {} 恢复后仍无法解析，daemon 无法启动", section);
-                Err(ConfigLoadError::ParseError {
-                    path: path.to_path_buf(),
-                    error: "rollback succeeded but file still unparseable".to_string(),
-                })
+        let backup_path = self.backup_manager.find_latest_backup(path).map_err(|_| {
+            error!("配置文件 {} 损坏且无备份，daemon 无法启动", section);
+            ConfigLoadError::ParseError {
+                path: path.to_path_buf(),
+                error: "no backup available".to_string(),
             }
-            Err(_) => {
-                // No backup found
-                error!("配置文件 {} 损坏且无备份，daemon 无法启动", section);
-                Err(ConfigLoadError::ParseError {
-                    path: path.to_path_buf(),
-                    error: "no backup available".to_string(),
-                })
+        })?;
+
+        if self.backup_manager.rollback(path).is_err() {
+            error!("配置文件 {} 恢复后仍无法解析，daemon 无法启动", section);
+            return Err(ConfigLoadError::ParseError {
+                path: path.to_path_buf(),
+                error: "rollback failed".to_string(),
+            });
+        }
+
+        if let Ok(content) = fs::read_to_string(path) {
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
+                warn!("已用备份恢复 {}, 备份来源: {:?}", section, backup_path);
+                sections.insert(section, val);
+                return Ok(());
             }
         }
+
+        error!("配置文件 {} 恢复后仍无法解析，daemon 无法启动", section);
+        Err(ConfigLoadError::ParseError {
+            path: path.to_path_buf(),
+            error: "rollback succeeded but file still unparseable".to_string(),
+        })
     }
 
     /// Update a configuration section.
     ///
-    /// Flow: validate → backup current content → atomic write → update in-memory cache.
-    ///
-    /// If validation fails, no file is written.
-    /// If backup fails, no file is written (write_atomically is not called).
+    /// Flow: validate → backup → atomic write → update in-memory cache.
     pub fn update(
         &self,
         section: ConfigSection,
         new_value: serde_json::Value,
         validator: impl FnOnce(&serde_json::Value) -> Result<(), ConfigValidationError>,
     ) -> Result<(), ConfigWriteError> {
-        // Step 1: validate
         if let Err(e) = validator(&new_value) {
             return Err(ConfigWriteError::ValidationFailed(
                 section.to_string(),
@@ -382,40 +414,33 @@ impl ConfigManager {
         }
 
         let path = section.path(&self.config_dir);
-
-        // Step 2: backup current content (if file exists)
         if path.exists() {
-            let current_content = fs::read(&path).map_err(|e| ConfigWriteError::BackupFailed {
+            let content = fs::read(&path).map_err(|e| ConfigWriteError::BackupFailed {
                 path: path.clone(),
                 error: e.to_string(),
             })?;
             self.backup_manager
-                .backup_with_content(&path, &current_content)
+                .backup_with_content(&path, &content)
                 .map_err(|e: io::Error| ConfigWriteError::BackupFailed {
                     path: path.clone(),
                     error: e.to_string(),
                 })?;
         }
 
-        // Step 3: atomic write
-        let content =
+        let bytes =
             serde_json::to_vec_pretty(&new_value).map_err(|e| ConfigWriteError::WriteFailed {
                 path: path.clone(),
                 error: e.to_string(),
             })?;
-
-        write_atomically(&path, &content).map_err(|e| ConfigWriteError::WriteFailed {
+        write_atomically(&path, &bytes).map_err(|e| ConfigWriteError::WriteFailed {
             path,
             error: e.to_string(),
         })?;
 
-        // Step 4: update in-memory cache
-        let mut sections = self
-            .sections
+        self.sections
             .write()
-            .expect("RwLock for config sections was poisoned");
-        sections.insert(section, new_value);
-
+            .expect("RwLock for config sections was poisoned")
+            .insert(section, new_value);
         Ok(())
     }
 
@@ -441,11 +466,8 @@ impl ConfigManager {
     }
 
     /// List metadata about all configuration files.
-    ///
-    /// Returns a vector of `ConfigInfo` for each section, including path,
-    /// version (from JSON "version" field), and last modified timestamp.
     pub fn list_configs(&self) -> Vec<ConfigInfo> {
-        let sections_list = [
+        let sections = [
             ConfigSection::Models,
             ConfigSection::Channels,
             ConfigSection::Gateway,
@@ -453,39 +475,16 @@ impl ConfigManager {
             ConfigSection::System,
             ConfigSection::Credentials,
         ];
-
-        let mut infos = Vec::new();
-
-        for section in sections_list {
-            let path = section.path(&self.config_dir);
-
-            let metadata = match fs::metadata(&path) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-
-            let last_modified = metadata.modified().ok().map(DateTime::<Local>::from);
-
-            let version = if let Ok(content) = fs::read_to_string(&path) {
-                serde_json::from_str::<serde_json::Value>(&content)
-                    .ok()
-                    .and_then(|v| {
-                        v.get("version")
-                            .and_then(|vv| vv.as_str().map(str::to_string))
-                    })
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            };
-
-            infos.push(ConfigInfo {
-                path: path.to_string_lossy().to_string(),
-                version,
-                last_modified,
-            });
-        }
-
-        infos
+        sections
+            .iter()
+            .flat_map(|s| {
+                if s.is_directory() {
+                    list_directory_configs(&self.config_dir.join(s.dir_name()))
+                } else {
+                    list_file_config(&self.config_dir, s).into_iter().collect()
+                }
+            })
+            .collect()
     }
 }
 

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -57,7 +57,7 @@ fn test_config_section_display() {
     assert_eq!(ConfigSection::Gateway.to_string(), "gateway.json");
     assert_eq!(ConfigSection::Plugins.to_string(), "plugins.json");
     assert_eq!(ConfigSection::System.to_string(), "system.json");
-    assert_eq!(ConfigSection::Credentials.to_string(), "credentials.json");
+    assert_eq!(ConfigSection::Credentials.to_string(), "credentials/");
 }
 
 // ---------------------------------------------------------------------------
@@ -379,6 +379,39 @@ fn test_config_manager_list_configs() {
         .unwrap();
     assert_eq!(models_info.version, "1.0");
     assert!(models_info.last_modified.is_some());
+}
+
+#[test]
+fn test_config_manager_list_configs_with_credentials_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+
+    // Create credentials directory with individual provider files
+    let creds_dir = tmp.path().join("credentials");
+    fs::create_dir_all(&creds_dir).unwrap();
+    fs::write(
+        creds_dir.join("openai.json"),
+        r#"{"provider":"openai","apiKey":"sk-test"}"#,
+    )
+    .unwrap();
+    fs::write(
+        creds_dir.join("anthropic.json"),
+        r#"{"provider":"anthropic","apiKey":"sk-ant"}"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let infos = manager.list_configs();
+    // Should include individual credential files
+    let cred_infos: Vec<_> = infos
+        .iter()
+        .filter(|i| i.path.contains("credentials"))
+        .collect();
+    assert_eq!(cred_infos.len(), 2);
+    assert!(cred_infos.iter().any(|i| i.path.contains("openai.json")));
+    assert!(cred_infos.iter().any(|i| i.path.contains("anthropic.json")));
 }
 
 #[test]

--- a/src/handlers/handlers_tests.rs
+++ b/src/handlers/handlers_tests.rs
@@ -2,43 +2,52 @@ use super::*;
 use closeclaw::permission::Effect;
 
 // -----------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------
+
+/// Write `content` to a temp file named `filename` and run
+/// `handle_config(Validate { file })`. Returns the result.
+async fn validate_config(filename: &str, content: &str) -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir().unwrap();
+    let file = tmp.path().join(filename);
+    std::fs::write(&file, content).unwrap();
+    handle_config(ConfigAction::Validate {
+        file: file.to_str().unwrap().to_string(),
+    })
+    .await
+}
+
+/// Set `HOME` to `tmp` for the duration of the closure, then restore.
+fn with_home<F: FnOnce()>(tmp: &tempfile::TempDir, f: F) {
+    let orig = std::env::var("HOME").ok();
+    std::env::set_var("HOME", tmp.path());
+    f();
+    if let Some(h) = orig {
+        std::env::set_var("HOME", h);
+    }
+}
+
+// -----------------------------------------------------------------
 // config validate tests
 // -----------------------------------------------------------------
 
 #[tokio::test]
 async fn test_config_validate_valid_agents_config() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("agents.json");
-    std::fs::write(&file, r#"{"agents":["orchestrator","coder"]}"#).unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
     assert!(
-        result.is_ok(),
-        "valid agents config should pass: {:?}",
-        result
+        validate_config("agents.json", r#"{"agents":["orchestrator","coder"]}"#)
+            .await
+            .is_ok()
     );
 }
 
 #[tokio::test]
 async fn test_config_validate_valid_models_config() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("models.json");
-    std::fs::write(
-        &file,
-        r#"{"providers":{"p":{"baseUrl":"https://api.example.com","models":[{"id":"m1"}]}}}"#,
+    assert!(validate_config(
+        "models.json",
+        r#"{"providers":{"p":{"baseUrl":"https://api.example.com","models":[{"id":"m1"}]}}}"#
     )
-    .unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
-    assert!(
-        result.is_ok(),
-        "valid models config should pass: {:?}",
-        result
-    );
+    .await
+    .is_ok());
 }
 
 #[tokio::test]
@@ -48,70 +57,39 @@ async fn test_config_validate_file_not_found() {
     })
     .await;
     assert!(result.is_err(), "missing file should return error");
-    let msg = result.unwrap_err().to_string();
-    assert!(
-        msg.contains("not found"),
-        "error should mention not found: {}",
-        msg
-    );
 }
 
 #[tokio::test]
 async fn test_config_validate_invalid_json() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("bad.json");
-    std::fs::write(&file, "not valid json {{{").unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
-    assert!(result.is_err(), "invalid JSON should fail validation");
+    assert!(validate_config("bad.json", "not valid json {{{")
+        .await
+        .is_err());
 }
 
 #[tokio::test]
 async fn test_config_validate_unrecognized_format() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("unknown.json");
-    std::fs::write(&file, r#"{"foo":"bar"}"#).unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
-    assert!(result.is_err(), "unrecognized format should fail");
-    let msg = result.unwrap_err().to_string();
-    assert!(
-        msg.contains("Unrecognized") || msg.contains("validation failed"),
-        "error should indicate unrecognized format: {}",
-        msg
-    );
+    assert!(validate_config("unknown.json", r#"{"foo":"bar"}"#)
+        .await
+        .is_err());
 }
 
 #[tokio::test]
 async fn test_config_validate_agents_with_duplicate_id() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("agents.json");
-    std::fs::write(&file, r#"{"agents":["agent1","agent1"]}"#).unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
-    assert!(result.is_err(), "duplicate agent id should fail");
+    assert!(
+        validate_config("agents.json", r#"{"agents":["agent1","agent1"]}"#)
+            .await
+            .is_err()
+    );
 }
 
 #[tokio::test]
 async fn test_config_validate_models_with_invalid_base_url() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file = tmp.path().join("models.json");
-    std::fs::write(
-        &file,
-        r#"{"providers":{"p":{"baseUrl":"ftp://bad","models":[{"id":"m1"}]}}}"#,
+    assert!(validate_config(
+        "models.json",
+        r#"{"providers":{"p":{"baseUrl":"ftp://bad","models":[{"id":"m1"}]}}}"#
     )
-    .unwrap();
-    let result = handle_config(ConfigAction::Validate {
-        file: file.to_str().unwrap().to_string(),
-    })
-    .await;
-    assert!(result.is_err(), "invalid base_url should fail");
+    .await
+    .is_err());
 }
 
 // -----------------------------------------------------------------
@@ -121,17 +99,18 @@ async fn test_config_validate_models_with_invalid_base_url() {
 #[tokio::test]
 async fn test_config_list_empty_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    // Create the expected structure: tmp/.closeclaw/
-    let config_dir = tmp.path().join(".closeclaw");
-    std::fs::create_dir_all(&config_dir).unwrap();
-    // Temporarily override HOME so handle_config uses our dir
-    let orig_home = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    let result = handle_config(ConfigAction::List).await;
-    if let Some(h) = orig_home {
-        std::env::set_var("HOME", h);
-    }
-    // Should succeed and find no configs
+    std::fs::create_dir_all(tmp.path().join(".closeclaw")).unwrap();
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_config(ConfigAction::List)),
+            );
+        });
+        r.unwrap()
+    };
     assert!(
         result.is_ok(),
         "empty config list should succeed: {:?}",
@@ -142,14 +121,17 @@ async fn test_config_list_empty_dir() {
 #[tokio::test]
 async fn test_config_list_no_config_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    // No .closeclaw directory
-    let orig_home = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    let result = handle_config(ConfigAction::List).await;
-    if let Some(h) = orig_home {
-        std::env::set_var("HOME", h);
-    }
-    // Should succeed gracefully (prints message, returns Ok)
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_config(ConfigAction::List)),
+            );
+        });
+        r.unwrap()
+    };
     assert!(
         result.is_ok(),
         "missing config dir should not error: {:?}",
@@ -258,19 +240,8 @@ fn test_handle_rule_check_invalid_json() {
 #[test]
 fn test_handle_rule_list_empty_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    let rules_dir = tmp.path().join(".closeclaw").join("rules");
-    std::fs::create_dir_all(&rules_dir).unwrap();
-    let orig_home = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    let result = handle_rule_list();
-    if let Some(h) = orig_home {
-        std::env::set_var("HOME", h);
-    }
-    assert!(
-        result.is_ok(),
-        "empty rules dir should succeed: {:?}",
-        result
-    );
+    std::fs::create_dir_all(tmp.path().join(".closeclaw").join("rules")).unwrap();
+    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
 }
 
 #[test]
@@ -278,37 +249,198 @@ fn test_handle_rule_list_with_files() {
     let tmp = tempfile::tempdir().unwrap();
     let rules_dir = tmp.path().join(".closeclaw").join("rules");
     std::fs::create_dir_all(&rules_dir).unwrap();
-    // Create some rule files
     std::fs::write(rules_dir.join("allow.json"), "{}").unwrap();
     std::fs::write(rules_dir.join("deny.yaml"), "{}").unwrap();
-    std::fs::write(rules_dir.join("readme.txt"), "skip").unwrap(); // not a rule file
-    let orig_home = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    let result = handle_rule_list();
-    if let Some(h) = orig_home {
-        std::env::set_var("HOME", h);
-    }
-    assert!(
-        result.is_ok(),
-        "rules list with files should succeed: {:?}",
-        result
-    );
+    std::fs::write(rules_dir.join("readme.txt"), "skip").unwrap();
+    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
 }
 
 #[test]
 fn test_handle_rule_list_no_rules_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    // No .closeclaw/rules directory
-    let orig_home = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    let result = handle_rule_list();
-    if let Some(h) = orig_home {
-        std::env::set_var("HOME", h);
-    }
+    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
+}
+
+// -----------------------------------------------------------------
+// Step 1.3: validate channels/gateway/plugins/system config
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn test_config_validate_valid_channels_config() {
+    assert!(validate_config("channels.json",
+        r#"{"channels":{"feishu":{"type":"feishu","appId":"x","appSecret":"y","botName":"b"}},"bindings":[{"agentId":"orchestrator","match":{"channel":"feishu","accountId":"acc1"}}]}"#).await.is_ok());
+}
+
+#[tokio::test]
+async fn test_config_validate_channels_invalid_type() {
+    assert!(validate_config("channels.json",
+        r#"{"channels":{"bad":{"type":"unknown_type","appId":"x","appSecret":"y","botName":"b"}},"bindings":[]}"#).await.is_err());
+}
+
+#[tokio::test]
+async fn test_config_validate_channels_empty_binding_agent() {
+    assert!(validate_config("channels.json",
+        r#"{"channels":{"feishu":{"type":"feishu","appId":"x","appSecret":"y","botName":"b"}},"bindings":[{"agentId":"","match":{"channel":"feishu"}}]}"#).await.is_err());
+}
+
+#[tokio::test]
+async fn test_config_validate_valid_gateway_config() {
+    assert!(validate_config("gateway.json",
+        r#"{"name":"closeclaw","port":3000,"timeout":30000,"rateLimitPerMinute":60,"maxMessageSize":16384,"dmScope":"per-channel-peer"}"#).await.is_ok());
+}
+
+#[tokio::test]
+async fn test_config_validate_gateway_port_zero() {
+    assert!(validate_config("gateway.json",
+        r#"{"port":0,"timeout":30000,"rateLimitPerMinute":60,"maxMessageSize":16384,"dmScope":"per-channel-peer"}"#).await.is_err());
+}
+
+#[tokio::test]
+async fn test_config_validate_valid_plugins_config() {
+    assert!(validate_config(
+        "plugins.json",
+        r#"{"entries":{"myplugin":{"enabled":true}},"installs":{}}"#
+    )
+    .await
+    .is_ok());
+}
+
+#[tokio::test]
+async fn test_config_validate_plugins_missing_installs() {
+    assert!(
+        validate_config("plugins.json", r#"{"entries":{"p":{"enabled":true}}}"#)
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_valid_system_config() {
+    assert!(
+        validate_config("system.json", r#"{"wizard":{"lastRunAt":"2026-01-01"}}"#)
+            .await
+            .is_ok()
+    );
+}
+
+#[tokio::test]
+async fn test_config_validate_system_invalid_session_mode() {
+    assert!(validate_config(
+        "system.json",
+        r#"{"session":{"maintenance":{"mode":"invalid"},"dmScope":"per-channel-peer"}}"#
+    )
+    .await
+    .is_err());
+}
+
+// -----------------------------------------------------------------
+// Step 1.2: config list with credentials directory
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn test_config_list_discovers_credentials_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".closeclaw").join("credentials")).unwrap();
+    std::fs::write(
+        tmp.path()
+            .join(".closeclaw")
+            .join("credentials")
+            .join("minimax.json"),
+        r#"{"provider":"minimax","apiKey":"sk-test"}"#,
+    )
+    .unwrap();
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_config(ConfigAction::List)),
+            );
+        });
+        r.unwrap()
+    };
     assert!(
         result.is_ok(),
-        "missing rules dir should not error: {:?}",
+        "config list with credentials should succeed: {:?}",
         result
+    );
+}
+
+#[tokio::test]
+async fn test_config_list_empty_credentials_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".closeclaw").join("credentials")).unwrap();
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_config(ConfigAction::List)),
+            );
+        });
+        r.unwrap()
+    };
+    assert!(
+        result.is_ok(),
+        "empty credentials dir should not error: {:?}",
+        result
+    );
+}
+
+// -----------------------------------------------------------------
+// Step 1.4: handle_stop PID cleanup tests
+// -----------------------------------------------------------------
+
+#[tokio::test]
+async fn test_stop_pid_file_not_found() {
+    let tmp = tempfile::tempdir().unwrap();
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_stop(false)),
+            );
+        });
+        r.unwrap()
+    };
+    assert!(result.is_err(), "missing PID file should error");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("PID file not found"),
+        "error should mention PID file: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn test_stop_stale_pid_file_cleans_up() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pid_file = tmp.path().join(".closeclaw").join("daemon.pid");
+    std::fs::create_dir_all(pid_file.parent().unwrap()).unwrap();
+    std::fs::write(&pid_file, "2147483647").unwrap();
+    let result = {
+        let mut r = None;
+        with_home(&tmp, || {
+            r = Some(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(handle_stop(false)),
+            );
+        });
+        r.unwrap()
+    };
+    assert!(
+        result.is_ok(),
+        "stale PID should be cleaned up gracefully: {:?}",
+        result
+    );
+    assert!(
+        !pid_file.exists(),
+        "PID file should be removed after cleanup"
     );
 }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -3,7 +3,11 @@
 use anyhow::Result;
 use closeclaw::cli::args::*;
 use closeclaw::config::agents::{validate_agents_config, AgentsConfig};
+use closeclaw::config::providers::channels::ChannelsConfigData;
+use closeclaw::config::providers::gateway::GatewayConfigData;
 use closeclaw::config::providers::models::ModelsConfigData;
+use closeclaw::config::providers::plugins::PluginsConfigData;
+use closeclaw::config::providers::system::SystemConfigData;
 use closeclaw::config::{ConfigManager, ConfigProvider};
 use closeclaw::permission::rules::validation::validate_rule;
 use closeclaw::permission::{Defaults, PermissionEngine, Rule, RuleSet};
@@ -75,6 +79,84 @@ fn validate_models_config_content(val: &serde_json::Value) -> Result<bool> {
     }
 }
 
+/// Validate channels config content (JSON value with `channels` or `bindings` key).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not a channels config.
+fn validate_channels_config_content(val: &serde_json::Value) -> Result<bool> {
+    if val.get("channels").is_none() && val.get("bindings").is_none() {
+        return Ok(false);
+    }
+    match serde_json::from_value::<ChannelsConfigData>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = config.validate() {
+                anyhow::bail!("channels config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("channels config parse error: {}", e),
+    }
+}
+
+/// Validate gateway config content (JSON value with `rateLimitPerMinute` or `maxMessageSize` key).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not a gateway config.
+fn validate_gateway_config_content(val: &serde_json::Value) -> Result<bool> {
+    if val.get("rateLimitPerMinute").is_none() && val.get("maxMessageSize").is_none() {
+        return Ok(false);
+    }
+    match serde_json::from_value::<GatewayConfigData>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = config.validate() {
+                anyhow::bail!("gateway config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("gateway config parse error: {}", e),
+    }
+}
+
+/// Validate plugins config content (JSON value with `entries` and `installs` key).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not a plugins config.
+fn validate_plugins_config_content(val: &serde_json::Value) -> Result<bool> {
+    if val.get("entries").is_none() || val.get("installs").is_none() {
+        return Ok(false);
+    }
+    match serde_json::from_value::<PluginsConfigData>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = config.validate() {
+                anyhow::bail!("plugins config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("plugins config parse error: {}", e),
+    }
+}
+
+/// Validate system config content (JSON value with any of the system-specific keys).
+/// Returns `Ok(true)` if recognized, `Ok(false)` if not a system config.
+fn validate_system_config_content(val: &serde_json::Value) -> Result<bool> {
+    let has_system_key = val.get("wizard").is_some()
+        || val.get("update").is_some()
+        || val.get("meta").is_some()
+        || val.get("messages").is_some()
+        || val.get("commands").is_some()
+        || val.get("session").is_some()
+        || val.get("cron").is_some()
+        || val.get("hooks").is_some()
+        || val.get("browser").is_some()
+        || val.get("auth").is_some();
+    if !has_system_key {
+        return Ok(false);
+    }
+    match serde_json::from_value::<SystemConfigData>(val.clone()) {
+        Ok(config) => {
+            if let Err(e) = config.validate() {
+                anyhow::bail!("system config: {}", e);
+            }
+            Ok(true)
+        }
+        Err(e) => anyhow::bail!("system config parse error: {}", e),
+    }
+}
+
 /// Validate config file content by detecting its type and running the appropriate validator.
 fn validate_config_content(content: &str) -> Result<()> {
     let val: serde_json::Value =
@@ -98,7 +180,43 @@ fn validate_config_content(content: &str) -> Result<()> {
         Err(e) => anyhow::bail!("{}", e),
     }
 
-    anyhow::bail!("Unrecognized config format: file is not a valid models.json or agents.json");
+    match validate_channels_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    match validate_gateway_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    match validate_plugins_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    match validate_system_config_content(&val) {
+        Ok(true) => {
+            println!("Config is valid");
+            return Ok(());
+        }
+        Ok(false) => {}
+        Err(e) => anyhow::bail!("{}", e),
+    }
+
+    anyhow::bail!("Unrecognized config format: file is not a recognized closeclaw config");
 }
 
 pub async fn handle_config(action: ConfigAction) -> Result<()> {
@@ -286,6 +404,19 @@ pub async fn handle_stop(force: bool) -> Result<()> {
             println!("Daemon (PID {}) stopped ({}).", pid, sig);
         }
         Ok(o) => {
+            // kill failed — check if the process is already gone
+            let is_alive = std::process::Command::new("kill")
+                .arg("-0")
+                .arg(pid.to_string())
+                .output()
+                .map(|r| r.status.success())
+                .unwrap_or(false);
+            if !is_alive {
+                // Process already exited; clean up stale PID file
+                let _ = std::fs::remove_file(&p);
+                println!("Daemon (PID {}) already stopped. PID file cleaned up.", pid);
+                return Ok(());
+            }
             anyhow::bail!("kill returned {}", o.status);
         }
         Err(e) => {


### PR DESCRIPTION
Fix CLI admin command behavior to match design doc.

- Fix config wizard writing to ~/.closeclaw/config/ instead of ~/.closeclaw/
- Unify credentials storage: ConfigSection::Credentials now uses directory structure matching CredentialsProvider
- Extend config validate to support all 6 config file types (channels, gateway, plugins, system)
- Fix stop command not cleaning PID file when daemon already exited

Source: design-doc (docs/design/cli/admin.md)
Type: fix
