### PR TITLE
fix: align agent spawn implementation with design doc

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -6,6 +6,17 @@ use crate::gateway::SessionManager;
 use std::sync::Arc;
 use thiserror::Error;
 
+/// Result of a successful spawn validation, containing the resolved
+/// target config and the effective max spawn depth for the child.
+#[derive(Debug, Clone)]
+pub struct SpawnValidationResult {
+    /// Resolved configuration of the target agent.
+    pub config: ResolvedAgentConfig,
+    /// Effective max spawn depth the child may use.
+    /// Computed as `min(child.max_spawn_depth, parent.max_spawn_depth - 1)`.
+    pub effective_max_spawn_depth: u32,
+}
+
 /// Errors returned by SpawnController validation.
 #[derive(Debug, Error)]
 pub enum SpawnError {
@@ -37,12 +48,16 @@ impl SpawnController {
         }
     }
 
-    /// Validate a spawn request. Returns the target agent's resolved config on success.
+    /// Validate a spawn request.
+    ///
+    /// Returns a [`SpawnValidationResult`] with the target agent's resolved
+    /// config and the effective max spawn depth for the child, or a
+    /// [`SpawnError`] on failure.
     pub async fn validate(
         &self,
         parent_session_id: &str,
         target_agent_id: Option<&str>,
-    ) -> Result<ResolvedAgentConfig, SpawnError> {
+    ) -> Result<SpawnValidationResult, SpawnError> {
         // 1. Get parent depth
         let parent_depth = self
             .session_manager
@@ -112,12 +127,17 @@ impl SpawnController {
             )
         };
 
-        // 6. Depth check
+        // 6. Depth check — effective max = min(child.max_spawn_depth, parent.max_spawn_depth - 1)
+        let child_max_spawn_depth = target_config
+            .as_ref()
+            .map(|c| c.subagents.max_spawn_depth)
+            .unwrap_or(1);
+        let effective_max = child_max_spawn_depth.min(max_spawn_depth.saturating_sub(1));
         let child_depth = parent_depth + 1;
-        if child_depth > max_spawn_depth {
+        if child_depth > effective_max {
             return Err(SpawnError::DepthExceeded {
                 current: child_depth,
-                max: max_spawn_depth,
+                max: effective_max,
             });
         }
 
@@ -141,7 +161,11 @@ impl SpawnController {
             });
         }
 
