### PR TITLE
chore: remove commit message format check from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,42 +38,6 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check commit message format
-        if: github.event_name == 'push'
-        run: |
-          set -e
-
-          msg=$(git log -1 --format='%B')
-
-          echo "=== Commit message ==="
-          echo "$msg"
-          echo ""
-
-          # 1. Check Source: footer
-          if ! echo "$msg" | grep -qE '^Source: (issue #[0-9]+|Fixes #|Refs #|Closes #|CI|user)'; then
-            echo "ERROR: Source footer must be one of:"
-            echo "  - issue #N"
-            echo "  - Fixes #N / Refs #N / Closes #N (legacy)"
-            echo "  - CI"
-            echo "  - user"
-            echo "Commit message:"
-            echo "$msg"
-            exit 1
-          fi
-
-          # 2. Check Type: footer
-          valid_types="feat|fix|docs|refactor|test|perf|chore"
-          if ! echo "$msg" | grep -qE "^Type: ($valid_types)"; then
-            echo "ERROR: Type footer must be one of: $valid_types"
-            echo "Commit message:"
-            echo "$msg"
-            exit 1
-          fi
-
-          echo "Commit message check passed"
-          echo "- Source: $(echo "$msg" | grep '^Source:' | sed 's/^Source: //')"
-          echo "- Type: $(echo "$msg" | grep '^Type:' | sed 's/^Type: //')"
-
       - name: Check formatting
         run: cargo fmt --check
 


### PR DESCRIPTION
Remove the "Check commit message format" step from CI workflow.

Source: user
Type: chore
