### PR TITLE
docs(design): 补充 compaction 两阶段 token 估算和 /status 缓存统计字段

### DIFF
--- a/docs/design/session/compact-process.md
+++ b/docs/design/session/compact-process.md
@@ -130,8 +130,8 @@ LLM 摘要步骤不修改 system prompt 内容。Compaction 结束后，SessionM
 
 - **LLM Provider**：被调用来执行实际的对话摘要生成。
 - **Checkpoint Manager**：压缩完成后触发 checkpoint 保存，持久化压缩后的 transcript（system prompt 为运行时字段，不进入 SessionCheckpoint）。
+- **Session Injection**：压缩完成后通知 SessionManager，由 SessionManager 触发注入流程重建 system prompt（间接下游，详见 [session-injection.md](session-injection.md)）。
 
 ### 无关
 
 - **Archive Sweeper**（无调用关系）：管理 session 的归档和清理生命周期，与压缩流程无交互。
-- **Session Injection**（间接关联）：压缩完成后通知 SessionManager，由 SessionManager 触发注入流程重建 system prompt。compact-process 不直接调用注入，详细触发时机见 [session-injection.md](session-injection.md)。

--- a/docs/design/session/compact-process.md
+++ b/docs/design/session/compact-process.md
@@ -38,7 +38,7 @@ Bootstrap 文件（AGENTS.md、SOUL.md、IDENTITY.md、USER.md、TOOLS.md 等）
 - **手动触发**：用户输入 `/compact` 斜杠命令，可附带自定义保留指令（如 `/compact 保留用户名和邮箱`）。仅输入 `/compact` 时不附带自定义指令。
 - **自动触发**：每次收到用户消息后，估算当前 token 用量，当剩余空间低于可配置阈值时自动执行压缩。自动触发内建了以下防护：
 
-**Token 估算**：用字符数乘以配置系数做线性估算，不依赖外部 tokenizer。不同模型的上下文窗口大小在内部维护。
+**Token 估算**：组合使用服务端精确用量和字符估算。已完成的 LLM 调用使用服务端返回的精确 usage 数据（prompt_tokens、completion_tokens、cache 相关 token），从会话统计（RunningStats）中读取；尚未发送的待估消息（如用户新输入）用字符数乘以配置系数做线性估算，不依赖外部 tokenizer。两者相加得到当前上下文 token 总量。不同模型的上下文窗口大小由模型发现子系统的知识库提供。
 
 **分级告警阈值**：根据剩余 token 空间分为正常、预警、触发自动压缩、阻塞四个级别。阻塞状态下拒绝新请求，要求用户手动压缩。
 
@@ -75,8 +75,9 @@ system prompt 包含 bootstrap 文件内容和工具/skill 列表，在会话创
   → 从消息历史中提取对话消息（排除 system prompt）
   → 构建压缩 prompt（含自定义指令）→ 调用 LLM
   → 从响应中提取摘要 → 组装 boundary 消息
-  → 统计 before/after 字符和 token 数
+  → 统计 before token 数（已返回消息用精确 usage + 待发送消息用字符估算）
   → 用 boundary 消息替换对话消息
+  → 统计 after token 数（boundary 消息用字符估算）
   → 通知 SessionManager，由 SessionManager 触发注入流程重建 system prompt 静态层
   → 持久化压缩后的 transcript（仅 boundary 消息）
   → 返回压缩统计给用户
@@ -122,6 +123,8 @@ LLM 摘要步骤不修改 system prompt 内容。Compaction 结束后，SessionM
 
 - **Chat Session**：检查自动压缩阈值，截获 `/compact` 命令触发压缩。
 - **Slash Command**：解析 `/compact [指令]` 格式。
+- **LLM 模块（会话统计）**：提供已完成的 LLM 调用的精确 usage 数据（prompt_tokens、completion_tokens、cache 相关 token），用于 token 估算。
+- **LLM 模块（模型发现）**：提供模型上下文窗口大小等推荐参数，用于阈值判断。
 
 ### 下游
 

