### PR TITLE
feat(hooks): add role-based hook system with dev role

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -6,10 +6,13 @@
 
 ```
 .githooks/
-├── commit-msg    # 提交信息格式检查（Source: + Type:）
-├── pre-commit    # 代码风格检查（行数 + fmt）
-├── pre-push      # 禁止 force push 到保护分支
-└── README.md     # 本文件
+├── commit-msg         # 提交信息格式检查（Source: + Type:）
+├── pre-commit         # 代码风格检查（行数 + fmt）+ 角色规则
+├── pre-push           # 禁止 force push 到保护分支 + 角色规则
+├── roles/             # 角色规则目录
+│   ├── dev.pre-commit # dev 角色：禁止改动 docs/design/ 和 CONTRIBUTING.md
+│   └── dev.pre-push   # dev 角色：push 前兜底检查
+└── README.md          # 本文件
 ```
 
 ## 配置
@@ -22,6 +25,46 @@ git config core.hooksPath .githooks
 
 **注意**：`core.hooksPath` 是 per-repo 配置，新克隆仓库后需重新执行上方命令。
 
+## 角色系统
+
+Hooks 支持基于角色的扩展检查。Base 检查对所有人生效，角色规则在此基础上增加额外约束。
+
+### 设置角色
+
+```bash
+git config hooks.role dev
+```
+
+取消角色（回到纯 base 检查）：
+
+```bash
+git config --unset hooks.role
+```
+
+### 可用角色
+
+| 角色 | 说明 | 限制 |
+|------|------|------|
+| `dev` | 普通开发者 | 禁止修改 `docs/design/` 和 `CONTRIBUTING.md` |
+
+### 工作原理
+
+Base hook 完成通用检查后，读取 `git config hooks.role`，如果存在对应的角色脚本（`roles/<role>.<hook-name>`），则加载并执行。
+
+```
+pre-commit 触发
+  → 1. Base 检查（行数、env 禁令、fmt）
+  → 2. 读取 hooks.role 配置
+  → 3. 执行 roles/<role>.pre-commit（如有）
+  → 4. 全部通过 → 放行
+```
+
+角色规则 **不允许绕过**（`--no-verify` 会跳过所有 hook，包括 base，不建议使用）。
+
+### 添加新角色
+
+在 `roles/` 目录下创建 `<role>.pre-commit` 和/或 `<role>.pre-push` 脚本即可。脚本以 bash 执行，退出非零则拦截。
+
 ## Hooks 说明
 
 ### pre-commit
@@ -32,8 +75,9 @@ git config core.hooksPath .githooks
 |---|---|---|---|
 | 1 | 文件行数 | ≤ 1000 行 | `ERROR: <file>: <N> 行（上限 1000）` |
 | 2 | `cargo fmt --check` | 行宽 100 等 | 格式不符合规范，运行 `cargo fmt` 修复 |
+| 3 | 角色规则 | 取决于角色 | 见上方角色说明 |
 
-**注意**：以上检查均仅针对 staged 的 `.rs` 文件，不背负历史技术债。
+**注意**：行数和 fmt 检查仅针对 staged 的 `.rs` 文件，不背负历史技术债。
 
 ### commit-msg
 
@@ -53,8 +97,6 @@ Type 支持：`feat` `fix` `docs` `refactor` `test` `perf` `chore`
 
 禁止 force push 到保护分支（`master` `main` `develop`）。
 
-检测原理：push 前 fetch remote sha，通过 `git merge-base --is-ancestor` 判断 remote sha 是否为 local sha 的祖先——若不是，则为 force push，拦截并报错。
-
 ## 团队同步
 
 `.githooks/` 目录已纳入版本控制，团队成员 pull 后需执行配置命令：
