### PR TITLE
docs: align permission evaluation to three-way intersection model

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -413,6 +413,18 @@ impl SessionManager {
             _ => None,
         }
     }
+
+    /// Get the sender_id (user ID) for a session from its checkpoint.
+    pub async fn get_sender_id(&self, session_id: &str) -> Option<String> {
+        let storage = self.storage.read().await;
+        let Some(storage) = storage.as_ref() else {
+            return None;
+        };
+        match storage.load_checkpoint(session_id).await {
+            Ok(Some(cp)) => cp.sender_id,
+            _ => None,
+        }
+    }
 }
 
 // Unit tests

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -133,9 +133,20 @@ impl PermissionEngine {
             "permission check initiated"
         );
 
+        let is_owner = caller.user_id == "owner";
+
         // Step 0.7: Agent effective permissions pre-check
         if let Some(response) = self.check_agent_effective_permissions(&agent_id, request.body()) {
             return response;
+        }
+
+        // Step 0.8: User effective permissions pre-check
+        if !is_owner {
+            if let Some(response) =
+                self.check_user_effective_permissions(&caller.user_id, request.body())
+            {
+                return response;
+            }
         }
 
         // Step 0: Creator rule (highest priority)
@@ -144,7 +155,6 @@ impl PermissionEngine {
         }
 
         let rules = self.rules.clone();
-        let is_owner = caller.user_id == "owner";
 
         // Step 1: Agent phase — collect AgentOnly candidates and evaluate
         let agent_candidates = self.collect_agent_candidates(&caller, &agent_id, &rules);

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -27,6 +27,9 @@ pub struct PermissionEngine {
     /// Per-agent effective permissions cache (populated by spawn validation)
     pub(crate) agent_permissions:
         std::sync::RwLock<HashMap<String, crate::agent::config::AgentPermissions>>,
+    /// Per-user effective permissions cache (populated by spawn validation)
+    pub(crate) user_effective_permissions:
+        std::sync::RwLock<HashMap<String, crate::agent::config::AgentPermissions>>,
 }
 
 // --- Construction & index management ---
