### PR TITLE
fix: align agent-spawn implementation with design doc

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -433,6 +433,8 @@ mod announce_tests;
 #[cfg(test)]
 mod bug904_tests;
 #[cfg(test)]
+mod concurrency_count_tests;
+#[cfg(test)]
 mod flush_tests;
 #[cfg(test)]
 mod model_priority_tests;

--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -160,6 +160,13 @@ impl SessionManager {
                 .await
                 .unregister_child_handle(child_session_id);
         }
+
+        // Remove the child entry from the parent's `children` tracking
+        // table so `count_active_children` no longer counts this
+        // completed session (fixes concurrency inflation for run-mode
+        // children that never go through `kill_child`).
+        self.remove_child_from_tracking(&parent_session_id, child_session_id)
+            .await;
     }
 
     /// Find the (parent_session_id, child_agent_id) of a child whose

--- a/src/gateway/session_manager/concurrency_count_tests.rs
+++ b/src/gateway/session_manager/concurrency_count_tests.rs
@@ -1,0 +1,227 @@
+//! Unit tests for concurrency count correctness (Step 1.1 / 1.3).
+//!
+//! Verifies that `count_active_children` returns correct values after
+//! run-mode children complete and session-mode children are killed.
+
+use super::spawn::SpawnMode;
+use super::test_helpers::make_response;
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::SessionManager;
+use crate::llm::session::ChatSession;
+use crate::llm::types::ContentBlock;
+use serial_test::serial;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::agent::config::SubagentsConfig;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::llm::session::ConversationSession;
+use crate::session::bootstrap::BootstrapMode;
+
+fn test_resolved_config(id: &str, workspace: Option<PathBuf>) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        permissions: None,
+        source: ConfigSource::Merged,
+    }
+}
+
+async fn register_parent_session(mgr: &SessionManager, parent_id: &str, workdir: PathBuf) {
+    let cs = ConversationSession::new(parent_id.to_string(), "test-model".to_string(), workdir);
+    let arc = Arc::new(RwLock::new(cs));
+    let mut conv = mgr.conversation_sessions.write().await;
+    conv.insert(parent_id.to_string(), arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+}
+
+/// Run-mode child: after `try_push_announce` completes, the child is
+/// removed from the `children` tracking table and `count_active_children`
+/// returns 0.
+#[tokio::test]
+#[serial]
+async fn test_run_mode_child_count_zero_after_announce() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("counter-child", None);
+
+    register_parent_session(&mgr, "parent-count", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-count",
+            1,
+            "count task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Verify child is tracked
+    assert_eq!(mgr.count_active_children("parent-count").await, 1);
+
+    // Simulate child completing: append an assistant message so
+    // try_push_announce can extract result_text.
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child should exist");
+    cs.write()
+        .await
+        .append_response(make_response(vec![ContentBlock::Text("done".to_string())]));
+
+    // Announce pushes event + removes from children table
+    mgr.try_push_announce(&child_id).await;
+
+    // Count should now be 0
+    assert_eq!(
+        mgr.count_active_children("parent-count").await,
+        0,
+        "count_active_children should return 0 after run-mode child announce"
+    );
+}
+
+/// Session-mode child: after `kill_child`, `count_active_children` returns 0.
+#[tokio::test]
+#[serial]
+async fn test_session_mode_child_count_zero_after_kill() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("kill-counter-child", None);
+
+    register_parent_session(&mgr, "parent-kill-count", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-kill-count",
+            1,
+            "kill task",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert_eq!(mgr.count_active_children("parent-kill-count").await, 1);
+
+    mgr.kill_child("parent-kill-count", &child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert_eq!(
+        mgr.count_active_children("parent-kill-count").await,
+        0,
+        "count_active_children should return 0 after kill_child"
+    );
+}
+
+/// Multiple run-mode children: count decrements correctly for each
+/// completion, and the final count is 0 when all have announced.
+#[tokio::test]
+#[serial]
+async fn test_multiple_run_mode_children_count_decrements_correctly() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    register_parent_session(&mgr, "parent-multi", tmp.path().to_path_buf()).await;
+
+    const N: usize = 4;
+    let mut child_ids: Vec<String> = Vec::with_capacity(N);
+
+    for i in 0..N {
+        let config = test_resolved_config(&format!("worker-{}", i), None);
+        let child_id = mgr
+            .create_child_session(
+                &config,
+                "parent-multi",
+                1,
+                &format!("task {}", i),
+                true,
+                None,
+                SpawnMode::Run,
+                false,
+                None,
+                None,
+                None,
+                3,
+            )
+            .await
+            .expect("create_child_session should succeed");
+        child_ids.push(child_id);
+    }
+
+    // All N children are tracked
+    assert_eq!(mgr.count_active_children("parent-multi").await, N);
+
+    // Complete children one by one, assert count after each
+    for (i, child_id) in child_ids.iter().enumerate() {
+        let cs = mgr
+            .get_conversation_session(child_id)
+            .await
+            .expect("child should exist");
+        cs.write()
+            .await
+            .append_response(make_response(vec![ContentBlock::Text(format!(
+                "answer-{}",
+                i
+            ))]));
+
+        mgr.try_push_announce(child_id).await;
+
+        let expected_count = N - (i + 1);
+        assert_eq!(
+            mgr.count_active_children("parent-multi").await,
+            expected_count,
+            "after completing child {}, count should be {}",
+            i,
+            expected_count
+        );
+    }
+
+    // Final count is 0
+    assert_eq!(
+        mgr.count_active_children("parent-multi").await,
+        0,
+        "count should be 0 after all run-mode children have announced"
+    );
+}

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -401,6 +401,19 @@ impl SessionManager {
         Ok(PathBuf::from("/tmp"))
     }
 
+    /// Remove a child session entry from the parent's `children` tracking
+    /// table. Extracted from `kill_child` so `try_push_announce` can also
+    /// clean up after a run-mode child completes.
+    pub(crate) async fn remove_child_from_tracking(&self, parent_id: &str, child_id: &str) {
+        let mut children = self.children.write().await;
+        if let Some(list) = children.get_mut(parent_id) {
+            list.retain(|info| info.session_id != child_id);
+            if list.is_empty() {
+                children.remove(parent_id);
+            }
+        }
+    }
+
     /// Validate that a child session is owned by the given parent and
     /// was spawned in `Session` mode (persistent). Returns the child
     /// info on success, `None` otherwise.
@@ -470,15 +483,7 @@ impl SessionManager {
         }
 
         // Remove from children tracking table.
-        {
-            let mut children = self.children.write().await;
-            if let Some(list) = children.get_mut(parent_id) {
-                list.retain(|info| info.session_id != child_id);
-                if list.is_empty() {
-                    children.remove(parent_id);
-                }
-            }
-        }
+        self.remove_child_from_tracking(parent_id, child_id).await;
 
         Ok(())
     }

