### PR TITLE
refactor: AgentRegistry 架构对齐——添加配置存储和查询能力

### DIFF
--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -1,0 +1,110 @@
+use crate::agent::config::SubagentsConfig;
+use crate::agent::registry::AgentRegistry;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::session::bootstrap::BootstrapMode;
+
+/// Helper: build a minimal `ResolvedAgentConfig` for tests.
+fn make_config(id: &str) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: None,
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        source: ConfigSource::User,
+    }
+}
+
+#[tokio::test]
+async fn test_populate_and_get_config() {
+    let registry = AgentRegistry::new(30);
+    let configs = vec![make_config("agent-a"), make_config("agent-b")];
+
+    registry.populate(configs).await;
+
+    let a = registry.get_config("agent-a").await;
+    assert!(a.is_some(), "agent-a should be found after populate");
+    assert_eq!(a.unwrap().id, "agent-a");
+
+    let b = registry.get_config("agent-b").await;
+    assert!(b.is_some(), "agent-b should be found after populate");
+    assert_eq!(b.unwrap().id, "agent-b");
+}
+
+#[tokio::test]
+async fn test_get_config_not_found() {
+    let registry = AgentRegistry::new(30);
+    registry.populate(vec![make_config("existing")]).await;
+
+    let result = registry.get_config("nonexistent").await;
+    assert!(result.is_none(), "querying a missing id should return None");
+}
+
+#[tokio::test]
+async fn test_reload_config() {
+    let registry = AgentRegistry::new(30);
+
+    // Populate with old data.
+    registry.populate(vec![make_config("old-agent")]).await;
+    assert!(
+        registry.get_config("old-agent").await.is_some(),
+        "old-agent should exist before reload"
+    );
+
+    // Reload with new data that does NOT include old-agent.
+    registry.reload_config(vec![make_config("new-agent")]).await;
+
+    assert!(
+        registry.get_config("old-agent").await.is_none(),
+        "old-agent should be gone after reload"
+    );
+    let new = registry.get_config("new-agent").await;
+    assert!(new.is_some(), "new-agent should be present after reload");
+    assert_eq!(new.unwrap().id, "new-agent");
+}
+
+#[tokio::test]
+async fn test_populate_empty() {
+    let registry = AgentRegistry::new(30);
+
+    // Should not panic on empty input.
+    registry.populate(vec![]).await;
+
+    assert!(
+        registry.get_config("anything").await.is_none(),
+        "empty populate should leave registry empty"
+    );
+}
+
+#[tokio::test]
+async fn test_reload_config_preserves_existing() {
+    let registry = AgentRegistry::new(30);
+
+    registry
+        .populate(vec![make_config("keep"), make_config("drop")])
+        .await;
+
+    // Reload: only "keep" and a new agent "added" exist.
+    registry
+        .reload_config(vec![make_config("keep"), make_config("added")])
+        .await;
+
+    assert!(
+        registry.get_config("keep").await.is_some(),
+        "'keep' should survive reload"
+    );
+    assert!(
+        registry.get_config("drop").await.is_none(),
+        "'drop' should be removed by reload"
+    );
+    assert!(
+        registry.get_config("added").await.is_some(),
+        "'added' should be present after reload"
+    );
+}

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -7,6 +7,7 @@ pub mod query;
 
 use crate::agent::process::{AgentProcess, AgentProcessHandle};
 use crate::agent::Agent;
+use crate::config::agents::ResolvedAgentConfig;
 use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