-        // 9. Return target config
-        target_config.ok_or(SpawnError::ConfigNotFound(target_id))
+        // 9. Return validation result with effective max spawn depth
+        let config = target_config.ok_or(SpawnError::ConfigNotFound(target_id))?;
+        Ok(SpawnValidationResult {
+            config,
+            effective_max_spawn_depth: effective_max,
+        })
     }
 }

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -131,14 +131,15 @@ async fn test_validate_passes() {
     let sm = Arc::new(make_session_manager());
     let controller = SpawnController::new(cm.clone(), sm.clone());
 
-    // Parent uses default subagents config (allow_agents=["*"], max_spawn_depth=1,
-    // max_children=5, require_agent_id=false).
-    let parent = make_agent("parent", SubagentsConfig::default());
+    // Parent uses max_spawn_depth=2 so child_depth=1 passes the depth check.
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
     // Target agent exists in the agents map.
     let child = make_agent("child", SubagentsConfig::default());
     inject_agents(&cm, vec![("parent", parent), ("child", child)]);
 
-    // Parent at depth 0 → child_depth=1, max_spawn_depth=1 → OK.
+    // Parent at depth 0 → child_depth=1, effective_max=min(1,2-1)=1 → OK.
     let parent_id = setup_parent_session(&sm, "parent").await;
 
     let result = controller
@@ -146,8 +147,11 @@ async fn test_validate_passes() {
         .await
         .expect("validate should succeed for a legal request");
 
-    assert_eq!(result.id, "child");
-    assert_eq!(result.source, ConfigSource::User);
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.config.source, ConfigSource::User);
+    // parent.max_spawn_depth=2, child.max_spawn_depth=1 (default)
+    // effective_max = min(1, 2-1) = 1
+    assert_eq!(result.effective_max_spawn_depth, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +177,7 @@ async fn test_validate_depth_exceeded() {
     let err = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("validate should reject when child_depth > max_spawn_depth");
+        .expect_err("validate should reject when child_depth > effective_max");
 
     match err {
         SpawnError::DepthExceeded { current, max } => {
@@ -195,8 +199,10 @@ async fn test_validate_max_children() {
     let controller = SpawnController::new(cm.clone(), sm.clone());
 
     // max_children=1 with 1 already-registered child → at the limit.
+    // max_spawn_depth=2 so depth check passes before concurrency check.
     let mut sub = SubagentsConfig::default();
     sub.max_children = 1;
+    sub.max_spawn_depth = 2;
     let parent = make_agent("parent", sub);
     let child = make_agent("child", SubagentsConfig::default());
     inject_agents(&cm, vec![("parent", parent), ("child", child)]);
@@ -229,8 +235,10 @@ async fn test_validate_agent_not_allowed() {
     let controller = SpawnController::new(cm.clone(), sm.clone());
 
     // Allowlist only contains "allowed-agent" — target "child" is denied.
+    // max_spawn_depth=2 so depth check passes before whitelist check.
     let mut sub = SubagentsConfig::default();
     sub.allow_agents = vec!["allowed-agent".to_string()];
+    sub.max_spawn_depth = 2;
     let parent = make_agent("parent", sub);
     let child = make_agent("child", SubagentsConfig::default());
     inject_agents(&cm, vec![("parent", parent), ("child", child)]);
@@ -294,6 +302,7 @@ async fn test_validate_wildcard_allow() {
     // Explicit "*" wildcard in allow_agents — any target should be permitted.
     let mut sub = SubagentsConfig::default();
     sub.allow_agents = vec!["*".to_string()];
+    sub.max_spawn_depth = 2;
     let parent = make_agent("parent", sub);
     // Pick a non-default, otherwise-unrestricted target id.
     let target = make_agent("any-arbitrary-agent", SubagentsConfig::default());
@@ -309,5 +318,271 @@ async fn test_validate_wildcard_allow() {
         .await
         .expect("validate should succeed when allow_agents contains '*'");
 
-    assert_eq!(result.id, "any-arbitrary-agent");
+    assert_eq!(result.config.id, "any-arbitrary-agent");
+    // parent.max_spawn_depth=2, child.max_spawn_depth=1 (default)
+    // effective_max = min(1, 2-1) = 1
+    assert_eq!(result.effective_max_spawn_depth, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 7. test_validate_cascade_parent_depth1_child_depth2
+// ---------------------------------------------------------------------------
+
+/// Parent maxSpawnDepth=1, child maxSpawnDepth=2
+/// → effective_max = min(2, 1-1) = 0
+/// → child_depth=1 > 0 → DepthExceeded.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth1_child_depth2() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 1;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 2;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 1);
+            assert_eq!(max, 0);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. test_validate_cascade_parent_depth2_child_depth2
+// ---------------------------------------------------------------------------
+
+/// Parent maxSpawnDepth=2, child maxSpawnDepth=2
+/// → effective_max = min(2, 2-1) = 1
+/// → child_depth=1 <= 1 → OK.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth2_child_depth2() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 2;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_max_spawn_depth, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 9. test_validate_cascade_parent_depth3_child_depth1
+// ---------------------------------------------------------------------------
+
+/// Parent maxSpawnDepth=3, child maxSpawnDepth=1
+/// → effective_max = min(1, 3-1) = 1
+/// → child_depth=1 <= 1 → OK.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth3_child_depth1() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 3;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 1;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_max_spawn_depth, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 10. test_validate_cascade_unknown_target_config_not_found
+// ---------------------------------------------------------------------------
+
+/// Target agent not in agents map → ConfigNotFound (existing behavior preserved).
+#[tokio::test]
+async fn test_validate_cascade_unknown_target_config_not_found() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+    inject_agents(&cm, vec![("parent", parent)]);
+    // NOTE: "unknown-child" is NOT injected → target_config = None
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("unknown-child"))
+        .await
+        .expect_err("should fail with ConfigNotFound for unknown target");
+
+    assert!(
+        matches!(err, SpawnError::ConfigNotFound(_)),
+        "expected ConfigNotFound, got {:?}",
+        err
+    );
+}
+
+// ── Step 1.4: additional cascading depth edge-case tests ─────────────────
+
+/// Parent maxSpawnDepth=5, child maxSpawnDepth=1
+/// → effective_max = min(1, 5-1) = 1
+/// → child_depth=1 <= 1 → OK.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth5_child_depth1() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 5;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 1;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_max_spawn_depth, 1);
+}
+
+/// Parent maxSpawnDepth=5, child maxSpawnDepth=3
+/// → effective_max = min(3, 5-1) = 3
+/// → child_depth=1 <= 3 → OK.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth5_child_depth3() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 5;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 3;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("should pass: effective_max=3, child_depth=1 <= 3");
+
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_max_spawn_depth, 3);
+}
+
+/// Parent maxSpawnDepth=0, child maxSpawnDepth=5
+/// → effective_max = min(5, 0-1) = min(5, 0 via saturating_sub) = 0
+/// → child_depth=1 > 0 → DepthExceeded.
+#[tokio::test]
+async fn test_validate_cascade_parent_depth0_child_depth5() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 0;
+    let parent = make_agent("parent", parent_sub);
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 5;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 1);
+            assert_eq!(max, 0);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+/// Target agent not configured (default max_spawn_depth=1)
+/// with parent max_spawn_depth=1
+/// → effective_max = min(1, 1-1) = 0
+/// → child_depth=1 > 0 → DepthExceeded.
+/// Verifies that unconfigured targets use the default max_spawn_depth=1.
+#[tokio::test]
+async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 1;
+    let parent = make_agent("parent", parent_sub);
+    // "child" has default max_spawn_depth=1
+    let child = make_agent("child", SubagentsConfig::default());
+    inject_agents(&cm, vec![("parent", parent), ("child", child)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 1);
+            assert_eq!(max, 0);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
 }

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -94,6 +94,7 @@ async fn test_try_push_announce_run_mode() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -141,6 +142,7 @@ async fn test_try_push_announce_session_mode_noop() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -264,6 +266,7 @@ async fn test_thinking_blocks_excluded() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/model_priority_tests.rs
+++ b/src/gateway/session_manager/model_priority_tests.rs
@@ -93,6 +93,7 @@ async fn test_model_priority_explicit_override_wins() {
             None,
             Some("override-model"),   // model_override
             Some("parent-sub-model"), // parent_subagents_model
+            3,                        // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -128,6 +129,7 @@ async fn test_model_priority_parent_subagents_wins() {
             None,
             None,                    // model_override
             Some("parent-override"), // parent_subagents_model
+            3,                       // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -163,6 +165,7 @@ async fn test_model_priority_target_agent_model() {
             None,
             None, // model_override
             None, // parent_subagents_model
+            3,    // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -198,6 +201,7 @@ async fn test_model_priority_system_default() {
             None,
             None, // model_override
             None, // parent_subagents_model
+            3,    // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -233,6 +237,7 @@ async fn test_model_priority_parent_subagents_beats_target() {
             None,
             None,                       // model_override
             Some("subagents-override"), // parent_subagents_model
+            3,                          // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -6,6 +6,7 @@
 //! table so `SpawnController` can enforce depth and concurrency limits.
 
 use super::SessionManager;
+use crate::agent::communication::CommunicationConfig;
 use crate::config::agents::ResolvedAgentConfig;
 use crate::gateway::Session;
 use crate::llm::session::ChatSession;
@@ -85,6 +86,7 @@ impl SessionManager {
         allowed_tools: Option<Vec<String>>,
         model_override: Option<&str>,
         parent_subagents_model: Option<&str>,
+        max_spawn_depth: u32,
     ) -> Result<String, String> {
         // Apply tool whitelist override: when allowed_tools is provided,
         // replace the config's tools list so the child session only has
@@ -154,6 +156,12 @@ impl SessionManager {
         .await;
         drop(tool_registry_guard);
 
+        // 4a. Append spawn context to the system prompt so the child
+        //     agent knows its role, depth limits, and communication
+        //     behavior.  Non-spawn sessions never reach this path.
+        let spawn_context = Self::build_spawn_context(depth, max_spawn_depth);
+        let prompt = format!("{}\n{}", prompt, spawn_context);
+
         // 5. Create ConversationSession
         // Model priority: explicit model param > parent agent.subagents.model
         // > target agent.model > system default
@@ -197,6 +205,12 @@ impl SessionManager {
         )
         .with_system_prompt(prompt)
         .with_reasoning_level(self.default_reasoning_level);
+
+        // 5b. Generate communication config: child may only
+        //     communicate with its parent agent.
+        let parent_agent_id = self.get_chat_id(parent_session_id).await;
+        let comm_config = CommunicationConfig::default_with_parent(parent_agent_id.as_deref());
+        cs = cs.with_communication_config(comm_config);
 
         // 6a. Fork mode: inject parent session's conversation history
         //     before the task so the child inherits the parent's context.
@@ -267,6 +281,40 @@ impl SessionManager {
 
         // 9. Return child session id
         Ok(child_session_id)
+    }
+
+    /// Build the spawn context paragraph appended to child system prompts.
+    ///
+    /// The paragraph tells the child agent:
+    /// - Its role (sub-agent)
+    /// - Current depth / maximum depth
+    /// - Communication behavior (push-based, no polling)
+    /// - Behavioral constraints (direct execution, no back-and-forth)
+    /// - Spawn guidance when depth allows further spawning
+    pub(crate) fn build_spawn_context(depth: u32, max_spawn_depth: u32) -> String {
+        let mut ctx = format!(
+            "## Spawn Context\n\
+             You are running as a sub-agent. \
+             Current depth: {depth} / Maximum depth: {max_spawn_depth}.\n\
+             **Communication behavior:** Your results are automatically \
+             pushed back to the parent agent when you finish. \
+             Do not poll for status. \
+             If you need to wait for sub-agent results, use the yield \
+             mechanism to end your current turn.\n\
+             **Behavioral constraints:**\n\
+             - Trust push-based completion notifications\n             - Do not call session query tools to check child agent status\n             - Execute the task directly; do not ask for confirmation \
+               or suggest next steps — the parent agent handles that"
+        );
+        if depth < max_spawn_depth {
+            let upper = max_spawn_depth - depth;
+            ctx.push_str(&format!(
+                "\n\
+             - You may spawn child agents for sub-tasks. \
+               Your effective maximum depth for children is {upper}."
+            ));
+        }
+        ctx.push('\n');
+        ctx
     }
 
     /// Resolve the workspace path for a child session.

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -10,7 +10,7 @@ use super::tests::{clear_global_prompt_state, make_test_mgr, test_config};
 use super::SessionManager;
 use crate::agent::config::SubagentsConfig;
 use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
-use crate::llm::session::ConversationSession;
+use crate::llm::session::{ChatSession, ConversationSession};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::{PersistenceService, SessionCheckpoint};
 use crate::session::ReasoningLevel;
@@ -52,6 +52,18 @@ async fn register_parent_session(mgr: &SessionManager, parent_id: &str, workdir:
     let arc = Arc::new(RwLock::new(cs));
     let mut conv = mgr.conversation_sessions.write().await;
     conv.insert(parent_id.to_string(), arc);
+    // Also register in `sessions` so `get_chat_id` can resolve the
+    // parent's agent_id for communication config generation.
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
 }
 
 #[tokio::test]
@@ -80,6 +92,7 @@ async fn test_create_child_session_basic() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -136,6 +149,7 @@ async fn test_create_child_session_workspace_fallback() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -158,6 +172,7 @@ async fn test_create_child_session_workspace_fallback() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session with explicit workspace should succeed");
@@ -196,6 +211,7 @@ async fn test_create_child_session_registers_child_info() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -237,6 +253,7 @@ async fn test_steer_child_injects_pending_message() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -290,6 +307,7 @@ async fn test_kill_child_removes_from_all_tables() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -353,6 +371,7 @@ async fn test_validate_child_ownership_returns_none_for_run_mode() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -391,6 +410,7 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -448,6 +468,7 @@ async fn test_create_child_session_allowed_tools_override() {
             Some(allowed),
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session with allowed_tools should succeed");
@@ -483,6 +504,7 @@ async fn test_create_child_session_no_allowed_tools_preserves_config() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session without allowed_tools should succeed");
@@ -525,6 +547,7 @@ async fn test_create_child_session_workspace_fallback_to_parent() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -603,6 +626,7 @@ async fn test_create_child_session_workspace_uses_actual_user_id() {
             None,
             None,
             None,
+            3, // max_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -629,4 +653,238 @@ async fn test_create_child_session_workspace_uses_actual_user_id() {
         "child-agent",
         actual_user_id
     );
+}
+
+// ── Step 1.4: spawn-context injection tests ─────────────────────────────
+
+/// Verify `build_spawn_context` produces the expected paragraph for
+/// depth=1, max_spawn_depth=3 (allows further spawning).
+#[test]
+fn test_build_spawn_context_allows_spawning() {
+    let ctx = SessionManager::build_spawn_context(1, 3);
+    assert!(ctx.contains("sub-agent"), "should declare sub-agent role");
+    assert!(
+        ctx.contains("Current depth: 1 / Maximum depth: 3"),
+        "should contain depth info"
+    );
+    assert!(
+        ctx.contains("results are automatically pushed back"),
+        "should describe push-based communication"
+    );
+    assert!(
+        ctx.contains("Do not poll for status"),
+        "should forbid polling"
+    );
+    assert!(
+        ctx.contains("Your effective maximum depth for children is 2"),
+        "should show effective spawn depth (3-1=2)"
+    );
+}
+
+/// Verify `build_spawn_context` omits spawn guidance when depth == max_spawn_depth.
+#[test]
+fn test_build_spawn_context_no_spawning_at_limit() {
+    let ctx = SessionManager::build_spawn_context(3, 3);
+    assert!(ctx.contains("sub-agent"));
+    assert!(
+        ctx.contains("Current depth: 3 / Maximum depth: 3"),
+        "should contain depth info"
+    );
+    assert!(
+        !ctx.contains("effective maximum depth"),
+        "should NOT include spawn guidance at limit"
+    );
+}
+
+/// Verify `build_spawn_context` at depth=0, max_spawn_depth=1 (allows spawning).
+#[test]
+fn test_build_spawn_context_depth_zero() {
+    let ctx = SessionManager::build_spawn_context(0, 1);
+    assert!(ctx.contains("Current depth: 0 / Maximum depth: 1"));
+    assert!(
+        ctx.contains("Your effective maximum depth for children is 1"),
+        "should show effective depth (1-0=1)"
+    );
+}
+
+/// Verify the behavioral constraints section is always present.
+#[test]
+fn test_build_spawn_context_behavioral_constraints() {
+    let ctx = SessionManager::build_spawn_context(0, 1);
+    assert!(
+        ctx.contains("Behavioral constraints"),
+        "should have behavioral constraints header"
+    );
+    assert!(
+        ctx.contains("Trust push-based completion"),
+        "should trust push-based notifications"
+    );
+    assert!(
+        ctx.contains("do not ask for confirmation"),
+        "should forbid confirmation-seeking"
+    );
+}
+
+// ── Step 1.4: child session spawn-context integration test ───────────────
+
+/// Integration test: `create_child_session` appends spawn context to
+/// the system prompt so the child agent knows its role and limits.
+#[tokio::test]
+#[serial]
+async fn test_child_session_system_prompt_contains_spawn_context() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("child-agent", None);
+
+    register_parent_session(&mgr, "parent-prompt", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-prompt",
+            2,
+            "test task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            4, // max_spawn_depth
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child session should exist");
+    let guard = cs.read().await;
+    let prompt = guard.system_prompt().expect("system prompt should be set");
+
+    assert!(
+        prompt.contains("sub-agent"),
+        "system prompt should contain sub-agent role declaration"
+    );
+    assert!(
+        prompt.contains("Current depth: 2 / Maximum depth: 4"),
+        "system prompt should contain depth info"
+    );
+    assert!(
+        prompt.contains("results are automatically pushed back"),
+        "system prompt should describe push-based communication"
+    );
+}
+
+// ── Step 1.4: communication config tests ─────────────────────────────────
+
+/// Verify the child session's communication config restricts
+/// communication to the parent agent only.
+#[tokio::test]
+#[serial]
+async fn test_child_session_communication_config_has_parent() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("comm-child", None);
+
+    register_parent_session(&mgr, "parent-comm", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-comm",
+            1,
+            "comm task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child session should exist");
+    let guard = cs.read().await;
+    let comm = guard
+        .communication_config()
+        .expect("communication_config should be set");
+
+    // Outbound should contain parent agent id
+    assert_eq!(comm.outbound.len(), 1);
+    // The parent agent id is looked up via get_chat_id which reads
+    // from sessions. The parent session was registered with
+    // agent_id="parent-agent" by the test setup, so the comm config
+    // should reference that.
+    assert!(
+        comm.outbound.contains(&"parent-agent".to_string()),
+        "outbound should contain parent agent id, got: {:?}",
+        comm.outbound
+    );
+
+    // Inbound should also contain parent agent id
+    assert_eq!(comm.inbound.len(), 1);
+    assert!(
+        comm.inbound.contains(&"parent-agent".to_string()),
+        "inbound should contain parent agent id, got: {:?}",
+        comm.inbound
+    );
+}
+
+/// Verify a non-spawn session does NOT have communication config.
+#[test]
+fn test_non_spawn_session_no_communication_config() {
+    use std::path::PathBuf;
+    let cs = crate::llm::session::ConversationSession::new(
+        "regular-session".to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    );
+    assert!(
+        cs.communication_config().is_none(),
+        "non-spawn session should not have communication_config"
+    );
+}
+
+/// Verify `CommunicationConfig::default_with_parent` with a valid parent id.
+#[test]
+fn test_communication_config_default_with_parent() {
+    use crate::agent::communication::CommunicationConfig;
+
+    let config = CommunicationConfig::default_with_parent(Some("agent-abc"));
+    assert_eq!(config.outbound, vec!["agent-abc".to_string()]);
+    assert_eq!(config.inbound, vec!["agent-abc".to_string()]);
+}
+
+/// Verify `CommunicationConfig::default_with_parent` with None parent.
+#[test]
+fn test_communication_config_default_with_parent_none() {
+    use crate::agent::communication::CommunicationConfig;
+
+    let config = CommunicationConfig::default_with_parent(None);
+    assert!(config.outbound.is_empty());
+    assert!(config.inbound.is_empty());
+}
+
+/// Verify `can_send_to` / `can_receive_from` respect the whitelist.
+#[test]
+fn test_communication_config_permission_checks() {
+    use crate::agent::communication::CommunicationConfig;
+
+    let config = CommunicationConfig::default_with_parent(Some("parent-1"));
+    assert!(config.can_send_to("parent-1"));
+    assert!(!config.can_send_to("other-agent"));
+    assert!(config.can_receive_from("parent-1"));
+    assert!(!config.can_receive_from("other-agent"));
 }

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -180,6 +180,7 @@ pub(super) async fn spawn_n_run_children(
                 None,
                 None,
                 None,
+                3, // max_spawn_depth
             )
             .await
             .expect("create_child_session should succeed");

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use tokio_util::sync::CancellationToken;
 
+use crate::agent::communication::CommunicationConfig;
 use crate::llm::session_state::{ChildSessionState, LlmState, ToolExecState};
 use crate::llm::stats::RunningStats;
 use crate::llm::streaming::StreamingSink;
@@ -112,6 +113,9 @@ pub struct ConversationSession {
     pub(crate) cancel_token: CancellationToken,
     /// `stop()` idempotency flag. See [`super::session_handles`].
     pub(crate) stopped: Arc<AtomicBool>,
+    /// Communication configuration for spawned child sessions.
+    /// When set, restricts which agents the child may communicate with.
+    communication_config: Option<CommunicationConfig>,
 }
 
 // `impl ConversationSession` is split across multiple blocks so each
@@ -147,6 +151,7 @@ impl ConversationSession {
             child_handles: Arc::new(RwLock::new(HashMap::new())),
             cancel_token: CancellationToken::new(),
             stopped: Arc::new(AtomicBool::new(false)),
+            communication_config: None,
         }
     }
 
@@ -188,6 +193,17 @@ impl ConversationSession {
     pub fn with_reasoning_level(mut self, level: ReasoningLevel) -> Self {
         self.reasoning_level = level;
         self
+    }
+
+    /// Sets the communication configuration.
+    pub fn with_communication_config(mut self, config: CommunicationConfig) -> Self {
+        self.communication_config = Some(config);
+        self
+    }
+
+    /// Returns the communication configuration, if set.
+    pub fn communication_config(&self) -> Option<&CommunicationConfig> {
+        self.communication_config.as_ref()
     }
 
     /// Returns the current reasoning level.
@@ -426,6 +442,7 @@ impl std::fmt::Debug for ConversationSession {
             )
             .field("cancel_token", &"<CancelToken>")
             .field("stopped", &self.stopped.load(Ordering::SeqCst))
+            .field("communication_config", &self.communication_config)
             .finish()
     }
 }

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -177,6 +177,7 @@ impl SessionsSpawnTool {
         allowed_tools: Option<Vec<String>>,
         model: Option<&str>,
         parent_subagents_model: Option<&str>,
+        max_spawn_depth: u32,
     ) -> Result<String, ToolCallError> {
         self.session_manager
             .create_child_session(
@@ -191,6 +192,7 @@ impl SessionsSpawnTool {
                 allowed_tools,
                 model,
                 parent_subagents_model,
+                max_spawn_depth,
             )
             .await
             .map_err(|e| {
@@ -297,13 +299,15 @@ impl Tool for SessionsSpawnTool {
         let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {
             ToolCallError::ExecutionFailed("no session_id in tool context".into())
         })?;
-        let config = self
+        let spawn_result = self
             .spawn_controller
             .validate(parent_session_id, spawn_args.agent_id.as_deref())
             .await
             .map_err(|e| {
                 ToolCallError::ExecutionFailed(format!("spawn validation failed: {}", e))
             })?;
+        let config = spawn_result.config;
+        let effective_max_spawn_depth = spawn_result.effective_max_spawn_depth;
         self.validate_spawn_permissions(&config, parent_session_id)
             .await?;
         // Look up the parent agent's subagents.model config
@@ -340,6 +344,7 @@ impl Tool for SessionsSpawnTool {
                 spawn_args.allowed_tools,
                 spawn_args.model.as_deref(),
                 parent_subagents_model.as_deref(),
+                effective_max_spawn_depth,
             )
             .await?;
         Ok(ToolResult {

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -158,7 +158,7 @@ impl Tool for SkillTool {
                 })?;
 
                 // Validate spawn with the parent agent's config
-                let config = self
+                let spawn_result = self
                     .spawn_controller
                     .validate(parent_session_id, None)
                     .await
@@ -168,6 +168,7 @@ impl Tool for SkillTool {
                             e
                         ))
                     })?;
+                let config = spawn_result.config;
 
                 // Get parent depth
                 let parent_depth = self
@@ -196,6 +197,7 @@ impl Tool for SkillTool {
                         allowed_tools,
                         None, // model_override
                         None, // parent_subagents_model
+                        1,    // max_spawn_depth (skill tool doesn't spawn)
                     )
                     .await
                     .map_err(|e| {


### PR DESCRIPTION
## Fix: Align agent spawn implementation with design doc

Three discrepancies between code and design doc `docs/design/agent/agent-spawn.md`:

1. **Spawn context in system prompt** - Child agents now receive role declaration, depth/maxDepth info, push-based communication rules, and behavioral constraints in their system prompt
2. **Cascade depth formula** - Depth check now applies `min(child.maxSpawnDepth, parent.maxSpawnDepth - 1)` instead of only checking against parent's limit
3. **Communication config** - Child sessions now generate `CommunicationConfig` with the parent agent as the sole communication partner

All fixes include comprehensive unit tests.

Source: user
Type: fix