@@ -41,6 +44,7 @@ impl PermissionEngine {
             templates: HashMap::new(),
             data_root,
             agent_permissions: std::sync::RwLock::new(HashMap::new()),
+            user_effective_permissions: std::sync::RwLock::new(HashMap::new()),
         };
         engine.rebuild_indices_with_rules(&rules);
         engine

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -15,7 +15,7 @@ use tracing::info;
 /// Permission Engine - evaluates access requests against rules
 pub struct PermissionEngine {
     /// RuleSet
-    rules: RuleSet,
+    pub(crate) rules: RuleSet,
     /// O(1) lookup index: agent_id -> list of rule indices
     agent_rule_index: HashMap<String, Vec<usize>>,
     /// O(1) lookup index: "{user_id}:{agent_id}" -> list of rule indices
@@ -303,7 +303,7 @@ impl PermissionEngine {
 
     /// Collect Subject::UserAndAgent candidate rule indices via user_agent_rule_index (O(1)),
     /// then via Glob fallback if no exact match (matches UserAndAgent only).
-    fn collect_user_agent_candidates(
+    pub(crate) fn collect_user_agent_candidates(
         &self,
         caller: &super::engine_types::Caller,
         agent_id: &str,
@@ -329,7 +329,7 @@ impl PermissionEngine {
     }
 
     /// Steps 3-4: Expand templates, then evaluate rules (deny-precedence).
-    fn match_rules(
+    pub(crate) fn match_rules(
         &self,
         candidates: &[usize],
         rules: &RuleSet,

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -104,4 +104,56 @@ impl super::engine_eval::PermissionEngine {
             }
         }
     }
+
+    /// Get the effective permissions for a given user from the cache.
+    ///
+    /// Returns `Some(AgentPermissions)` if the user has been previously validated
+    /// and injected into the cache, `None` if not found.
+    pub fn get_user_effective_permissions(&self, user_id: &str) -> Option<AgentPermissions> {
+        let cache = self
+            .user_effective_permissions
+            .read()
+            .expect("user_effective_permissions lock poisoned");
+        cache.get(user_id).cloned()
+    }
+
+    /// Check the user effective permissions cache for a given request body.
+    ///
+    /// Returns:
+    /// - `None` if dimension is unknown (e.g., SlashCommand) or cache miss
+    /// - `Some(Denied)` if the dimension is denied
+    /// - `None` if the dimension is allowed (continue with normal evaluate)
+    pub fn check_user_effective_permissions(
+        &self,
+        user_id: &str,
+        body: &PermissionRequestBody,
+    ) -> Option<PermissionResponse> {
+        let dim = body.dimension_name()?;
+
+        let cache = self
+            .user_effective_permissions
+            .read()
+            .expect("user_effective_permissions lock poisoned");
+
+        match cache.get(user_id) {
+            None => None, // cache miss → continue with normal evaluate
+            Some(perms) => {
+                let allowed = perms
+                    .permissions
+                    .get(dim)
+                    .map(|p| p.allowed)
+                    .unwrap_or(false);
+
+                if allowed {
+                    None // allowed → continue with normal evaluate
+                } else {
+                    Some(PermissionResponse::Denied {
+                        reason: format!("user effective permission denied for dimension '{}'", dim),
+                        rule: "<user_effective_permissions>".to_string(),
+                        risk_level: super::engine_risk::assess_risk_level(body),
+                    })
+                }
+            }
+        }
+    }
 }

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -2,6 +2,7 @@
 
 use super::engine_types::{PermissionRequestBody, PermissionResponse};
 use crate::agent::config::AgentPermissions;
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// Error type for spawn permission validation failures.
@@ -192,6 +193,106 @@ impl super::engine_eval::PermissionEngine {
                     })
                 }
             }
+        }
+    }
+}
+
+// --- User permissions evaluation from RuleSet ---
+
+impl super::engine_eval::PermissionEngine {
+    /// Evaluate user permissions across all dimensions for a given user and agent,
+    /// returning an `AgentPermissions` that can be used for spawn-time intersection.
+    ///
+    /// Iterates over each permission dimension (exec, file_read, file_write, network,
+    /// spawn, tool_call, config_write), constructs a representative request body,
+    /// evaluates the User phase (UserAndAgent rules only), and collects the results
+    /// into an `AgentPermissions`.
+    pub fn evaluate_user_permissions(&self, user_id: &str, agent_id: &str) -> AgentPermissions {
+        let dimensions = [
+            (
+                "exec",
+                PermissionRequestBody::CommandExec {
+                    agent: agent_id.to_string(),
+                    cmd: String::new(),
+                    args: Vec::new(),
+                },
+            ),
+            (
+                "file_read",
+                PermissionRequestBody::FileOp {
+                    agent: agent_id.to_string(),
+                    path: String::new(),
+                    op: "read".to_string(),
+                },
+            ),
+            (
+                "file_write",
+                PermissionRequestBody::FileOp {
+                    agent: agent_id.to_string(),
+                    path: String::new(),
+                    op: "write".to_string(),
+                },
+            ),
+            (
+                "network",
+                PermissionRequestBody::NetOp {
+                    agent: agent_id.to_string(),
+                    host: String::new(),
+                    port: 0,
+                },
+            ),
+            (
+                "spawn",
+                PermissionRequestBody::InterAgentMsg {
+                    from: agent_id.to_string(),
+                    to: String::new(),
+                },
+            ),
+            (
+                "tool_call",
+                PermissionRequestBody::ToolCall {
+                    agent: agent_id.to_string(),
+                    skill: String::new(),
+                    method: String::new(),
+                },
+            ),
+            (
+                "config_write",
+                PermissionRequestBody::ConfigWrite {
+                    agent: agent_id.to_string(),
+                    config_file: String::new(),
+                },
+            ),
+        ];
+
+        let caller = super::engine_types::Caller {
+            user_id: user_id.to_string(),
+            agent: agent_id.to_string(),
+            creator_id: String::new(),
+        };
+        let rules = self.rules.clone();
+
+        let mut permissions = HashMap::with_capacity(dimensions.len());
+        for (dim, body) in &dimensions {
+            let candidates = self.collect_user_agent_candidates(&caller, agent_id, &rules);
+            let result = self.match_rules(&candidates, &rules, &caller, body);
+            let allowed = matches!(
+                result,
+                Some(super::engine_types::PermissionResponse::Allowed { .. })
+            );
+            permissions.insert(
+                dim.to_string(),
+                crate::agent::config::ActionPermission {
+                    allowed,
+                    limits: crate::agent::config::PermissionLimits::default(),
+                },
+            );
+        }
+
+        AgentPermissions {
+            agent_id: agent_id.to_string(),
+            permissions,
+            inherited_from: None,
         }
     }
 }

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -14,6 +14,14 @@ pub enum SpawnPermissionError {
         child_agent_id: String,
         parent_agent_id: String,
     },
