### PR TITLE
chore: fix all clippy warnings and enable strict CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,20 +93,7 @@ jobs:
         run: cargo check
 
       - name: Run clippy
-        run: cargo clippy --all 2>&1 | tee clippy-output.txt
-        continue-on-error: true
-
-      - name: Check clippy warnings
-        run: |
-          warnings=$(grep -c '^warning' clippy-output.txt || true)
-          if [ "$warnings" -gt 0 ]; then
-            echo "⚠️ $warnings clippy warnings found. Fix before enabling strict mode."
-            echo "List of warnings:"
-            grep -E '(warning\[|warning:)' clippy-output.txt || true
-            echo ""
-            echo "Once all warnings are resolved, remove continue-on-error from the clippy step"
-            echo "and add -- -D warnings to fail on warnings."
-          fi
+        run: cargo clippy --all -- -D warnings
 
       - name: Run unit and binary tests
         run: cargo test --lib --bins

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -290,7 +290,7 @@ impl AgentPermissions {
             "config_write",
         ]
         .iter()
-        .any(|&dim| self.permissions.get(dim).map_or(false, |p| p.allowed))
+        .any(|&dim| self.permissions.get(dim).is_some_and(|p| p.allowed))
     }
 }
 

--- a/src/config/agents/types.rs
+++ b/src/config/agents/types.rs
@@ -9,16 +9,10 @@ use serde::{Deserialize, Serialize};
 
 /// Agent registration list from agents.json (JSONC format).
 /// Only contains registered agent IDs; commented-out IDs are excluded.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct AgentsConfig {
     /// Registered agent ID list
     pub agents: Vec<String>,
-}
-
-impl Default for AgentsConfig {
-    fn default() -> Self {
-        Self { agents: vec![] }
-    }
 }
 
 #[cfg(test)]

--- a/src/config/providers/channels.rs
+++ b/src/config/providers/channels.rs
@@ -36,7 +36,7 @@ pub struct BindingEntry {
 }
 
 /// Root channels configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelsConfigData {
     #[serde(default)]
@@ -44,15 +44,6 @@ pub struct ChannelsConfigData {
 
     #[serde(default)]
     pub bindings: Vec<BindingEntry>,
-}
-
-impl Default for ChannelsConfigData {
-    fn default() -> Self {
-        Self {
-            channels: HashMap::new(),
-            bindings: Vec::new(),
-        }
-    }
 }
 
 /// Allowed channel types in the system.