@@ -37,6 +38,8 @@ pub struct AgentRegistry {
     pub(super) agents: RwLock<HashMap<String, Agent>>,
     /// Map of agent ID to running process handle
     pub(super) processes: RwLock<HashMap<String, AgentProcessHandle>>,
+    /// Map of agent ID to resolved agent config (read-only query layer)
+    pub(super) configs: RwLock<HashMap<String, ResolvedAgentConfig>>,
 }
 
 impl Default for AgentRegistry {
@@ -62,6 +65,32 @@ impl AgentRegistry {
         Self {
             agents: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
+            configs: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Populate the config store with the given resolved agent configs.
+    /// Called once at startup by Daemon after ConfigManager loads agents.
+    pub async fn populate(&self, configs: Vec<ResolvedAgentConfig>) {
+        let mut map = self.configs.write().await;
+        for cfg in configs {
+            map.insert(cfg.id.clone(), cfg);
+        }
+    }
+
+    /// Look up a resolved agent config by ID.
+    /// Returns `None` if no config with the given ID exists.
+    pub async fn get_config(&self, id: &str) -> Option<ResolvedAgentConfig> {
+        let map = self.configs.read().await;
+        map.get(id).cloned()
+    }
+
+    /// Replace all stored configs with the given set (hot-reload).
+    pub async fn reload_config(&self, configs: Vec<ResolvedAgentConfig>) {
+        let mut map = self.configs.write().await;
+        map.clear();
+        for cfg in configs {
+            map.insert(cfg.id.clone(), cfg);
         }
     }
 }

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -104,11 +104,4 @@ pub fn create_registry(heartbeat_timeout_secs: i64) -> SharedAgentRegistry {
 }
 
 #[cfg(test)]
-mod tests {
-    // Note: state-machine tests (`test_state_transition_validation` /
-    // `test_graceful_shutdown_config`) were removed in Step 1.3 along
-    // with the registry's `update_state` API and the `wait_timeout_secs`
-    // / `grace_period_secs` knobs. The `AgentState` machine itself still
-    // lives in `crate::agent::state` and is exercised by its own unit
-    // tests.
-}
+mod config_tests;

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -4,6 +4,7 @@
 //! Watches individual config JSON files and the agents/ directory, triggering
 //! incremental or full reloads on the ConfigManager.
 
+use crate::agent::registry::AgentRegistry;
 use crate::config::manager::{ConfigManager, ConfigSection};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::{Path, PathBuf};
@@ -81,23 +82,35 @@ fn setup_watcher(
     Ok((watcher, rx))
 }
 
-/// Reload all agent configs and log the result.
-fn reload_agents_with_log(path: &std::path::Path, cm: &ConfigManager) {
+/// Reload all agent configs and sync the AgentRegistry.
+async fn reload_agents_with_log(
+    path: &std::path::Path,
+    cm: &ConfigManager,
+    agent_registry: &AgentRegistry,
+) {
     info!(
         path = %path.display(),
         "agent config change detected, reloading agents"
     );
     if let Err(e) = cm.reload_agents() {
         tracing::warn!(error = %e, "failed to reload agent configs");
+        return;
     }
+    // Sync the new configs into AgentRegistry (design-doc hot-reload path).
+    let configs: Vec<_> = cm.agents().into_iter().map(|(_, c)| c).collect();
+    agent_registry.reload_config(configs).await;
 }
 
 /// Handle a single changed file path: reload agents or the matching section.
-async fn handle_changed_path(path: &std::path::Path, cm: &ConfigManager) {
+async fn handle_changed_path(
+    path: &std::path::Path,
+    cm: &ConfigManager,
+    agent_registry: &AgentRegistry,
+) {
     let path_str = path.to_string_lossy();
 
     if path_str.contains("/agents/") || path_str.contains("\\agents\\") {
-        reload_agents_with_log(path, cm);
+        reload_agents_with_log(path, cm, agent_registry).await;
         return;
     }
 
@@ -107,7 +120,7 @@ async fn handle_changed_path(path: &std::path::Path, cm: &ConfigManager) {
     };
 
     if filename == "agents.json" {
-        reload_agents_with_log(path, cm);
+        reload_agents_with_log(path, cm, agent_registry).await;
         return;
     }
 
@@ -143,6 +156,7 @@ async fn handle_changed_path(path: &std::path::Path, cm: &ConfigManager) {
 fn spawn_event_consumer(
     mut rx: mpsc::Receiver<notify::Result<Event>>,
     config_manager: Arc<ConfigManager>,
+    agent_registry: Arc<AgentRegistry>,
 ) {
     tokio::spawn(async move {
         let debounce = Duration::from_millis(500);
@@ -169,7 +183,7 @@ fn spawn_event_consumer(
             last_reload = now;
 
             for path in &event.paths {
-                handle_changed_path(path, &config_manager).await;
+                handle_changed_path(path, &config_manager, &agent_registry).await;
             }
         }
     });
@@ -182,9 +196,10 @@ fn spawn_event_consumer(
 pub(crate) fn init_config_hot_reload(
     config_dir: &str,
     config_manager: Arc<ConfigManager>,
+    agent_registry: Arc<AgentRegistry>,
 ) -> anyhow::Result<ConfigWatcherHandle> {
     let (watcher, rx) = setup_watcher(config_dir)?;
-    spawn_event_consumer(rx, Arc::clone(&config_manager));
+    spawn_event_consumer(rx, Arc::clone(&config_manager), Arc::clone(&agent_registry));
 
     let config_path = Path::new(config_dir);
     let agents_dir = config_path.join("agents");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -30,7 +30,7 @@ use crate::session::storage::SqliteStorage;
 use crate::session::sweeper::ArchiveSweeper;
 use crate::skills::builtin::builtin_skills_with_engine_and_approval_flow;
 use crate::skills::{DiskSkillRegistry, SkillWatcherHandle};
-use crate::tools::builtin::register_builtin_tools;
+use crate::tools::builtin::{register_builtin_tools, BuiltinToolContext};
 use crate::tools::ToolRegistry;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -292,16 +292,15 @@ impl Daemon {
                     Arc::clone(&config_manager),
                     Arc::clone(&session_manager),
                 ));
-                register_builtin_tools(
-                    &tool_registry,
-                    disk_reg,
-                    Arc::clone(&permission_engine),
+                let builtin_ctx = Arc::new(BuiltinToolContext {
+                    config_manager: Arc::clone(&config_manager),
+                    agent_registry: Arc::clone(&agent_registry),
+                    disk_registry: disk_reg,
+                    permission_engine: Arc::clone(&permission_engine),
                     spawn_controller,
-                    Arc::clone(&session_manager),
-                    Arc::clone(&config_manager),
-                    Arc::clone(&agent_registry),
-                )
-                .await;
+                    session_manager: Arc::clone(&session_manager),
+                });
+                register_builtin_tools(&tool_registry, builtin_ctx).await;
             }
         }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -70,7 +70,7 @@ mod llm_init;
 /// Global daemon state
 pub struct Daemon {
     pub gateway: Arc<Gateway>,
-    pub agent_registry: Arc<RwLock<crate::agent::registry::AgentRegistry>>,
+    pub agent_registry: Arc<crate::agent::registry::AgentRegistry>,
     pub permission_engine: Arc<PermissionEngine>,
     pub shutdown: shutdown::ShutdownHandle,
     /// SQLite storage for session persistence
@@ -163,7 +163,7 @@ impl Daemon {
             sweeper_for_task.run(sweeper_rx).await;
         });
         info!("ArchiveSweeper spawned");
-        let agent_registry = Arc::new(RwLock::new(crate::agent::registry::AgentRegistry::new(30)));
+        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
         info!("Agent registry initialized",);
         let gateway_config = GatewayConfig {
             name: "closeclaw".to_string(),
@@ -249,15 +249,33 @@ impl Daemon {
                     );
                 }
 
+                // Populate AgentRegistry with resolved configs from ConfigManager.
+                // This fulfills the design-doc startup flow:
+                //   ConfigManager.load_agents() → AgentRegistry.populate()
+                {
+                    let configs: Vec<_> = config_manager
+                        .agents()
+                        .into_iter()
+                        .map(|(_, c)| c)
+                        .collect();
+                    agent_registry.populate(configs).await;
+                }
+
                 // Pass config_manager to SessionManager for agent tool/skill filtering.
                 session_manager
                     .set_config_manager(Arc::clone(&config_manager))
+                    .await;
+
+                // Pass agent_registry to SessionManager for design-doc config queries.
+                session_manager
+                    .set_agent_registry(Arc::clone(&agent_registry))
                     .await;
 
                 // Initialize config hot-reload: watch JSON files + agents/ dir
                 config_watcher = match config_reload::init_config_hot_reload(
                     config_dir,
                     Arc::clone(&config_manager),
+                    Arc::clone(&agent_registry),
                 ) {
                     Ok(handle) => Some(handle),
                     Err(e) => {
@@ -281,6 +299,7 @@ impl Daemon {
                     spawn_controller,
                     Arc::clone(&session_manager),
                     Arc::clone(&config_manager),
+                    Arc::clone(&agent_registry),
                 )
                 .await;
             }

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -67,6 +67,8 @@ pub struct SessionManager {
     key_registry: RwLock<HashMap<String, String>>,
     /// Config manager for looking up agent-level tool/skill filtering.
     config_manager: RwLock<Option<Arc<ConfigManager>>>,
+    /// Agent registry for looking up resolved agent configs (design-doc query layer).
+    agent_registry: RwLock<Option<Arc<crate::agent::registry::AgentRegistry>>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -103,6 +105,7 @@ impl SessionManager {
             channel_active_sessions: RwLock::new(HashMap::new()),
             key_registry: RwLock::new(HashMap::new()),
             config_manager: RwLock::new(None),
+            agent_registry: RwLock::new(None),
         }
     }
 
@@ -111,13 +114,21 @@ impl SessionManager {
         *self.config_manager.write().await = Some(config_manager);
     }
 
-    /// Look up agent config by ID from the config manager.
+    /// Set the agent registry for resolved config lookups.
+    pub async fn set_agent_registry(
+        &self,
+        agent_registry: Arc<crate::agent::registry::AgentRegistry>,
+    ) {
+        *self.agent_registry.write().await = Some(agent_registry);
+    }
+
+    /// Look up agent config by ID via the AgentRegistry.
     async fn get_agent_config(
         &self,
         agent_id: &str,
     ) -> Option<crate::config::agents::ResolvedAgentConfig> {
-        let guard = self.config_manager.read().await;
-        guard.as_ref()?.agent(agent_id)
+        let guard = self.agent_registry.read().await;
+        guard.as_ref()?.get_config(agent_id).await
     }
 
     /// Set priority prompt overrides.

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -298,6 +298,7 @@ async fn test_find_or_create_with_tool_registry() {
             .expect("failed to create ConfigManager for test"),
     );
     let spawn_controller = Arc::new(SpawnController::new(Arc::clone(&cfg_mgr), Arc::clone(&mgr)));
+    let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
     register_builtin_tools(
         &tool_registry,
         disk_reg,
@@ -305,6 +306,7 @@ async fn test_find_or_create_with_tool_registry() {
         spawn_controller,
         Arc::clone(&mgr),
         Arc::clone(&cfg_mgr),
+        agent_registry,
     )
     .await;
     mgr.set_tool_registry(tool_registry).await;

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -269,7 +269,7 @@ async fn test_find_or_create_with_tool_registry() {
     use crate::permission::engine::engine_eval::PermissionEngine;
     use crate::permission::rules::RuleSetBuilder;
     use crate::skills::DiskSkillRegistry;
-    use crate::tools::builtin::register_builtin_tools;
+    use crate::tools::builtin::{register_builtin_tools, BuiltinToolContext};
     use crate::tools::ToolRegistry;
 
     clear_global_prompt_state();
@@ -299,16 +299,15 @@ async fn test_find_or_create_with_tool_registry() {
     );
     let spawn_controller = Arc::new(SpawnController::new(Arc::clone(&cfg_mgr), Arc::clone(&mgr)));
     let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
-    register_builtin_tools(
-        &tool_registry,
-        disk_reg,
-        perm_engine,
-        spawn_controller,
-        Arc::clone(&mgr),
-        Arc::clone(&cfg_mgr),
+    let builtin_ctx = Arc::new(BuiltinToolContext {
+        config_manager: Arc::clone(&cfg_mgr),
         agent_registry,
-    )
-    .await;
+        disk_registry: disk_reg,
+        permission_engine: perm_engine,
+        spawn_controller,
+        session_manager: Arc::clone(&mgr),
+    });
+    register_builtin_tools(&tool_registry, builtin_ctx).await;
     mgr.set_tool_registry(tool_registry).await;
 
     let msg = test_message();

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -50,7 +50,7 @@ mod tests {
     use crate::session::bootstrap::BootstrapMode;
     use crate::session::persistence::ReasoningLevel;
     use crate::skills::DiskSkillRegistry;
-    use crate::tools::builtin::register_builtin_tools;
+    use crate::tools::builtin::{register_builtin_tools, BuiltinToolContext};
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -95,6 +95,24 @@ mod tests {
         (spawn_controller, session_manager, cfg_mgr, agent_registry)
     }
 
+    fn make_builtin_ctx(
+        disk_registry: Arc<DiskSkillRegistry>,
+        permission_engine: Arc<PermissionEngine>,
+        spawn_controller: Arc<SpawnController>,
+        session_manager: Arc<SessionManager>,
+        config_manager: Arc<ConfigManager>,
+        agent_registry: Arc<crate::agent::registry::AgentRegistry>,
+    ) -> Arc<BuiltinToolContext> {
+        Arc::new(BuiltinToolContext {
+            config_manager,
+            agent_registry,
+            disk_registry,
+            permission_engine,
+            spawn_controller,
+            session_manager,
+        })
+    }
+
     #[tokio::test]
     async fn test_build_tools_section_returns_tools_section() {
         let registry = ToolRegistry::new();
@@ -102,12 +120,14 @@ mod tests {
         let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
-            disk_registry,
-            test_permission_engine(),
-            spawn_controller,
-            session_manager,
-            config_manager,
-            agent_registry,
+            make_builtin_ctx(
+                disk_registry,
+                test_permission_engine(),
+                spawn_controller,
+                session_manager,
+                config_manager,
+                agent_registry,
+            ),
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -131,12 +151,14 @@ mod tests {
         let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
-            disk_registry,
-            test_permission_engine(),
-            spawn_controller,
-            session_manager,
-            config_manager,
-            agent_registry,
+            make_builtin_ctx(
+                disk_registry,
+                test_permission_engine(),
+                spawn_controller,
+                session_manager,
+                config_manager,
+                agent_registry,
+            ),
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -166,12 +188,14 @@ mod tests {
         let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
-            disk_registry,
-            test_permission_engine(),
-            spawn_controller,
-            session_manager,
-            config_manager,
-            agent_registry,
+            make_builtin_ctx(
+                disk_registry,
+                test_permission_engine(),
+                spawn_controller,
+                session_manager,
+                config_manager,
+                agent_registry,
+            ),
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -211,12 +235,14 @@ mod tests {
         let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
-            disk_registry,
-            test_permission_engine(),
-            spawn_controller,
-            session_manager,
-            config_manager,
-            agent_registry,
+            make_builtin_ctx(
+                disk_registry,
+                test_permission_engine(),
+                spawn_controller,
+                session_manager,
+                config_manager,
+                agent_registry,
+            ),
         )
         .await;
         let ctx = crate::tools::ToolContext {

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -66,6 +66,7 @@ mod tests {
         Arc<SpawnController>,
         Arc<SessionManager>,
         Arc<ConfigManager>,
+        Arc<crate::agent::registry::AgentRegistry>,
     ) {
         let tmp = TempDir::new().expect("tempdir for test");
         let cfg_mgr = Arc::new(
@@ -90,14 +91,15 @@ mod tests {
             Arc::clone(&cfg_mgr),
             Arc::clone(&session_manager),
         ));
-        (spawn_controller, session_manager, cfg_mgr)
+        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+        (spawn_controller, session_manager, cfg_mgr, agent_registry)
     }
 
     #[tokio::test]
     async fn test_build_tools_section_returns_tools_section() {
         let registry = ToolRegistry::new();
         let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let (spawn_controller, session_manager, config_manager) = test_spawn_deps();
+        let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
             disk_registry,
@@ -105,6 +107,7 @@ mod tests {
             spawn_controller,
             session_manager,
             config_manager,
+            agent_registry,
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -125,7 +128,7 @@ mod tests {
     async fn test_build_tools_section_contains_group_headers() {
         let registry = ToolRegistry::new();
         let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let (spawn_controller, session_manager, config_manager) = test_spawn_deps();
+        let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
             disk_registry,
@@ -133,6 +136,7 @@ mod tests {
             spawn_controller,
             session_manager,
             config_manager,
+            agent_registry,
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -159,7 +163,7 @@ mod tests {
     async fn test_build_tools_section_contains_tool_names() {
         let registry = ToolRegistry::new();
         let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let (spawn_controller, session_manager, config_manager) = test_spawn_deps();
+        let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
             disk_registry,
@@ -167,6 +171,7 @@ mod tests {
             spawn_controller,
             session_manager,
             config_manager,
+            agent_registry,
         )
         .await;
         let ctx = crate::tools::ToolContext {
@@ -203,7 +208,7 @@ mod tests {
     async fn test_build_tools_section_respects_max_length() {
         let registry = ToolRegistry::new();
         let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
-        let (spawn_controller, session_manager, config_manager) = test_spawn_deps();
+        let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
         register_builtin_tools(
             &registry,
             disk_registry,
@@ -211,6 +216,7 @@ mod tests {
             spawn_controller,
             session_manager,
             config_manager,
+            agent_registry,
         )
         .await;
         let ctx = crate::tools::ToolContext {

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -36,6 +36,19 @@ use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::skills::DiskSkillRegistry;
 
+/// Shared dependencies for built-in tool registration.
+///
+/// Bundles the common `Arc` handles so that [`register_builtin_tools`]
+/// stays within the 6-parameter limit defined in CONTRIBUTING.md.
+pub struct BuiltinToolContext {
+    pub config_manager: Arc<crate::config::ConfigManager>,
+    pub agent_registry: Arc<crate::agent::registry::AgentRegistry>,
+    pub disk_registry: Arc<DiskSkillRegistry>,
+    pub permission_engine: Arc<PermissionEngine>,
+    pub spawn_controller: Arc<SpawnController>,
+    pub session_manager: Arc<SessionManager>,
+}
+
 /// Registers all built-in tools with the given registry.
 ///
 /// Currently registers 19 tools:
@@ -72,12 +85,7 @@ use crate::skills::DiskSkillRegistry;
 /// - [`SkillTool`]
 pub async fn register_builtin_tools(
     registry: &crate::tools::ToolRegistry,
-    disk_registry: Arc<DiskSkillRegistry>,
-    permission_engine: Arc<PermissionEngine>,
-    spawn_controller: Arc<SpawnController>,
-    session_manager: Arc<SessionManager>,
-    config_manager: Arc<crate::config::ConfigManager>,
-    agent_registry: Arc<crate::agent::registry::AgentRegistry>,
+    context: Arc<BuiltinToolContext>,
 ) {
     // file_ops
     registry.register(ReadTool::new()).await.ok();
@@ -100,35 +108,35 @@ pub async fn register_builtin_tools(
     // bash
     let bg_manager = Arc::new(crate::tasks::BackgroundTaskManager::new());
     registry
-        .register(BashTool::new(permission_engine.clone(), bg_manager))
+        .register(BashTool::new(context.permission_engine.clone(), bg_manager))
         .await
         .ok();
     // skills
     registry
         .register(SkillTool::new(
-            disk_registry,
-            spawn_controller.clone(),
-            session_manager.clone(),
+            context.disk_registry.clone(),
+            context.spawn_controller.clone(),
+            context.session_manager.clone(),
         ))
         .await
         .ok();
     // sessions
     registry
         .register(SessionsSpawnTool::new(
-            spawn_controller,
-            session_manager.clone(),
-            permission_engine.clone(),
-            config_manager,
-            agent_registry,
+            context.spawn_controller.clone(),
+            context.session_manager.clone(),
+            context.permission_engine.clone(),
+            context.config_manager.clone(),
+            context.agent_registry.clone(),
         ))
         .await
         .ok();
     registry
-        .register(SessionsSteerTool::new(session_manager.clone()))
+        .register(SessionsSteerTool::new(context.session_manager.clone()))
         .await
         .ok();
     registry
-        .register(SessionsKillTool::new(session_manager))
+        .register(SessionsKillTool::new(context.session_manager.clone()))
         .await
         .ok();
 }

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -77,6 +77,7 @@ pub async fn register_builtin_tools(
     spawn_controller: Arc<SpawnController>,
     session_manager: Arc<SessionManager>,
     config_manager: Arc<crate::config::ConfigManager>,
+    agent_registry: Arc<crate::agent::registry::AgentRegistry>,
 ) {
     // file_ops
     registry.register(ReadTool::new()).await.ok();
@@ -118,6 +119,7 @@ pub async fn register_builtin_tools(
             session_manager.clone(),
             permission_engine.clone(),
             config_manager,
+            agent_registry,
         ))
         .await
         .ok();

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -1,6 +1,7 @@
 //! Built-in sessions_spawn tool — creates child sessions for sub-agents.
 
 use crate::agent::prompt_template::PromptTemplate;
+use crate::agent::registry::AgentRegistry;
 use crate::agent::spawn::SpawnController;
 use crate::config::ConfigManager;
 use crate::gateway::session_manager::{SessionManager, SpawnMode};
@@ -21,6 +22,7 @@ pub struct SessionsSpawnTool {
     session_manager: Arc<SessionManager>,
     permission_engine: Arc<PermissionEngine>,
     config_manager: Arc<ConfigManager>,
+    agent_registry: Arc<AgentRegistry>,
 }
 
 /// Parsed arguments for a `sessions_spawn` tool call.
@@ -44,12 +46,14 @@ impl SessionsSpawnTool {
         session_manager: Arc<SessionManager>,
         permission_engine: Arc<PermissionEngine>,
         config_manager: Arc<ConfigManager>,
+        agent_registry: Arc<AgentRegistry>,
     ) -> Self {
         Self {
             spawn_controller,
             session_manager,
             permission_engine,
             config_manager,
+            agent_registry,
         }
     }
 
@@ -292,10 +296,14 @@ impl Tool for SessionsSpawnTool {
         // Look up the parent agent's subagents.model config
         // (used as priority level 2 in the model priority chain).
         let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
-        let parent_subagents_model = parent_agent_id
-            .as_ref()
-            .and_then(|id| self.config_manager.agent(id))
-            .and_then(|c| c.subagents.model.clone());
+        let parent_subagents_model = match &parent_agent_id {
+            Some(id) => self
+                .agent_registry
+                .get_config(id)
+                .await
+                .and_then(|c| c.subagents.model.clone()),
+            None => None,
+        };
         let parent_depth = self
             .session_manager
             .get_session_depth(parent_session_id)

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -69,7 +69,8 @@ fn make_tool() -> SessionsSpawnTool {
     let sm = Arc::new(make_session_manager());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
     let pe = Arc::new(make_permission_engine());
-    SessionsSpawnTool::new(controller, sm, pe, cm)
+    let ar = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+    SessionsSpawnTool::new(controller, sm, pe, cm, ar)
 }
 
 /// A `ToolContext` with `session_id = None` — used to exercise the


### PR DESCRIPTION
## AgentRegistry 架构对齐：添加配置存储和查询能力

### 背景

AgentRegistry 的代码实现与设计文档 `docs/design/agent/agent-registry.md` 存在架构级不一致：
- **文档定义**：AgentRegistry 是运行时配置查询入口，以 `agent_id` 为键提供 `ResolvedAgentConfig` 的只读查找，不管理 agent 生命周期。
- **代码现状**：AgentRegistry 存储运行时元数据和进程句柄，负责生命周期管理。配置查询散落在 `ConfigManager::agent()` 中。

### 变更内容

1. **配置存储层**：给 `AgentRegistry` 添加 `configs: RwLock<HashMap<String, ResolvedAgentConfig>>` 字段，实现 `populate()` / `get_config()` / `reload_config()` 接口
2. **Daemon 填充**：启动时调用 `AgentRegistry::populate()` 一次性填充配置，替代分散的直接调用
3. **消费模块迁移**：`sessions_spawn` 和 `session_manager` 改用 `AgentRegistry::get_config()` 查询配置
4. **热重载接通**：Config Agent 配置变更 → `ConfigManager.reload_agents()` → `AgentRegistry.reload_config()` 自动更新
5. **参数超限修复**：将 `register_builtin_tools` 参数从 7 个减至 2 个，通过 `BuiltinToolContext` struct 合并依赖

### 改动文件

- `src/agent/registry/mod.rs` — 添加配置存储字段和查询方法
- `src/agent/registry/config_tests.rs` — 新增单元测试
- `src/daemon/mod.rs` — 启动流程调用 populate
- `src/daemon/config_reload.rs` — 热重载路径接通 reload_config
- `src/tools/builtin/mod.rs` — 定义 BuiltinToolContext，精简参数
- `src/tools/builtin/sessions_spawn.rs` — 改用 AgentRegistry 查询配置
- `src/gateway/session_manager.rs` — 改用 AgentRegistry 查询配置
- `src/system_prompt/tools_section.rs` — 适配 BuiltinToolContext

### 验收标准

- 编译通过（`cargo build`）
- 测试通过（`cargo test`）
- AgentRegistry 包含配置存储和查询能力
- 下游模块通过 AgentRegistry 获取配置

Source: design-doc
Type: refactor
