### PR TITLE
fix: align agent permissions and workspace resolution with design doc

### DIFF
--- a/src/agent/config/config_tests.rs
+++ b/src/agent/config/config_tests.rs
@@ -418,3 +418,92 @@ fn test_agent_config_ignores_removed_fields() {
         "gracePeriodSecs should not be serialized"
     );
 }
+
+// Step 1.1 — Inline permissions in AgentConfig
+
+#[test]
+fn test_agent_config_inline_permissions_load() {
+    let json = r#"{
+        "id": "agent-with-perms",
+        "name": "Agent With Inline Perms",
+        "permissions": {
+            "agent_id": "agent-with-perms",
+            "permissions": {
+                "exec": { "allowed": true, "limits": { "commands": ["git"], "paths": [], "timeout_ms": 30000 } },
+                "file_read": { "allowed": true },
+                "file_write": { "allowed": false }
+            }
+        }
+    }"#;
+
+    let config: AgentConfig = serde_json::from_str(json).unwrap();
+    let perms = config.permissions.unwrap();
+    assert_eq!(perms.agent_id, "agent-with-perms");
+    assert!(perms.is_allowed("exec"));
+    assert!(perms.is_allowed("file_read"));
+    assert!(!perms.is_allowed("file_write"));
+}
+
+#[test]
+fn test_agent_config_inline_permissions_none_when_absent() {
+    let json = r#"{ "id": "no-perms" }"#;
+    let config: AgentConfig = serde_json::from_str(json).unwrap();
+    assert!(config.permissions.is_none());
+}
+
+#[test]
+fn test_agent_config_inline_permissions_roundtrip() {
+    let perms = AgentPermissions {
+        agent_id: "rt-agent".to_string(),
+        permissions: HashMap::from([
+            (
+                "exec".to_string(),
+                ActionPermission {
+                    allowed: true,
+                    limits: PermissionLimits::default(),
+                },
+            ),
+            (
+                "network".to_string(),
+                ActionPermission {
+                    allowed: false,
+                    limits: PermissionLimits::default(),
+                },
+            ),
+        ]),
+        inherited_from: None,
+    };
+    let config = AgentConfig {
+        id: "rt-agent".to_string(),
+        permissions: Some(perms),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&config).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(
+        parsed.get("permissions").is_some(),
+        "permissions should be serialized"
+    );
+
+    let deserialized: AgentConfig = serde_json::from_str(&json).unwrap();
+    let p = deserialized.permissions.unwrap();
+    assert_eq!(p.agent_id, "rt-agent");
+    assert!(p.is_allowed("exec"));
+    assert!(!p.is_allowed("network"));
+}
+
+#[test]
+fn test_agent_config_inline_permissions_omitted_when_none() {
+    let config = AgentConfig {
+        id: "skip-none".to_string(),
+        permissions: None,
+        ..Default::default()
+    };
+    let json_str = serde_json::to_string(&config).unwrap();
+    let reparsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert!(
+        reparsed.get("permissions").is_none(),
+        "permissions should be omitted when None (skip_serializing_if)"
+    );
+}

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -48,6 +48,10 @@ pub struct AgentConfig {
     /// Disallowed tool names blacklist.
     #[serde(default)]
     pub disallowed_tools: Vec<String>,
+    /// Inline permissions for this agent (from config.json).
+    /// When present, takes priority over external permissions.json.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<AgentPermissions>,
     /// Sub-agent spawn control parameters.
     #[serde(default)]
     pub subagents: SubagentsConfig,
@@ -119,6 +123,7 @@ impl Default for AgentConfig {
             skills: default_all(),
             tools: default_all(),
             disallowed_tools: Vec::new(),
+            permissions: None,
             subagents: SubagentsConfig::default(),
         }
     }

