### PR TITLE
feat: create master agent config during CLI wizard setup

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -6,6 +6,8 @@ pub mod types;
 pub use fetch::*;
 pub use types::*;
 
+use crate::agent::config::AgentConfig;
+use crate::config::agents::AgentsConfig;
 use crate::config::providers::{
     credentials::{AnyProviderCredentials, ApiKeyCredentials},
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
@@ -111,6 +113,78 @@ fn config_dir() -> PathBuf {
     PathBuf::from(home).join(".closeclaw")
 }
 
+/// Merge models from wizard output into existing config, then write models.json.
+///
+/// Preserves existing providers not being updated and their non-selected models.
+fn merge_and_write_models(config_path: &Path, output: &WizardOutput) -> anyhow::Result<PathBuf> {
+    let models_path = config_path.join("models.json");
+    let existing: ModelsConfigData = if models_path.exists() {
+        let content = std::fs::read_to_string(&models_path)?;
+        ModelsConfigData::from_json_str(&content).unwrap_or_else(|_| ModelsConfigData::default())
+    } else {
+        ModelsConfigData::default()
+    };
+
+    let new_provider_models: Vec<ModelDefinition> = output
+        .selected_models
+        .iter()
+        .map(|m| ModelDefinition {
+            id: m.id.clone(),
+            name: Some(m.name.clone()),
+            enabled: Some(true),
+        })
+        .collect();
+
+    let recommended_protocol = output.selected_models.first().map(|m| {
+        let kb = ProviderModelKnowledge::new();
+        kb.recommended_protocol(&output.provider_id, &m.id)
+            .to_string()
+    });
+
+    let mut providers = existing.providers;
+    providers.remove(&output.provider_id);
+    providers.insert(
+        output.provider_id.clone(),
+        ProviderConfig {
+            base_url: None,
+            api_key: None,
+            api: None,
+            protocol: recommended_protocol,
+            models: new_provider_models,
+        },
+    );
+
+    let merged = ModelsConfigData {
+        mode: "merge".to_string(),
+        providers,
+    };
+    <ModelsConfigData as crate::config::providers::ConfigProvider>::validate(&merged)
+        .map_err(|e| anyhow::anyhow!("merged config validation failed: {}", e))?;
+
+    let json = serde_json::to_string_pretty(&merged)?;
+    std::fs::write(&models_path, json)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", models_path.display(), e))?;
+    Ok(models_path)
+}
+
+/// Write provider API key to credentials directory.
+fn write_provider_credentials(
+    config_path: &Path,
+    output: &WizardOutput,
+) -> anyhow::Result<PathBuf> {
+    let creds_dir = config_path.join("credentials");
+    std::fs::create_dir_all(&creds_dir)?;
+    let cred_file = creds_dir.join(format!("{}.json", output.provider_id));
+    let creds = AnyProviderCredentials::ApiKey(ApiKeyCredentials {
+        provider: output.provider_id.clone(),
+        api_key: output.credential.clone(),
+    });
+    let creds_json = serde_json::to_string_pretty(&creds)?;
+    std::fs::write(&cred_file, creds_json)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", cred_file.display(), e))?;
+    Ok(cred_file)
+}
+
 /// Write wizard output to config files.
 ///
 /// Merging strategy:
@@ -128,77 +202,65 @@ fn config_dir() -> PathBuf {
 pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(config_path)?;
 
-    // ── Load or create models.json ─────────────────────────────────────────────
-    let models_path = config_path.join("models.json");
-    let existing: ModelsConfigData = if models_path.exists() {
-        let content = std::fs::read_to_string(&models_path)?;
-        ModelsConfigData::from_json_str(&content).unwrap_or_else(|_| ModelsConfigData::default())
-    } else {
-        ModelsConfigData::default()
-    };
-
-    // ── Build the new provider config from WizardOutput.selected_models ────────
-    let new_provider_models: Vec<ModelDefinition> = output
-        .selected_models
-        .iter()
-        .map(|m| ModelDefinition {
-            id: m.id.clone(),
-            name: Some(m.name.clone()),
-            enabled: Some(true),
-        })
-        .collect();
-
-    // ── Query recommended_protocol from knowledge base ────────────────────────
-    let recommended_protocol = output.selected_models.first().map(|m| {
-        let kb = ProviderModelKnowledge::new();
-        kb.recommended_protocol(&output.provider_id, &m.id)
-            .to_string()
-    });
-
-    // ── Merge: preserve all existing providers, replace selected provider ───────
-    let mut providers = existing.providers;
-    // Remove entries for the selected provider so we can replace them
-    providers.remove(&output.provider_id);
-
-    let new_provider_config = ProviderConfig {
-        base_url: None,
-        api_key: None,
-        api: None,
-        protocol: recommended_protocol,
-        models: new_provider_models,
-    };
-    providers.insert(output.provider_id.clone(), new_provider_config);
-
-    let merged = ModelsConfigData {
-        mode: "merge".to_string(),
-        providers,
-    };
-    <ModelsConfigData as crate::config::providers::ConfigProvider>::validate(&merged)
-        .map_err(|e| anyhow::anyhow!("merged config validation failed: {}", e))?;
-
-    // ── Write models.json ─────────────────────────────────────────────────────
-    let json = serde_json::to_string_pretty(&merged)?;
-    std::fs::write(&models_path, json)
-        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", models_path.display(), e))?;
-
-    // ── Write credentials ────────────────────────────────────────────────────
-    let creds_dir = config_path.join("credentials");
-    std::fs::create_dir_all(&creds_dir)?;
-    let cred_file = creds_dir.join(format!("{}.json", output.provider_id));
-    let creds = AnyProviderCredentials::ApiKey(ApiKeyCredentials {
-        provider: output.provider_id.clone(),
-        api_key: output.credential.clone(),
-    });
-    let creds_json = serde_json::to_string_pretty(&creds)?;
-    std::fs::write(&cred_file, creds_json)
-        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", cred_file.display(), e))?;
+    let models_path = merge_and_write_models(config_path, output)?;
+    let cred_file = write_provider_credentials(config_path, output)?;
+    let master_config_path = create_master_agent_config(config_path)?;
+    let agents_json_path = register_master_in_agents_json(config_path)?;
 
     println!(
-        "✅ Configuration written:\n   models: {}\n   credentials: {}",
+        "✅ Configuration written:\n   models: {}\n   credentials: {}\n   agent: {}\n   agents registry: {}",
         models_path.display(),
-        cred_file.display()
+        cred_file.display(),
+        master_config_path.display(),
+        agents_json_path.display()
     );
     Ok(())
+}
+
+/// Create master agent directory and config.json.
+///
+/// If `config.json` already exists, it is not overwritten (idempotent).
+fn create_master_agent_config(config_path: &Path) -> anyhow::Result<PathBuf> {
+    let agents_dir = config_path.join("agents").join("master");
+    let master_config_path = agents_dir.join("config.json");
+    if !master_config_path.exists() {
+        std::fs::create_dir_all(&agents_dir)
+            .map_err(|e| anyhow::anyhow!("failed to create agent dir: {}", e))?;
+        let master_config = AgentConfig {
+            id: "master".to_string(),
+            ..AgentConfig::default()
+        };
+        master_config
+            .save(&master_config_path)
+            .map_err(|e| anyhow::anyhow!("failed to write master config: {}", e))?;
+    }
+    Ok(master_config_path)
+}
+
+/// Read or create agents.json, then register `"master"` in it.
+///
+/// If agents.json already contains `"master"`, no duplicate is added (idempotent).
+fn register_master_in_agents_json(config_path: &Path) -> anyhow::Result<PathBuf> {
+    let agents_config_dir = config_path.join("config");
+    std::fs::create_dir_all(&agents_config_dir)
+        .map_err(|e| anyhow::anyhow!("failed to create config dir: {}", e))?;
+    let agents_json_path = agents_config_dir.join("agents.json");
+    let mut agents_config: AgentsConfig = if agents_json_path.exists() {
+        let content = std::fs::read_to_string(&agents_json_path)
+            .map_err(|e| anyhow::anyhow!("failed to read agents.json: {}", e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("failed to parse agents.json: {}", e))?
+    } else {
+        AgentsConfig::default()
+    };
+    if !agents_config.agents.contains(&"master".to_string()) {
+        agents_config.agents.push("master".to_string());
+    }
+    let agents_json = serde_json::to_string_pretty(&agents_config)
+        .map_err(|e| anyhow::anyhow!("failed to serialize agents.json: {}", e))?;
+    std::fs::write(&agents_json_path, agents_json)
+        .map_err(|e| anyhow::anyhow!("failed to write agents.json: {}", e))?;
+    Ok(agents_json_path)
 }
 
 /// Write wizard output to config files in the default config directory.

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -472,3 +472,156 @@ mod credentials_path_tests {
         );
     }
 }
