### PR TITLE
chore: add set_var/remove_var prohibition with hook and CI enforcement

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,25 @@ if [ -n "$staged_rs" ]; then
         fi
     done
 
-    # cargo fmt --check — 仅检查 staged 文件，不背负历史技术债
+    # 环境变量禁令 — 禁止 set_var / remove_var（load_env_file 除外）
+    # 详见 CONTRIBUTING.md「环境变量禁令」
+    if git diff --cached --diff-filter=ACMR -- $staged_rs | grep -E '^\+.*\b(set_var|remove_var)\b' | grep -v 'load_env_file' | grep -v '^+++ '; then
+        echo ""
+        echo "ERROR: 检测到 std::env::set_var / remove_var 调用"
+        echo ""
+        echo "环境变量修改在多线程和并行测试中会导致数据竞争，全代码库禁止使用。"
+        echo "唯一例外：daemon/mod.rs 中的 load_env_file()（启动阶段加载 .env 文件）。"
+        echo ""
+        echo "正确做法："
+        echo "  - 配置值通过参数/config struct 传递，不写入全局 env"
+        echo "  - 测试中用依赖注入或临时文件路径代替 set_var"
+        echo "  - 只读取环境变量请用 std::env::var（安全）"
+        echo ""
+        echo "详见 CONTRIBUTING.md「环境变量禁令」"
+        exit 1
+    fi
+
+    # cargo fmt check — 仅检查 staged 文件，不背负历史技术债
     # 行宽（默认 100）、缩进、空白等格式问题一并覆盖
     if ! cargo fmt --check -- $staged_rs 2>&1; then
         echo "ERROR: 以上文件格式不符合规范，请运行 'cargo fmt' 修复后重新提交"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,54 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Check env var prohibition
+        run: |
+          set -e
+          # 禁止 set_var / remove_var（load_env_file 除外）
+          # 详见 CONTRIBUTING.md「环境变量禁令」
+          #
+          # 白名单：已知存量违规文件，待逐步清理后移除
+          whitelist=(
+            src/daemon/mod.rs
+            src/handlers/handlers_tests.rs
+            src/llm/protocol/glm_test.rs
+            src/llm/model_discovery.rs
+            src/daemon/unit_tests.rs
+          )
+          matches=$(grep -rn '\bset_var\b\|\bremove_var\b' src/ --include='*.rs' | grep -v 'load_env_file' || true)
+          if [ -n "$matches" ]; then
+            violations=""
+            while IFS= read -r line; do
+              file=$(echo "$line" | cut -d: -f1)
+              is_whitelisted=false
+              for wl in "${whitelist[@]}"; do
+                if [ "$file" = "$wl" ]; then
+                  is_whitelisted=true
+                  break
+                fi
+              done
+              if [ "$is_whitelisted" = false ]; then
+                violations="$violations\n$line"
+              fi
+            done <<< "$matches"
+            if [ -n "$violations" ]; then
+              echo "ERROR: 检测到 std::env::set_var / remove_var 调用："
+              echo -e "$violations"
+              echo ""
+              echo "环境变量修改在多线程和并行测试中会导致数据竞争，全代码库禁止使用。"
+              echo "唯一例外：daemon/mod.rs 中的 load_env_file()（启动阶段加载 .env 文件）。"
+              echo ""
+              echo "正确做法："
+              echo "  - 配置值通过参数/config struct 传递，不写入全局 env"
+              echo "  - 测试中用依赖注入或临时文件路径代替 set_var"
+              echo "  - 只读取环境变量请用 std::env::var（安全）"
+              echo ""
+              echo "详见 CONTRIBUTING.md「环境变量禁令」"
+              exit 1
+            fi
+          fi
+          echo "env var check passed"
+
       - name: Strict warning check
         run: cargo check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ cargo build && cargo test
 | enum 变体数 | **20** |
 | 嵌套 match/if | **3 层** |
 | unsafe 块 | **0（除非注释说明）** |
+| `std::env::set_var` / `remove_var` | **禁止**（`load_env_file` 除外） |
 
 ---
 
@@ -121,11 +122,22 @@ tests/
 |------|------|
 | **临时文件/目录** | 用 `tempfile::TempDir`，不可硬编码路径 |
 | **端口** | 不硬编码，用 port 0 系统分配 |
-| **环境变量** | 不泄漏到其他测试 |
+| **环境变量** | 禁止 `std::env::set_var` / `remove_var`，详见下方「环境变量禁令」 |
 | **网络** | 禁止外部网络访问，全部 mock |
 | **超时** | 单测 30s |
 | **LLM** | 禁止真实 LLM 调用 |
 | **并行安全** | 测试间不共享可变状态；涉及端口/文件锁加 `#[serial_test::serial]` |
+
+### 环境变量禁令
+
+`std::env::set_var` / `std::env::remove_var` 修改进程全局环境，在多线程和并行测试中会导致数据竞争。**全代码库禁止使用**，唯一例外是 `daemon/mod.rs` 中的 `load_env_file()`（启动阶段加载 `.env` 文件）。
+
+正确做法：
+- 配置值通过参数/config struct 传递，不写入全局 env
+- 测试需要隔离配置时，用依赖注入或临时文件路径，不用 `set_var`
+- 需要读取环境变量时用 `std::env::var`（只读，安全）
+
+违反此规则的 commit 会被 pre-commit hook 和 CI 拦截。
 
 ### 布局
 


### PR DESCRIPTION
## 背景

最近多个 PR 在修 CI 测试失败（#1053, #1050, #1043, #1039 等），根因是测试代码直接操作全局环境变量（`std::env::set_var` / `remove_var`），在并行执行时产生数据竞争。

## 改动

1. **CONTRIBUTING.md** 新增「环境变量禁令」章节
   - 全代码库禁止 `set_var` / `remove_var`（`load_env_file` 除外）
   - 说明正确做法：依赖注入、config struct、只读 `env::var`
   - 硬性限制表新增对应条目

2. **Pre-commit hook**（`.githooks/pre-commit`）
   - 检查 staged diff 中新增的 `set_var`/`remove_var`
   - 白名单豁免 `load_env_file`
   - 失败时输出完整解释 + 指向 CONTRIBUTING.md

3. **CI check**（`.github/workflows/ci.yml`）
   - 全量扫描 `src/` 下所有 `.rs` 文件
   - 白名单豁免 5 个存量违规文件（待 #1054 逐步清理后移除）
   - 新增违规立即拦截

## 存量清理

存量 10 处测试代码违规已记录在 #1054，后续逐步清理并从 CI 白名单移除。

Source: user
Type: chore
