### PR TITLE
fix: isolate ensure_master_agent tests to eliminate parallel race condition

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -121,9 +121,7 @@ fn config_dir() -> PathBuf {
 /// - `~/.closeclaw/config/agents.json` (appends "master" if missing)
 ///
 /// Idempotent: skips files that already exist.
-fn ensure_master_agent(config_dir: &Path) -> anyhow::Result<()> {
-    let agents_dir = config_dir.parent().unwrap_or(config_dir).join("agents");
-
+fn ensure_master_agent(config_dir: &Path, agents_dir: &Path) -> anyhow::Result<()> {
     // ── Write master agent config.json if missing ──────────────────────────────
     let master_config_path = agents_dir.join("master").join("config.json");
     if !master_config_path.exists() {
@@ -512,7 +510,8 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
     // Create initial master agent if it does not exist yet.
     // Failure here is non-fatal: the wizard config (models + credentials) is
     // already written and should not be rolled back.
-    if let Err(e) = ensure_master_agent(&config_dir()) {
+    let agents_dir = config_dir().parent().unwrap().join("agents");
+    if let Err(e) = ensure_master_agent(&config_dir(), &agents_dir) {
         eprintln!("[WARNING] Failed to create master agent: {}", e);
     }
 

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -395,6 +395,16 @@ mod ensure_master_agent_tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Helper: create isolated config_dir and agents_dir inside a TempDir.
+    /// Returns (config_dir, agents_dir).
+    fn isolated_dirs(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+        let config_dir = tmp.path().join("config");
+        let agents_dir = tmp.path().join("agents");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        (config_dir, agents_dir)
+    }
+
     /// Helper: assert master agent config.json has expected defaults.
     fn assert_master_config(config_path: &std::path::Path) {
         assert!(config_path.exists(), "master config.json should exist");
@@ -430,13 +440,13 @@ mod ensure_master_agent_tests {
     #[test]
     fn test_creates_on_empty_dir() {
         let tmp = TempDir::new().unwrap();
-        ensure_master_agent(tmp.path()).unwrap();
+        let (config_dir, agents_dir) = isolated_dirs(&tmp);
+        ensure_master_agent(&config_dir, &agents_dir).unwrap();
 
-        let agents_dir = tmp.path().parent().unwrap().join("agents");
-        let config_path = agents_dir.join("master").join("config.json");
-        let agents_json_path = tmp.path().join("agents.json");
+        let master_config_path = agents_dir.join("master").join("config.json");
+        let agents_json_path = config_dir.join("agents.json");
 
-        assert_master_config(&config_path);
+        assert_master_config(&master_config_path);
         assert_agents_json(&agents_json_path, &["master"]);
     }
 
@@ -444,19 +454,19 @@ mod ensure_master_agent_tests {
     #[test]
     fn test_idempotent() {
         let tmp = TempDir::new().unwrap();
-        ensure_master_agent(tmp.path()).unwrap();
+        let (config_dir, agents_dir) = isolated_dirs(&tmp);
+        ensure_master_agent(&config_dir, &agents_dir).unwrap();
 
-        let agents_dir = tmp.path().parent().unwrap().join("agents");
-        let config_path = agents_dir.join("master").join("config.json");
-        let agents_json_path = tmp.path().join("agents.json");
+        let master_config_path = agents_dir.join("master").join("config.json");
+        let agents_json_path = config_dir.join("agents.json");
 
-        let config_before = std::fs::read_to_string(&config_path).unwrap();
+        let config_before = std::fs::read_to_string(&master_config_path).unwrap();
         let agents_before = std::fs::read_to_string(&agents_json_path).unwrap();
 
         // Second call should not change anything
-        ensure_master_agent(tmp.path()).unwrap();
+        ensure_master_agent(&config_dir, &agents_dir).unwrap();
 
-        let config_after = std::fs::read_to_string(&config_path).unwrap();
+        let config_after = std::fs::read_to_string(&master_config_path).unwrap();
         let agents_after = std::fs::read_to_string(&agents_json_path).unwrap();
 
         assert_eq!(
@@ -473,8 +483,9 @@ mod ensure_master_agent_tests {
     #[test]
     fn test_appends_master_to_existing_agents_json() {
         let tmp = TempDir::new().unwrap();
-        let agents_json_path = tmp.path().join("agents.json");
-        std::fs::create_dir_all(tmp.path()).unwrap();
+        let (config_dir, agents_dir) = isolated_dirs(&tmp);
+
+        let agents_json_path = config_dir.join("agents.json");
         std::fs::write(
             &agents_json_path,
             serde_json::to_string_pretty(&AgentsConfig {
@@ -484,22 +495,21 @@ mod ensure_master_agent_tests {
         )
         .unwrap();
 
-        ensure_master_agent(tmp.path()).unwrap();
+        ensure_master_agent(&config_dir, &agents_dir).unwrap();
 
         // agents.json should now contain helper, researcher, master
         assert_agents_json(&agents_json_path, &["helper", "researcher", "master"]);
 
         // master config.json should also exist
-        let agents_dir = tmp.path().parent().unwrap().join("agents");
-        let config_path = agents_dir.join("master").join("config.json");
-        assert_master_config(&config_path);
+        let master_config_path = agents_dir.join("master").join("config.json");
+        assert_master_config(&master_config_path);
     }
 
     /// Test 4: config.json exists but agents.json missing master → master appended.
     #[test]
     fn test_agents_json_missing_master_only() {
         let tmp = TempDir::new().unwrap();
-        let agents_dir = tmp.path().parent().unwrap().join("agents");
+        let (config_dir, agents_dir) = isolated_dirs(&tmp);
 
         // Pre-create master config.json (already exists)
         std::fs::create_dir_all(agents_dir.join("master")).unwrap();
@@ -514,7 +524,7 @@ mod ensure_master_agent_tests {
         .unwrap();
 
         // Pre-create agents.json WITHOUT master
-        let agents_json_path = tmp.path().join("agents.json");
+        let agents_json_path = config_dir.join("agents.json");
         std::fs::write(
             &agents_json_path,
             serde_json::to_string_pretty(&AgentsConfig {
@@ -524,7 +534,7 @@ mod ensure_master_agent_tests {
         )
         .unwrap();
 
-        ensure_master_agent(tmp.path()).unwrap();
+        ensure_master_agent(&config_dir, &agents_dir).unwrap();
 
         // config.json should remain unchanged (not overwritten)
         let config_content =


### PR DESCRIPTION
## 概述

修复 CI 中 `test_creates_on_empty_dir` 测试在并行执行时的 race condition。

`ensure_master_agent` 函数通过 `config_dir.parent().join("agents")` 隐式定位 agents 目录，测试传入 `TempDir::path()` 时 `.parent()` 回退到 `/tmp`，导致 4 个并行测试共享同一个 `/tmp/agents` 目录，产生竞态条件。

## 变更

- **`src/cli/config_wizard/mod.rs`**：`ensure_master_agent` 新增 `agents_dir: &Path` 参数，移除隐式路径推导；调用点显式计算并传入 agents_dir
- **`src/cli/config_wizard/tests.rs`**：每个测试创建独立的 `config_dir` 和 `agents_dir`（在各自 TempDir 内），彻底消除并行竞争

## 验证

- `cargo test --lib cli::config_wizard::tests::ensure_master_agent_tests` 连续 5 次全部通过
- `cargo test --lib` 全量 1991 个测试通过

Source: CI
Type: fix