@@ -63,4 +105,14 @@ Type 支持：`feat` `fix` `docs` `refactor` `test` `perf` `chore`
 git config core.hooksPath .githooks
 ```
 
-或者在克隆时通过 `git clone --config core.hooksPath=.githooks` 自动配置。
+开发者还需设置自己的角色：
+
+```bash
+git config hooks.role dev
+```
+
+或者在克隆时一步到位：
+
+```bash
+git clone --config core.hooksPath=.githooks --config hooks.role=dev git@github.com:jpxthu/CloseClaw.git
+```

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,4 +39,11 @@ if [ -n "$staged_rs" ]; then
     fi
 fi
 
+# 角色检查 — 读取 git config hooks.role，加载对应的角色规则
+hook_name=$(basename "$0")
+role=$(git config hooks.role 2>/dev/null || true)
+if [ -n "$role" ] && [ -f ".githooks/roles/${role}.${hook_name}" ]; then
+    bash ".githooks/roles/${role}.${hook_name}"
+fi
+
 echo "All checks passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,3 +6,10 @@ while read local_ref local_sha remote_ref remote_sha; do
         exit 1
     fi
 done
+
+# 角色检查 — 读取 git config hooks.role，加载对应的角色规则
+hook_name=$(basename "$0")
+role=$(git config hooks.role 2>/dev/null || true)
+if [ -n "$role" ] && [ -f ".githooks/roles/${role}.${hook_name}" ]; then
+    bash ".githooks/roles/${role}.${hook_name}"
+fi

--- a/.githooks/roles/dev.pre-commit
+++ b/.githooks/roles/dev.pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+# dev role: 禁止改动 docs/design/ 和 CONTRIBUTING.md
+# 这些文件由项目维护者管控，开发者如需修改请联系维护者或提 issue 讨论
+
+protected=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(docs/design/|CONTRIBUTING\.md$)' || true)
+if [ -n "$protected" ]; then
+    echo ""
+    echo "ERROR: dev 角色不允许修改以下受保护文件："
+    echo "$protected"
+    echo ""
+    echo "docs/design/ 和 CONTRIBUTING.md 由项目维护者管控。"
+    echo "如需修改，请联系维护者或提 issue 讨论。"
+    exit 1
+fi

--- a/.githooks/roles/dev.pre-commit
+++ b/.githooks/roles/dev.pre-commit
@@ -5,10 +5,10 @@
 protected=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(docs/design/|CONTRIBUTING\.md$)' || true)
 if [ -n "$protected" ]; then
     echo ""
-    echo "ERROR: dev 角色不允许修改以下受保护文件："
+    echo "ERROR: 以下受保护文件不允许修改："
     echo "$protected"
     echo ""
-    echo "docs/design/ 和 CONTRIBUTING.md 由项目维护者管控。"
-    echo "如需修改，请联系维护者或提 issue 讨论。"
+    echo "禁止更改 design doc 和开发规范，如若违反一定会被 owner revert。"
+    echo "请勿绕过限制，及时撤销或上报（给主脑）违规更改。"
     exit 1
 fi

--- a/.githooks/roles/dev.pre-push
+++ b/.githooks/roles/dev.pre-push
@@ -14,11 +14,11 @@ while read local_ref local_sha remote_ref remote_sha; do
     protected=$(git diff --name-only "$base" "$local_sha" | grep -E '^(docs/design/|CONTRIBUTING\.md$)' || true)
     if [ -n "$protected" ]; then
         echo ""
-        echo "ERROR: dev 角色不允许修改以下受保护文件："
+        echo "ERROR: 以下受保护文件不允许修改："
         echo "$protected"
         echo ""
-        echo "docs/design/ 和 CONTRIBUTING.md 由项目维护者管控。"
-        echo "如需修改，请联系维护者或提 issue 讨论。"
+        echo "禁止更改 design doc 和开发规范，如若违反一定会被 owner revert。"
+        echo "请勿绕过限制，及时撤销或上报（给主脑）违规更改。"
         exit 1
     fi
 done

--- a/.githooks/roles/dev.pre-push
+++ b/.githooks/roles/dev.pre-push
@@ -1,0 +1,24 @@
+#!/bin/bash
+# dev role: push 前兜底检查，确保没有绕过 pre-commit 修改受保护文件
+# 与 dev.pre-commit 保持一致
+
+while read local_ref local_sha remote_ref remote_sha; do
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        base="$local_sha"
+    elif [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    else
+        base="$remote_sha"
+    fi
+
+    protected=$(git diff --name-only "$base" "$local_sha" | grep -E '^(docs/design/|CONTRIBUTING\.md$)' || true)
+    if [ -n "$protected" ]; then
+        echo ""
+        echo "ERROR: dev 角色不允许修改以下受保护文件："
+        echo "$protected"
+        echo ""
+        echo "docs/design/ 和 CONTRIBUTING.md 由项目维护者管控。"
+        echo "如需修改，请联系维护者或提 issue 讨论。"
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Summary

新增模块化 hook 分层架构：base hook 执行通用检查后，根据 `git config hooks.role` 加载角色专属规则。

## Changes

- `pre-commit` / `pre-push`：末尾新增角色分发逻辑，读取 `hooks.role` 配置并 source 对应脚本
- `roles/dev.pre-commit`：dev 角色 pre-commit 规则，拦截 `docs/design/` 和 `CONTRIBUTING.md` 改动
- `roles/dev.pre-push`：dev 角色 pre-push 兜底检查（防止 `--no-verify` 绕过）
- `README.md`：更新文档，说明角色系统用法

## Usage

```bash
# 激活 dev 角色
git config hooks.role dev

# 取消角色
git config --unset hooks.role
```

## Design

```
pre-commit 触发
  → 1. Base 检查（行数、env 禁令、fmt）
  → 2. 读取 hooks.role
  → 3. 执行 roles/<role>.pre-commit（如有）
  → 4. 全部通过 → 放行
```

角色脚本在 base 检查通过后执行，退出非零则拦截。扩展新角色只需在 `roles/` 下添加对应脚本。

Source: user
Type: feat