--- a/src/tools/builtin/sessions_kill.rs
+++ b/src/tools/builtin/sessions_kill.rs
@@ -57,12 +57,12 @@ impl Tool for SessionsKillTool {
         json!({
             "type": "object",
             "properties": {
-                "childId": {
+                "sessionId": {
                     "type": "string",
                     "description": "The session ID of the child session to kill"
                 }
             },
-            "required": ["childId"]
+            "required": ["sessionId"]
         })
     }
 
@@ -76,9 +76,11 @@ impl Tool for SessionsKillTool {
     async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
         // 1. Extract parameters
         let child_id = args
-            .get("childId")
+            .get("sessionId")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolCallError::InvalidArgs("missing required field 'childId'".into()))?;
+            .ok_or_else(|| {
+                ToolCallError::InvalidArgs("missing required field 'sessionId'".into())
+            })?;
 
         // 2. Get parent session_id from context
         let parent_session_id = ctx.session_id.as_deref().ok_or_else(|| {

--- a/src/tools/builtin/sessions_steer.rs
+++ b/src/tools/builtin/sessions_steer.rs
@@ -57,7 +57,7 @@ impl Tool for SessionsSteerTool {
         json!({
             "type": "object",
             "properties": {
-                "childId": {
+                "sessionId": {
                     "type": "string",
                     "description": "The session ID of the child session to steer"
                 },
@@ -66,7 +66,7 @@ impl Tool for SessionsSteerTool {
                     "description": "The new task to inject into the child session"
                 }
             },
-            "required": ["childId", "task"]
+            "required": ["sessionId", "task"]
         })
     }
 
@@ -80,9 +80,11 @@ impl Tool for SessionsSteerTool {
     async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
         // 1. Extract parameters
         let child_id = args
-            .get("childId")
+            .get("sessionId")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolCallError::InvalidArgs("missing required field 'childId'".into()))?;
+            .ok_or_else(|| {
+                ToolCallError::InvalidArgs("missing required field 'sessionId'".into())
+            })?;
         let task = args
             .get("task")
             .and_then(|v| v.as_str())

--- a/src/tools/builtin/sessions_steer_kill_tests.rs
+++ b/src/tools/builtin/sessions_steer_kill_tests.rs
@@ -72,7 +72,7 @@ fn ctx_without_session() -> ToolContext {
 }
 
 // ---------------------------------------------------------------------------
-// Steer: missing childId
+// Steer: missing sessionId
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -84,12 +84,12 @@ async fn test_steer_missing_child_id() {
 
     let result = tool.call(json!({"task": "something"}), &ctx).await;
 
-    let err = result.expect_err("steer should fail when childId is missing");
+    let err = result.expect_err("steer should fail when sessionId is missing");
     match err {
         ToolCallError::InvalidArgs(msg) => {
             assert!(
-                msg.contains("childId"),
-                "error should mention childId, got: {}",
+                msg.contains("sessionId"),
+                "error should mention sessionId, got: {}",
                 msg
             );
         }
@@ -108,7 +108,7 @@ async fn test_steer_missing_task() {
     let tool = SessionsSteerTool::new(mgr, pe);
     let ctx = ctx_with_session("parent-x");
 
-    let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
+    let result = tool.call(json!({"sessionId": "some-id"}), &ctx).await;
 
     let err = result.expect_err("steer should fail when task is missing");
     match err {
@@ -124,7 +124,7 @@ async fn test_steer_missing_task() {
 }
 
 // ---------------------------------------------------------------------------
-// Kill: missing childId
+// Kill: missing sessionId
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -136,12 +136,12 @@ async fn test_kill_missing_child_id() {
 
     let result = tool.call(json!({}), &ctx).await;
 
-    let err = result.expect_err("kill should fail when childId is missing");
+    let err = result.expect_err("kill should fail when sessionId is missing");
     match err {
         ToolCallError::InvalidArgs(msg) => {
             assert!(
-                msg.contains("childId"),
-                "error should mention childId, got: {}",
+                msg.contains("sessionId"),
+                "error should mention sessionId, got: {}",
                 msg
             );
         }
@@ -161,7 +161,7 @@ async fn test_steer_no_session_id_in_context() {
     let ctx = ctx_without_session();
 
     let result = tool
-        .call(json!({"childId": "some-id", "task": "something"}), &ctx)
+        .call(json!({"sessionId": "some-id", "task": "something"}), &ctx)
         .await;
 
     let err = result.expect_err("steer should fail when session_id is None");
@@ -188,7 +188,7 @@ async fn test_kill_no_session_id_in_context() {
     let tool = SessionsKillTool::new(mgr, pe);
     let ctx = ctx_without_session();
 
-    let result = tool.call(json!({"childId": "some-id"}), &ctx).await;
+    let result = tool.call(json!({"sessionId": "some-id"}), &ctx).await;
 
     let err = result.expect_err("kill should fail when session_id is None");
     match err {
@@ -216,7 +216,7 @@ async fn test_steer_child_not_found() {
 
     let result = tool
         .call(
-            json!({"childId": "nonexistent-child", "task": "redo"}),
+            json!({"sessionId": "nonexistent-child", "task": "redo"}),
             &ctx,
         )
         .await;
@@ -246,7 +246,7 @@ async fn test_kill_child_not_found() {
     let ctx = ctx_with_session("parent-x");
 
     let result = tool
-        .call(json!({"childId": "nonexistent-child"}), &ctx)
+        .call(json!({"sessionId": "nonexistent-child"}), &ctx)
         .await;
 
     let err = result.expect_err("kill should fail when child not found");
@@ -386,7 +386,7 @@ async fn test_steer_permission_allowed() {
     };
 
     let result = tool
-        .call(json!({"childId": child_id, "task": "new task"}), &ctx)
+        .call(json!({"sessionId": child_id, "task": "new task"}), &ctx)
         .await;
 
     let tool_result = result.expect("steer should succeed when permission is allowed");
@@ -419,7 +419,7 @@ async fn test_steer_permission_denied() {
     };
 
     let result = tool
-        .call(json!({"childId": child_id, "task": "new task"}), &ctx)
+        .call(json!({"sessionId": child_id, "task": "new task"}), &ctx)
         .await;
 
     let err = result.expect_err("steer should fail when permission is denied");
@@ -459,7 +459,7 @@ async fn test_kill_permission_allowed() {
         session: None,
     };
 
-    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+    let result = tool.call(json!({"sessionId": child_id}), &ctx).await;
 
     let tool_result = result.expect("kill should succeed when permission is allowed");
     assert_eq!(tool_result.data["child_id"], child_id);
@@ -490,7 +490,7 @@ async fn test_kill_permission_denied() {
         session: None,
     };
 
-    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+    let result = tool.call(json!({"sessionId": child_id}), &ctx).await;
 
     let err = result.expect_err("kill should fail when permission is denied");
     match err {
@@ -533,7 +533,7 @@ async fn test_steer_explicit_allow_overrides_default_deny() {
     };
 
     let result = tool
-        .call(json!({"childId": child_id, "task": "steer task"}), &ctx)
+        .call(json!({"sessionId": child_id, "task": "steer task"}), &ctx)
         .await;
 
     let tool_result =
@@ -568,7 +568,7 @@ async fn test_kill_explicit_allow_overrides_default_deny() {
         session: None,
     };
 
-    let result = tool.call(json!({"childId": child_id}), &ctx).await;
+    let result = tool.call(json!({"sessionId": child_id}), &ctx).await;
 
     let tool_result =
         result.expect("kill should succeed when explicit allow rule overrides default deny");


### PR DESCRIPTION
fix: align agent-spawn implementation with design doc — concurrency inflation, param naming, UT

修复 F2b 设计文档深度对比发现的 3 个 must_fix 差异：

1. **并发计数膨胀**：run-mode 子 session 完成后未从 `children` 跟踪表移除，导致 `count_active_children` 计数只增不减，`MaxChildrenReached` 误拒。提取 `remove_child_from_tracking` 公共方法，在 `try_push_announce` 完成后清理已完成的子 session 条目。

2. **参数名不一致**：`sessions_steer` / `sessions_kill` 的参数名从 `childId` 改为 `sessionId`，与 `docs/design/session/session-tools.md` 定义一致。

3. **并发计数单元测试**：添加 3 个测试用例验证 run-mode 和 session-mode 子 session 完成/移除后 `count_active_children` 返回正确值。

Source: 设计文档对齐
Type: fix
