### PR TITLE
refactor: eliminate global env var race conditions via dependency injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
           # 白名单：已知存量违规文件，待逐步清理后移除
           whitelist=(
             src/daemon/mod.rs
-            src/handlers/handlers_tests.rs
-            src/llm/protocol/glm_test.rs
-            src/llm/model_discovery.rs
-            src/daemon/unit_tests.rs
           )
           matches=$(grep -rn '\bset_var\b\|\bremove_var\b' src/ --include='*.rs' | grep -v 'load_env_file' || true)
           if [ -n "$matches" ]; then

--- a/src/daemon/llm_init.rs
+++ b/src/daemon/llm_init.rs
@@ -1,5 +1,7 @@
 //! LLM provider registration helpers
 
+use std::collections::HashMap;
+
 use super::*;
 use crate::config::providers::CredentialsProvider;
 use crate::llm::anthropic::AnthropicProvider;
@@ -15,6 +17,20 @@ impl Daemon {
     /// 2. Fall back to the corresponding env var if the file does not have it
     #[allow(dead_code)] // only invoked from `#[cfg(test)] mod unit_tests`
     pub(crate) async fn init_llm_registry(config_dir: &Path) -> Arc<LLMRegistry> {
+        Self::init_llm_registry_with_env(config_dir, &HashMap::new()).await
+    }
+
+    /// Same as [`init_llm_registry`] but accepts an override map for env-var fallback.
+    ///
+    /// For each provider the lookup order is:
+    /// 1. Credentials file
+    /// 2. `env_overrides` map
+    /// 3. Process environment variable
+    #[allow(dead_code)] // only invoked from `#[cfg(test)] mod unit_tests`
+    pub(crate) async fn init_llm_registry_with_env(
+        config_dir: &Path,
+        env_overrides: &HashMap<&str, &str>,
+    ) -> Arc<LLMRegistry> {
         let registry = Arc::new(LLMRegistry::new());
 
         // Load credentials from config/credentials/ directory
@@ -34,7 +50,12 @@ impl Daemon {
         // Register OpenAI provider: credentials file first, then env var fallback
         let openai_key = creds_provider
             .get_api_key("openai")
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            .or_else(|| {
+                env_overrides
+                    .get("OPENAI_API_KEY")
+                    .map(|s| s.to_string())
+                    .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            })
             .filter(|k| !k.is_empty());
         if let Some(api_key) = openai_key {
             let provider: Arc<dyn crate::llm::provider::Provider> =
@@ -46,7 +67,12 @@ impl Daemon {
         // Register Anthropic provider: credentials file first, then env var fallback
         let anthropic_key = creds_provider
             .get_api_key("anthropic")
-            .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+            .or_else(|| {
+                env_overrides
+                    .get("ANTHROPIC_API_KEY")
+                    .map(|s| s.to_string())
+                    .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+            })
             .filter(|k| !k.is_empty());
         if let Some(api_key) = anthropic_key {
             let provider: Arc<dyn crate::llm::provider::Provider> =
@@ -58,7 +84,12 @@ impl Daemon {
         // Register MiniMax provider: credentials file first, then env var fallback
         let minimax_key = creds_provider
             .get_api_key("minimax")
-            .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+            .or_else(|| {
+                env_overrides
+                    .get("MINIMAX_API_KEY")
+                    .map(|s| s.to_string())
+                    .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+            })
             .filter(|k| !k.is_empty());
         if let Some(api_key) = minimax_key {
             let provider: Arc<dyn crate::llm::provider::Provider> =

--- a/src/daemon/unit_tests.rs
+++ b/src/daemon/unit_tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for daemon private functions
 
 use super::*;
-use std::env::{remove_var, set_var};
+use std::collections::HashMap;
 use std::io::Write;
 use tempfile::TempDir;
 
@@ -178,51 +178,41 @@ fn test_build_permission_engine_with_templates_dir() {
 
 #[tokio::test]
 async fn test_init_llm_registry_credentials_file_priority() {
-    // Arrange: temp dir with config/credentials/openai.json containing an api key
+    // Arrange: temp dir with credentials/openai.json containing an api key
     let tmp = TempDir::new().unwrap();
-    let creds_dir = tempfile::TempDir::new_in(tmp.path()).unwrap();
+    let creds_dir = tmp.path().join("credentials");
+    std::fs::create_dir_all(&creds_dir).unwrap();
     std::fs::write(
-        creds_dir.path().join("openai.json"),
+        creds_dir.join("openai.json"),
         r#"{"provider":"openai","apiKey":"file-key-123"}"#,
     )
     .unwrap();
-    // Also write env var (should NOT be used since file has key)
-    let old_openai_key = std::env::var("OPENAI_API_KEY").ok();
-    set_var("OPENAI_API_KEY", "env-key-should-not-be-used");
+    // Pass empty HashMap — file key should win over any env override
+    let env_overrides = HashMap::new();
 
     // Act
-    let registry = Daemon::init_llm_registry(tmp.path()).await;
+    let registry = Daemon::init_llm_registry_with_env(tmp.path(), &env_overrides).await;
 
     // Assert: provider registered with file key
-    let provider = registry.get("openai").await;
-    assert!(provider.is_some(), "openai provider should be registered");
-    // StubProvider returns "stub response"; verify it IS a stub (in test mode)
-    // The registry should contain a real OpenAIProvider or StubProvider
-    // Since we used file key, it should be registered
     let listed = registry.list().await;
-    assert!(listed.contains(&"openai".to_string()));
-
-    // Restore original env var
-    if let Some(v) = old_openai_key {
-        set_var("OPENAI_API_KEY", v);
-    } else {
-        remove_var("OPENAI_API_KEY");
-    }
+    assert!(
+        listed.contains(&"openai".to_string()),
+        "openai provider should be registered from credentials file"
+    );
 }
 
 #[tokio::test]
 async fn test_init_llm_registry_env_fallback() {
-    // Arrange: temp dir with NO credentials files, env vars set
+    // Arrange: temp dir with NO credentials files; pass env overrides via HashMap
     let tmp = TempDir::new().unwrap();
-    let old_openai_key = std::env::var("OPENAI_API_KEY").ok();
-    let old_anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok();
-    set_var("OPENAI_API_KEY", "env-key-456");
-    set_var("ANTHROPIC_API_KEY", "env-anthropic-key");
+    let mut env_overrides = HashMap::new();
+    env_overrides.insert("OPENAI_API_KEY", "env-key-456");
+    env_overrides.insert("ANTHROPIC_API_KEY", "env-anthropic-key");
 
     // Act
-    let registry = Daemon::init_llm_registry(tmp.path()).await;
+    let registry = Daemon::init_llm_registry_with_env(tmp.path(), &env_overrides).await;
 
-    // Assert: providers registered from env vars
+    // Assert: providers registered from env overrides
     let listed = registry.list().await;
     assert!(
         listed.contains(&"openai".to_string()),
@@ -232,33 +222,16 @@ async fn test_init_llm_registry_env_fallback() {
         listed.contains(&"anthropic".to_string()),
         "anthropic should be registered from env"
     );
-
-    // Restore original env vars
-    if let Some(v) = old_openai_key {
-        set_var("OPENAI_API_KEY", v);
-    } else {
-        remove_var("OPENAI_API_KEY");
-    }
-    if let Some(v) = old_anthropic_key {
-        set_var("ANTHROPIC_API_KEY", v);
-    } else {
-        remove_var("ANTHROPIC_API_KEY");
-    }
 }
 
 #[tokio::test]
 async fn test_init_llm_registry_both_absent_no_registration() {
-    // Arrange: temp dir with NO credentials files, no env vars set
+    // Arrange: temp dir with NO credentials files, empty env overrides
     let tmp = TempDir::new().unwrap();
-    let old_openai_key = std::env::var("OPENAI_API_KEY").ok();
-    let old_anthropic_key = std::env::var("ANTHROPIC_API_KEY").ok();
-    let old_minimax_key = std::env::var("MINIMAX_API_KEY").ok();
-    remove_var("OPENAI_API_KEY");
-    remove_var("ANTHROPIC_API_KEY");
-    remove_var("MINIMAX_API_KEY");
+    let env_overrides = HashMap::new();
 
     // Act
-    let registry = Daemon::init_llm_registry(tmp.path()).await;
+    let registry = Daemon::init_llm_registry_with_env(tmp.path(), &env_overrides).await;
 
     // Assert: no providers registered
     let listed = registry.list().await;
@@ -266,21 +239,4 @@ async fn test_init_llm_registry_both_absent_no_registration() {
         listed.is_empty(),
         "no providers should be registered when no credentials"
     );
-
-    // Restore original env vars
-    if let Some(v) = old_openai_key {
-        set_var("OPENAI_API_KEY", v);
-    } else {
-        remove_var("OPENAI_API_KEY");
-    }
-    if let Some(v) = old_anthropic_key {
-        set_var("ANTHROPIC_API_KEY", v);
-    } else {
-        remove_var("ANTHROPIC_API_KEY");
-    }
-    if let Some(v) = old_minimax_key {
-        set_var("MINIMAX_API_KEY", v);
-    } else {
-        remove_var("MINIMAX_API_KEY");
-    }
 }

--- a/src/handlers/handlers_tests.rs
+++ b/src/handlers/handlers_tests.rs
@@ -17,16 +17,6 @@ async fn validate_config(filename: &str, content: &str) -> anyhow::Result<()> {
     .await
 }
 
-/// Set `HOME` to `tmp` for the duration of the closure, then restore.
-fn with_home<F: FnOnce()>(tmp: &tempfile::TempDir, f: F) {
-    let orig = std::env::var("HOME").ok();
-    std::env::set_var("HOME", tmp.path());
-    f();
-    if let Some(h) = orig {
-        std::env::set_var("HOME", h);
-    }
-}
-
 // -----------------------------------------------------------------
 // config validate tests
 // -----------------------------------------------------------------
@@ -100,17 +90,9 @@ async fn test_config_validate_models_with_invalid_base_url() {
 fn test_config_list_empty_dir() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tmp.path().join(".closeclaw")).unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_config(ConfigAction::List)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_config_at(ConfigAction::List, Some(tmp.path())));
     assert!(
         result.is_ok(),
         "empty config list should succeed: {:?}",
@@ -121,17 +103,9 @@ fn test_config_list_empty_dir() {
 #[test]
 fn test_config_list_no_config_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_config(ConfigAction::List)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_config_at(ConfigAction::List, Some(tmp.path())));
     assert!(
         result.is_ok(),
         "missing config dir should not error: {:?}",
@@ -241,7 +215,7 @@ fn test_handle_rule_check_invalid_json() {
 fn test_handle_rule_list_empty_dir() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tmp.path().join(".closeclaw").join("rules")).unwrap();
-    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
+    assert!(handle_rule_list_at(Some(tmp.path())).is_ok());
 }
 
 #[test]
@@ -252,13 +226,13 @@ fn test_handle_rule_list_with_files() {
     std::fs::write(rules_dir.join("allow.json"), "{}").unwrap();
     std::fs::write(rules_dir.join("deny.yaml"), "{}").unwrap();
     std::fs::write(rules_dir.join("readme.txt"), "skip").unwrap();
-    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
+    assert!(handle_rule_list_at(Some(tmp.path())).is_ok());
 }
 
 #[test]
 fn test_handle_rule_list_no_rules_dir() {
     let tmp = tempfile::tempdir().unwrap();
-    with_home(&tmp, || assert!(handle_rule_list().is_ok()));
+    assert!(handle_rule_list_at(Some(tmp.path())).is_ok());
 }
 
 // -----------------------------------------------------------------
@@ -349,17 +323,9 @@ fn test_config_list_discovers_credentials_files() {
         r#"{"provider":"minimax","apiKey":"sk-test"}"#,
     )
     .unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_config(ConfigAction::List)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_config_at(ConfigAction::List, Some(tmp.path())));
     assert!(
         result.is_ok(),
         "config list with credentials should succeed: {:?}",
@@ -371,17 +337,9 @@ fn test_config_list_discovers_credentials_files() {
 fn test_config_list_empty_credentials_dir() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tmp.path().join(".closeclaw").join("credentials")).unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_config(ConfigAction::List)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_config_at(ConfigAction::List, Some(tmp.path())));
     assert!(
         result.is_ok(),
         "empty credentials dir should not error: {:?}",
@@ -396,17 +354,9 @@ fn test_config_list_empty_credentials_dir() {
 #[test]
 fn test_stop_pid_file_not_found() {
     let tmp = tempfile::tempdir().unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_stop(false)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_stop_at(false, Some(tmp.path())));
     assert!(result.is_err(), "missing PID file should error");
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -422,17 +372,9 @@ fn test_stop_stale_pid_file_cleans_up() {
     let pid_file = tmp.path().join(".closeclaw").join("daemon.pid");
     std::fs::create_dir_all(pid_file.parent().unwrap()).unwrap();
     std::fs::write(&pid_file, "2147483647").unwrap();
-    let result = {
-        let mut r = None;
-        with_home(&tmp, || {
-            r = Some(
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(handle_stop(false)),
-            );
-        });
-        r.unwrap()
-    };
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(handle_stop_at(false, Some(tmp.path())));
     assert!(
         result.is_ok(),
         "stale PID should be cleaned up gracefully: {:?}",

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -24,8 +24,12 @@ pub fn mask_key(key: &str) -> String {
 }
 
 pub fn pid_file_path() -> PathBuf {
-    let home = std::env::var("HOME").expect("HOME not set");
-    PathBuf::from(home).join(".closeclaw").join("daemon.pid")
+    pid_file_path_at(&dirs::home_dir().expect("HOME not set"))
+}
+
+#[allow(dead_code)]
+pub fn pid_file_path_at(home: &std::path::Path) -> PathBuf {
+    home.join(".closeclaw").join("daemon.pid")
 }
 
 pub async fn handle_agent(action: AgentAction, user_id: &str) -> Result<()> {
@@ -220,6 +224,14 @@ fn validate_config_content(content: &str) -> Result<()> {
 }
 
 pub async fn handle_config(action: ConfigAction) -> Result<()> {
+    handle_config_at(action, None).await
+}
+
+#[allow(dead_code)]
+pub async fn handle_config_at(
+    action: ConfigAction,
+    home_dir: Option<&std::path::Path>,
+) -> Result<()> {
     match action {
         ConfigAction::Validate { file } => {
             let path = std::path::Path::new(&file);
@@ -230,9 +242,12 @@ pub async fn handle_config(action: ConfigAction) -> Result<()> {
             validate_config_content(&content)?;
         }
         ConfigAction::List => {
-            let config_dir = dirs::home_dir()
-                .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
-                .join(".closeclaw");
+            let config_dir = match home_dir {
+                Some(home) => home.join(".closeclaw"),
+                None => dirs::home_dir()
+                    .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+                    .join(".closeclaw"),
+            };
             if !config_dir.exists() {
                 println!("Config directory not found at {}", config_dir.display());
                 return Ok(());
@@ -306,10 +321,19 @@ fn handle_rule_check(rule: &str) -> Result<()> {
 
 /// List rule files from ~/.closeclaw/rules/ directory.
 fn handle_rule_list() -> Result<()> {
-    let rules_dir = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
-        .join(".closeclaw")
-        .join("rules");
+    handle_rule_list_at(None)
+}
+
+/// List rule files from ~/.closeclaw/rules/ directory, with optional home override.
+#[allow(dead_code)]
+fn handle_rule_list_at(home_dir: Option<&std::path::Path>) -> Result<()> {
+    let rules_dir = match home_dir {
+        Some(home) => home.join(".closeclaw").join("rules"),
+        None => dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?
+            .join(".closeclaw")
+            .join("rules"),
+    };
     if !rules_dir.exists() {
         println!("No rules directory found at {}", rules_dir.display());
         return Ok(());
@@ -381,7 +405,15 @@ pub async fn handle_skill(action: SkillAction, user_id: &str) -> Result<()> {
 }
 
 pub async fn handle_stop(force: bool) -> Result<()> {
-    let p = pid_file_path();
+    handle_stop_at(force, None).await
+}
+
+#[allow(dead_code)]
+pub async fn handle_stop_at(force: bool, home_dir: Option<&std::path::Path>) -> Result<()> {
+    let p = match home_dir {
+        Some(home) => pid_file_path_at(home),
+        None => pid_file_path(),
+    };
     let pid: u32 = if p.exists() {
         std::fs::read_to_string(&p)?
             .trim()

--- a/src/llm/model_cache.rs
+++ b/src/llm/model_cache.rs
@@ -73,6 +73,14 @@ impl ModelCache {
         Self { persist_path }
     }
 
+    /// Construct a ModelCache that persists to the given path,
+    /// without reading any environment variables.
+    pub fn with_path(path: &std::path::Path) -> Self {
+        Self {
+            persist_path: path.to_path_buf(),
+        }
+    }
+
     /// Retrieve cached models for the given provider + token.
     ///
     /// Returns `None` if:

--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -132,8 +132,7 @@ mod tests {
     /// Helper: create a ModelDiscovery with an isolated temp-dir cache.
     fn make_discovery(dir: &tempfile::TempDir) -> ModelDiscovery {
         let path = dir.path().join("cache.json");
-        std::env::set_var("MODEL_CACHE_FILE", &path);
-        let cache = ModelCache::new();
+        let cache = ModelCache::with_path(&path);
         ModelDiscovery {
             cache,
             knowledge: ProviderModelKnowledge::new(),
@@ -178,8 +177,6 @@ mod tests {
         assert_eq!(result[0].id, "test-model-1");
         // fetch closure must NOT have been called
         assert_eq!(fetch_count.load(Ordering::SeqCst), 0);
-
-        std::env::remove_var("MODEL_CACHE_FILE");
     }
 
     #[tokio::test]
@@ -209,8 +206,6 @@ mod tests {
 
         assert_eq!(result2.len(), 1);
         assert_eq!(fetch_count.load(Ordering::SeqCst), 0);
-
-        std::env::remove_var("MODEL_CACHE_FILE");
     }
 
     #[tokio::test]
@@ -230,8 +225,6 @@ mod tests {
             !result.is_empty(),
             "knowledge fallback should return models"
         );
-
-        std::env::remove_var("MODEL_CACHE_FILE");
     }
 
     #[tokio::test]
@@ -266,16 +259,12 @@ mod tests {
         // Should have re-fetched (not returned old-model)
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, "test-model-1");
-
-        std::env::remove_var("MODEL_CACHE_FILE");
     }
 
     #[test]
     fn test_knowledge_fallback_returns_known_models() {
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("MODEL_CACHE_FILE", dir.path().join("cache.json"));
-        let discovery = ModelDiscovery::new();
-        std::env::remove_var("MODEL_CACHE_FILE");
+        let discovery = make_discovery(&dir);
 
         let models = discovery.knowledge_fallback("minimax");
         assert!(!models.is_empty(), "minimax should have known models");

--- a/src/llm/protocol/glm.rs
+++ b/src/llm/protocol/glm.rs
@@ -26,12 +26,21 @@ const PATH: &str = "/api/paas/v4/chat/completions";
 #[derive(Debug, Clone)]
 pub struct GlmProtocol {
     id: ProtocolId,
+    api_key: Option<String>,
 }
 
 impl GlmProtocol {
     pub fn new() -> Self {
         Self {
             id: ProtocolId::new("glm"),
+            api_key: None,
+        }
+    }
+
+    pub fn with_api_key(key: String) -> Self {
+        Self {
+            id: ProtocolId::new("glm"),
+            api_key: Some(key),
         }
     }
 }
@@ -137,7 +146,10 @@ impl ChatProtocol for GlmProtocol {
 
     fn decorate_headers(&self, headers: &mut HeaderMap) -> Result<()> {
         // GLM uses the same Bearer token format as OpenAI.
-        let api_key = std::env::var("GLM_API_KEY").unwrap_or_default();
+        let api_key = self
+            .api_key
+            .clone()
+            .unwrap_or_else(|| std::env::var("GLM_API_KEY").unwrap_or_default());
         let bearer = format!("Bearer {api_key}");
         let auth_value = HeaderValue::from_str(&bearer)
             .map_err(|e| ProtocolError::HeaderDecorate(e.to_string()))?;

--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -131,8 +131,7 @@ fn test_parse_response_empty_choices() {
 
 #[test]
 fn test_decorate_headers_bearer() {
-    std::env::remove_var("GLM_API_KEY");
-    let proto = GlmProtocol::new();
+    let proto = GlmProtocol::with_api_key("".into());
     let mut headers = HeaderMap::new();
     proto.decorate_headers(&mut headers).unwrap();
     let auth = headers.get(AUTHORIZATION).unwrap();


### PR DESCRIPTION
## 概述

消除全局环境变量竞争问题：通过依赖注入替代 `set_var`/`remove_var`，根治并行测试中的环境变量竞争。

## 改动

- **ModelCache**: 新增 `with_path()` 构造函数，测试可注入临时路径
- **GlmProtocol**: 新增 `api_key` 字段和 `with_api_key()` 构造函数，测试直接传入 key
- **handle_config / handle_stop / handle_rule_list**: 新增 `_at` 变体接受 `home_dir` 参数，测试注入临时目录
- **init_llm_registry**: 新增 `init_llm_registry_with_env()` 接受 env override map，测试不再修改全局 env
- **CI**: 从 env var 检查白名单中移除已清理的 4 个文件，仅保留 `load_env_file` 例外

所有改动向后兼容，原 API 保留为 wrapper。

## Commits

- `f3b1c40` refactor: add ModelCache::with_path() for DI in tests
- `4388b2a` refactor: remove set_var/remove_var from model_discovery tests
- `2359800` refactor: add GlmProtocol::with_api_key() for DI in tests
- `819fe2b` refactor: use GlmProtocol::with_api_key() in test, remove remove_var
- `c74b00f` refactor: add injectable home_dir variants for handle_config/stop/rule_list
- `ed85ea2` refactor: replace with_home() with injectable home_dir in handlers tests
- `39acc89` refactor: add init_llm_registry_with_env() for DI in tests
- `49a6060` refactor: use init_llm_registry_with_env() in daemon tests
- `8e364bb` chore: remove cleaned-up files from env var CI whitelist

Source: issue #1054
Type: refactor