+    #[error(
+        "spawn denied: '{child_agent_id}' denied by three-way intersection (parent: '{parent_agent_id}', user: '{user_id}')"
+    )]
+    FullyDeniedWithUser {
+        child_agent_id: String,
+        parent_agent_id: String,
+        user_id: String,
+    },
 }
 
 impl super::engine_eval::PermissionEngine {
@@ -32,36 +40,66 @@ impl super::engine_eval::PermissionEngine {
     /// Validate that a child agent's permissions after intersection with parent
     /// are not fully denied, then inject the result into the cache.
     ///
-    /// - Computes `child_perms.intersect(parent_perms)`
-    /// - If fully denied → returns `Err(SpawnPermissionError::FullyDenied)`
-    /// - Otherwise → injects into `self.agent_permissions` cache
+    /// - Computes `child_perms.intersect(parent_perms)` (owner path, `user_perms` is `None`)
+    ///   or `child_perms.intersect(parent_perms).intersect(user_perms)` (non-owner path)
+    /// - If fully denied → returns `Err(SpawnPermissionError::FullyDenied)` or
+    ///   `Err(SpawnPermissionError::FullyDeniedWithUser)` if user context is present
+    /// - Otherwise → injects into `self.agent_permissions` cache (agent effective permissions)
+    ///   and, when `user_perms` is provided, also injects the intersection result into
+    ///   `self.user_effective_permissions` cache (user effective permissions for eval pre-check)
     /// - Idempotent: if already cached, returns `Ok(())` immediately
     pub fn validate_and_inject_spawn(
         &self,
         child_agent_id: &str,
         child_perms: &AgentPermissions,
         parent_perms: &AgentPermissions,
+        user_perms: Option<&AgentPermissions>,
+        user_id: Option<&str>,
     ) -> Result<(), SpawnPermissionError> {
-        let mut cache = self
+        let mut agent_cache = self
             .agent_permissions
             .write()
             .expect("agent_permissions lock poisoned");
 
         // Idempotent: already cached
-        if cache.contains_key(child_agent_id) {
+        if agent_cache.contains_key(child_agent_id) {
             return Ok(());
         }
 
+        // Step 1: child ∩ parent
         let effective = child_perms.intersect(parent_perms);
 
-        if effective.is_fully_denied() {
+        // Step 2: if user_perms provided, also intersect with user permissions
+        let final_effective = match user_perms {
+            Some(user) => effective.intersect(user),
+            None => effective,
+        };
+
+        if final_effective.is_fully_denied() {
+            if let Some(uid) = user_id {
+                return Err(SpawnPermissionError::FullyDeniedWithUser {
+                    child_agent_id: child_agent_id.to_string(),
+                    parent_agent_id: parent_perms.agent_id.clone(),
+                    user_id: uid.to_string(),
+                });
+            }
             return Err(SpawnPermissionError::FullyDenied {
                 child_agent_id: child_agent_id.to_string(),
                 parent_agent_id: parent_perms.agent_id.clone(),
             });
         }
 
-        cache.insert(child_agent_id.to_string(), effective);
+        agent_cache.insert(child_agent_id.to_string(), final_effective.clone());
+
+        // Inject user effective permissions for eval pre-check (non-owner path only)
+        if let Some(uid) = user_id {
+            let mut user_cache = self
+                .user_effective_permissions
+                .write()
+                .expect("user_effective_permissions lock poisoned");
+            user_cache.insert(uid.to_string(), final_effective);
+        }
+
         Ok(())
     }
 

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -112,6 +112,139 @@ fn test_validate_and_inject_spawn_idempotent() {
 }
 
 // -------------------------------------------------------------------------
+// Three-way intersection tests (child ∩ parent ∩ user)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_validate_and_inject_spawn_user_deny_overrides() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    let user = make_fully_denied_perms("user-1");
+
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-1"));
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDeniedWithUser {
+            child_agent_id,
+            parent_agent_id,
+            user_id,
+        } => {
+            assert_eq!(child_agent_id, "child");
+            assert_eq!(parent_agent_id, "parent");
+            assert_eq!(user_id, "user-1");
+        }
+        other => panic!("expected FullyDeniedWithUser, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_validate_and_inject_spawn_user_partial_deny() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+
+    // User denies exec but allows everything else
+    let mut user_perms_map = HashMap::new();
+    for dim in &[
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ] {
+        user_perms_map.insert(
+            dim.to_string(),
+            crate::agent::config::ActionPermission {
+                allowed: *dim != "exec",
+                limits: crate::agent::config::PermissionLimits::default(),
+            },
+        );
+    }
+    let user = AgentPermissions {
+        agent_id: "user-2".to_string(),
+        permissions: user_perms_map,
+        inherited_from: None,
+    };
+
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-2"));
+    assert!(result.is_ok());
+
+    // Verify cached agent perms: exec should be denied (user denied it)
+    let cache = engine.agent_permissions.read().unwrap();
+    let cached = cache.get("child").unwrap();
+    assert!(!cached.permissions.get("exec").unwrap().allowed);
+    // Other dims should be allowed
+    assert!(cached.permissions.get("file_read").unwrap().allowed);
+    assert!(cached.permissions.get("spawn").unwrap().allowed);
+}
+
+#[test]
+fn test_validate_and_inject_spawn_user_allow_full() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    let user = make_allowed_perms("user-3");
+
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-3"));
+    assert!(result.is_ok());
+
+    // Verify cached agent perms: all allowed
+    let cache = engine.agent_permissions.read().unwrap();
+    let cached = cache.get("child").unwrap();
+    for dim in &[
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ] {
+        assert!(
+            cached.permissions.get(*dim).unwrap().allowed,
+            "{} should be allowed",
+            dim
+        );
+    }
+}
+
+#[test]
+fn test_validate_and_inject_spawn_user_cache_injection() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    let user = make_allowed_perms("user-4");
+
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-4"));
+    assert!(result.is_ok());
+
+    // Verify user_effective_permissions cache was populated
+    let user_cache = engine.user_effective_permissions.read().unwrap();
+    assert!(user_cache.contains_key("user-4"));
+}
+
+#[test]
+fn test_validate_and_inject_spawn_no_user_no_cache() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+
+    // No user → user cache should NOT be populated
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
+    assert!(result.is_ok());
+
+    let user_cache = engine.user_effective_permissions.read().unwrap();
+    assert!(user_cache.is_empty());
+}
+
+// -------------------------------------------------------------------------
 // check_agent_effective_permissions tests
 // -------------------------------------------------------------------------
 

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -64,7 +64,7 @@ fn test_validate_and_inject_spawn_success() {
     let child = make_allowed_perms("child");
     let parent = make_allowed_perms("parent");
 
-    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
     assert!(result.is_ok());
 
     // Verify cache was populated
@@ -78,7 +78,7 @@ fn test_validate_and_inject_spawn_fully_denied() {
     let child = make_fully_denied_perms("child");
     let parent = make_allowed_perms("parent");
 
-    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
     assert!(result.is_err());
     match result.unwrap_err() {
         SpawnPermissionError::FullyDenied {
@@ -88,6 +88,7 @@ fn test_validate_and_inject_spawn_fully_denied() {
             assert_eq!(child_agent_id, "child");
             assert_eq!(parent_agent_id, "parent");
         }
+        other => panic!("expected FullyDenied, got {:?}", other),
     }
 
     // Verify cache was NOT populated
@@ -103,10 +104,10 @@ fn test_validate_and_inject_spawn_idempotent() {
 
     // First call succeeds
     engine
-        .validate_and_inject_spawn("child", &child, &parent)
+        .validate_and_inject_spawn("child", &child, &parent, None, None)
         .unwrap();
     // Second call succeeds (idempotent)
-    let result = engine.validate_and_inject_spawn("child", &child, &parent);
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
     assert!(result.is_ok());
 }
 
@@ -246,7 +247,13 @@ fn test_concurrent_spawn_and_evaluate() {
         let parent = Arc::clone(&parent);
         handles.push(thread::spawn(move || {
             let child = make_allowed_perms(&format!("child-{}", i));
-            let result = engine.validate_and_inject_spawn(&format!("child-{}", i), &child, &parent);
+            let result = engine.validate_and_inject_spawn(
+                &format!("child-{}", i),
+                &child,
+                &parent,
+                None,
+                None,
+            );
             assert!(result.is_ok());
         }));
     }

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -137,8 +137,20 @@ impl SessionsSpawnTool {
                         .cloned()
                 });
             if let Some(parent_perms) = parent_perms {
+                // Get user_id from parent session checkpoint for three-way intersection.
+                let user_id = self.session_manager.get_sender_id(parent_session_id).await;
+                let user_perms = user_id.as_ref().map(|uid| {
+                    self.permission_engine
+                        .evaluate_user_permissions(uid, &config.id)
+                });
                 self.permission_engine
-                    .validate_and_inject_spawn(&config.id, &child_perms, &parent_perms, None, None)
+                    .validate_and_inject_spawn(
+                        &config.id,
+                        &child_perms,
+                        &parent_perms,
+                        user_perms.as_ref(),
+                        user_id.as_deref(),
+                    )
                     .map_err(|e| {
                         ToolCallError::ExecutionFailed(format!("spawn permission denied: {}", e))
                     })?;

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -138,7 +138,7 @@ impl SessionsSpawnTool {
                 });
             if let Some(parent_perms) = parent_perms {
                 self.permission_engine
-                    .validate_and_inject_spawn(&config.id, &child_perms, &parent_perms)
+                    .validate_and_inject_spawn(&config.id, &child_perms, &parent_perms, None, None)
                     .map_err(|e| {
                         ToolCallError::ExecutionFailed(format!("spawn permission denied: {}", e))
                     })?;

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -87,7 +87,7 @@ async fn test_child_all_deny_spawn_returns_permission_denied() {
 
     // Simulate the permission validation that sessions_spawn performs.
     // Child all-deny × parent all-allow = fully denied.
-    let result = engine.validate_and_inject_spawn("child-all-deny", &child, &parent);
+    let result = engine.validate_and_inject_spawn("child-all-deny", &child, &parent, None, None);
 
     match result {
         Err(SpawnPermissionError::FullyDenied {
@@ -96,6 +96,9 @@ async fn test_child_all_deny_spawn_returns_permission_denied() {
         }) => {
             assert_eq!(child_agent_id, "child-all-deny");
             assert_eq!(parent_agent_id, "parent-agent");
+        }
+        Err(SpawnPermissionError::FullyDeniedWithUser { .. }) => {
+            panic!("expected FullyDenied, not FullyDeniedWithUser");
         }
         other => panic!(
             "expected FullyDenied error for all-deny child, got: {:?}",
@@ -125,7 +128,7 @@ async fn test_child_partial_deny_spawn_success_injects_cache() {
     let parent = make_all_allow("parent-agent");
 
     // Spawn should succeed (child is not fully denied).
-    let result = engine.validate_and_inject_spawn("child-partial", &child, &parent);
+    let result = engine.validate_and_inject_spawn("child-partial", &child, &parent, None, None);
     assert!(
         result.is_ok(),
         "spawn should succeed for partial-deny child"
@@ -196,7 +199,7 @@ async fn test_parent_effective_permissions_from_cache() {
 
     // Spawn A under grandparent.
     engine
-        .validate_and_inject_spawn("child-a", &child_a, &grandparent)
+        .validate_and_inject_spawn("child-a", &child_a, &grandparent, None, None)
         .expect("spawn of child-a should succeed");
 
     // Verify A's effective permissions are in cache.
@@ -213,7 +216,7 @@ async fn test_parent_effective_permissions_from_cache() {
 
     // Spawn B under A (using A's effective permissions as parent).
     engine
-        .validate_and_inject_spawn("child-b", &child_b, &a_effective)
+        .validate_and_inject_spawn("child-b", &child_b, &a_effective, None, None)
         .expect("spawn of child-b under child-a should succeed");
 
     // Verify B's cached effective permissions.
@@ -294,7 +297,7 @@ async fn test_runtime_permission_enforcement() {
 
     // Spawn child (injects into cache).
     engine
-        .validate_and_inject_spawn("child-rt", &child, &parent)
+        .validate_and_inject_spawn("child-rt", &child, &parent, None, None)
         .expect("spawn should succeed");
 
     // Simulate an exec operation for child-rt.
@@ -362,7 +365,7 @@ async fn test_multi_generation_spawn_chain() {
 
     // Spawn child under root.
     engine
-        .validate_and_inject_spawn("child-agent", &child, &root)
+        .validate_and_inject_spawn("child-agent", &child, &root, None, None)
         .expect("spawn of child under root should succeed");
 
     // Verify child's effective permissions: exec=deny (inherited from root).
@@ -387,7 +390,13 @@ async fn test_multi_generation_spawn_chain() {
 
     // Spawn grandchild under child.
     engine
-        .validate_and_inject_spawn("grandchild-agent", &grandchild, &child_effective)
+        .validate_and_inject_spawn(
+            "grandchild-agent",
+            &grandchild,
+            &child_effective,
+            None,
+            None,
+        )
         .expect("spawn of grandchild under child should succeed");
 
     // Verify grandchild's effective permissions: exec=deny (inherited chain).


### PR DESCRIPTION
将权限评估从两阶段模型对齐到三方交集模型（child ∩ parent ∩ user）

Design doc 描述权限为 spawn 时三方交集（child ∩ parent ∩ user），但代码实现为两阶段模型：spawn 阶段仅做 child ∩ parent 二路交集，user 权限在 eval 阶段独立评估后合并。按文档优先原则，本次将代码对齐到 doc 的三方交集模型。

变更内容：
- 在 PermissionEngine 中新增 user_effective_permissions 缓存字段，与 agent_permissions 并列
- 修改 validate_and_inject_spawn 签名，增加 user_perms 参数，执行 child ∩ parent ∩ user 三方交集
- 更新 sessions_spawn 调用点，传入 user 权限
- 修改 eval 阶段：用缓存的 user 有效权限做 pre-check，替代独立的 UserAndAgent 规则评估（cache miss 时降级到现有评估）
- Owner 跳过 User 维度语义保持不变
- 更新所有相关测试

Source: CI
Type: docs
