### PR TITLE
fix: align merge_agent_ids semantics with design doc

### DIFF
--- a/docs/design/agent/agent-config.md
+++ b/docs/design/agent/agent-config.md
@@ -19,7 +19,7 @@ Agent 权限规则存储在独立的 `permissions.json` 中，与 `config.json` 
 | `id` | agent 唯一标识 | 是 | - |
 | `name` | 显示名称 | 否 | 同 id |
 | `parentId` | 父 agent ID（agent 创建时写入，运行时不变） | 否 | null |
-| `model` | 默认 LLM 模型及 fallback 列表 | 否 | 系统默认模型 |
+| `model` | 默认 LLM 模型标识（单个模型）。模型 fallback 链由系统级 LLM 模块（FallbackClient）管理 | 否 | 系统默认模型 |
 | `workspace` | 工作目录路径 | 否 | 系统默认 workspace |
 | `agentDir` | bootstrap 文件所在目录 | 否 | 系统默认 agent 目录 |
 | `bootstrapMode` | bootstrap 加载模式 | 否 | `"full"` |

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -50,7 +50,7 @@ impl ConfigManager {
     pub(crate) fn merge_agent_ids(user: &[String], project: &[String]) -> Vec<String> {
         let mut seen = HashSet::new();
         let mut merged = Vec::new();
-        for id in user.iter().chain(project.iter()) {
+        for id in project.iter().chain(user.iter()) {
             if seen.insert(id.clone()) {
                 merged.push(id.clone());
             }

--- a/src/config/agent_loader_tests.rs
+++ b/src/config/agent_loader_tests.rs
@@ -96,6 +96,43 @@ fn test_merge_agent_ids_both_empty() {
     assert!(merged.is_empty());
 }
 
+/// When user list is empty, merged result equals project list.
+#[test]
+fn test_merge_agent_ids_empty_user() {
+    let user: Vec<String> = vec![];
+    let project = vec!["x".to_string(), "y".to_string()];
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+    assert_eq!(merged, vec!["x", "y"]);
+}
+
+/// Completely disjoint lists — all IDs from both are preserved,
+/// project IDs first, then user IDs.
+#[test]
+fn test_merge_agent_ids_disjoint() {
+    let user = vec!["u1".to_string(), "u2".to_string()];
+    let project = vec!["p1".to_string(), "p2".to_string()];
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+    assert_eq!(merged.len(), 4, "should have 4 unique IDs");
+    // project-first ordering
+    assert_eq!(merged[0], "p1");
+    assert_eq!(merged[1], "p2");
+    assert_eq!(merged[2], "u1");
+    assert_eq!(merged[3], "u2");
+}
+
+/// Same ID in both lists — project entry is kept (project-first semantics).
+#[test]
+fn test_merge_agent_ids_same_id_project_wins() {
+    let user = vec!["shared".to_string()];
+    let project = vec!["shared".to_string()];
+    let merged = ConfigManager::merge_agent_ids(&user, &project);
+    assert_eq!(merged.len(), 1, "shared ID should appear once");
+    assert_eq!(
+        merged[0], "shared",
+        "project entry should be kept (first-wins)"
+    );
+}
+
 // ===========================================================================
 // load_agents_json tests
 // ===========================================================================

--- a/src/config/agent_loader_tests.rs
+++ b/src/config/agent_loader_tests.rs
@@ -71,10 +71,11 @@ fn test_merge_agent_ids_union() {
     let merged = ConfigManager::merge_agent_ids(&user, &project);
 
     assert_eq!(merged.len(), 4, "should have 4 unique IDs");
-    assert_eq!(merged[0], "alpha");
-    assert_eq!(merged[1], "beta");
-    assert_eq!(merged[2], "gamma");
-    assert_eq!(merged[3], "delta");
+    // project-first: project yields beta, delta, alpha; then user yields gamma
+    assert_eq!(merged[0], "beta");
+    assert_eq!(merged[1], "delta");
+    assert_eq!(merged[2], "alpha");
+    assert_eq!(merged[3], "gamma");
 }
 
 /// When project list is empty, merged result equals user list.


### PR DESCRIPTION
fix: align merge_agent_ids semantics with design doc

修复 merge_agent_ids 的合并语义与设计文档不一致的问题。

**变更内容：**
1. 修改 `merge_agent_ids` 遍历顺序为 project-first，使同 ID 时项目级覆盖用户级（符合设计文档"同 ID 项目覆盖用户"）
2. 修正 design doc 中 `model` 字段描述，明确为单个模型标识，fallback 链由系统级管理
3. 更新相关测试断言，补充边界情况测试

Source: design doc
Type: fix
