### PR TITLE
fix: align spawn permission denied error type with design doc

### DIFF
--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -151,8 +151,8 @@ impl SessionsSpawnTool {
                         user_perms.as_ref(),
                         user_id.as_deref(),
                     )
-                    .map_err(|e| {
-                        ToolCallError::ExecutionFailed(format!("spawn permission denied: {}", e))
+                    .map_err(|_| {
+                        ToolCallError::PermissionDenied("spawn permission denied".to_string())
                     })?;
             }
         }

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -151,8 +151,9 @@ impl SessionsSpawnTool {
                         user_perms.as_ref(),
                         user_id.as_deref(),
                     )
-                    .map_err(|_| {
-                        ToolCallError::PermissionDenied("spawn permission denied".to_string())
+                    .map_err(|e| {
+                        tracing::debug!(error = %e, "spawn permission denied");
+                        ToolCallError::PermissionDenied("spawn".to_string())
                     })?;
             }
         }

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -705,7 +705,7 @@ fn test_recursive_permission_intersection_three_layers() {
 // ===========================================================================
 
 /// Test: When a child agent is fully denied, `validate_spawn_permissions`
-/// returns `ToolCallError::PermissionDenied` with the FullyDenied error.
+/// returns `ToolCallError::PermissionDenied("spawn")`.
 /// The child session is NOT created — the error short-circuits the spawn
 /// pipeline before `create_child` is reached.
 /// The error message is generic and does not expose internal agent_id details.
@@ -788,8 +788,13 @@ async fn test_fully_denied_silent_return_no_session_created() {
         other => panic!("expected PermissionDenied, got: {:?}", other),
     };
     assert!(
-        err_msg.contains("denied"),
-        "error should mention 'denied', got: {}",
+        err_msg.contains("spawn"),
+        "error should contain 'spawn', got: {}",
+        err_msg
+    );
+    assert!(
+        !err_msg.contains("denied-child"),
+        "error must not expose internal agent_id, got: {}",
         err_msg
     );
 

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -705,9 +705,10 @@ fn test_recursive_permission_intersection_three_layers() {
 // ===========================================================================
 
 /// Test: When a child agent is fully denied, `validate_spawn_permissions`
-/// returns `ToolCallError::ExecutionFailed` with the FullyDenied error.
+/// returns `ToolCallError::PermissionDenied` with the FullyDenied error.
 /// The child session is NOT created — the error short-circuits the spawn
 /// pipeline before `create_child` is reached.
+/// The error message is generic and does not expose internal agent_id details.
 #[tokio::test]
 async fn test_fully_denied_silent_return_no_session_created() {
     let tmp = TempDir::new().unwrap();
@@ -783,14 +784,9 @@ async fn test_fully_denied_silent_return_no_session_created() {
 
     assert!(result.is_err(), "spawn should fail for fully-denied child");
     let err_msg = match result.unwrap_err() {
-        ToolCallError::ExecutionFailed(msg) => msg,
-        other => panic!("expected ExecutionFailed, got: {:?}", other),
+        ToolCallError::PermissionDenied(msg) => msg,
+        other => panic!("expected PermissionDenied, got: {:?}", other),
     };
-    assert!(
-        err_msg.contains("denied-child"),
-        "error should mention the denied agent_id, got: {}",
-        err_msg
-    );
     assert!(
         err_msg.contains("denied"),
         "error should mention 'denied', got: {}",


### PR DESCRIPTION
fix: align spawn permission denied error type with design doc

Use `ToolCallError::PermissionDenied("spawn")` instead of
`ToolCallError::ExecutionFailed("spawn permission denied: ...")` to match
the design doc's error semantics. The error message is now generic and does
not expose internal agent_id / parent_agent_id details. Diagnostic logging
via `tracing::debug!` preserves the full error for debugging.

Source: user
Type: fix