--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -17,6 +17,7 @@ fn make_config(id: &str) -> ResolvedAgentConfig {
         tools: vec![],
         disallowed_tools: vec![],
         subagents: SubagentsConfig::default(),
+        permissions: None,
         source: ConfigSource::User,
     }
 }

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -67,6 +67,7 @@ fn make_agent(id: &str, subagents: SubagentsConfig) -> ResolvedAgentConfig {
         tools: vec![],
         disallowed_tools: vec![],
         subagents,
+        permissions: None,
         source: ConfigSource::User,
     }
 }

--- a/src/config/agents/resolved.rs
+++ b/src/config/agents/resolved.rs
@@ -24,7 +24,7 @@
 
 use std::path::PathBuf;
 
-use crate::agent::config::{AgentConfig, SubagentsConfig};
+use crate::agent::config::{AgentConfig, AgentPermissions, SubagentsConfig};
 use crate::config::ConfigError;
 use crate::session::bootstrap::BootstrapMode;
 
@@ -56,6 +56,9 @@ pub struct ResolvedAgentConfig {
     pub tools: Vec<String>,
     pub disallowed_tools: Vec<String>,
     pub subagents: SubagentsConfig,
+    /// Inline permissions for this agent.
+    /// When present, takes priority over external permissions.json.
+    pub permissions: Option<AgentPermissions>,
     /// Which configuration level this was resolved from.
     pub source: ConfigSource,
 }
@@ -99,6 +102,7 @@ impl ResolvedAgentConfig {
             tools: config.tools,
             disallowed_tools: config.disallowed_tools,
             subagents: config.subagents,
+            permissions: config.permissions,
             source,
         })
     }
@@ -168,6 +172,7 @@ impl ResolvedAgentConfig {
                 user.disallowed_tools
             },
             subagents: merge_subagents(project.subagents, user.subagents),
+            permissions: project.permissions.or(user.permissions),
             source: ConfigSource::Merged,
         })
     }

