### PR TITLE
fix: align agent-spawn implementation with design doc

### DIFF
--- a/docs/design/agent/agent-spawn.md
+++ b/docs/design/agent/agent-spawn.md
@@ -8,7 +8,7 @@ Spawn 是父 session 创建子 session 执行子任务的机制。一次 spawn =
 
 ### 入口：sessions_spawn 工具
 
-`sessions_spawn` 由 Session 模块注册到 ToolRegistry（分组 `session_ops`），参数定义详见 [session-tools.md](../session/session-tools.md)。以下展开 spawn 特有的行为描述。
+`sessions_spawn` 由 Session 模块注册到 ToolRegistry（分组 `sessions`），参数定义详见 [session-tools.md](../session/session-tools.md)。以下展开 spawn 特有的行为描述。
 
 ### Spawn 控制流程
 

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -12,16 +12,18 @@ use thiserror::Error;
 pub struct SpawnValidationResult {
     /// Resolved configuration of the target agent.
     pub config: ResolvedAgentConfig,
-    /// Effective max spawn depth the child may use.
+    /// Remaining spawn depth the child has after this spawn.
     /// Computed as `min(child.max_spawn_depth, parent.max_spawn_depth - 1)`.
-    pub effective_max_spawn_depth: u32,
+    pub effective_remaining_depth: u32,
 }
 
 /// Errors returned by SpawnController validation.
 #[derive(Debug, Error)]
 pub enum SpawnError {
-    #[error("spawn depth limit exceeded: current depth {current} >= max {max}")]
-    DepthExceeded { current: u32, max: u32 },
+    #[error(
+        "spawn depth exhausted: child has no remaining spawn capability (remaining={remaining})"
+    )]
+    DepthExhausted { remaining: u32 },
     #[error("max concurrent children reached: {current} >= {max}")]
     MaxChildrenReached { current: usize, max: u32 },
     #[error("agent '{agent_id}' not in allowlist")]
@@ -51,21 +53,14 @@ impl SpawnController {
     /// Validate a spawn request.
     ///
     /// Returns a [`SpawnValidationResult`] with the target agent's resolved
-    /// config and the effective max spawn depth for the child, or a
+    /// config and the child's remaining spawn depth, or a
     /// [`SpawnError`] on failure.
     pub async fn validate(
         &self,
         parent_session_id: &str,
         target_agent_id: Option<&str>,
     ) -> Result<SpawnValidationResult, SpawnError> {
-        // 1. Get parent depth
-        let parent_depth = self
-            .session_manager
-            .get_session_depth(parent_session_id)
-            .await
-            .unwrap_or(0);
-
-        // 2. Determine parent agent_id from session manager
+        // 1. Determine parent agent_id from session manager
         let parent_agent_id = self
             .session_manager
             .get_chat_id(parent_session_id)
@@ -127,19 +122,25 @@ impl SpawnController {
             )
         };
 
-        // 6. Depth check — effective max = min(child.max_spawn_depth, parent.max_spawn_depth - 1)
+        // 6. Depth check — reject if the parent itself has reached its depth
+        //    limit.  The child's effective remaining spawn depth is
+        //    min(child.max_spawn_depth, parent.max_spawn_depth - parent_depth - 1).
+        //    A value of 0 is still valid (child is allowed to exist, it just
+        //    cannot spawn further).
+        let parent_depth = self
+            .session_manager
+            .get_session_depth(parent_session_id)
+            .await
+            .unwrap_or(0);
+        if parent_depth >= max_spawn_depth {
+            return Err(SpawnError::DepthExhausted { remaining: 0 });
+        }
         let child_max_spawn_depth = target_config
             .as_ref()
             .map(|c| c.subagents.max_spawn_depth)
             .unwrap_or(1);
-        let effective_max = child_max_spawn_depth.min(max_spawn_depth.saturating_sub(1));
-        let child_depth = parent_depth + 1;
-        if child_depth > effective_max {
-            return Err(SpawnError::DepthExceeded {
-                current: child_depth,
-                max: effective_max,
-            });
-        }
+        let effective_remaining =
+            child_max_spawn_depth.min(max_spawn_depth.saturating_sub(parent_depth + 1));
 
         // 7. Concurrency check
         // No lock held here — safe to await.
@@ -161,11 +162,11 @@ impl SpawnController {
             });
         }
 
-        // 9. Return validation result with effective max spawn depth
+        // 9. Return validation result with child's remaining spawn depth
         let config = target_config.ok_or(SpawnError::ConfigNotFound(target_id))?;
         Ok(SpawnValidationResult {
             config,
-            effective_max_spawn_depth: effective_max,
+            effective_remaining_depth: effective_remaining,
         })
     }
 }

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -150,16 +150,16 @@ async fn test_validate_passes() {
     assert_eq!(result.config.id, "child");
     assert_eq!(result.config.source, ConfigSource::User);
     // parent.max_spawn_depth=2, child.max_spawn_depth=1 (default)
-    // effective_max = min(1, 2-1) = 1
-    assert_eq!(result.effective_max_spawn_depth, 1);
+    // effective_remaining = min(1, 2-1) = 1
+    assert_eq!(result.effective_remaining_depth, 1);
 }
 
 // ---------------------------------------------------------------------------