--- a/src/config/providers/models.rs
+++ b/src/config/providers/models.rs
@@ -122,8 +122,9 @@ impl ConfigProvider for ModelsConfigData {
             }
 
             if let Some(ref base_url) = provider.base_url {
-                if !base_url.is_empty()
-                    && !(base_url.starts_with("http://") || base_url.starts_with("https://"))
+                if !(base_url.is_empty()
+                    || base_url.starts_with("http://")
+                    || base_url.starts_with("https://"))
                 {
                     return Err(ConfigError::ValueError {
                         field: "base_url".to_string(),

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -97,7 +97,7 @@ async fn reload_agents_with_log(
         return;
     }
     // Sync the new configs into AgentRegistry (design-doc hot-reload path).
-    let configs: Vec<_> = cm.agents().into_iter().map(|(_, c)| c).collect();
+    let configs: Vec<_> = cm.agents().into_values().collect();
     agent_registry.reload_config(configs).await;
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -253,11 +253,7 @@ impl Daemon {
                 // This fulfills the design-doc startup flow:
                 //   ConfigManager.load_agents() → AgentRegistry.populate()
                 {
-                    let configs: Vec<_> = config_manager
-                        .agents()
-                        .into_iter()
-                        .map(|(_, c)| c)
-                        .collect();
+                    let configs: Vec<_> = config_manager.agents().into_values().collect();
                     agent_registry.populate(configs).await;
                 }
 

--- a/src/gateway/approval.rs
+++ b/src/gateway/approval.rs
@@ -104,7 +104,7 @@ impl Gateway {
 
         // Verify sender is the owner
         match sender_id {
-            Some(id) if id == "owner" => {}
+            Some("owner") => {}
             _ => return None, // Not owner — fall through to normal message flow
         }
 
@@ -142,7 +142,7 @@ impl Gateway {
             match flow.approve_request(request_id, mode) {
                 Ok(true) => {
                     tracing::info!(session_id, request_id, ?mode, "approval request approved");
-                    return Some(HandleResult::ApprovalProcessed);
+                    Some(HandleResult::ApprovalProcessed)
                 }
                 Ok(false) => {
                     tracing::warn!(
@@ -150,7 +150,7 @@ impl Gateway {
                         request_id,
                         "approval request not found or already resolved"
                     );
-                    return Some(HandleResult::ApprovalProcessed);
+                    Some(HandleResult::ApprovalProcessed)
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -160,13 +160,13 @@ impl Gateway {
                         "approval request rejected"
                     );
                     // Still consumed the command — don't fall through to LLM
-                    return Some(HandleResult::ApprovalProcessed);
+                    Some(HandleResult::ApprovalProcessed)
                 }
             }
         } else {
             let denied = flow.deny_request(request_id);
             tracing::info!(session_id, request_id, denied, "approval request denied");
-            return Some(HandleResult::ApprovalProcessed);
+            Some(HandleResult::ApprovalProcessed)
         }
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 
 use crate::permission::approval_flow::ApprovalFlow;
 use crate::permission::engine::engine_eval::PermissionEngine;
@@ -33,6 +33,11 @@ use crate::slash::SlashDispatcher;
 pub use crate::processor_chain::ProcessorRegistry;
 pub use session_handler::{HandleResult, SessionMessageHandler};
 pub use session_manager::SessionManager;
+
+use crate::llm::types::ContentBlock;
+
+/// Type alias for the output channel sender used across session handler modules.
+pub(crate) type OutputTx = Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>;
 
 /// DM session scope - controls how session keys are partitioned.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -27,6 +27,8 @@ use crate::session::compaction::{
 use crate::session::persistence::ReasoningLevel;
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
+
+use super::OutputTx;
 use tokio_util::sync::CancellationToken;
 
 /// Metadata about an inbound message, passed through the handling pipeline.
@@ -64,7 +66,7 @@ pub enum HandleResult {
 pub struct SessionMessageHandler {
     pub(super) session_manager: Arc<SessionManager>,
     pub(super) fallback_client: Arc<FallbackClient>,
-    pub(super) output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    pub(super) output_tx: OutputTx,
     pub(super) compaction_service: Arc<std::sync::Mutex<CompactionService>>,
     pub(super) unified_fallback_client: Arc<UnifiedFallbackClient>,
     /// Optional back-reference to the owning [`Gateway`] (weak).
@@ -202,7 +204,7 @@ impl SessionMessageHandler {
             return;
         }
         let result =
-            execute_compact(&llm_messages, &*self.fallback_client, &model, None, true).await;
+            execute_compact(&llm_messages, &self.fallback_client, &model, None, true).await;
         finalize_auto_compact(
             &self.session_manager,
             &self.compaction_service,
@@ -238,7 +240,7 @@ impl SessionMessageHandler {
                 cs_read.turn_count(),
                 cs_read.workdir().to_string_lossy().into_owned(),
                 cs_read.system_appends().to_vec(),
-                cs_read.reasoning_level().clone(),
+                cs_read.reasoning_level(),
             )
         } else {
             (
@@ -335,11 +337,11 @@ impl SessionMessageHandler {
 fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
     blocks
         .iter()
-        .filter_map(|b| match b {
-            ContentBlock::Text(t) => Some(t.as_str()),
-            ContentBlock::Thinking(t) => Some(t.as_str()),
-            ContentBlock::ToolUse { input, .. } => Some(input.as_str()),
-            ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
+        .map(|b| match b {
+            ContentBlock::Text(t) => t.as_str(),
+            ContentBlock::Thinking(t) => t.as_str(),
+            ContentBlock::ToolUse { input, .. } => input.as_str(),
+            ContentBlock::ToolResult { content, .. } => content.as_str(),
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -380,10 +382,7 @@ async fn apply_compact_result(
     sm.rebuild_system_prompt(session_id).await;
 }
 
-async fn send_output(
-    output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
-    text: &str,
-) {
+async fn send_output(output_tx: &OutputTx, text: &str) {
     let guard = output_tx.read().await;
     if let Some(tx) = guard.as_ref() {
         let _ = tx.send((text.to_string(), vec![])).await;
@@ -405,14 +404,14 @@ async fn load_compact_inputs(
 async fn run_manual_compact(
     sm: Arc<SessionManager>,
     fc: Arc<FallbackClient>,
-    output_tx: Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+    output_tx: OutputTx,
     svc: Arc<std::sync::Mutex<CompactionService>>,
     sid: String,
     model: String,
     llm_messages: Vec<ChatMessage>,
     instruction: Option<String>,
 ) {
-    let result = execute_compact(&llm_messages, &*fc, &model, instruction.as_deref(), false).await;
+    let result = execute_compact(&llm_messages, &fc, &model, instruction.as_deref(), false).await;
     match result {
         Ok(r) => {
             apply_compact_result(&sm, &sid, &r).await;

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -18,9 +18,9 @@
 //!    constraint.
 
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
 
 use super::session_handler::{MessageMetadata, SessionMessageHandler};
+use super::OutputTx;
 use crate::gateway::outbound::StreamResult;
 use crate::gateway::session_manager::SessionManager;
 use crate::llm::session::ChatSession;
@@ -40,7 +40,7 @@ impl SessionMessageHandler {
         session_id: &str,
         result: Result<StreamResult, crate::llm::LLMError>,
         unified_fallback_client: &Arc<UnifiedFallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+        output_tx: &OutputTx,
     ) {
         Self::clear_busy_and_send(session_manager, session_id, result, output_tx).await;
         Self::drain_pending_loop(
@@ -56,7 +56,7 @@ impl SessionMessageHandler {
         session_manager: &Arc<SessionManager>,
         session_id: &str,
         result: Result<StreamResult, crate::llm::LLMError>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+        output_tx: &OutputTx,
     ) {
         if let Some(cs) = session_manager.get_conversation_session(session_id).await {
             let cs = cs.write().await;
@@ -114,7 +114,7 @@ impl SessionMessageHandler {
         session_manager: &Arc<SessionManager>,
         session_id: &str,
         unified_fallback_client: &Arc<UnifiedFallbackClient>,
-        output_tx: &Arc<RwLock<Option<mpsc::Sender<(String, Vec<ContentBlock>)>>>>,
+        output_tx: &OutputTx,
     ) {
         // Step 1.5: drain queued announces.
         Self::drain_announce_events(session_manager, session_id).await;

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -70,7 +70,7 @@ impl SessionMessageHandler {
                 cs_read.turn_count(),
                 cs_read.workdir().to_string_lossy().into_owned(),
                 cs_read.system_appends().to_vec(),
-                cs_read.reasoning_level().clone(),
+                cs_read.reasoning_level(),
             )
         } else {
             (

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -406,9 +406,7 @@ impl SessionManager {
     /// Returns None if the session has no thread_id or the storage is not available.
     pub async fn get_thread_id(&self, session_id: &str) -> Option<String> {
         let storage = self.storage.read().await;
-        let Some(storage) = storage.as_ref() else {
-            return None;
-        };
+        let storage = storage.as_ref()?;
         match storage.load_checkpoint(session_id).await {
             Ok(Some(cp)) => cp.thread_id,
             _ => None,
@@ -418,9 +416,7 @@ impl SessionManager {
     /// Get the sender_id (user ID) for a session from its checkpoint.
     pub async fn get_sender_id(&self, session_id: &str) -> Option<String> {
         let storage = self.storage.read().await;
-        let Some(storage) = storage.as_ref() else {
-            return None;
-        };
+        let storage = storage.as_ref()?;
         match storage.load_checkpoint(session_id).await {
             Ok(Some(cp)) => cp.sender_id,
             _ => None,

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -195,7 +195,7 @@ impl Gateway {
                     .get_conversation_session(session_id)
                     .await
                 {
-                    cs.write().await.set_reasoning_level(level.clone());
+                    cs.write().await.set_reasoning_level(level);
                     if let Some(sh) = self.session_handler.as_ref() {
                         sh.send_reply(format!("推理深度已设置为 {:?}", level)).await;
                     }
@@ -281,20 +281,19 @@ impl Gateway {
                             let mut cs = conv.write().await;
                             cs.cancel_token.cancel();
                             // Cascade stop to child handles.
-                            {
+                            let handles_to_stop: Vec<_> = {
                                 let child_handles = cs
                                     .child_handles
                                     .read()
                                     .expect("child_handles lock poisoned");
-                                let handles_to_stop: Vec<_> =
-                                    child_handles.values().filter_map(|w| w.upgrade()).collect();
-                                drop(child_handles);
-                                for child in handles_to_stop {
-                                    let child_cs = child.read().await;
-                                    child_cs.cancel_token.cancel();
-                                }
-                            }
+                                child_handles.values().filter_map(|w| w.upgrade()).collect()
+                            };
                             cs.clear_pending();
+                            drop(cs);
+                            for child in handles_to_stop {
+                                let child_cs = child.read().await;
+                                child_cs.cancel_token.cancel();
+                            }
                         }
                         if let Some(sh) = self.session_handler.as_ref() {
                             sh.send_reply("已停止当前任务".to_owned()).await;

--- a/src/im_adapter/code_block.rs
+++ b/src/im_adapter/code_block.rs
@@ -31,7 +31,7 @@ pub enum ContentSegment {
 ///   everything else becomes [`Markdown`](ContentSegment::Markdown).
 /// - An unclosed fence is treated as regular markdown text.
 /// - Backtick fences nested inside a code block are preserved as content.
-/// Emit accumulated code-block lines as regular markdown (unclosed fence).
+///   Emit accumulated code-block lines as regular markdown (unclosed fence).
 fn flush_unclosed_fence(lang: &str, code_lines: &[&str], segments: &mut Vec<ContentSegment>) {
     let opening = if lang.is_empty() {
         "```".to_string()
@@ -47,8 +47,7 @@ fn flush_unclosed_fence(lang: &str, code_lines: &[&str], segments: &mut Vec<Cont
 /// Process a line outside a code block.
 fn process_outside_line(line: &str, segments: &mut Vec<ContentSegment>) -> Option<String> {
     let trimmed = line.trim_end();
-    if trimmed.starts_with("```") {
-        let after_ticks = &trimmed[3..];
+    if let Some(after_ticks) = trimmed.strip_prefix("```") {
         if after_ticks.is_empty() || !after_ticks.contains(' ') {
             return Some(after_ticks.to_string()); // opening fence
         }

--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -381,9 +381,9 @@ impl ModelLister for DeepSeekProvider {
                 let input_types: Vec<crate::llm::InputType> = m
                     .input_modalities
                     .iter()
-                    .filter_map(|m| match m.to_lowercase().as_str() {
-                        "image" => Some(crate::llm::InputType::Image),
-                        _ => Some(crate::llm::InputType::Text),
+                    .map(|m| match m.to_lowercase().as_str() {
+                        "image" => crate::llm::InputType::Image,
+                        _ => crate::llm::InputType::Text,
                     })
                     .collect();
                 let input_types = if input_types.is_empty() {

--- a/src/llm/volcengine.rs
+++ b/src/llm/volcengine.rs
@@ -367,9 +367,9 @@ impl ModelLister for VolcEngineProvider {
                 let input_types: Vec<crate::llm::InputType> = props
                     .input_modalities
                     .iter()
-                    .filter_map(|m| match m.to_lowercase().as_str() {
-                        "image" => Some(crate::llm::InputType::Image),
-                        _ => Some(crate::llm::InputType::Text),
+                    .map(|m| match m.to_lowercase().as_str() {
+                        "image" => crate::llm::InputType::Image,
+                        _ => crate::llm::InputType::Text,
                     })
                     .collect();
                 let input_types = if input_types.is_empty() {

--- a/src/permission/templates.rs
+++ b/src/permission/templates.rs
@@ -69,7 +69,7 @@ pub fn load_templates_from_dir(
 
     let mut file_names: Vec<_> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map_or(false, |ext| ext == "json"))
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
         .map(|e| e.path())
         .collect();
 

--- a/src/processor_chain/loader.rs
+++ b/src/processor_chain/loader.rs
@@ -144,7 +144,7 @@ impl ProcessorChainLoader {
                 Ok(Arc::new(processor))
             }
             ProcessorConfig::ContentNormalizer => Ok(Arc::new(ContentNormalizer::new())),
-            ProcessorConfig::DslParser => Ok(Arc::new(DslParser::default())),
+            ProcessorConfig::DslParser => Ok(Arc::new(DslParser)),
         }
     }
 }

--- a/src/session/bootstrap/protection.rs
+++ b/src/session/bootstrap/protection.rs
@@ -103,7 +103,7 @@ impl BootstrapProtection {
     }
 
     /// Find bootstrap content in transcript by heuristic
-    fn find_bootstrap_content<'a>(&self, transcript: &'a str, file_name: &str) -> Option<String> {
+    fn find_bootstrap_content(&self, transcript: &str, file_name: &str) -> Option<String> {
         use super::types::BOOTSTRAP_REGION_START;
 
         // Try to find content between known markers first

--- a/src/session/bootstrap/types.rs
+++ b/src/session/bootstrap/types.rs
@@ -58,7 +58,7 @@ impl BootstrapRegion {
         let full_hash = Self::compute_hash(content);
         // Store first 12 hex chars for marker compactness
         let content_hash = full_hash[..12].to_string();
-        let region_id = format!("{}_{}", file_name, content_hash[..8].to_string());
+        let region_id = format!("{}_{}", file_name, &content_hash[..8]);
 
         Self {
             region_id,

--- a/src/session/checkpoint_manager.rs
+++ b/src/session/checkpoint_manager.rs
@@ -42,7 +42,7 @@ impl<S: PersistenceService + ?Sized + 'static> CheckpointManager<S> {
 
     /// Get a reference to the underlying storage
     pub fn storage(&self) -> &S {
-        &*self.storage
+        &self.storage
     }
 
     /// 保存 Checkpoint（异步写入，不阻塞主流程）

--- a/src/session/events.rs
+++ b/src/session/events.rs
@@ -7,7 +7,7 @@ use crate::session::persistence::ReasoningMode;
 use std::sync::Arc;
 
 /// User Intent — parsed user input for reasoning
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct UserIntent {
     /// Raw user input
     pub raw_input: String,
@@ -34,18 +34,8 @@ impl UserIntent {
     }
 }
 
-impl Default for UserIntent {
-    fn default() -> Self {
-        Self {
-            raw_input: String::new(),
-            parsed_goal: None,
-            entities: vec![],
-        }
-    }
-}
-
 /// Mode Switch Event — triggered when reasoning mode changes
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ModeSwitchEvent {
     /// Requested mode (from user or config)
     pub requested_mode: Option<ReasoningMode>,
@@ -55,17 +45,6 @@ pub struct ModeSwitchEvent {
     pub user_intent: Option<Arc<UserIntent>>,
     /// Session ID
     pub session_id: Option<String>,
-}
-
-impl Default for ModeSwitchEvent {
-    fn default() -> Self {
-        Self {
-            requested_mode: None,
-            target_mode: None,
-            user_intent: None,
-            session_id: None,
-        }
-    }
 }
 
 impl ModeSwitchEvent {

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -294,7 +294,7 @@ pub fn load_checkpoint_inner(
         last_message_at,
         message_count: msg_count as u64,
         platform: {
-            let has_new = platform_new.as_deref().map_or(false, |s| !s.is_empty());
+            let has_new = platform_new.as_deref().is_some_and(|s| !s.is_empty());
             if has_new {
                 platform_new
             } else if channel.is_empty() {
@@ -304,7 +304,7 @@ pub fn load_checkpoint_inner(
             }
         },
         peer_id: {
-            let has_new = peer_id_new.as_deref().map_or(false, |s| !s.is_empty());
+            let has_new = peer_id_new.as_deref().is_some_and(|s| !s.is_empty());
             if has_new {
                 peer_id_new
             } else if chat_id.is_empty() {

--- a/src/skills/builtin/discovery.rs
+++ b/src/skills/builtin/discovery.rs
@@ -7,19 +7,10 @@ use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-#[allow(clippy::new_without_default)]
+#[derive(Default)]
 pub struct SkillDiscoverySkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
     approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
-}
-
-impl Default for SkillDiscoverySkill {
-    fn default() -> Self {
-        Self {
-            engine: None,
-            approval_flow: None,
-        }
-    }
 }
 
 impl SkillDiscoverySkill {

--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -6,19 +6,10 @@ use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-#[allow(clippy::new_without_default)]
+#[derive(Default)]
 pub struct FileOpsSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
     approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
-}
-
-impl Default for FileOpsSkill {
-    fn default() -> Self {
-        Self {
-            engine: None,
-            approval_flow: None,
-        }
-    }
 }
 
 impl FileOpsSkill {

--- a/src/skills/disk/types.rs
+++ b/src/skills/disk/types.rs
@@ -49,19 +49,14 @@ pub enum SkillContext {
 }
 
 /// Effort level required to execute a skill.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SkillEffort {
     Trivial,
     Small,
     Medium,
     Large,
+    #[default]
     Unknown,
-}
-
-impl Default for SkillEffort {
-    fn default() -> Self {
-        SkillEffort::Unknown
-    }
 }
 
 /// Manifest parsed from a SKILL.md frontmatter block.

--- a/src/skills/skill_creator.rs
+++ b/src/skills/skill_creator.rs
@@ -7,6 +7,12 @@ use async_trait::async_trait;
 
 pub struct SkillCreatorSkill;
 
+impl Default for SkillCreatorSkill {
+    fn default() -> Self {
+        Self
+    }
+}
+
 const GUIDE_JSON: &str = r##"{"content":"# Creating a CloseClaw Skill\\n\\n## 1. Create the Skill File\\nCreate `src/skills/your_skill_name.rs`:\\n\\n```rust\\nuse async_trait::async_trait;\\nuse crate::skills::{Skill, SkillManifest, SkillError};\\n\\npub struct YourSkill;\\n\\nimpl YourSkill {\\n    pub fn new() -> Self { Self }\\n}\\n\\n#[async_trait]\\nimpl Skill for YourSkill {\\n    fn manifest(&self) -> SkillManifest {\\n        SkillManifest {\\n            name: \"your_skill_name\".to_string(),\\n            version: \"1.0.0\".to_string(),\\n            description: \"What your skill does\".to_string(),\\n            author: Some(\"Your Name\".to_string()),\\n            dependencies: vec![],\\n        }\\n    }\\n\\n    fn methods(&self) -> Vec<&str> {\\n        vec![\"method1\", \"method2\"]\\n    }\\n\\n    async fn execute(&self, method: &str, args: serde_json::Value) -> Result<serde_json::Value, SkillError> {\\n        match method {\\n            \"method1\" => { /* ... */ }\\n            _ => Err(SkillError::MethodNotFound { ... })\\n        }\\n    }\\n}\\n```\\n\\n## 2. Register in mod.rs\\n```rust\\npub mod your_skill_name;\\npub use your_skill_name::YourSkill;\\n```\\n\\n## 3. Create SKILL.md Documentation\\nCreate `docs/skills/your_skill_name/SKILL.md` following the standard format.\\n","format":"markdown"}"##;
 
 const TEMPLATE_JSON: &str = r##"{"template":"---\\nname: skill-name\\ndescription: |\\n  One-line description of what this skill does.\\n---\\n\\n# Skill Name\\n\\n## Overview\\nDescription of the skill.\\n\\n## Quick Reference\\n| User Intent | Tool | action | Required |\\n|-------------|------|--------|----------|\\n| ... | ... | ... | ... |\\n\\n## Usage\\nDetailed usage instructions.\\n","format":"markdown"}"##;

--- a/src/slash/registry.rs
+++ b/src/slash/registry.rs
@@ -13,6 +13,12 @@ pub struct HandlerRegistry {
     handlers: std::sync::RwLock<HashMap<String, Arc<dyn SlashHandler>>>,
 }
 
+impl Default for HandlerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HandlerRegistry {
     /// Create an empty registry.
     pub fn new() -> Self {


### PR DESCRIPTION
Fix all 44 clippy warnings and enable strict CI clippy gate.

Changes:
- config: derive Default instead of manual impls, use is_some_and, simplify boolean
- gateway: remove needless returns, redundant guards, clone_on_copy; add type alias for complex type; refactor await_holding_lock
- im_adapter: fix doc lazy continuation, use strip_prefix
- session/permission/processor/llm: derive Default, remove needless lifetimes, fix to_string_in_format_args, use is_some_and
- skills/slash/daemon: derive Default, use into_values, add new_without_default impls
- CI: enable clippy -D warnings, remove continue-on-error

Source: issue #1104
Type: chore