--- a/src/gateway/session_manager/model_priority_tests.rs
+++ b/src/gateway/session_manager/model_priority_tests.rs
@@ -37,6 +37,7 @@ fn test_resolved_config(
         tools: vec![],
         disallowed_tools: vec![],
         subagents: SubagentsConfig::default(),
+        permissions: None,
         source: ConfigSource::Merged,
     }
 }

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -103,7 +103,9 @@ impl SessionManager {
         let child_session_id = Uuid::new_v4().to_string();
 
         // 2. Determine workspace path (3-level fallback)
-        let workdir_path = self.resolve_child_workspace(config, workspace).await?;
+        let workdir_path = self
+            .resolve_child_workspace(config, workspace, parent_session_id)
+            .await?;
 
         // 3. Determine bootstrap_mode
         let bootstrap_mode = if light_context {
@@ -273,12 +275,14 @@ impl SessionManager {
     /// Fallback order:
     /// 1. Explicit `workspace` arg (if provided) — used as-is.
     /// 2. `config.workspace` (if set).
-    /// 3. `self.workspace_dir/<agent_id>/spawn` via `ensure_workspace_dir`.
+    /// 3. `<parent_workspace>/<child_agent_id>/` — subdirectory under the
+    ///    parent session's workspace.
     /// 4. `/tmp` (last resort).
     async fn resolve_child_workspace(
         &self,
         config: &ResolvedAgentConfig,
         workspace: Option<&str>,
+        parent_session_id: &str,
     ) -> Result<PathBuf, String> {
         if let Some(ws) = workspace {
             return Ok(PathBuf::from(ws));
@@ -286,8 +290,22 @@ impl SessionManager {
         if let Some(ref ws) = config.workspace {
             return Ok(ws.clone());
         }
-        if let Some(ref root) = self.workspace_dir {
-            return workspace::ensure_workspace_dir(root, &config.id, "spawn")
+        // Level 3: create subdirectory under parent session's workspace.
+        let parent_workspace = {
+            let conv_sessions = self.conversation_sessions.read().await;
+            conv_sessions.get(parent_session_id).map(|cs| {
+                // Clone the path while holding a short-lived read lock;
+                // the guard is dropped when the closure returns.
+                let cs_clone = cs.clone();
+                async move {
+                    let guard = cs_clone.read().await;
+                    guard.workdir().to_path_buf()
+                }
+            })
+        };
+        if let Some(make_parent_ws) = parent_workspace {
+            let parent_ws = make_parent_ws.await;
+            return workspace::ensure_workspace_dir(&parent_ws, &config.id, "default")
                 .map_err(|e| format!("workspace creation failed: {}", e));
         }
         Ok(PathBuf::from("/tmp"))

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -12,7 +12,6 @@ use crate::llm::session::ChatSession;
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
 use crate::session::persistence::PendingMessage;
-use crate::session::workspace;
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::ToolContext;
@@ -275,8 +274,9 @@ impl SessionManager {
     /// Fallback order:
     /// 1. Explicit `workspace` arg (if provided) — used as-is.
     /// 2. `config.workspace` (if set).
-    /// 3. `<parent_workspace>/<child_agent_id>/` — subdirectory under the
-    ///    parent session's workspace.
+    /// 3. `<parent_workspace>/<child_agent_id>/<user_id>/` — subdirectory under the
+    ///    parent session's workspace, using the actual user_id from the parent's
+    ///    session context (fallback to "default" if unavailable).
     /// 4. `/tmp` (last resort).
     async fn resolve_child_workspace(
         &self,
@@ -305,8 +305,17 @@ impl SessionManager {
         };
         if let Some(make_parent_ws) = parent_workspace {
             let parent_ws = make_parent_ws.await;
-            return workspace::ensure_workspace_dir(&parent_ws, &config.id, "default")
-                .map_err(|e| format!("workspace creation failed: {}", e));
+            // Use actual user_id from parent session context instead of
+            // hardcoding "default", per design doc: workspace path =
+            // <parent_workspace>/<child_agent_id>/<user_id>/.
+            let user_id = self
+                .get_sender_id(parent_session_id)
+                .await
+                .unwrap_or_else(|| "default".to_string());
+            let child_ws = parent_ws.join(&config.id).join(&user_id);
+            std::fs::create_dir_all(&child_ws)
+                .map_err(|e| format!("workspace creation failed: {}", e))?;
+            return Ok(child_ws);
         }
         Ok(PathBuf::from("/tmp"))
     }

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -487,3 +487,65 @@ async fn test_create_child_session_no_allowed_tools_preserves_config() {
 
     assert!(mgr.has_session(&child_id).await);
 }
+
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_workspace_fallback_to_parent() {
+    clear_global_prompt_state();
+
+    // Set up manager with a workspace root.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Parent workspace: {tmp}/workspaces/parent-agent/default/
+    let parent_workspace = tmp
+        .path()
+        .join("workspaces")
+        .join("parent-agent")
+        .join("default");
+    std::fs::create_dir_all(&parent_workspace).unwrap();
+
+    let config = test_resolved_config("child-agent", None);
+
+    // Register parent session with the parent workspace as its workdir.
+    register_parent_session(&mgr, "parent-ws", parent_workspace.clone()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-ws",
+            1,
+            "test workspace fallback",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Verify child session exists
+    assert!(mgr.has_session(&child_id).await);
+
+    // Verify child workspace is a subdirectory of parent workspace.
+    let child_cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child conversation session should exist");
+    let child_workdir = child_cs.read().await.workdir().to_path_buf();
+    assert!(
+        child_workdir.starts_with(&parent_workspace),
+        "child workdir {:?} should be under parent workspace {:?}",
+        child_workdir,
+        parent_workspace
+    );
+    // Verify the child agent_id appears in the path
+    assert!(
+        child_workdir.to_string_lossy().contains("child-agent"),
+        "child workdir {:?} should contain child agent id",
+        child_workdir
+    );
+}

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -30,6 +30,7 @@ fn test_resolved_config(id: &str, workspace: Option<PathBuf>) -> ResolvedAgentCo
         tools: vec![],
         disallowed_tools: vec![],
         subagents: SubagentsConfig::default(),
+        permissions: None,
         source: ConfigSource::Merged,
     }
 }
@@ -424,6 +425,7 @@ async fn test_create_child_session_allowed_tools_override() {
         tools: vec!["ToolA".into(), "ToolB".into(), "ToolC".into()],
         disallowed_tools: vec![],
         subagents: SubagentsConfig::default(),
+        permissions: None,
         source: ConfigSource::Merged,
     };
 

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -6,12 +6,14 @@
 //! `super::tests` at `pub(super)` visibility.
 
 use super::spawn::SpawnMode;
-use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::tests::{clear_global_prompt_state, make_test_mgr, test_config};
 use super::SessionManager;
 use crate::agent::config::SubagentsConfig;
 use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{PersistenceService, SessionCheckpoint};
+use crate::session::ReasoningLevel;
 use serial_test::serial;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -547,5 +549,84 @@ async fn test_create_child_session_workspace_fallback_to_parent() {
         child_workdir.to_string_lossy().contains("child-agent"),
         "child workdir {:?} should contain child agent id",
         child_workdir
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_workspace_uses_actual_user_id() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Set up MemoryStorage with a parent checkpoint that has a sender_id.
+    let storage = Arc::new(crate::session::storage::memory::MemoryStorage::new());
+    let parent_session_id = "parent-with-user";
+    let parent_agent_id = "parent-agent";
+    let actual_user_id = "ou_actual_user_123";
+    let mut cp = SessionCheckpoint::new(parent_session_id.to_string());
+    cp.sender_id = Some(actual_user_id.to_string());
+    cp.agent_id = Some(parent_agent_id.to_string());
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    // Parent workspace: {tmp}/workspaces/parent-agent/default/
+    let parent_workspace = tmp
+        .path()
+        .join("workspaces")
+        .join(parent_agent_id)
+        .join("default");
+    std::fs::create_dir_all(&parent_workspace).unwrap();
+
+    let config = test_resolved_config("child-agent", None);
+
+    // Register parent session with the parent workspace as its workdir.
+    register_parent_session(&mgr, parent_session_id, parent_workspace.clone()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            parent_session_id,
+            1,
+            "test user_id passing",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Verify child workspace path contains the actual user_id.
+    let child_cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child conversation session should exist");
+    let child_workdir = child_cs.read().await.workdir().to_path_buf();
+    assert!(
+        child_workdir.to_string_lossy().contains(actual_user_id),
+        "child workdir {:?} should contain actual user_id '{}'",
+        child_workdir,
+        actual_user_id
+    );
+    // Verify it does NOT contain the hardcoded "default" user_id.
+    // The path should be: <parent_workspace>/<child_agent_id>/<actual_user_id>/
+    let expected_suffix = format!("{}/{}", "child-agent", actual_user_id);
+    assert!(
+        child_workdir.to_string_lossy().ends_with(&expected_suffix),
+        "child workdir {:?} should end with '{}/{}'",
+        child_workdir,
+        "child-agent",
+        actual_user_id
     );
 }

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -31,6 +31,7 @@ pub(super) fn test_resolved_config(id: &str, workspace: Option<PathBuf>) -> Reso
         tools: vec![],
         disallowed_tools: vec![],
         subagents: SubagentsConfig::default(),
+        permissions: None,
         source: ConfigSource::Merged,
     }
 }

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -115,16 +115,17 @@ impl SessionsSpawnTool {
     ///
     /// Returns `Ok(())` if the spawn is permitted (or if there are no permissions to check),
     /// or `Err(ToolCallError)` if the spawn is fully denied.
-    async fn validate_spawn_permissions(
+    pub(crate) async fn validate_spawn_permissions(
         &self,
         config: &crate::config::agents::ResolvedAgentConfig,
         parent_session_id: &str,
     ) -> Result<(), ToolCallError> {
-        let child_perms = self
-            .config_manager
-            .agent_permissions()
-            .get(&config.id)
-            .cloned();
+        let child_perms = config.permissions.clone().or_else(|| {
+            self.config_manager
+                .agent_permissions()
+                .get(&config.id)
+                .cloned()
+        });
         let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
         if let (Some(child_perms), Some(parent_agent_id)) = (child_perms, parent_agent_id) {
             let parent_perms = self

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -11,10 +11,19 @@
 use std::collections::HashMap;
 
 use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits};
+use crate::agent::registry::AgentRegistry;
+use crate::agent::spawn::SpawnController;
+use crate::config::ConfigManager;
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::{DmScope, GatewayConfig, Session};
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_spawn::SpawnPermissionError;
 use crate::permission::engine::engine_types::PermissionRequestBody;
 use crate::permission::rules::RuleSetBuilder;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use crate::tools::builtin::sessions_spawn::SessionsSpawnTool;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -460,5 +469,225 @@ async fn test_multi_generation_spawn_chain() {
     assert!(
         result.is_none(),
         "file_read should be allowed at runtime for grandchild-agent"
+    );
+}
+
+// ===========================================================================
+// Inline permissions priority test (Step 1.2)
+// ===========================================================================
+
+/// Test: Inline permissions from AgentConfig.permissions take priority over
+/// external permissions.json loaded via config_manager.agent_permissions().
+///
+/// Setup:
+/// - ConfigManager has external permissions: all-deny for "priority-agent"
+/// - ResolvedAgentConfig has inline permissions: exec-deny, rest-allow
+/// - Expected: inline permissions are used (not the external all-deny)
+#[tokio::test]
+async fn test_inline_permissions_override_external() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create ConfigManager with external all-deny permissions for the agent.
+    let cm = Arc::new(
+        ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed"),
+    );
+    {
+        let mut ext_perms = cm.agent_permissions.write().unwrap();
+        ext_perms.insert(
+            "priority-agent".to_string(),
+            make_all_deny("priority-agent"),
+        );
+    }
+
+    // Create ResolvedAgentConfig with inline permissions (exec-deny, rest-allow).
+    let inline_perms = make_partial_deny("priority-agent", &["exec"]);
+    let config = crate::config::agents::ResolvedAgentConfig {
+        id: "priority-agent".to_string(),
+        name: "priority-agent".to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: crate::agent::config::SubagentsConfig::default(),
+        permissions: Some(inline_perms.clone()),
+        source: crate::config::agents::ConfigSource::Merged,
+    };
+
+    // Build SessionManager with a parent session.
+    let gw_config = GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    };
+    let sm = Arc::new(SessionManager::new(
+        &gw_config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    {
+        let mut sessions = sm.sessions.write().await;
+        sessions.insert(
+            "parent-sess".to_string(),
+            Session {
+                id: "parent-sess".to_string(),
+                agent_id: "parent-agent".to_string(),
+                channel: "feishu".to_string(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    let pe = Arc::new(make_permission_engine());
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
+    let ar = Arc::new(AgentRegistry::new(30));
+    let tool = SessionsSpawnTool::new(controller, sm, pe.clone(), cm.clone(), ar);
+
+    // Insert parent effective permissions into the engine cache so
+    // validate_spawn_permissions can retrieve them.
+    let parent_perms = make_all_allow("parent-agent");
+    {
+        let mut cache = pe.agent_permissions.write().unwrap();
+        cache.insert("parent-agent".to_string(), parent_perms);
+    }
+
+    // Call validate_spawn_permissions with the inline-permissions config.
+    let result = tool
+        .validate_spawn_permissions(&config, "parent-sess")
+        .await;
+
+    // Should succeed: inline perms (exec-deny) × parent (all-allow) = not fully denied.
+    assert!(
+        result.is_ok(),
+        "spawn should succeed with inline permissions (not fully denied)"
+    );
+
+    // Verify the engine cache was populated with the inline-permissions result
+    // (exec=deny, rest=allow), NOT the external all-deny result.
+    let cached = pe
+        .get_agent_effective_permissions("priority-agent")
+        .expect("agent should be cached after successful spawn");
+
+    // exec should be denied (from inline permissions).
+    assert!(
+        !cached.permissions.get("exec").unwrap().allowed,
+        "exec should be denied from inline permissions"
+    );
+    // file_read should be ALLOWED (from inline permissions), not denied (external would deny all).
+    assert!(
+        cached.permissions.get("file_read").unwrap().allowed,
+        "file_read should be allowed from inline permissions (external would deny)"
+    );
+    // network should be ALLOWED (from inline permissions).
+    assert!(
+        cached.permissions.get("network").unwrap().allowed,
+        "network should be allowed from inline permissions"
+    );
+}
+
+/// Test: When AgentConfig.permissions is None, fallback to config_manager's
+/// external permissions.json.
+#[tokio::test]
+async fn test_external_permissions_used_when_inline_absent() {
+    let tmp = TempDir::new().unwrap();
+
+    // Create ConfigManager with external exec-deny permissions.
+    let cm = Arc::new(
+        ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed"),
+    );
+    {
+        let mut ext_perms = cm.agent_permissions.write().unwrap();
+        ext_perms.insert(
+            "fallback-agent".to_string(),
+            make_partial_deny("fallback-agent", &["exec"]),
+        );
+    }
+
+    // Create ResolvedAgentConfig with NO inline permissions (None).
+    let config = crate::config::agents::ResolvedAgentConfig {
+        id: "fallback-agent".to_string(),
+        name: "fallback-agent".to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: crate::agent::config::SubagentsConfig::default(),
+        permissions: None,
+        source: crate::config::agents::ConfigSource::Merged,
+    };
+
+    // Build SessionManager with a parent session.
+    let gw_config = GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    };
+    let sm = Arc::new(SessionManager::new(
+        &gw_config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    {
+        let mut sessions = sm.sessions.write().await;
+        sessions.insert(
+            "parent-sess-2".to_string(),
+            Session {
+                id: "parent-sess-2".to_string(),
+                agent_id: "parent-agent-2".to_string(),
+                channel: "feishu".to_string(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    let pe = Arc::new(make_permission_engine());
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
+    let ar = Arc::new(AgentRegistry::new(30));
+    let tool = SessionsSpawnTool::new(controller, sm, pe.clone(), cm.clone(), ar);
+
+    // Insert parent effective permissions into the engine cache.
+    let parent_perms = make_all_allow("parent-agent-2");
+    {
+        let mut cache = pe.agent_permissions.write().unwrap();
+        cache.insert("parent-agent-2".to_string(), parent_perms);
+    }
+
+    // Call validate_spawn_permissions — should use external permissions (exec-deny).
+    let result = tool
+        .validate_spawn_permissions(&config, "parent-sess-2")
+        .await;
+    assert!(
+        result.is_ok(),
+        "spawn should succeed with external permissions"
+    );
+
+    // Verify the cached permissions match the external exec-deny config.
+    let cached = pe
+        .get_agent_effective_permissions("fallback-agent")
+        .expect("agent should be cached after successful spawn");
+    assert!(
+        !cached.permissions.get("exec").unwrap().allowed,
+        "exec should be denied from external permissions"
+    );
+    assert!(
+        cached.permissions.get("file_read").unwrap().allowed,
+        "file_read should be allowed from external permissions"
     );
 }

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -23,6 +23,7 @@ use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::tools::builtin::sessions_spawn::SessionsSpawnTool;
+use crate::tools::ToolCallError;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -689,5 +690,237 @@ async fn test_external_permissions_used_when_inline_absent() {
     assert!(
         cached.permissions.get("file_read").unwrap().allowed,
         "file_read should be allowed from external permissions"
+    );
+}
+
+// ===========================================================================
+// Multi-layer recursive permission intersection (Step 1.4)
+// ===========================================================================
+
+/// Test: Three-layer spawn chain where each level introduces different
+/// permission restrictions. Verify the grandchild's effective permissions
+/// are the intersection of all restrictions along the full chain.
+///
+/// Chain:
+///   depth=0 (root-agent):  deny exec, deny file_write
+///   depth=1 (child-agent): deny network, deny file_read
+///   depth=2 (grandchild):  deny spawn
+///
+/// Expected grandchild effective:
+///   exec=deny (root), file_read=deny (child), file_write=deny (root),
+///   network=deny (child), spawn=deny (grandchild),
+///   tool_call=allow, config_write=allow
+#[test]
+fn test_recursive_permission_intersection_three_layers() {
+    let engine = make_permission_engine();
+
+    // depth=0: root denies exec + file_write, allows rest.
+    let root = make_partial_deny("root-agent", &["exec", "file_write"]);
+
+    // depth=1: child denies network + file_read, allows rest.
+    let child = make_partial_deny("child-agent", &["network", "file_read"]);
+
+    // Spawn child under root: effective = child ∩ root.
+    engine
+        .validate_and_inject_spawn("child-agent", &child, &root, None, None)
+        .expect("spawn of child-agent should succeed");
+
+    let child_effective = engine
+        .get_agent_effective_permissions("child-agent")
+        .expect("child-agent should be in cache");
+
+    // Child effective: exec=deny (root), file_read=deny (child),
+    // file_write=deny (root), network=deny (child),
+    // spawn=allow, tool_call=allow, config_write=allow.
+    assert!(!child_effective.permissions.get("exec").unwrap().allowed);
+    assert!(
+        !child_effective
+            .permissions
+            .get("file_read")
+            .unwrap()
+            .allowed
+    );
+    assert!(
+        !child_effective
+            .permissions
+            .get("file_write")
+            .unwrap()
+            .allowed
+    );
+    assert!(!child_effective.permissions.get("network").unwrap().allowed);
+    assert!(child_effective.permissions.get("spawn").unwrap().allowed);
+    assert!(
+        child_effective
+            .permissions
+            .get("tool_call")
+            .unwrap()
+            .allowed
+    );
+    assert!(
+        child_effective
+            .permissions
+            .get("config_write")
+            .unwrap()
+            .allowed
+    );
+
+    // depth=2: grandchild denies spawn, allows rest.
+    let grandchild = make_partial_deny("grandchild-agent", &["spawn"]);
+
+    // Spawn grandchild under child: effective = grandchild ∩ child_effective.
+    engine
+        .validate_and_inject_spawn(
+            "grandchild-agent",
+            &grandchild,
+            &child_effective,
+            None,
+            None,
+        )
+        .expect("spawn of grandchild-agent should succeed");
+
+    let gc_effective = engine
+        .get_agent_effective_permissions("grandchild-agent")
+        .expect("grandchild-agent should be in cache");
+
+    // Grandchild effective: all denied dims from every level accumulate.
+    assert!(
+        !gc_effective.permissions.get("exec").unwrap().allowed,
+        "exec should be denied (from root)"
+    );
+    assert!(
+        !gc_effective.permissions.get("file_read").unwrap().allowed,
+        "file_read should be denied (from child)"
+    );
+    assert!(
+        !gc_effective.permissions.get("file_write").unwrap().allowed,
+        "file_write should be denied (from root)"
+    );
+    assert!(
+        !gc_effective.permissions.get("network").unwrap().allowed,
+        "network should be denied (from child)"
+    );
+    assert!(
+        !gc_effective.permissions.get("spawn").unwrap().allowed,
+        "spawn should be denied (from grandchild)"
+    );
+    assert!(
+        gc_effective.permissions.get("tool_call").unwrap().allowed,
+        "tool_call should be allowed (no restriction in chain)"
+    );
+    assert!(
+        gc_effective
+            .permissions
+            .get("config_write")
+            .unwrap()
+            .allowed,
+        "config_write should be allowed (no restriction in chain)"
+    );
+
+    // Verify inherited_from chain is correct.
+    assert_eq!(gc_effective.inherited_from, Some("child-agent".to_string()));
+    assert_eq!(
+        child_effective.inherited_from,
+        Some("root-agent".to_string())
+    );
+}
+
+// ===========================================================================
+// FullyDenied silent return through SessionsSpawnTool (Step 1.4)
+// ===========================================================================
+
+/// Test: When a child agent is fully denied, `validate_spawn_permissions`
+/// returns `ToolCallError::ExecutionFailed` with the FullyDenied error.
+/// The child session is NOT created — the error short-circuits the spawn
+/// pipeline before `create_child` is reached.
+#[tokio::test]
+async fn test_fully_denied_silent_return_no_session_created() {
+    let tmp = TempDir::new().unwrap();
+
+    let cm = Arc::new(
+        ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed"),
+    );
+    // No external permissions — child has inline all-deny.
+
+    let config = crate::config::agents::ResolvedAgentConfig {
+        id: "denied-child".to_string(),
+        name: "denied-child".to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: crate::agent::config::SubagentsConfig::default(),
+        permissions: Some(make_all_deny("denied-child")),
+        source: crate::config::agents::ConfigSource::Merged,
+    };
+
+    let gw_config = GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    };
+    let sm = Arc::new(SessionManager::new(
+        &gw_config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    {
+        let mut sessions = sm.sessions.write().await;
+        sessions.insert(
+            "parent-sess-deny".to_string(),
+            Session {
+                id: "parent-sess-deny".to_string(),
+                agent_id: "parent-agent-deny".to_string(),
+                channel: "feishu".to_string(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    let pe = Arc::new(make_permission_engine());
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
+    let ar = Arc::new(AgentRegistry::new(30));
+    let tool = SessionsSpawnTool::new(controller, sm.clone(), pe.clone(), cm.clone(), ar);
+
+    // Parent has all-allow effective permissions in cache.
+    let parent_perms = make_all_allow("parent-agent-deny");
+    {
+        let mut cache = pe.agent_permissions.write().unwrap();
+        cache.insert("parent-agent-deny".to_string(), parent_perms);
+    }
+
+    // validate_spawn_permissions should fail with FullyDenied.
+    let result = tool
+        .validate_spawn_permissions(&config, "parent-sess-deny")
+        .await;
+
+    assert!(result.is_err(), "spawn should fail for fully-denied child");
+    let err_msg = match result.unwrap_err() {
+        ToolCallError::ExecutionFailed(msg) => msg,
+        other => panic!("expected ExecutionFailed, got: {:?}", other),
+    };
+    assert!(
+        err_msg.contains("denied-child"),
+        "error should mention the denied agent_id, got: {}",
+        err_msg
+    );
+    assert!(
+        err_msg.contains("denied"),
+        "error should mention 'denied', got: {}",
+        err_msg
+    );
+
+    // Verify the child was NOT cached (spawn was rejected).
+    assert!(
+        pe.get_agent_effective_permissions("denied-child").is_none(),
+        "fully-denied child should NOT be in permission cache after rejection"
     );
 }

--- a/src/tools/builtin/skill_tool_tests.rs
+++ b/src/tools/builtin/skill_tool_tests.rs
@@ -93,6 +93,7 @@ mod tests {
                 model: None,
             },
             source: ConfigSource::Merged,
+            permissions: None,
         };
         {
             let mut agents = config_manager.agents.write().unwrap();
@@ -112,6 +113,7 @@ mod tests {
             tools: vec![],
             disallowed_tools: vec![],
             subagents: SubagentsConfig::default(),
+            permissions: None,
             source: ConfigSource::Merged,
         };
         {


### PR DESCRIPTION
Align agent permissions and workspace resolution with design doc.

Two gaps identified by design doc review:
1. Added `permissions` field to `AgentConfig` for inline permission definitions, with fallback to external permissions.json
2. Fixed child workspace resolution to create under parent workspace instead of global root, and use actual user_id instead of hardcoded default

Source: design-doc
Type: fix
