### PR TITLE
feat: 实现 CLI 配置向导创建初始 master Agent

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -509,6 +509,13 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         anyhow::bail!("write_wizard_config failed: {}", e);
     }
 
+    // Create initial master agent if it does not exist yet.
+    // Failure here is non-fatal: the wizard config (models + credentials) is
+    // already written and should not be rolled back.
+    if let Err(e) = ensure_master_agent(&config_dir()) {
+        eprintln!("[WARNING] Failed to create master agent: {}", e);
+    }
+
     Ok(Some(WizardOutput {
         provider_id: out_provider_id,
         credential: out_credential,

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -6,6 +6,8 @@ pub mod types;
 pub use fetch::*;
 pub use types::*;
 
+use crate::agent::config::AgentConfig;
+use crate::config::agents::{AgentsConfig, AgentsConfigProvider};
 use crate::config::providers::{
     credentials::{AnyProviderCredentials, ApiKeyCredentials},
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
@@ -109,6 +111,59 @@ pub fn parse_model_selection(input: &str, total: usize) -> anyhow::Result<Vec<us
 fn config_dir() -> PathBuf {
     let home = std::env::var("HOME").expect("HOME not set");
     PathBuf::from(home).join(".closeclaw").join("config")
+}
+
+#[allow(dead_code)]
+/// Create the initial `master` agent if it does not already exist.
+///
+/// Writes:
+/// - `~/.closeclaw/agents/master/config.json`
+/// - `~/.closeclaw/config/agents.json` (appends "master" if missing)
+///
+/// Idempotent: skips files that already exist.
+fn ensure_master_agent(config_dir: &Path) -> anyhow::Result<()> {
+    let agents_dir = config_dir.parent().unwrap_or(config_dir).join("agents");
+
+    // ── Write master agent config.json if missing ──────────────────────────────
+    let master_config_path = agents_dir.join("master").join("config.json");
+    if !master_config_path.exists() {
+        let dir = master_config_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("cannot determine agent directory"))?;
+        std::fs::create_dir_all(dir)?;
+
+        let config = AgentConfig {
+            id: "master".to_string(),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&config)
+            .map_err(|e| anyhow::anyhow!("failed to serialize AgentConfig: {}", e))?;
+        std::fs::write(&master_config_path, json)?;
+    }
+
+    // ── Update agents.json registration list ───────────────────────────────────
+    let agents_json_path = config_dir.join("agents.json");
+    if agents_json_path.exists() {
+        let content = std::fs::read_to_string(&agents_json_path)?;
+        let provider = AgentsConfigProvider::from_json_str(&content)?;
+        let mut agents_config = provider.inner().clone();
+        if !agents_config.agents.contains(&"master".to_string()) {
+            agents_config.agents.push("master".to_string());
+            let json = serde_json::to_string_pretty(&agents_config)
+                .map_err(|e| anyhow::anyhow!("failed to serialize agents.json: {}", e))?;
+            std::fs::write(&agents_json_path, json)?;
+        }
+    } else {
+        let agents_config = AgentsConfig {
+            agents: vec!["master".to_string()],
+        };
+        let json = serde_json::to_string_pretty(&agents_config)
+            .map_err(|e| anyhow::anyhow!("failed to serialize agents.json: {}", e))?;
+        std::fs::write(&agents_json_path, json)?;
+    }
+
+    Ok(())
 }
 
 /// Write wizard output to config files.

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -389,3 +389,150 @@ mod write_wizard_config_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod ensure_master_agent_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Helper: assert master agent config.json has expected defaults.
+    fn assert_master_config(config_path: &std::path::Path) {
+        assert!(config_path.exists(), "master config.json should exist");
+        let content = std::fs::read_to_string(config_path).unwrap();
+        let config: AgentConfig =
+            serde_json::from_str(&content).expect("master config.json should be valid JSON");
+        assert_eq!(config.id, "master");
+        assert!(config.name.is_none());
+        assert!(config.parent_id.is_none());
+        assert!(config.model.is_none());
+        assert!(config.workspace.is_none());
+        assert!(config.agent_dir.is_none());
+        assert_eq!(
+            config.bootstrap_mode,
+            crate::session::bootstrap::BootstrapMode::Full
+        );
+        assert_eq!(config.skills, vec!["*"]);
+        assert_eq!(config.tools, vec!["*"]);
+        assert!(config.disallowed_tools.is_empty());
+    }
+
+    /// Helper: assert agents.json contains exactly the given agent IDs.
+    fn assert_agents_json(agents_json_path: &std::path::Path, expected: &[&str]) {
+        assert!(agents_json_path.exists(), "agents.json should exist");
+        let content = std::fs::read_to_string(agents_json_path).unwrap();
+        let config: AgentsConfig =
+            serde_json::from_str(&content).expect("agents.json should be valid JSON");
+        let expected_owned: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+        assert_eq!(config.agents, expected_owned);
+    }
+
+    /// Test 1: empty directory → both files created with correct content.
+    #[test]
+    fn test_creates_on_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        ensure_master_agent(tmp.path()).unwrap();
+
+        let agents_dir = tmp.path().parent().unwrap().join("agents");
+        let config_path = agents_dir.join("master").join("config.json");
+        let agents_json_path = tmp.path().join("agents.json");
+
+        assert_master_config(&config_path);
+        assert_agents_json(&agents_json_path, &["master"]);
+    }
+
+    /// Test 2: idempotent — calling twice does not modify existing files.
+    #[test]
+    fn test_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        ensure_master_agent(tmp.path()).unwrap();
+
+        let agents_dir = tmp.path().parent().unwrap().join("agents");
+        let config_path = agents_dir.join("master").join("config.json");
+        let agents_json_path = tmp.path().join("agents.json");
+
+        let config_before = std::fs::read_to_string(&config_path).unwrap();
+        let agents_before = std::fs::read_to_string(&agents_json_path).unwrap();
+
+        // Second call should not change anything
+        ensure_master_agent(tmp.path()).unwrap();
+
+        let config_after = std::fs::read_to_string(&config_path).unwrap();
+        let agents_after = std::fs::read_to_string(&agents_json_path).unwrap();
+
+        assert_eq!(
+            config_before, config_after,
+            "config.json should not be modified"
+        );
+        assert_eq!(
+            agents_before, agents_after,
+            "agents.json should not be modified"
+        );
+    }
+
+    /// Test 3: agents.json already has other agents → master is appended.
+    #[test]
+    fn test_appends_master_to_existing_agents_json() {
+        let tmp = TempDir::new().unwrap();
+        let agents_json_path = tmp.path().join("agents.json");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        std::fs::write(
+            &agents_json_path,
+            serde_json::to_string_pretty(&AgentsConfig {
+                agents: vec!["helper".to_string(), "researcher".to_string()],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_master_agent(tmp.path()).unwrap();
+
+        // agents.json should now contain helper, researcher, master
+        assert_agents_json(&agents_json_path, &["helper", "researcher", "master"]);
+
+        // master config.json should also exist
+        let agents_dir = tmp.path().parent().unwrap().join("agents");
+        let config_path = agents_dir.join("master").join("config.json");
+        assert_master_config(&config_path);
+    }
+
+    /// Test 4: config.json exists but agents.json missing master → master appended.
+    #[test]
+    fn test_agents_json_missing_master_only() {
+        let tmp = TempDir::new().unwrap();
+        let agents_dir = tmp.path().parent().unwrap().join("agents");
+
+        // Pre-create master config.json (already exists)
+        std::fs::create_dir_all(agents_dir.join("master")).unwrap();
+        let existing_config = AgentConfig {
+            id: "master".to_string(),
+            ..Default::default()
+        };
+        std::fs::write(
+            agents_dir.join("master").join("config.json"),
+            serde_json::to_string_pretty(&existing_config).unwrap(),
+        )
+        .unwrap();
+
+        // Pre-create agents.json WITHOUT master
+        let agents_json_path = tmp.path().join("agents.json");
+        std::fs::write(
+            &agents_json_path,
+            serde_json::to_string_pretty(&AgentsConfig {
+                agents: vec!["helper".to_string()],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        ensure_master_agent(tmp.path()).unwrap();
+
+        // config.json should remain unchanged (not overwritten)
+        let config_content =
+            std::fs::read_to_string(agents_dir.join("master").join("config.json")).unwrap();
+        let config: AgentConfig = serde_json::from_str(&config_content).unwrap();
+        assert_eq!(config.id, "master");
+
+        // agents.json should now include master
+        assert_agents_json(&agents_json_path, &["helper", "master"]);
+    }
+}


### PR DESCRIPTION
feat: 实现 CLI 配置向导创建初始 master Agent

在 `run_wizard()` 成功完成后，自动创建初始 `master` agent：

- 实现 `ensure_master_agent()` 函数，检查并创建 `agents/master/config.json` 和 `agents.json` 注册清单
- 使用 `AgentConfig::default()` + `id = "master"` 作为默认配置，幂等设计避免重复写入
- 在 wizard 流程末尾集成调用，失败时仅打印 warning 不阻塞配置写入
- 添加完整单元测试覆盖：空目录创建、幂等性、agents.json 追加等场景

Source: user
Type: feat