+
+// -----------------------------------------------------------------
+// Step 1.2: master agent creation tests
+// -----------------------------------------------------------------
+
+#[cfg(test)]
+mod master_agent_tests {
+    use super::*;
+    use crate::agent::config::AgentConfig;
+    use crate::config::agents::AgentsConfig;
+    use tempfile::TempDir;
+
+    fn make_wizard_output() -> WizardOutput {
+        WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "test-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "MiniMax-M2.7".to_string(),
+                name: "MiniMax M2.7".to_string(),
+                context_window: 1000,
+                max_tokens: 1000,
+                default_temperature: None,
+                reasoning: false,
+                input_types: vec![],
+            }],
+        }
+    }
+
+    #[test]
+    fn test_wizard_creates_master_agent_config() {
+        let tmp = TempDir::new().unwrap();
+        let output = make_wizard_output();
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        let master_config_path = tmp.path().join("agents").join("master").join("config.json");
+        assert!(
+            master_config_path.exists(),
+            "agents/master/config.json should exist after wizard run"
+        );
+
+        let config = AgentConfig::load(&master_config_path)
+            .expect("master config.json should be valid AgentConfig");
+        assert_eq!(config.id, "master");
+    }
+
+    #[test]
+    fn test_wizard_registers_master_in_agents_json() {
+        let tmp = TempDir::new().unwrap();
+        let output = make_wizard_output();
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        let agents_json_path = tmp.path().join("config").join("agents.json");
+        assert!(
+            agents_json_path.exists(),
+            "config/agents.json should exist after wizard run"
+        );
+
+        let content = std::fs::read_to_string(&agents_json_path).unwrap();
+        let agents_config: AgentsConfig =
+            serde_json::from_str(&content).expect("agents.json should be valid JSON");
+        assert!(
+            agents_config.agents.contains(&"master".to_string()),
+            "agents.json should contain 'master', got: {:?}",
+            agents_config.agents
+        );
+    }
+
+    #[test]
+    fn test_wizard_idempotent_master_agent() {
+        let tmp = TempDir::new().unwrap();
+
+        // Manually create master config with custom content
+        let master_dir = tmp.path().join("agents").join("master");
+        std::fs::create_dir_all(&master_dir).unwrap();
+        let master_config_path = master_dir.join("config.json");
+        let custom_config = AgentConfig {
+            id: "master".to_string(),
+            name: Some("My Custom Agent".to_string()),
+            ..AgentConfig::default()
+        };
+        custom_config.save(&master_config_path).unwrap();
+
+        // Run wizard
+        let output = make_wizard_output();
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        // Verify: config.json should NOT be overwritten
+        let loaded = AgentConfig::load(&master_config_path).unwrap();
+        assert_eq!(
+            loaded.name.as_deref(),
+            Some("My Custom Agent"),
+            "existing master config.json should not be overwritten by wizard"
+        );
+    }
+
+    #[test]
+    fn test_wizard_idempotent_agents_json() {
+        let tmp = TempDir::new().unwrap();
+
+        // Manually create agents.json with master already registered
+        let agents_config_dir = tmp.path().join("config");
+        std::fs::create_dir_all(&agents_config_dir).unwrap();
+        let agents_json_path = agents_config_dir.join("agents.json");
+        let initial = AgentsConfig {
+            agents: vec!["master".to_string()],
+        };
+        let json = serde_json::to_string_pretty(&initial).unwrap();
+        std::fs::write(&agents_json_path, json).unwrap();
+
+        // Run wizard
+        let output = make_wizard_output();
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        // Verify: master should appear exactly once
+        let content = std::fs::read_to_string(&agents_json_path).unwrap();
+        let agents_config: AgentsConfig = serde_json::from_str(&content).unwrap();
+        let master_count = agents_config
+            .agents
+            .iter()
+            .filter(|id| id.as_str() == "master")
+            .count();
+        assert_eq!(
+            master_count, 1,
+            "master should appear exactly once in agents.json, got {}",
+            master_count
+        );
+    }
+
+    #[test]
+    fn test_wizard_invalid_agents_json_returns_error() {
+        let tmp = TempDir::new().unwrap();
+
+        // Manually create agents.json with invalid JSON
+        let agents_config_dir = tmp.path().join("config");
+        std::fs::create_dir_all(&agents_config_dir).unwrap();
+        let agents_json_path = agents_config_dir.join("agents.json");
+        std::fs::write(&agents_json_path, "not valid json {{{").unwrap();
+
+        // Run wizard — should return an error
+        let output = make_wizard_output();
+        let result = write_wizard_config_to(&output, tmp.path());
+        assert!(
+            result.is_err(),
+            "invalid agents.json should cause an error, got Ok",
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("agents.json"),
+            "error message should mention agents.json, got: {}",
+            err_msg,
+        );
+    }
+}


### PR DESCRIPTION
feat: create master agent config during CLI wizard setup

Add master agent directory creation and agents.json registration
to write_wizard_config_to(), ensuring idempotent behavior on
re-runs. Includes unit tests and error handling improvements.

Source: user
Type: feat