--- a/docs/design/slash/status.md
+++ b/docs/design/slash/status.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-`/status` 指令用于查看当前会话的运行状态，包括模式、模型、推理深度、上下文用量、缓存命中率、活跃子 agent 数、工作目录和 system prompt 追加指令列表。
+`/status` 指令用于查看当前会话的运行状态，包括模式、模型、推理深度、上下文用量、缓存命中率、缓存读写 token 累计、活跃子 agent 数、工作目录和 system prompt 追加指令列表。
 
 ## 架构
 
@@ -29,7 +29,7 @@ Gateway 直接回复用户
 
 - **输入**：无参数
 - **处理**：读取 SlashContext 中的会话状态字段
-- **输出**：Reply 包含当前模式、模型名称、推理深度、上下文用量、缓存命中率（会话累计缓存命中 token / 会话累计 prompt token，数据来源为会话统计 RunningStats）、缓存读取与写入 token 累计值、活跃子 agent 数量、工作目录、system prompt 追加指令列表
+- **输出**：Reply 包含当前模式、模型名称、推理深度、上下文用量、缓存命中率（会话累计缓存命中 token / 会话累计 prompt token，数据来源为会话统计 RunningStats）、缓存读写 token 累计、活跃子 agent 数、工作目录、system prompt 追加指令列表
 
 ## 模块关系
 

--- a/docs/design/slash/status.md
+++ b/docs/design/slash/status.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-`/status` 指令用于查看当前会话的运行状态，包括模式、模型、上下文用量、活跃子 agent 数、工作目录和 system prompt 追加内容。
+`/status` 指令用于查看当前会话的运行状态，包括模式、模型、推理深度、上下文用量、缓存命中率、活跃子 agent 数、工作目录和 system prompt 追加指令列表。
 
 ## 架构
 
@@ -12,9 +12,11 @@ StatusHandler 从 SlashContext 读取会话状态并格式化输出。标记为 
 /status
   ↓
 StatusHandler 从 SlashContext 读取：
-  - current_mode, current_model
+  - current_mode, current_model, current_reasoning
   - context_usage, subagent_count
   - workdir, system_append
+  - cache_hit_rate (会话累计缓存命中率，数据来源：会话统计 RunningStats)
+  - cache_read_tokens, cache_write_tokens (会话累计值，数据来源同上)
   ↓
 格式化为状态文本
   ↓
@@ -27,10 +29,10 @@ Gateway 直接回复用户
 
 - **输入**：无参数
 - **处理**：读取 SlashContext 中的会话状态字段
-- **输出**：Reply 包含当前模式、模型名称、上下文用量、活跃子 agent 数量、工作目录、system prompt 追加指令列表
+- **输出**：Reply 包含当前模式、模型名称、推理深度、上下文用量、缓存命中率（会话累计缓存命中 token / 会话累计 prompt token，数据来源为会话统计 RunningStats）、缓存读取与写入 token 累计值、活跃子 agent 数量、工作目录、system prompt 追加指令列表
 
 ## 模块关系
 
 - **上游**：Gateway → Dispatcher → StatusHandler
-- **下游**：无（仅读取 SlashContext，不触发副作用）
-- **无关**：LLM 对话流程
+- **下游**：Gateway（Reply 经 Gateway 返回用户）
+- **无关**：LLM 对话流程（/status 为 Immediate 指令，不经过 LLM 处理）


### PR DESCRIPTION
docs(design): 补充 compaction 两阶段 token 估算和 /status 缓存统计字段

compact-process.md:
- Token 估算改为组合策略：已完成的 LLM 调用用精确 usage（从 RunningStats 读取），待发送消息用字符估算
- 手动压缩数据流明确 before/after 各阶段的估算来源
- 模块关系补充 LLM 模块（会话统计 + 模型发现）两个上游

status.md:
- 新增缓存命中率、缓存读取/写入 token 累计值字段
- 数据来源标注为会话统计 RunningStats
- 补充推理深度字段（代码已有、文档遗漏）
- 修正模块关系（下游=Gateway，无关=LLM 重新定义）

Source: user
Type: docs
