### PR TITLE
chore: add STANDARDS.md to ddt blacklist

### DIFF
--- a/scripts/design-doc-tracker/ddt.py
+++ b/scripts/design-doc-tracker/ddt.py
@@ -86,6 +86,7 @@ def _save_records(records: List[Dict[str, str]]) -> None:
 # Paths excluded from check output (relative to REPO_ROOT)
 BLACKLIST = frozenset({
     "docs/design/README.md",
+    "docs/design/STANDARDS.md",
 })
 
 

--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -1,9 +1,1 @@
-[
-  {
-    "path": "/home/admin/code/closeclaw/docs/design/STANDARDS.md",
-    "commit": "",
-    "commit_time": "",
-    "confirmed_time": "2026-06-16T01:12:47.991586+08:00",
-    "comment": "blocked: meta-doc violates own red-lines and structure rules"
-  }
-]
+[]


### PR DESCRIPTION
STANDARDS.md is a meta-document defining design doc writing conventions, not a product design doc. It should be permanently excluded from ddt scanning.

Changes:
- Add  to  BLACKLIST
- Remove the blocked record for STANDARDS.md from 

Fixes #1065