### PR TITLE
feat: 补充 agent-spawn 设计文档缺失的两项提示词注入

### DIFF
--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -314,6 +314,24 @@ impl SessionManager {
                Your effective maximum depth for children is {remaining_depth}."
             ));
         }
+
+        // Structured output guidance (optional, per design doc §结构化输出).
+        // Helps the parent agent parse and act on the child's results.
+        ctx.push_str(
+            "\n\
+             **Structured output (optional):** \
+             When you complete your task, consider structuring your \
+             response with the following sections:\n\
+             - **Task scope**: one-sentence confirmation of what you \
+               understood\n\
+             - **Execution results**: key findings or answers\n\
+             - **Files involved**: relevant file paths\n\
+             - **File changes**: modified files and what changed\n\
+             - **Issues found**: problems or risks encountered\n\
+             Structured output is a suggestion — you may reply freely — \
+             but it helps the parent agent process your results.",
+        );
+
         ctx.push('\n');
         ctx
     }

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -791,6 +791,69 @@ async fn test_child_session_system_prompt_contains_spawn_context() {
     );
 }
 
+// ── Step 1.2: structured output guidance tests ─────────────────────────────
+
+/// Verify `build_spawn_context` includes the structured output guidance
+/// section (per design doc §结构化输出) when remaining_depth > 0.
+#[test]
+fn test_build_spawn_context_structured_output_guidance() {
+    let ctx = SessionManager::build_spawn_context(1, 2);
+    assert!(
+        ctx.contains("Structured output (optional)"),
+        "should contain structured output header"
+    );
+    assert!(
+        ctx.contains("Task scope"),
+        "should contain Task scope section"
+    );
+    assert!(
+        ctx.contains("Execution results"),
+        "should contain Execution results section"
+    );
+    assert!(
+        ctx.contains("Files involved"),
+        "should contain Files involved section"
+    );
+    assert!(
+        ctx.contains("File changes"),
+        "should contain File changes section"
+    );
+    assert!(
+        ctx.contains("Issues found"),
+        "should contain Issues found section"
+    );
+}
+
+/// Verify the structured output guidance explicitly states it is optional
+/// and that the child may reply freely.
+#[test]
+fn test_build_spawn_context_structured_output_is_optional() {
+    let ctx = SessionManager::build_spawn_context(0, 1);
+    assert!(
+        ctx.contains("suggestion"),
+        "should indicate structured output is a suggestion"
+    );
+    assert!(
+        ctx.contains("may reply freely"),
+        "should state the child may reply freely"
+    );
+}
+
+/// Verify structured output guidance is present even at remaining_depth == 0
+/// (it is independent of spawn depth — it always applies).
+#[test]
+fn test_build_spawn_context_structured_output_at_depth_limit() {
+    let ctx = SessionManager::build_spawn_context(3, 0);
+    assert!(
+        ctx.contains("Structured output (optional)"),
+        "structured output should be present even at spawn depth limit"
+    );
+    assert!(
+        ctx.contains("Task scope"),
+        "Task scope should be present at depth limit"
+    );
+}
+
 // ── Step 1.4: communication config tests ─────────────────────────────────
 
 /// Verify the child session's communication config restricts

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -6,6 +6,18 @@
 use super::sections::Section;
 use crate::tools::{PromptGenerationContext, ToolContext, ToolRegistry};
 
+/// Task writing guidance appended to the tools section when spawn is available.
+/// Source: docs/design/agent/agent-spawn.md §父 Agent 的 Task 编写指引
+const TASK_WRITING_GUIDANCE: &str = concat!(
+    "\n\n## Task Writing Guidance for Spawning Sub-Agents\n\n\n",
+    "When spawning a sub-agent, write the task as you would brief a smart colleague ",
+    "who just walked into the room \u{2014} explain what you need done and why.\n\n",
+    "- Do NOT push judgment calls onto the sub-agent. The parent agent should ",
+    "complete understanding and decision-making; the sub-agent executes.\n",
+    "- Use fork mode when the sub-agent needs full context of the ongoing conversation. ",
+    "Use normal spawn for independent, self-contained tasks."
+);
+
 /// Build the Tools section content from a registry.
 ///
 /// The registry's `build_tools_section` requires a [`PromptGenerationContext`]
@@ -36,6 +48,19 @@ pub async fn build_tools_section(
 
     // 3. Acquire the registry lock again and render the section.
     let content = registry.build_tools_section(&prompt_ctx).await;
+
+    // 4. If the spawn tool is available, append task writing guidance.
+    let content = if prompt_ctx
+        .available_tool_names
+        .iter()
+        .any(|n| n == "sessions_spawn")
+    {
+        let guidance = TASK_WRITING_GUIDANCE;
+        format!("{}\n{}", content, guidance)
+    } else {
+        content
+    };
+
     Section::ToolsSection(content)
 }
 

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -310,4 +310,79 @@ mod tests {
             content
         );
     }
+
+    #[tokio::test]
+    async fn test_task_writing_guidance_when_spawn_available() {
+        let registry = ToolRegistry::new();
+        let disk_registry = Arc::new(DiskSkillRegistry::new(vec![]));
+        let (spawn_controller, session_manager, config_manager, agent_registry) = test_spawn_deps();
+        register_builtin_tools(
+            &registry,
+            make_builtin_ctx(
+                disk_registry,
+                test_permission_engine(),
+                spawn_controller,
+                session_manager,
+                config_manager,
+                agent_registry,
+            ),
+        )
+        .await;
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+            session_id: None,
+            call_id: None,
+            session: None,
+        };
+        let section = build_tools_section(&registry, &ctx, None, None).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        assert!(
+            content.contains("smart colleague"),
+            "missing 'smart colleague' in guidance: {}",
+            &content[content.len().min(content.len().saturating_sub(500))..]
+        );
+        assert!(
+            content.contains("judgment calls"),
+            "missing 'judgment calls' in guidance"
+        );
+        assert!(
+            content.contains("fork mode"),
+            "missing 'fork mode' in guidance"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_task_writing_guidance_absent_when_spawn_unavailable() {
+        // Empty registry → sessions_spawn is not in available_tool_names
+        let registry = ToolRegistry::new();
+        let ctx = crate::tools::ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+            session_id: None,
+            call_id: None,
+            session: None,
+        };
+        let section = build_tools_section(&registry, &ctx, None, None).await;
+        let content = match section {
+            Section::ToolsSection(c) => c,
+            _ => panic!("expected ToolsSection"),
+        };
+        assert!(
+            !content.contains("smart colleague"),
+            "task writing guidance should NOT appear without sessions_spawn, got: {}",
+            content
+        );
+        assert!(
+            !content.contains("judgment calls"),
+            "task writing guidance should NOT appear without sessions_spawn"
+        );
+        assert!(
+            !content.contains("fork mode"),
+            "task writing guidance should NOT appear without sessions_spawn"
+        );
+    }
 }


### PR DESCRIPTION
补充 agent-spawn 设计文档中描述的两项提示词注入功能：

1. **结构化输出引导**：在 `build_spawn_context()` 末尾追加引导段落，引导子 agent 输出结构化摘要（任务范围、执行结果、涉及文件、文件变更、发现的问题），标注为可选引导
2. **父 Agent Task 编写指引**：在系统提示词 tools section 中，当 spawn 工具可用时追加 task 编写策略建议（像给聪明同事交代任务、不要把综合判断推给子 agent、fork 模式 vs 普通 spawn 的使用场景）

Source: design-doc
Type: feat
