### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "path": "/home/admin/code/closeclaw/docs/design/STANDARDS.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-16T01:12:47.991586+08:00",
+    "comment": "blocked: meta-doc violates own red-lines and structure rules"
+  }
+]


### PR DESCRIPTION
操作文档：docs/design/STANDARDS.md
操作类型：blocked
原因：已将该文档标记为 blocked，记录同步更新。