-// 2. test_validate_depth_exceeded
+// 2. test_validate_depth_exhausted
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_validate_depth_exceeded() {
+async fn test_validate_depth_exhausted() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
     let controller = SpawnController::new(cm.clone(), sm.clone());
@@ -171,20 +171,19 @@ async fn test_validate_depth_exceeded() {
     let child = make_agent("child", SubagentsConfig::default());
     inject_agents(&cm, vec![("parent", parent), ("child", child)]);
 
-    // Parent at depth 0 → child_depth=1 > 0 → DepthExceeded.
+    // Parent at depth 0 → effective_remaining=0 → DepthExhausted.
     let parent_id = setup_parent_session(&sm, "parent").await;
 
     let err = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("validate should reject when child_depth > effective_max");
+        .expect_err("validate should reject when effective_remaining == 0");
 
     match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
+        SpawnError::DepthExhausted { remaining } => {
+            assert_eq!(remaining, 0);
         }
-        other => panic!("expected DepthExceeded, got {:?}", other),
+        other => panic!("expected DepthExhausted, got {:?}", other),
     }
 }
 
@@ -320,8 +319,8 @@ async fn test_validate_wildcard_allow() {
 
     assert_eq!(result.config.id, "any-arbitrary-agent");
     // parent.max_spawn_depth=2, child.max_spawn_depth=1 (default)
-    // effective_max = min(1, 2-1) = 1
-    assert_eq!(result.effective_max_spawn_depth, 1);
+    // effective_remaining = min(1, 2-1) = 1
+    assert_eq!(result.effective_remaining_depth, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -329,8 +328,8 @@ async fn test_validate_wildcard_allow() {
 // ---------------------------------------------------------------------------
 
 /// Parent maxSpawnDepth=1, child maxSpawnDepth=2
-/// → effective_max = min(2, 1-1) = 0
-/// → child_depth=1 > 0 → DepthExceeded.
+/// → effective_remaining = min(2, 1-1) = 0
+/// → child has no spawn capability but is itself valid → OK.
 #[tokio::test]
 async fn test_validate_cascade_parent_depth1_child_depth2() {
     let cm = Arc::new(make_config_manager());
@@ -348,18 +347,13 @@ async fn test_validate_cascade_parent_depth1_child_depth2() {
 
     let parent_id = setup_parent_session(&sm, "parent").await;
 
-    let err = controller
+    let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+        .expect("should pass: child is valid, remaining=0 means no further spawn");
 
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_remaining_depth, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -389,10 +383,10 @@ async fn test_validate_cascade_parent_depth2_child_depth2() {
     let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+        .expect("should pass: effective_remaining=1, child is valid");
 
     assert_eq!(result.config.id, "child");
-    assert_eq!(result.effective_max_spawn_depth, 1);
+    assert_eq!(result.effective_remaining_depth, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -422,10 +416,10 @@ async fn test_validate_cascade_parent_depth3_child_depth1() {
     let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+        .expect("should pass: effective_remaining=1, child is valid");
 
     assert_eq!(result.config.id, "child");
-    assert_eq!(result.effective_max_spawn_depth, 1);
+    assert_eq!(result.effective_remaining_depth, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -484,14 +478,14 @@ async fn test_validate_cascade_parent_depth5_child_depth1() {
     let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect("should pass: effective_max=1, child_depth=1 <= 1");
+        .expect("should pass: effective_remaining=1, child is valid");
 
     assert_eq!(result.config.id, "child");
-    assert_eq!(result.effective_max_spawn_depth, 1);
+    assert_eq!(result.effective_remaining_depth, 1);
 }
 
 /// Parent maxSpawnDepth=5, child maxSpawnDepth=3
-/// → effective_max = min(3, 5-1) = 3
+/// → effective_remaining = min(3, 5-1) = 3
 /// → child_depth=1 <= 3 → OK.
 #[tokio::test]
 async fn test_validate_cascade_parent_depth5_child_depth3() {
@@ -516,12 +510,12 @@ async fn test_validate_cascade_parent_depth5_child_depth3() {
         .expect("should pass: effective_max=3, child_depth=1 <= 3");
 
     assert_eq!(result.config.id, "child");
-    assert_eq!(result.effective_max_spawn_depth, 3);
+    assert_eq!(result.effective_remaining_depth, 3);
 }
 
 /// Parent maxSpawnDepth=0, child maxSpawnDepth=5
-/// → effective_max = min(5, 0-1) = min(5, 0 via saturating_sub) = 0
-/// → child_depth=1 > 0 → DepthExceeded.
+/// → effective_remaining = min(5, 0-1) = min(5, 0 via saturating_sub) = 0
+/// → child has no spawn capability → DepthExhausted.
 #[tokio::test]
 async fn test_validate_cascade_parent_depth0_child_depth5() {
     let cm = Arc::new(make_config_manager());
@@ -542,21 +536,20 @@ async fn test_validate_cascade_parent_depth0_child_depth5() {
     let err = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+        .expect_err("should reject: effective_remaining=0");
 
     match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
+        SpawnError::DepthExhausted { remaining } => {
+            assert_eq!(remaining, 0);
         }
-        other => panic!("expected DepthExceeded, got {:?}", other),
+        other => panic!("expected DepthExhausted, got {:?}", other),
     }
 }
 
 /// Target agent not configured (default max_spawn_depth=1)
 /// with parent max_spawn_depth=1
-/// → effective_max = min(1, 1-1) = 0
-/// → child_depth=1 > 0 → DepthExceeded.
+/// → effective_remaining = min(1, 1-0-1) = 0
+/// → child is valid but has no spawn capability → OK.
 /// Verifies that unconfigured targets use the default max_spawn_depth=1.
 #[tokio::test]
 async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
@@ -573,16 +566,11 @@ async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
 
     let parent_id = setup_parent_session(&sm, "parent").await;
 
-    let err = controller
+    let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+        .expect("should pass: child is valid, remaining=0 means no further spawn");
 
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+    assert_eq!(result.config.id, "child");
+    assert_eq!(result.effective_remaining_depth, 0);
 }

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -94,7 +94,7 @@ async fn test_try_push_announce_run_mode() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -142,7 +142,7 @@ async fn test_try_push_announce_session_mode_noop() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -266,7 +266,7 @@ async fn test_thinking_blocks_excluded() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -156,11 +156,12 @@ impl SessionManager {
         .await;
         drop(tool_registry_guard);
 
-        // 4a. Append spawn context to the system prompt so the child
-        //     agent knows its role, depth limits, and communication
-        //     behavior.  Non-spawn sessions never reach this path.
+        // 4a. Build spawn context — injected as the first part of
+        //     the pending user message (not in the system prompt).
+        //     The design doc requires the child's first message to
+        //     contain context告知 (role, depth, comms) followed by
+        //     the task content.
         let spawn_context = Self::build_spawn_context(depth, max_spawn_depth);
-        let prompt = format!("{}\n{}", prompt, spawn_context);
 
         // 5. Create ConversationSession
         // Model priority: explicit model param > parent agent.subagents.model
@@ -221,9 +222,9 @@ impl SessionManager {
             }
         }
 
-        // 6. Inject task as pending message
-        let pending_msg =
-            PendingMessage::new(format!("{}-task", child_session_id), task.to_string());
+        // 6. Inject context告知 + task as pending message
+        let content = format!("{}\n\n{}", spawn_context, task);
+        let pending_msg = PendingMessage::new(format!("{}-task", child_session_id), content);
         cs.push_pending(pending_msg);
 
         // 7. Register to conversation_sessions and sessions mappings

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -291,11 +291,12 @@ impl SessionManager {
     /// - Communication behavior (push-based, no polling)
     /// - Behavioral constraints (direct execution, no back-and-forth)
     /// - Spawn guidance when depth allows further spawning
-    pub(crate) fn build_spawn_context(depth: u32, max_spawn_depth: u32) -> String {
+    pub(crate) fn build_spawn_context(depth: u32, remaining_depth: u32) -> String {
         let mut ctx = format!(
             "## Spawn Context\n\
              You are running as a sub-agent. \
-             Current depth: {depth} / Maximum depth: {max_spawn_depth}.\n\
+             Current depth: {depth}. \
+             Remaining spawn depth: {remaining_depth}.\n\
              **Communication behavior:** Your results are automatically \
              pushed back to the parent agent when you finish. \
              Do not poll for status. \
@@ -305,12 +306,11 @@ impl SessionManager {
              - Trust push-based completion notifications\n             - Do not call session query tools to check child agent status\n             - Execute the task directly; do not ask for confirmation \
                or suggest next steps — the parent agent handles that"
         );
-        if depth < max_spawn_depth {
-            let upper = max_spawn_depth - depth;
+        if remaining_depth > 0 {
             ctx.push_str(&format!(
                 "\n\
              - You may spawn child agents for sub-tasks. \
-               Your effective maximum depth for children is {upper}."
+               Your effective maximum depth for children is {remaining_depth}."
             ));
         }
         ctx.push('\n');

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -92,7 +92,7 @@ async fn test_create_child_session_basic() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -149,7 +149,7 @@ async fn test_create_child_session_workspace_fallback() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -172,7 +172,7 @@ async fn test_create_child_session_workspace_fallback() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session with explicit workspace should succeed");
@@ -211,7 +211,7 @@ async fn test_create_child_session_registers_child_info() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -253,7 +253,7 @@ async fn test_steer_child_injects_pending_message() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -307,7 +307,7 @@ async fn test_kill_child_removes_from_all_tables() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -371,7 +371,7 @@ async fn test_validate_child_ownership_returns_none_for_run_mode() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -410,7 +410,7 @@ async fn test_validate_child_ownership_returns_info_for_session_mode() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -468,7 +468,7 @@ async fn test_create_child_session_allowed_tools_override() {
             Some(allowed),
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session with allowed_tools should succeed");
@@ -504,7 +504,7 @@ async fn test_create_child_session_no_allowed_tools_preserves_config() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session without allowed_tools should succeed");
@@ -547,7 +547,7 @@ async fn test_create_child_session_workspace_fallback_to_parent() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -626,7 +626,7 @@ async fn test_create_child_session_workspace_uses_actual_user_id() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3, // remaining_spawn_depth
         )
         .await
         .expect("create_child_session should succeed");
@@ -658,13 +658,13 @@ async fn test_create_child_session_workspace_uses_actual_user_id() {
 // ── Step 1.4: spawn-context injection tests ─────────────────────────────
 
 /// Verify `build_spawn_context` produces the expected paragraph for
-/// depth=1, max_spawn_depth=3 (allows further spawning).
+/// depth=1, remaining_depth=3 (allows further spawning).
 #[test]
 fn test_build_spawn_context_allows_spawning() {
     let ctx = SessionManager::build_spawn_context(1, 3);
     assert!(ctx.contains("sub-agent"), "should declare sub-agent role");
     assert!(
-        ctx.contains("Current depth: 1 / Maximum depth: 3"),
+        ctx.contains("Current depth: 1. Remaining spawn depth: 3"),
         "should contain depth info"
     );
     assert!(
@@ -676,34 +676,34 @@ fn test_build_spawn_context_allows_spawning() {
         "should forbid polling"
     );
     assert!(
-        ctx.contains("Your effective maximum depth for children is 2"),
-        "should show effective spawn depth (3-1=2)"
+        ctx.contains("Your effective maximum depth for children is 3"),
+        "should show remaining spawn depth"
     );
 }
 
-/// Verify `build_spawn_context` omits spawn guidance when depth == max_spawn_depth.
+/// Verify `build_spawn_context` omits spawn guidance when remaining_depth == 0.
 #[test]
 fn test_build_spawn_context_no_spawning_at_limit() {
-    let ctx = SessionManager::build_spawn_context(3, 3);
+    let ctx = SessionManager::build_spawn_context(3, 0);
     assert!(ctx.contains("sub-agent"));
     assert!(
-        ctx.contains("Current depth: 3 / Maximum depth: 3"),
+        ctx.contains("Current depth: 3. Remaining spawn depth: 0"),
         "should contain depth info"
     );
     assert!(
         !ctx.contains("effective maximum depth"),
-        "should NOT include spawn guidance at limit"
+        "should NOT include spawn guidance when remaining is 0"
     );
 }
 
-/// Verify `build_spawn_context` at depth=0, max_spawn_depth=1 (allows spawning).
+/// Verify `build_spawn_context` at depth=0, remaining_depth=1 (allows spawning).
 #[test]
 fn test_build_spawn_context_depth_zero() {
     let ctx = SessionManager::build_spawn_context(0, 1);
-    assert!(ctx.contains("Current depth: 0 / Maximum depth: 1"));
+    assert!(ctx.contains("Current depth: 0. Remaining spawn depth: 1"));
     assert!(
         ctx.contains("Your effective maximum depth for children is 1"),
-        "should show effective depth (1-0=1)"
+        "should show remaining depth"
     );
 }
 
@@ -770,7 +770,7 @@ async fn test_child_session_system_prompt_contains_spawn_context() {
         "system prompt should contain sub-agent role declaration"
     );
     assert!(
-        prompt.contains("Current depth: 2 / Maximum depth: 4"),
+        prompt.contains("Current depth: 2. Remaining spawn depth: 4"),
         "system prompt should contain depth info"
     );
     assert!(

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -10,7 +10,7 @@ use super::tests::{clear_global_prompt_state, make_test_mgr, test_config};
 use super::SessionManager;
 use crate::agent::config::SubagentsConfig;
 use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
-use crate::llm::session::{ChatSession, ConversationSession};
+use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::{PersistenceService, SessionCheckpoint};
 use crate::session::ReasoningLevel;
@@ -116,9 +116,19 @@ async fn test_create_child_session_basic() {
         .expect("conversation session should exist");
     let cs_guard = cs.read().await;
     assert_eq!(cs_guard.get_pending_messages().len(), 1);
-    assert_eq!(
-        cs_guard.get_pending_messages()[0].content,
-        "do something useful"
+    // Spawn context is now injected into the first user message
+    let first_msg = &cs_guard.get_pending_messages()[0].content;
+    assert!(
+        first_msg.contains("do something useful"),
+        "pending message should contain the task"
+    );
+    assert!(
+        first_msg.contains("Spawn Context"),
+        "pending message should contain spawn context"
+    );
+    assert!(
+        first_msg.contains("sub-agent"),
+        "pending message should contain sub-agent role declaration"
     );
 }
 
@@ -763,19 +773,21 @@ async fn test_child_session_system_prompt_contains_spawn_context() {
         .await
         .expect("child session should exist");
     let guard = cs.read().await;
-    let prompt = guard.system_prompt().expect("system prompt should be set");
 
+    // Spawn context is now injected into the first user message
+    // (not the system prompt) per the design doc.
+    let first_msg = &guard.get_pending_messages()[0].content;
     assert!(
-        prompt.contains("sub-agent"),
-        "system prompt should contain sub-agent role declaration"
+        first_msg.contains("sub-agent"),
+        "first user message should contain sub-agent role declaration"
     );
     assert!(
-        prompt.contains("Current depth: 2. Remaining spawn depth: 4"),
-        "system prompt should contain depth info"
+        first_msg.contains("Current depth: 2. Remaining spawn depth: 4"),
+        "first user message should contain depth info"
     );
     assert!(
-        prompt.contains("results are automatically pushed back"),
-        "system prompt should describe push-based communication"
+        first_msg.contains("results are automatically pushed back"),
+        "first user message should describe push-based communication"
     );
 }
 

--- a/src/gateway/session_manager/test_helpers.rs
+++ b/src/gateway/session_manager/test_helpers.rs
@@ -180,7 +180,7 @@ pub(super) async fn spawn_n_run_children(
                 None,
                 None,
                 None,
-                3, // max_spawn_depth
+                3, // remaining_spawn_depth
             )
             .await
             .expect("create_child_session should succeed");

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -132,11 +132,17 @@ pub async fn register_builtin_tools(
         .await
         .ok();
     registry
-        .register(SessionsSteerTool::new(context.session_manager.clone()))
+        .register(SessionsSteerTool::new(
+            context.session_manager.clone(),
+            context.permission_engine.clone(),
+        ))
         .await
         .ok();
     registry
-        .register(SessionsKillTool::new(context.session_manager.clone()))
+        .register(SessionsKillTool::new(
+            context.session_manager.clone(),
+            context.permission_engine.clone(),
+        ))
         .await
         .ok();
 }

--- a/src/tools/builtin/sessions_kill.rs
+++ b/src/tools/builtin/sessions_kill.rs
@@ -1,6 +1,8 @@
 //! Built-in sessions_kill tool — terminates a persistent child session and releases resources.
 
 use crate::gateway::SessionManager;
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_types::{Caller, PermissionRequest, PermissionRequestBody};
 use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
 
 use async_trait::async_trait;
@@ -13,12 +15,19 @@ use std::sync::Arc;
 /// Only works on `mode=session` children owned by the calling parent.
 pub struct SessionsKillTool {
     session_manager: Arc<SessionManager>,
+    permission_engine: Arc<PermissionEngine>,
 }
 
 impl SessionsKillTool {
     /// Create a new `SessionsKillTool` with the given dependencies.
-    pub fn new(session_manager: Arc<SessionManager>) -> Self {
-        Self { session_manager }
+    pub fn new(
+        session_manager: Arc<SessionManager>,
+        permission_engine: Arc<PermissionEngine>,
+    ) -> Self {
+        Self {
+            session_manager,
+            permission_engine,
+        }
     }
 }
 
@@ -77,7 +86,8 @@ impl Tool for SessionsKillTool {
         })?;
 
         // 3. Validate ownership
-        self.session_manager
+        let child_info = self
+            .session_manager
             .validate_child_ownership(parent_session_id, child_id)
             .await
             .ok_or_else(|| {
@@ -86,13 +96,46 @@ impl Tool for SessionsKillTool {
                 )
             })?;
 
-        // 4. Kill the child session
+        // 4. Permission engine check — cross-agent communication
+        let user_id = self
+            .session_manager
+            .get_sender_id(parent_session_id)
+            .await
+            .unwrap_or_default();
+        let caller = Caller {
+            user_id,
+            agent: ctx.agent_id.clone(),
+            ..Caller::default()
+        };
+        let body = PermissionRequestBody::InterAgentMsg {
+            from: ctx.agent_id.clone(),
+            to: child_info.agent_id.clone(),
+        };
+        match self.permission_engine.evaluate(
+            PermissionRequest::WithCaller {
+                caller,
+                request: body,
+            },
+            None,
+        ) {
+            crate::permission::engine::engine_types::PermissionResponse::Allowed { .. } => {}
+            crate::permission::engine::engine_types::PermissionResponse::Denied {
+                reason, ..
+            } => {
+                return Err(ToolCallError::ExecutionFailed(format!(
+                    "permission denied: {}",
+                    reason
+                )));
+            }
+        }
+
+        // 5. Kill the child session
         self.session_manager
             .kill_child(parent_session_id, child_id)
             .await
             .map_err(ToolCallError::ExecutionFailed)?;
 
-        // 5. Return result
+        // 6. Return result
         Ok(ToolResult {
             data: json!({
                 "child_id": child_id,

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -307,7 +307,7 @@ impl Tool for SessionsSpawnTool {
                 ToolCallError::ExecutionFailed(format!("spawn validation failed: {}", e))
             })?;
         let config = spawn_result.config;
-        let effective_max_spawn_depth = spawn_result.effective_max_spawn_depth;
+        let effective_remaining_depth = spawn_result.effective_remaining_depth;
         self.validate_spawn_permissions(&config, parent_session_id)
             .await?;
         // Look up the parent agent's subagents.model config
@@ -344,7 +344,7 @@ impl Tool for SessionsSpawnTool {
                 spawn_args.allowed_tools,
                 spawn_args.model.as_deref(),
                 parent_subagents_model.as_deref(),
-                effective_max_spawn_depth,
+                effective_remaining_depth,
             )
             .await?;
         Ok(ToolResult {

--- a/src/tools/builtin/sessions_steer.rs
+++ b/src/tools/builtin/sessions_steer.rs
@@ -1,6 +1,8 @@
 //! Built-in sessions_steer tool — injects a new task into a persistent child session.
 
 use crate::gateway::SessionManager;
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_types::{Caller, PermissionRequest, PermissionRequestBody};
 use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
 
 use async_trait::async_trait;
@@ -13,12 +15,19 @@ use std::sync::Arc;
 /// Only works on `mode=session` children owned by the calling parent.
 pub struct SessionsSteerTool {
     session_manager: Arc<SessionManager>,
+    permission_engine: Arc<PermissionEngine>,
 }
 
 impl SessionsSteerTool {
     /// Create a new `SessionsSteerTool` with the given dependencies.
-    pub fn new(session_manager: Arc<SessionManager>) -> Self {
-        Self { session_manager }
+    pub fn new(
+        session_manager: Arc<SessionManager>,
+        permission_engine: Arc<PermissionEngine>,
+    ) -> Self {
+        Self {
+            session_manager,
+            permission_engine,
+        }
     }
 }
 
@@ -85,7 +94,8 @@ impl Tool for SessionsSteerTool {
         })?;
 
         // 3. Validate ownership
-        self.session_manager
+        let child_info = self
+            .session_manager
             .validate_child_ownership(parent_session_id, child_id)
             .await
             .ok_or_else(|| {
@@ -94,13 +104,46 @@ impl Tool for SessionsSteerTool {
                 )
             })?;
 
-        // 4. Steer the child session
+        // 4. Permission engine check — cross-agent communication
+        let user_id = self
+            .session_manager
+            .get_sender_id(parent_session_id)
+            .await
+            .unwrap_or_default();
+        let caller = Caller {
+            user_id,
+            agent: ctx.agent_id.clone(),
+            ..Caller::default()
+        };
+        let body = PermissionRequestBody::InterAgentMsg {
+            from: ctx.agent_id.clone(),
+            to: child_info.agent_id.clone(),
+        };
+        match self.permission_engine.evaluate(
+            PermissionRequest::WithCaller {
+                caller,
+                request: body,
+            },
+            None,
+        ) {
+            crate::permission::engine::engine_types::PermissionResponse::Allowed { .. } => {}
+            crate::permission::engine::engine_types::PermissionResponse::Denied {
+                reason, ..
+            } => {
+                return Err(ToolCallError::ExecutionFailed(format!(
+                    "permission denied: {}",
+                    reason
+                )));
+            }
+        }
+
+        // 5. Steer the child session
         self.session_manager
             .steer_child(child_id, task)
             .await
             .map_err(ToolCallError::ExecutionFailed)?;
 
-        // 5. Return result
+        // 6. Return result
         Ok(ToolResult {
             data: json!({
                 "child_id": child_id,

--- a/src/tools/builtin/sessions_steer_kill_tests.rs
+++ b/src/tools/builtin/sessions_steer_kill_tests.rs
@@ -1,8 +1,7 @@
 //! Unit tests for `SessionsSteerTool` and `SessionsKillTool`.
 //!
-//! Covers early-error (validation) tests only.
-//! Tests requiring real parent/child sessions (which access private fields
-//! on `SessionManager`) have been removed; those belong in integration tests.
+//! Covers early-error (validation) tests and permission engine
+//! cross-agent communication checks.
 
 use std::sync::Arc;
 
@@ -10,6 +9,8 @@ use serde_json::json;
 
 use crate::gateway::session_manager::SessionManager;
 use crate::gateway::{DmScope, GatewayConfig};
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::tools::builtin::sessions_kill::SessionsKillTool;
@@ -40,6 +41,13 @@ fn make_session_manager() -> Arc<SessionManager> {
     ))
 }
 
+/// Build a `PermissionEngine` with an empty RuleSet (all defaults apply).
+fn make_permission_engine() -> Arc<PermissionEngine> {
+    Arc::new(PermissionEngine::new_with_default_data_root(
+        RuleSetBuilder::new().build().unwrap(),
+    ))
+}
+
 fn ctx_with_session(session_id: &str) -> ToolContext {
     ToolContext {
         agent_id: "test-agent".to_string(),
@@ -67,7 +75,8 @@ fn ctx_without_session() -> ToolContext {
 #[tokio::test]
 async fn test_steer_missing_child_id() {
     let mgr = make_session_manager();
-    let tool = SessionsSteerTool::new(mgr);
+    let pe = make_permission_engine();
+    let tool = SessionsSteerTool::new(mgr, pe);
     let ctx = ctx_with_session("parent-x");
 
     let result = tool.call(json!({"task": "something"}), &ctx).await;
@@ -92,7 +101,8 @@ async fn test_steer_missing_child_id() {
 #[tokio::test]
 async fn test_steer_missing_task() {
     let mgr = make_session_manager();
-    let tool = SessionsSteerTool::new(mgr);
+    let pe = make_permission_engine();
+    let tool = SessionsSteerTool::new(mgr, pe);
     let ctx = ctx_with_session("parent-x");
 
     let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
@@ -117,7 +127,8 @@ async fn test_steer_missing_task() {
 #[tokio::test]
 async fn test_kill_missing_child_id() {
     let mgr = make_session_manager();
-    let tool = SessionsKillTool::new(mgr);
+    let pe = make_permission_engine();
+    let tool = SessionsKillTool::new(mgr, pe);
     let ctx = ctx_with_session("parent-x");
 
     let result = tool.call(json!({}), &ctx).await;
@@ -142,7 +153,8 @@ async fn test_kill_missing_child_id() {
 #[tokio::test]
 async fn test_steer_no_session_id_in_context() {
     let mgr = make_session_manager();
-    let tool = SessionsSteerTool::new(mgr);
+    let pe = make_permission_engine();
+    let tool = SessionsSteerTool::new(mgr, pe);
     let ctx = ctx_without_session();
 
     let result = tool
@@ -169,7 +181,8 @@ async fn test_steer_no_session_id_in_context() {
 #[tokio::test]
 async fn test_kill_no_session_id_in_context() {
     let mgr = make_session_manager();
-    let tool = SessionsKillTool::new(mgr);
+    let pe = make_permission_engine();
+    let tool = SessionsKillTool::new(mgr, pe);
     let ctx = ctx_without_session();
 
     let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
@@ -180,6 +193,65 @@ async fn test_kill_no_session_id_in_context() {
             assert!(
                 msg.contains("session_id"),
                 "error should mention session_id, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer: child session not found (ownership + permission path)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_child_not_found() {
+    let mgr = make_session_manager();
+    let pe = make_permission_engine();
+    let tool = SessionsSteerTool::new(mgr, pe);
+    let ctx = ctx_with_session("parent-x");
+
+    let result = tool
+        .call(
+            json!({"childId": "nonexistent-child", "task": "redo"}),
+            &ctx,
+        )
+        .await;
+
+    let err = result.expect_err("steer should fail when child not found");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("child session not found"),
+                "error should mention ownership, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kill: child session not found (ownership + permission path)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_child_not_found() {
+    let mgr = make_session_manager();
+    let pe = make_permission_engine();
+    let tool = SessionsKillTool::new(mgr, pe);
+    let ctx = ctx_with_session("parent-x");
+
+    let result = tool
+        .call(json!({"childId": "nonexistent-child"}), &ctx)
+        .await;
+
+    let err = result.expect_err("kill should fail when child not found");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("child session not found"),
+                "error should mention ownership, got: {}",
                 msg
             );
         }

--- a/src/tools/builtin/sessions_steer_kill_tests.rs
+++ b/src/tools/builtin/sessions_steer_kill_tests.rs
@@ -7,10 +7,13 @@ use std::sync::Arc;
 
 use serde_json::json;
 
-use crate::gateway::session_manager::SessionManager;
-use crate::gateway::{DmScope, GatewayConfig};
+use crate::gateway::session_manager::{ChildSessionInfo, SessionManager, SpawnMode};
+use crate::gateway::{DmScope, GatewayConfig, Session};
+use crate::llm::session::ConversationSession;
+use crate::permission::actions::ActionBuilder;
 use crate::permission::engine::engine_eval::PermissionEngine;
-use crate::permission::rules::RuleSetBuilder;
+use crate::permission::engine::engine_types::{Effect, Rule};
+use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::tools::builtin::sessions_kill::SessionsKillTool;
@@ -257,4 +260,317 @@ async fn test_kill_child_not_found() {
         }
         other => panic!("expected ExecutionFailed, got {:?}", other),
     }
+}
+
+// ===========================================================================
+// Step 1.5: Permission engine cross-agent communication tests
+// ===========================================================================
+
+/// Helper: build a `SessionManager` with a parent session registered
+/// in `sessions` (for agent_id lookup), a parent `ConversationSession`
+/// in `conversation_sessions`, and a child session registered in
+/// `children` (for ownership validation) with its own
+/// `ConversationSession` (required by steer/kill operations).
+async fn setup_parent_child(
+    mgr: &SessionManager,
+    parent_session_id: &str,
+    parent_agent_id: &str,
+    child_session_id: &str,
+    child_agent_id: &str,
+) {
+    // Register parent session (for get_chat_id lookup).
+    mgr.sessions.write().await.insert(
+        parent_session_id.to_string(),
+        Session {
+            id: parent_session_id.to_string(),
+            agent_id: parent_agent_id.to_string(),
+            channel: "test-channel".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    // Register a ConversationSession for the parent.
+    let parent_cs = ConversationSession::new(
+        parent_session_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    mgr.conversation_sessions.write().await.insert(
+        parent_session_id.to_string(),
+        Arc::new(tokio::sync::RwLock::new(parent_cs)),
+    );
+
+    // Register a ConversationSession for the child (required by
+    // steer_child / kill_child which call get_conversation_session).
+    let child_cs = ConversationSession::new(
+        child_session_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    mgr.conversation_sessions.write().await.insert(
+        child_session_id.to_string(),
+        Arc::new(tokio::sync::RwLock::new(child_cs)),
+    );
+
+    // Register child in the children tracking table.
+    mgr.register_child(
+        parent_session_id,
+        ChildSessionInfo {
+            session_id: child_session_id.to_string(),
+            parent_session_id: parent_session_id.to_string(),
+            agent_id: child_agent_id.to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+}
+
+/// Helper: build a `PermissionEngine` with a specific inter_agent
+/// default effect and optional explicit allow rule for a given agent
+/// communicating to a target agent.
+fn make_permission_engine_with_rules(
+    default_inter_agent: Effect,
+    allow_rules: Vec<Rule>,
+) -> Arc<PermissionEngine> {
+    let mut builder = RuleSetBuilder::new().default_inter_agent(default_inter_agent);
+    for rule in allow_rules {
+        builder = builder.rule(rule);
+    }
+    Arc::new(PermissionEngine::new_with_default_data_root(
+        builder.build().unwrap(),
+    ))
+}
+
+/// Helper: build an allow rule for inter-agent communication from
+/// `from_agent` to `to_agent`.
+fn inter_agent_allow_rule(from_agent: &str, to_agent: &str) -> Rule {
+    RuleBuilder::new()
+        .name(format!("allow-{}-to-{}", from_agent, to_agent))
+        .subject_agent(from_agent)
+        .allow()
+        .action(
+            ActionBuilder::inter_agent()
+                .with_agents(vec![to_agent.to_string()])
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Steer: permission allowed → steer succeeds
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_permission_allowed() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Allow → permission engine allows the operation.
+    let pe = make_permission_engine_with_rules(Effect::Allow, vec![]);
+    let tool = SessionsSteerTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-perm-ok";
+    let child_id = "child-perm-ok";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool
+        .call(json!({"childId": child_id, "task": "new task"}), &ctx)
+        .await;
+
+    let tool_result = result.expect("steer should succeed when permission is allowed");
+    assert_eq!(tool_result.data["child_id"], child_id);
+    assert_eq!(tool_result.data["task"], "new task");
+}
+
+// ---------------------------------------------------------------------------
+// Steer: permission denied → steer fails with permission error
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_permission_denied() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Deny, no allow rule → permission engine denies.
+    let pe = make_permission_engine_with_rules(Effect::Deny, vec![]);
+    let tool = SessionsSteerTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-perm-deny";
+    let child_id = "child-perm-deny";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool
+        .call(json!({"childId": child_id, "task": "new task"}), &ctx)
+        .await;
+
+    let err = result.expect_err("steer should fail when permission is denied");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("permission denied"),
+                "error should mention permission denied, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kill: permission allowed → kill succeeds
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_permission_allowed() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Allow → permission engine allows the operation.
+    let pe = make_permission_engine_with_rules(Effect::Allow, vec![]);
+    let tool = SessionsKillTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-kill-perm-ok";
+    let child_id = "child-kill-perm-ok";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+
+    let tool_result = result.expect("kill should succeed when permission is allowed");
+    assert_eq!(tool_result.data["child_id"], child_id);
+    assert_eq!(tool_result.data["status"], "killed");
+}
+
+// ---------------------------------------------------------------------------
+// Kill: permission denied → kill fails with permission error
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_permission_denied() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Deny, no allow rule → permission engine denies.
+    let pe = make_permission_engine_with_rules(Effect::Deny, vec![]);
+    let tool = SessionsKillTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-kill-perm-deny";
+    let child_id = "child-kill-perm-deny";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+
+    let err = result.expect_err("kill should fail when permission is denied");
+    match err {
+        ToolCallError::ExecutionFailed(msg) => {
+            assert!(
+                msg.contains("permission denied"),
+                "error should mention permission denied, got: {}",
+                msg
+            );
+        }
+        other => panic!("expected ExecutionFailed, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer: explicit allow rule overrides default deny
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_steer_explicit_allow_overrides_default_deny() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Deny, but explicit allow rule for parent-agent → child-agent.
+    let pe = make_permission_engine_with_rules(
+        Effect::Deny,
+        vec![inter_agent_allow_rule("parent-agent", "child-agent")],
+    );
+    let tool = SessionsSteerTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-explicit-ok";
+    let child_id = "child-explicit-ok";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool
+        .call(json!({"childId": child_id, "task": "steer task"}), &ctx)
+        .await;
+
+    let tool_result =
+        result.expect("steer should succeed when explicit allow rule overrides default deny");
+    assert_eq!(tool_result.data["child_id"], child_id);
+}
+
+// ---------------------------------------------------------------------------
+// Kill: explicit allow rule overrides default deny
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_kill_explicit_allow_overrides_default_deny() {
+    let mgr = make_session_manager();
+
+    // Default inter_agent = Deny, but explicit allow rule for parent-agent → child-agent.
+    let pe = make_permission_engine_with_rules(
+        Effect::Deny,
+        vec![inter_agent_allow_rule("parent-agent", "child-agent")],
+    );
+    let tool = SessionsKillTool::new(mgr.clone(), pe);
+
+    let parent_id = "parent-kill-explicit-ok";
+    let child_id = "child-kill-explicit-ok";
+    setup_parent_child(&mgr, parent_id, "parent-agent", child_id, "child-agent").await;
+
+    let ctx = ToolContext {
+        agent_id: "parent-agent".to_string(),
+        workdir: None,
+        session_id: Some(parent_id.to_string()),
+        call_id: None,
+        session: None,
+    };
+
+    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+
+    let tool_result =
+        result.expect("kill should succeed when explicit allow rule overrides default deny");
+    assert_eq!(tool_result.data["child_id"], child_id);
 }

--- a/src/tools/builtin/skill_tool_tests.rs
+++ b/src/tools/builtin/skill_tool_tests.rs
@@ -241,13 +241,20 @@ mod tests {
         assert_eq!(sm.get_session_depth(child_id).await, Some(1));
 
         // Verify the child session has the skill body as its pending task
+        // (spawn context is prepended by create_child_session)
         let cs = sm
             .get_conversation_session(child_id)
             .await
             .expect("child conversation session should exist");
         let pending = cs.read().await.get_pending_messages();
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].content, "# Fork Skill\n\nDo the fork thing.");
+        assert!(
+            pending[0]
+                .content
+                .ends_with("# Fork Skill\n\nDo the fork thing."),
+            "pending message should end with skill body, got: {}",
+            pending[0].content
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Align agent-spawn implementation with design doc

Fix 4 must_fix differences between code and design docs:
- Fix depth check logic: use remaining capacity (min(child, parent-1)) instead of absolute depth comparison
- Move spawn context from system prompt to first user message as required by design doc
- Add Permission engine cross-agent communication check to steer/kill tools
- Fix group name inconsistency (session_ops → sessions) in agent-spawn.md
- Add comprehensive UT for depth boundary cases and permission engine checks

Source: design doc diff scan
Type: fix
