### PR TITLE
refactor: align AgentRegistry with design doc API contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "cargo-llvm-cov",
  "chrono",
  "clap",
+ "dashmap",
  "dialoguer",
  "dirs",
  "flume",
@@ -557,6 +558,19 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ regex-lite = "0.1"
 # Async trait (for IMAdapter)
 async-trait = "0.1"
 
+# Concurrent HashMap (used by AgentRegistry for lock-free reads)
+dashmap = "5"
+
 # Redis client for session persistence
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 

--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -136,3 +136,208 @@ fn test_reload_config_preserves_existing() {
         "'added' should be present after reload"
     );
 }
+
+// ---- DashMap reference return type tests ----
+
+#[test]
+fn test_get_returns_valid_reference() {
+    let registry = AgentRegistry::new(30);
+    registry.populate(vec![make_config("agent-1")]);
+
+    // The DashMap Ref implements Deref<Target = ResolvedAgentConfig>,
+    // so we can access fields directly.
+    let agent = registry.get("agent-1").expect("agent-1 should exist");
+    assert_eq!(agent.id, "agent-1");
+    assert_eq!(agent.name, "agent-1");
+    assert_eq!(agent.bootstrap_mode, BootstrapMode::Full);
+    assert!(agent.skills.is_empty());
+    assert!(agent.tools.is_empty());
+    assert!(agent.disallowed_tools.is_empty());
+}
+
+#[test]
+fn test_get_reference_sees_populated_data() {
+    let registry = AgentRegistry::new(30);
+    let mut cfg = make_config("agent-x");
+    cfg.skills = vec!["skill-a".into(), "skill-b".into()];
+    cfg.tools = vec!["tool-1".into()];
+    cfg.disallowed_tools = vec!["tool-2".into()];
+    registry.populate(vec![cfg]);
+
+    let agent = registry.get("agent-x").expect("agent-x should exist");
+    assert_eq!(agent.skills, vec!["skill-a", "skill-b"]);
+    assert_eq!(agent.tools, vec!["tool-1"]);
+    assert_eq!(agent.disallowed_tools, vec!["tool-2"]);
+}
+
+#[test]
+fn test_get_reference_sees_reload_data() {
+    let registry = AgentRegistry::new(30);
+    registry.populate(vec![make_config("old")]);
+
+    // Verify old data is visible through reference
+    {
+        let old = registry.get("old").expect("old should exist");
+        assert_eq!(old.id, "old");
+    } // DashMap Ref dropped here
+
+    // Reload with new config
+    let mut new_cfg = make_config("old");
+    new_cfg.skills = vec!["updated-skill".into()];
+    registry.reload_config(vec![new_cfg]);
+
+    // Reference should see updated data
+    let old = registry.get("old").expect("old should exist after reload");
+    assert_eq!(old.skills, vec!["updated-skill"]);
+}
+
+// ---- query_bootstrap_mode tests ----
+
+#[test]
+fn test_query_bootstrap_mode_full() {
+    let registry = AgentRegistry::new(30);
+    let mut cfg = make_config("agent-full");
+    cfg.bootstrap_mode = BootstrapMode::Full;
+    registry.populate(vec![cfg]);
+
+    let mode = registry.query_bootstrap_mode("agent-full");
+    assert_eq!(mode, Some(BootstrapMode::Full));
+}
+
+#[test]
+fn test_query_bootstrap_mode_minimal() {
+    let registry = AgentRegistry::new(30);
+    let mut cfg = make_config("agent-minimal");
+    cfg.bootstrap_mode = BootstrapMode::Minimal;
+    registry.populate(vec![cfg]);
+
+    let mode = registry.query_bootstrap_mode("agent-minimal");
+    assert_eq!(mode, Some(BootstrapMode::Minimal));
+}
+
+#[test]
+fn test_query_bootstrap_mode_not_found() {
+    let registry = AgentRegistry::new(30);
+    registry.populate(vec![make_config("existing")]);
+
+    let mode = registry.query_bootstrap_mode("nonexistent");
+    assert_eq!(mode, None);
+}
+
+#[test]
+fn test_query_bootstrap_mode_empty_registry() {
+    let registry = AgentRegistry::new(30);
+    let mode = registry.query_bootstrap_mode("any-id");
+    assert_eq!(mode, None);
+}
+
+// ---- Concurrent access tests ----
+
+#[test]
+fn test_concurrent_get_and_populate() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let registry = Arc::new(AgentRegistry::new(30));
+
+    // Spawn threads that read and write concurrently
+    let mut handles = vec![];
+
+    // Writer thread: populate with configs
+    let reg_write = Arc::clone(&registry);
+    handles.push(thread::spawn(move || {
+        for i in 0..50 {
+            let cfg = make_config(&format!("writer-{}", i));
+            reg_write.populate(vec![cfg]);
+        }
+    }));
+
+    // Reader threads: query configs
+    for _t in 0..5 {
+        let reg_read = Arc::clone(&registry);
+        handles.push(thread::spawn(move || {
+            for _i in 0..50 {
+                let id = format!("writer-{}", _i);
+                let _result = reg_read.get(&id);
+                // Just verify no panic — DashMap handles concurrent access
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+
+    // After all writers, at least some configs should be present
+    assert!(!registry.get("writer-0").is_none() || !registry.get("writer-49").is_none());
+}
+
+#[test]
+fn test_concurrent_get_and_reload() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let registry = Arc::new(AgentRegistry::new(30));
+    registry.populate(vec![make_config("initial")]);
+
+    let mut handles = vec![];
+
+    // Reload thread: repeatedly replace all configs
+    let reg_write = Arc::clone(&registry);
+    handles.push(thread::spawn(move || {
+        for i in 0..30 {
+            let configs: Vec<_> = (0..10)
+                .map(|j| make_config(&format!("reload-{}-{}", i, j)))
+                .collect();
+            reg_write.reload_config(configs);
+        }
+    }));
+
+    // Reader threads
+    for _ in 0..5 {
+        let reg_read = Arc::clone(&registry);
+        handles.push(thread::spawn(move || {
+            for _i in 0..50 {
+                // Query any ID — should never panic
+                let _ = reg_read.get("reload-0-0");
+                let _ = reg_read.query_bootstrap_mode("any");
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn test_concurrent_query_bootstrap_mode() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let registry = Arc::new(AgentRegistry::new(30));
+    let mut cfg_full = make_config("full-agent");
+    cfg_full.bootstrap_mode = BootstrapMode::Full;
+    let mut cfg_min = make_config("min-agent");
+    cfg_min.bootstrap_mode = BootstrapMode::Minimal;
+    registry.populate(vec![cfg_full, cfg_min]);
+
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let reg = Arc::clone(&registry);
+        handles.push(thread::spawn(move || {
+            for _ in 0..100 {
+                let mode_full = reg.query_bootstrap_mode("full-agent");
+                assert_eq!(mode_full, Some(BootstrapMode::Full));
+                let mode_min = reg.query_bootstrap_mode("min-agent");
+                assert_eq!(mode_min, Some(BootstrapMode::Minimal));
+                let mode_none = reg.query_bootstrap_mode("missing");
+                assert_eq!(mode_none, None);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}

--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -5,32 +5,32 @@ use crate::session::bootstrap::BootstrapMode;
 
 // ---- Construction tests ----
 
-#[tokio::test]
-async fn test_new_construction() {
+#[test]
+fn test_new_construction() {
     let registry = AgentRegistry::new(30);
     // After construction the config map must be empty.
     assert!(
-        registry.get("any-id").await.is_none(),
+        registry.get("any-id").is_none(),
         "newly created registry should have no configs"
     );
 }
 
-#[tokio::test]
-async fn test_new_with_graceful_shutdown() {
+#[test]
+fn test_new_with_graceful_shutdown() {
     let registry = AgentRegistry::new_with_graceful_shutdown(30);
     // Must construct successfully and start empty.
     assert!(
-        registry.get("any-id").await.is_none(),
+        registry.get("any-id").is_none(),
         "registry created via new_with_graceful_shutdown should have no configs"
     );
 }
 
-#[tokio::test]
-async fn test_default_trait() {
+#[test]
+fn test_default_trait() {
     let registry = AgentRegistry::default();
     // Default() delegates to new_with_graceful_shutdown, should be empty.
     assert!(
-        registry.get("any-id").await.is_none(),
+        registry.get("any-id").is_none(),
         "default registry should have no configs"
     );
 }
@@ -53,90 +53,86 @@ fn make_config(id: &str) -> ResolvedAgentConfig {
     }
 }
 
-#[tokio::test]
-async fn test_populate_and_get() {
+#[test]
+fn test_populate_and_get() {
     let registry = AgentRegistry::new(30);
     let configs = vec![make_config("agent-a"), make_config("agent-b")];
 
-    registry.populate(configs).await;
+    registry.populate(configs);
 
-    let a = registry.get("agent-a").await;
+    let a = registry.get("agent-a");
     assert!(a.is_some(), "agent-a should be found after populate");
     assert_eq!(a.unwrap().id, "agent-a");
 
-    let b = registry.get("agent-b").await;
+    let b = registry.get("agent-b");
     assert!(b.is_some(), "agent-b should be found after populate");
     assert_eq!(b.unwrap().id, "agent-b");
 }
 
-#[tokio::test]
-async fn test_get_not_found() {
+#[test]
+fn test_get_not_found() {
     let registry = AgentRegistry::new(30);
-    registry.populate(vec![make_config("existing")]).await;
+    registry.populate(vec![make_config("existing")]);
 
-    let result = registry.get("nonexistent").await;
+    let result = registry.get("nonexistent");
     assert!(result.is_none(), "querying a missing id should return None");
 }
 
-#[tokio::test]
-async fn test_reload_config() {
+#[test]
+fn test_reload_config() {
     let registry = AgentRegistry::new(30);
 
     // Populate with old data.
-    registry.populate(vec![make_config("old-agent")]).await;
+    registry.populate(vec![make_config("old-agent")]);
     assert!(
-        registry.get("old-agent").await.is_some(),
+        registry.get("old-agent").is_some(),
         "old-agent should exist before reload"
     );
 
     // Reload with new data that does NOT include old-agent.
-    registry.reload_config(vec![make_config("new-agent")]).await;
+    registry.reload_config(vec![make_config("new-agent")]);
 
     assert!(
-        registry.get("old-agent").await.is_none(),
+        registry.get("old-agent").is_none(),
         "old-agent should be gone after reload"
     );
-    let new = registry.get("new-agent").await;
+    let new = registry.get("new-agent");
     assert!(new.is_some(), "new-agent should be present after reload");
     assert_eq!(new.unwrap().id, "new-agent");
 }
 
-#[tokio::test]
-async fn test_populate_empty() {
+#[test]
+fn test_populate_empty() {
     let registry = AgentRegistry::new(30);
 
     // Should not panic on empty input.
-    registry.populate(vec![]).await;
+    registry.populate(vec![]);
 
     assert!(
-        registry.get("anything").await.is_none(),
+        registry.get("anything").is_none(),
         "empty populate should leave registry empty"
     );
 }
 
-#[tokio::test]
-async fn test_reload_config_preserves_existing() {
+#[test]
+fn test_reload_config_preserves_existing() {
     let registry = AgentRegistry::new(30);
 
-    registry
-        .populate(vec![make_config("keep"), make_config("drop")])
-        .await;
+    registry.populate(vec![make_config("keep"), make_config("drop")]);
 
     // Reload: only "keep" and a new agent "added" exist.
-    registry
-        .reload_config(vec![make_config("keep"), make_config("added")])
-        .await;
+    registry.reload_config(vec![make_config("keep"), make_config("added")]);
 
     assert!(
-        registry.get("keep").await.is_some(),
+        registry.get("keep").is_some(),
         "'keep' should survive reload"
     );
     assert!(
-        registry.get("drop").await.is_none(),
+        registry.get("drop").is_none(),
         "'drop' should be removed by reload"
     );
     assert!(
-        registry.get("added").await.is_some(),
+        registry.get("added").is_some(),
         "'added' should be present after reload"
     );
 }

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -5,6 +5,7 @@
 //! queries. All runtime state (processes, lifecycle) lives elsewhere.
 
 use crate::config::agents::ResolvedAgentConfig;
+use crate::session::bootstrap::loader::BootstrapMode;
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -57,6 +58,18 @@ impl AgentRegistry {
         for cfg in configs {
             self.configs.insert(cfg.id.clone(), cfg);
         }
+    }
+
+    /// Query the bootstrap mode for an agent by ID.
+    ///
+    /// Returns the agent's configured `BootstrapMode` (Full or Minimal).
+    /// Returns `None` if the agent is not found in the registry.
+    ///
+    /// This is the System Prompt → AgentRegistry query path described in
+    /// the design doc: System Prompt queries bootstrap mode configuration
+    /// directly from AgentRegistry.
+    pub fn query_bootstrap_mode(&self, agent_id: &str) -> Option<BootstrapMode> {
+        self.configs.get(agent_id).map(|cfg| cfg.bootstrap_mode)
     }
 }
 

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -5,15 +5,14 @@
 //! queries. All runtime state (processes, lifecycle) lives elsewhere.
 
 use crate::config::agents::ResolvedAgentConfig;
-use std::collections::HashMap;
+use dashmap::DashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 /// Thread-safe agent configuration registry.
 #[derive(Debug)]
 pub struct AgentRegistry {
     /// Map of agent ID to resolved agent config.
-    pub(super) configs: RwLock<HashMap<String, ResolvedAgentConfig>>,
+    pub(super) configs: DashMap<String, ResolvedAgentConfig>,
 }
 
 impl Default for AgentRegistry {
@@ -31,32 +30,32 @@ impl AgentRegistry {
     /// Create a new registry with graceful shutdown configuration.
     pub fn new_with_graceful_shutdown(_heartbeat_timeout_secs: i64) -> Self {
         Self {
-            configs: RwLock::new(HashMap::new()),
+            configs: DashMap::new(),
         }
     }
 
     /// Populate the config store with the given resolved agent configs.
     /// Called once at startup by Daemon after ConfigManager loads agents.
-    pub async fn populate(&self, configs: Vec<ResolvedAgentConfig>) {
-        let mut map = self.configs.write().await;
+    pub fn populate(&self, configs: Vec<ResolvedAgentConfig>) {
         for cfg in configs {
-            map.insert(cfg.id.clone(), cfg);
+            self.configs.insert(cfg.id.clone(), cfg);
         }
     }
 
     /// Look up a resolved agent config by ID.
     /// Returns `None` if no config with the given ID exists.
-    pub async fn get(&self, id: &str) -> Option<ResolvedAgentConfig> {
-        let map = self.configs.read().await;
-        map.get(id).cloned()
+    pub fn get(
+        &self,
+        id: &str,
+    ) -> Option<dashmap::mapref::one::Ref<'_, String, ResolvedAgentConfig>> {
+        self.configs.get(id)
     }
 
     /// Replace all stored configs with the given set (hot-reload).
-    pub async fn reload_config(&self, configs: Vec<ResolvedAgentConfig>) {
-        let mut map = self.configs.write().await;
-        map.clear();
+    pub fn reload_config(&self, configs: Vec<ResolvedAgentConfig>) {
+        self.configs.clear();
         for cfg in configs {
-            map.insert(cfg.id.clone(), cfg);
+            self.configs.insert(cfg.id.clone(), cfg);
         }
     }
 }

--- a/src/config/agents/resolved.rs
+++ b/src/config/agents/resolved.rs
@@ -74,6 +74,48 @@ pub struct ResolvedAgentConfig {
 }
 
 impl ResolvedAgentConfig {
+    /// Check whether a list is a wildcard (empty or `["*"]`), meaning
+    /// "no filtering — allow all".
+    pub fn is_wildcard_list(list: &[String]) -> bool {
+        list.is_empty() || list == ["*"]
+    }
+
+    /// Return the effective skills whitelist.
+    ///
+    /// Returns `None` when the list is wildcard (empty or `["*"]`), meaning
+    /// no filtering applies. Otherwise returns `Some(whitelist)`.
+    pub fn effective_skills(&self) -> Option<Vec<String>> {
+        if Self::is_wildcard_list(&self.skills) {
+            None
+        } else {
+            Some(self.skills.clone())
+        }
+    }
+
+    /// Return the effective tools whitelist.
+    ///
+    /// Returns `None` when the list is wildcard (empty or `["*"]`), meaning
+    /// no filtering applies. Otherwise returns `Some(whitelist)`.
+    pub fn effective_tools(&self) -> Option<Vec<String>> {
+        if Self::is_wildcard_list(&self.tools) {
+            None
+        } else {
+            Some(self.tools.clone())
+        }
+    }
+
+    /// Return the effective disallowed tools blacklist.
+    ///
+    /// Returns `None` when the list is empty (no tools are disallowed).
+    /// A non-empty list means those tools are explicitly blocked.
+    pub fn effective_disallowed_tools(&self) -> Option<Vec<String>> {
+        if self.disallowed_tools.is_empty() {
+            None
+        } else {
+            Some(self.disallowed_tools.clone())
+        }
+    }
+
     /// Convert a single `AgentConfig` into a resolved form, tagging it
     /// with the given `source` level. The `path` argument is used purely
     /// for error reporting when `id` validation fails.

--- a/src/config/agents/resolved.rs
+++ b/src/config/agents/resolved.rs
@@ -79,7 +79,6 @@ impl ResolvedAgentConfig {
     pub fn is_wildcard_list(list: &[String]) -> bool {
         list.is_empty() || list == ["*"]
     }
-
     /// Return the effective skills whitelist.
     ///
     /// Returns `None` when the list is wildcard (empty or `["*"]`), meaning
@@ -91,7 +90,6 @@ impl ResolvedAgentConfig {
             Some(self.skills.clone())
         }
     }
-
     /// Return the effective tools whitelist.
     ///
     /// Returns `None` when the list is wildcard (empty or `["*"]`), meaning
@@ -103,7 +101,6 @@ impl ResolvedAgentConfig {
             Some(self.tools.clone())
         }
     }
-
     /// Return the effective disallowed tools blacklist.
     ///
     /// Returns `None` when the list is empty (no tools are disallowed).
@@ -115,7 +112,9 @@ impl ResolvedAgentConfig {
             Some(self.disallowed_tools.clone())
         }
     }
+}
 
+impl ResolvedAgentConfig {
     /// Convert a single `AgentConfig` into a resolved form, tagging it
     /// with the given `source` level. The `path` argument is used purely
     /// for error reporting when `id` validation fails.
@@ -141,7 +140,6 @@ impl ResolvedAgentConfig {
             .name
             .filter(|n| !n.is_empty())
             .unwrap_or_else(|| config.id.clone());
-
         Ok(Self {
             id: config.id,
             name,
@@ -157,7 +155,6 @@ impl ResolvedAgentConfig {
             source,
         })
     }
-
     /// Merge project-level and user-level configs into a resolved form.
     ///
     /// Project fields take precedence over user fields; see the module
@@ -188,7 +185,6 @@ impl ResolvedAgentConfig {
             .filter(|n| !n.is_empty())
             .or_else(|| user.name.filter(|n| !n.is_empty()))
             .unwrap_or_else(|| id.clone());
-
         Ok(Self {
             id,
             name,

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -98,7 +98,7 @@ async fn reload_agents_with_log(
     }
     // Sync the new configs into AgentRegistry (design-doc hot-reload path).
     let configs: Vec<_> = cm.agents().into_values().collect();
-    agent_registry.reload_config(configs).await;
+    agent_registry.reload_config(configs);
 }
 
 /// Handle a single changed file path: reload agents or the matching section.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -254,7 +254,7 @@ impl Daemon {
                 //   ConfigManager.load_agents() → AgentRegistry.populate()
                 {
                     let configs: Vec<_> = config_manager.agents().into_values().collect();
-                    agent_registry.populate(configs).await;
+                    agent_registry.populate(configs);
                 }
 
                 // Pass config_manager to SessionManager for agent tool/skill filtering.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -266,6 +266,12 @@ impl Daemon {
                     }
                 }
 
+                // Inject AgentRegistry into ToolRegistry so the Tools
+                // Registry can query agent tools config directly (design-doc query path).
+                tool_registry
+                    .set_agent_registry(Arc::clone(&agent_registry))
+                    .await;
+
                 // Pass config_manager to SessionManager for agent tool/skill filtering.
                 session_manager
                     .set_config_manager(Arc::clone(&config_manager))

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -268,9 +268,7 @@ impl Daemon {
 
                 // Inject AgentRegistry into ToolRegistry so the Tools
                 // Registry can query agent tools config directly (design-doc query path).
-                tool_registry
-                    .set_agent_registry(Arc::clone(&agent_registry))
-                    .await;
+                tool_registry.set_agent_registry(Arc::clone(&agent_registry));
 
                 // Pass config_manager to SessionManager for agent tool/skill filtering.
                 session_manager

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -257,6 +257,15 @@ impl Daemon {
                     agent_registry.populate(configs);
                 }
 
+                // Inject AgentRegistry into DiskSkillRegistry so the Skills
+                // Registry can query agent configs directly (design-doc query path).
+                {
+                    let mut guard = skill_registry.write().unwrap();
+                    if let Some(ref mut disk_reg) = *guard {
+                        disk_reg.set_agent_registry(Arc::clone(&agent_registry));
+                    }
+                }
+
                 // Pass config_manager to SessionManager for agent tool/skill filtering.
                 session_manager
                     .set_config_manager(Arc::clone(&config_manager))

--- a/src/daemon/skill_reload.rs
+++ b/src/daemon/skill_reload.rs
@@ -39,7 +39,18 @@ pub(crate) async fn init_skill_hot_reload(
     let watcher = start_skill_watcher(
         skill_dirs,
         Box::new(move || {
-            let new_registry = init_disk_skills(&watcher_config);
+            let mut new_registry = init_disk_skills(&watcher_config);
+
+            // Preserve the AgentRegistry reference from the old registry
+            // so the Skills Registry can continue querying agent configs
+            // directly after hot-reload.
+            if let Ok(guard) = registry_for_watcher.read() {
+                if let Some(ref old_reg) = *guard {
+                    if let Some(agent_reg) = old_reg.agent_registry() {
+                        new_registry.set_agent_registry(Arc::clone(agent_reg));
+                    }
+                }
+            }
 
             // Update shared state
             if let Ok(mut guard) = registry_for_watcher.write() {

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -129,7 +129,7 @@ impl SessionManager {
         agent_id: &str,
     ) -> Option<crate::config::agents::ResolvedAgentConfig> {
         let guard = self.agent_registry.read().await;
-        guard.as_ref()?.get(agent_id).await
+        guard.as_ref()?.get(agent_id).map(|r| r.value().clone())
     }
 
     /// Set priority prompt overrides.

--- a/src/gateway/session_manager/rebuild.rs
+++ b/src/gateway/session_manager/rebuild.rs
@@ -40,6 +40,7 @@ impl SessionManager {
         let tool_registry_guard = self.tool_registry.read().await;
         let tool_registry_ref = tool_registry_guard.as_ref().map(|r| r.as_ref());
         let skill_registry = self.skill_registry.read().await.clone();
+        let agent_registry = self.agent_registry.read().await.clone();
         let session_workdir = {
             let cs_read = cs.read().await;
             cs_read.workdir().to_path_buf()
@@ -70,6 +71,7 @@ impl SessionManager {
                 agent_skills: filters.agent_skills,
                 dynamic_sections: vec![],
                 append_section: None,
+                agent_registry,
             },
         )
         .await;

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -21,25 +21,10 @@ use tracing::warn;
 impl SessionManager {
     /// Extract tool/skill filter configuration from an agent config.
     pub(super) fn extract_agent_filters(config: &ResolvedAgentConfig) -> AgentToolSkillConfig {
-        let agent_tools = if config.tools.is_empty() || config.tools == ["*"] {
-            None
-        } else {
-            Some(config.tools.clone())
-        };
-        let agent_disallowed_tools = if config.disallowed_tools.is_empty() {
-            None
-        } else {
-            Some(config.disallowed_tools.clone())
-        };
-        let agent_skills = if config.skills.is_empty() || config.skills == ["*"] {
-            None
-        } else {
-            Some(config.skills.clone())
-        };
         AgentToolSkillConfig {
-            agent_tools,
-            agent_disallowed_tools,
-            agent_skills,
+            agent_tools: config.effective_tools(),
+            agent_disallowed_tools: config.effective_disallowed_tools(),
+            agent_skills: config.effective_skills(),
         }
     }
 

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -109,6 +109,7 @@ impl SessionManager {
                                 .as_ref()
                                 .map(Self::extract_agent_filters)
                                 .unwrap_or_default();
+                            let agent_registry = self.agent_registry.read().await.clone();
                             let prompt = session_helpers::build_session_system_prompt(
                                 &self.workspace_dir,
                                 self.bootstrap_mode,
@@ -116,6 +117,7 @@ impl SessionManager {
                                 skill_registry,
                                 &agent_id,
                                 &filters,
+                                agent_registry,
                             )
                             .await;
 
@@ -194,6 +196,7 @@ impl SessionManager {
             .as_ref()
             .map(Self::extract_agent_filters)
             .unwrap_or_default();
+        let agent_registry = self.agent_registry.read().await.clone();
         let prompt = session_helpers::build_session_system_prompt(
             &self.workspace_dir,
             self.bootstrap_mode,
@@ -201,6 +204,7 @@ impl SessionManager {
             skill_registry,
             &agent_id,
             &filters,
+            agent_registry,
         )
         .await;
 

--- a/src/gateway/session_manager/session_helpers.rs
+++ b/src/gateway/session_manager/session_helpers.rs
@@ -1,6 +1,7 @@
 //! Helper functions extracted from SessionManager::find_or_create
 //! to keep the main file under the 500-line limit.
 
+use crate::agent::registry::AgentRegistry;
 use crate::gateway::Message;
 use crate::im::IMAdapter;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
@@ -42,6 +43,7 @@ pub(super) async fn build_session_system_prompt(
     skill_registry: Option<Arc<std::sync::RwLock<Option<DiskSkillRegistry>>>>,
     agent_id: &str,
     filters: &AgentToolSkillConfig,
+    agent_registry: Option<Arc<AgentRegistry>>,
 ) -> String {
     let bootstrap_files = if let Some(ref workspace) = workspace_dir {
         load_bootstrap_files(workspace, bootstrap_mode)
@@ -76,6 +78,7 @@ pub(super) async fn build_session_system_prompt(
             agent_skills: filters.agent_skills.clone(),
             dynamic_sections: vec![],
             append_section: None,
+            agent_registry,
         },
     )
     .await

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -127,6 +127,7 @@ impl SessionManager {
         let tool_registry_guard = self.tool_registry.read().await;
         let tool_registry_ref = tool_registry_guard.as_ref().map(|r| r.as_ref());
         let skill_registry = self.skill_registry.read().await.clone();
+        let agent_registry = self.agent_registry.read().await.clone();
         let agent_id = config.id.clone();
         let tool_ctx = ToolContext {
             agent_id: agent_id.clone(),
@@ -151,6 +152,7 @@ impl SessionManager {
                 agent_skills: filters.agent_skills,
                 dynamic_sections: vec![],
                 append_section: None,
+                agent_registry,
             },
         )
         .await;

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -24,6 +24,10 @@ impl Default for DiskSkillRegistry {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Construction & basic accessors
+// ---------------------------------------------------------------------------
+
 impl DiskSkillRegistry {
     /// Creates a new registry with the given skills and no agent registry.
     pub fn new(skills: Vec<DiskSkill>) -> Self {
@@ -47,10 +51,11 @@ impl DiskSkillRegistry {
         self.agent_registry = Some(registry);
     }
 
-    /// Returns skills that have path-based conditional activation (`paths` is non-empty).
+    /// Returns skills that have path-based conditional activation
+    /// (`paths` is non-empty).
     ///
-    /// These skills are only auto-activated when the current operation context
-    /// involves files matching one of their glob patterns.
+    /// These skills are only auto-activated when the current operation
+    /// context involves files matching one of their glob patterns.
     pub fn conditional_skills(&self) -> Vec<&DiskSkill> {
         self.skills
             .iter()
@@ -58,8 +63,8 @@ impl DiskSkillRegistry {
             .collect()
     }
 
-    /// Returns `true` if any path in `paths` matches one of the glob patterns
-    /// defined in the named skill's manifest `paths` field.
+    /// Returns `true` if any path in `paths` matches one of the glob
+    /// patterns defined in the named skill's manifest `paths` field.
     ///
     /// Returns `false` when:
     /// - The skill does not exist
@@ -115,13 +120,20 @@ impl DiskSkillRegistry {
             .map(|s| s.manifest.name.as_str())
             .collect()
     }
+}
 
+// ---------------------------------------------------------------------------
+// Path matching & source filtering
+// ---------------------------------------------------------------------------
+
+impl DiskSkillRegistry {
     /// Returns all conditional skills (those with non-empty `paths`) that
-    /// match any of the given file paths, sorted by [`SkillSource`] priority
-    /// (Project > Agent > Global > ExtraDirs > Bundled) with deduplication
-    /// by name (higher-priority skill wins).
+    /// match any of the given file paths, sorted by [`SkillSource`]
+    /// priority (Project > Agent > Global > ExtraDirs > Bundled) with
+    /// deduplication by name (higher-priority skill wins).
     ///
-    /// Returns an empty vec when `paths` is empty or no conditional skills match.
+    /// Returns an empty vec when `paths` is empty or no conditional
+    /// skills match.
     pub fn find_matching_skills(&self, paths: &[&Path]) -> Vec<&DiskSkill> {
         if paths.is_empty() {
             return Vec::new();
@@ -150,69 +162,80 @@ impl DiskSkillRegistry {
     pub fn filter_by_source(&self, source: SkillSource) -> Vec<&DiskSkill> {
         self.skills.iter().filter(|s| s.source == source).collect()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Listing generation (AgentRegistry query path)
+// ---------------------------------------------------------------------------
+
+impl DiskSkillRegistry {
+    /// Look up the skills whitelist directly from the AgentRegistry
+    /// for the given agent_id.
+    ///
+    /// Returns `None` when:
+    /// - `agent_id` is `None`
+    /// - The agent registry is not set
+    /// - The agent config is not found
+    /// - The skills list is wildcard (empty or `["*"]`)
+    fn lookup_whitelist_from_agent_registry(&self, agent_id: Option<&str>) -> Option<Vec<String>> {
+        let agent_id = agent_id?;
+        let registry = self.agent_registry.as_ref()?;
+        let cfg = registry.get(agent_id)?;
+        cfg.effective_skills()
+    }
 
     /// Generates a formatted skill listing string for the given agent_id.
     ///
-    /// - Sorts by SkillSource priority (Project > Agent > Global > ExtraDirs > Bundled)
+    /// - Sorts by SkillSource priority
+    ///   (Project > Agent > Global > ExtraDirs > Bundled)
     /// - Within the same priority, sorts by name alphabetically
-    /// - Filters: only includes skills where `agent_id` is empty or matches the given agent_id,
-    ///   and `user_invocable` is true (skills with `user_invocable: false` are excluded)
-    /// - When `skills_whitelist` is `Some(list)`, only skills whose name appears in
-    ///   the list are included (unless the list is `["*"]`, which means no filter).
-    /// - When `skills_whitelist` is `None` and an `agent_registry` is set, the whitelist
-    ///   is looked up directly from the agent config (direct query path, per design doc).
-    /// - Format: `- **{name}**: {description}` + optionally ` — {when_to_use}`
+    /// - Filters: only includes skills where `agent_id` is empty or
+    ///   matches the given agent_id, and `user_invocable` is true
+    /// - When `skills_whitelist` is `Some(list)`, only skills whose
+    ///   name appears in the list are included (unless the list is
+    ///   `["*"]`, which means no filter).
+    /// - When `skills_whitelist` is `None` and an `agent_registry` is
+    ///   set, the whitelist is looked up directly from the agent config
+    ///   (direct query path, per design doc).
+    /// - Format: `- **{name}**: {description}` + optionally
+    ///   ` — {when_to_use}`
     /// - Returns empty string if no skills match
     pub fn generate_listing(
         &self,
         agent_id: Option<&str>,
         skills_whitelist: Option<&[String]>,
     ) -> String {
-        // When no explicit whitelist is provided, attempt to look it up
-        // directly from the AgentRegistry (design-doc query path).
         let resolved_whitelist = match skills_whitelist {
             Some(w) => Some(w.to_vec()),
-            None => self
-                .agent_registry
-                .as_ref()
-                .and_then(|reg| reg.get(agent_id.unwrap_or("")))
-                .and_then(|cfg| {
-                    let skills = &cfg.skills;
-                    if skills.is_empty() || *skills == ["*"] {
-                        None
-                    } else {
-                        Some(skills.clone())
-                    }
-                }),
+            None => self.lookup_whitelist_from_agent_registry(agent_id),
         };
         let resolved_ref = resolved_whitelist.as_deref();
         self.generate_listing_inner(agent_id, resolved_ref)
     }
 
-    /// Generates a skill listing by directly querying the AgentRegistry for
-    /// the agent's skills whitelist.
+    /// Generates a skill listing by directly querying the AgentRegistry
+    /// for the agent's skills whitelist.
     ///
-    /// This is the primary entry point per the design doc: the Skills Registry
-    /// queries the AgentRegistry to obtain the skills configuration. Falls back
-    /// to showing all skills when the agent registry is not set or the agent
-    /// config is not found.
+    /// This is the primary entry point per the design doc: the Skills
+    /// Registry queries the AgentRegistry to obtain the skills
+    /// configuration. Falls back to showing all skills when the agent
+    /// registry is not set or the agent config is not found.
     pub fn generate_listing_for_agent(&self, agent_id: &str) -> String {
         let resolved_whitelist = self
             .agent_registry
             .as_ref()
             .and_then(|reg| reg.get(agent_id))
-            .and_then(|cfg| {
-                let skills = &cfg.skills;
-                if skills.is_empty() || *skills == ["*"] {
-                    None
-                } else {
-                    Some(skills.clone())
-                }
-            });
+            .and_then(|cfg| cfg.effective_skills());
         let resolved_ref = resolved_whitelist.as_deref();
         self.generate_listing_inner(Some(agent_id), resolved_ref)
     }
+}
 
+// ---------------------------------------------------------------------------
+// Listing filtering
+// ---------------------------------------------------------------------------
+
+impl DiskSkillRegistry {
     /// Internal implementation shared by `generate_listing` and
     /// `generate_listing_for_agent`.
     fn generate_listing_inner(
@@ -252,8 +275,21 @@ impl DiskSkillRegistry {
             return String::new();
         }
 
+        Self::render_listing(&mut filtered)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Listing rendering
+// ---------------------------------------------------------------------------
+
+impl DiskSkillRegistry {
+    /// Render a pre-filtered, pre-sorted skill slice into a listing
+    /// string. Each line is formatted as:
+    ///   `- **{name}**: {description} — {when_to_use} ⚡ auto-activates on: {paths}`
+    fn render_listing(skills: &mut Vec<&DiskSkill>) -> String {
         // Sort by source priority (lower is higher priority), then by name
-        filtered.sort_by(|a, b| {
+        skills.sort_by(|a, b| {
             let src_cmp = a.source.cmp(&b.source);
             if src_cmp != std::cmp::Ordering::Equal {
                 return src_cmp;
@@ -261,7 +297,7 @@ impl DiskSkillRegistry {
             a.manifest.name.cmp(&b.manifest.name)
         });
 
-        let lines: Vec<String> = filtered
+        let lines: Vec<String> = skills
             .iter()
             .map(|s| {
                 let when = if s.manifest.when_to_use.is_empty() {
@@ -280,7 +316,6 @@ impl DiskSkillRegistry {
                 )
             })
             .collect();
-
         lines.join("\n")
     }
 }

--- a/src/skills/disk/registry.rs
+++ b/src/skills/disk/registry.rs
@@ -1,20 +1,50 @@
 //! DiskSkillRegistry - in-memory registry for disk-loaded skills.
 
+use crate::agent::registry::AgentRegistry;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::path_matcher::PathMatcher;
 use super::types::{DiskSkill, SkillSource};
 
 /// In-memory registry holding all discovered disk skills.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct DiskSkillRegistry {
     skills: Vec<DiskSkill>,
+    /// Optional reference to the agent configuration registry.
+    /// When set, `generate_listing` can look up the skills whitelist
+    /// directly from the agent config, avoiding the need for the caller
+    /// to pass it explicitly.
+    agent_registry: Option<Arc<AgentRegistry>>,
+}
+
+impl Default for DiskSkillRegistry {
+    fn default() -> Self {
+        Self::empty()
+    }
 }
 
 impl DiskSkillRegistry {
-    /// Creates a new registry with the given skills.
+    /// Creates a new registry with the given skills and no agent registry.
     pub fn new(skills: Vec<DiskSkill>) -> Self {
-        Self { skills }
+        Self {
+            skills,
+            agent_registry: None,
+        }
+    }
+
+    /// Creates an empty registry with no skills and no agent registry.
+    fn empty() -> Self {
+        Self {
+            skills: Vec::new(),
+            agent_registry: None,
+        }
+    }
+
+    /// Inject the agent configuration registry for direct skills-whitelist
+    /// lookups.
+    pub fn set_agent_registry(&mut self, registry: Arc<AgentRegistry>) {
+        self.agent_registry = Some(registry);
     }
 
     /// Returns skills that have path-based conditional activation (`paths` is non-empty).
@@ -51,6 +81,11 @@ impl DiskSkillRegistry {
             Err(_) => return false,
         };
         paths.iter().any(|p| matcher.matches(p))
+    }
+
+    /// Returns a reference to the agent configuration registry, if set.
+    pub fn agent_registry(&self) -> Option<&Arc<AgentRegistry>> {
+        self.agent_registry.as_ref()
     }
 
     /// Returns the number of registered skills.
@@ -124,9 +159,63 @@ impl DiskSkillRegistry {
     ///   and `user_invocable` is true (skills with `user_invocable: false` are excluded)
     /// - When `skills_whitelist` is `Some(list)`, only skills whose name appears in
     ///   the list are included (unless the list is `["*"]`, which means no filter).
+    /// - When `skills_whitelist` is `None` and an `agent_registry` is set, the whitelist
+    ///   is looked up directly from the agent config (direct query path, per design doc).
     /// - Format: `- **{name}**: {description}` + optionally ` — {when_to_use}`
     /// - Returns empty string if no skills match
     pub fn generate_listing(
+        &self,
+        agent_id: Option<&str>,
+        skills_whitelist: Option<&[String]>,
+    ) -> String {
+        // When no explicit whitelist is provided, attempt to look it up
+        // directly from the AgentRegistry (design-doc query path).
+        let resolved_whitelist = match skills_whitelist {
+            Some(w) => Some(w.to_vec()),
+            None => self
+                .agent_registry
+                .as_ref()
+                .and_then(|reg| reg.get(agent_id.unwrap_or("")))
+                .and_then(|cfg| {
+                    let skills = &cfg.skills;
+                    if skills.is_empty() || *skills == ["*"] {
+                        None
+                    } else {
+                        Some(skills.clone())
+                    }
+                }),
+        };
+        let resolved_ref = resolved_whitelist.as_deref();
+        self.generate_listing_inner(agent_id, resolved_ref)
+    }
+
+    /// Generates a skill listing by directly querying the AgentRegistry for
+    /// the agent's skills whitelist.
+    ///
+    /// This is the primary entry point per the design doc: the Skills Registry
+    /// queries the AgentRegistry to obtain the skills configuration. Falls back
+    /// to showing all skills when the agent registry is not set or the agent
+    /// config is not found.
+    pub fn generate_listing_for_agent(&self, agent_id: &str) -> String {
+        let resolved_whitelist = self
+            .agent_registry
+            .as_ref()
+            .and_then(|reg| reg.get(agent_id))
+            .and_then(|cfg| {
+                let skills = &cfg.skills;
+                if skills.is_empty() || *skills == ["*"] {
+                    None
+                } else {
+                    Some(skills.clone())
+                }
+            });
+        let resolved_ref = resolved_whitelist.as_deref();
+        self.generate_listing_inner(Some(agent_id), resolved_ref)
+    }
+
+    /// Internal implementation shared by `generate_listing` and
+    /// `generate_listing_for_agent`.
+    fn generate_listing_inner(
         &self,
         agent_id: Option<&str>,
         skills_whitelist: Option<&[String]>,

--- a/src/skills/disk/registry_tests/mod.rs
+++ b/src/skills/disk/registry_tests/mod.rs
@@ -425,3 +425,187 @@ fn test_find_matching_skills_priority_dedup_mixed() {
     let names3: Vec<&str> = m3.iter().map(|s| s.manifest.name.as_str()).collect();
     assert_eq!(names3, ["rs", "md"]);
 }
+
+// ---- AgentRegistry query path tests ----
+// Tests for DiskSkillRegistry's ability to query AgentRegistry directly
+// for skills whitelist configuration, per design-doc query path.
+
+use crate::agent::registry::AgentRegistry;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::session::bootstrap::loader::BootstrapMode;
+use std::sync::Arc;
+
+fn make_agent_config(id: &str, skills: Vec<String>) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: None,
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills,
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: Default::default(),
+        source: ConfigSource::User,
+    }
+}
+
+#[test]
+fn test_set_agent_registry_and_accessor() {
+    let mut r = DiskSkillRegistry::new(vec![]);
+    assert!(r.agent_registry().is_none());
+
+    let arc_reg = Arc::new(AgentRegistry::new(30));
+    r.set_agent_registry(Arc::clone(&arc_reg));
+    assert!(r.agent_registry().is_some());
+    // The returned Arc should point to the same registry
+    let returned = r.agent_registry().unwrap();
+    assert!(Arc::ptr_eq(returned, &arc_reg));
+}
+
+#[test]
+fn test_generate_listing_for_agent_with_whitelist() {
+    // Agent has skills whitelist ["foo", "bar"]
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-1",
+        vec!["foo".into(), "bar".into()],
+    )]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Bundled),
+        skill("bar", SkillSource::Bundled),
+        skill("baz", SkillSource::Bundled),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    let listing = r.generate_listing_for_agent("agent-1");
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("**bar**"));
+    assert!(!listing.contains("**baz**"));
+}
+
+#[test]
+fn test_generate_listing_for_agent_agent_not_found() {
+    // Agent not in registry — should show all skills (no whitelist)
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Bundled),
+        skill("bar", SkillSource::Bundled),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    let listing = r.generate_listing_for_agent("nonexistent");
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("**bar**"));
+}
+
+#[test]
+fn test_generate_listing_for_agent_wildcard_whitelist() {
+    // Agent skills = ["*"] means show all
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config("agent-wild", vec!["*".into()])]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Bundled),
+        skill("bar", SkillSource::Global),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    let listing = r.generate_listing_for_agent("agent-wild");
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("**bar**"));
+}
+
+#[test]
+fn test_generate_listing_for_agent_empty_skills() {
+    // Agent skills = [] means show all (no filtering)
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config("agent-empty", vec![])]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Bundled),
+        skill("bar", SkillSource::Global),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    let listing = r.generate_listing_for_agent("agent-empty");
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("**bar**"));
+}
+
+#[test]
+fn test_generate_listing_for_agent_no_registry_set() {
+    // No agent_registry set — should show all skills
+    let r = DiskSkillRegistry::new(vec![
+        skill("foo", SkillSource::Bundled),
+        skill("bar", SkillSource::Bundled),
+    ]);
+    // Not setting agent_registry
+
+    let listing = r.generate_listing_for_agent("any-agent");
+    assert!(listing.contains("**foo**"));
+    assert!(listing.contains("**bar**"));
+}
+
+#[test]
+fn test_generate_listing_fallback_to_agent_registry() {
+    // When no explicit whitelist is passed, generate_listing should
+    // fall back to AgentRegistry lookup.
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config("agent-fb", vec!["skill-a".into()])]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("skill-a", SkillSource::Bundled),
+        skill("skill-b", SkillSource::Bundled),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    // Pass None for skills_whitelist — should use AgentRegistry
+    let listing = r.generate_listing(Some("agent-fb"), None);
+    assert!(listing.contains("**skill-a**"));
+    assert!(!listing.contains("**skill-b**"));
+}
+
+#[test]
+fn test_generate_listing_explicit_whitelist_overrides_registry() {
+    // When explicit whitelist is provided, AgentRegistry is not used
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config("agent-ov", vec!["skill-a".into()])]);
+
+    let mut r = DiskSkillRegistry::new(vec![
+        skill("skill-a", SkillSource::Bundled),
+        skill("skill-b", SkillSource::Bundled),
+    ]);
+    r.set_agent_registry(agent_reg);
+
+    // Explicit whitelist allows skill-b (not in agent config)
+    let listing = r.generate_listing(Some("agent-ov"), Some(&["skill-b".into()]));
+    assert!(!listing.contains("**skill-a**"));
+    assert!(listing.contains("**skill-b**"));
+}
+
+#[test]
+fn test_generate_listing_for_agent_user_invocable_filter() {
+    // user_invocable: false skills should still be excluded
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-inv",
+        vec!["visible".into(), "hidden".into()],
+    )]);
+
+    let visible = skill("visible", SkillSource::Bundled);
+    let mut hidden = skill("hidden", SkillSource::Bundled);
+    hidden.manifest.user_invocable = false;
+
+    let mut r = DiskSkillRegistry::new(vec![visible, hidden]);
+    r.set_agent_registry(agent_reg);
+
+    let listing = r.generate_listing_for_agent("agent-inv");
+    assert!(listing.contains("**visible**"));
+    assert!(!listing.contains("**hidden**"));
+}

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -314,4 +314,140 @@ mod tests {
         let result2 = build_system_prompt(sections, None);
         assert_eq!(result1, result2);
     }
+
+    // ---- AgentRegistry bootstrap mode query path tests ----
+
+    #[test]
+    fn test_workspace_build_config_has_agent_registry_field() {
+        // Verify the agent_registry field is accessible and defaults to None
+        let ctx = ToolContext {
+            agent_id: "test".to_string(),
+            workdir: None,
+            session_id: None,
+            call_id: None,
+            session: None,
+        };
+        let config = WorkspaceBuildConfig {
+            bootstrap_files: vec![],
+            tool_registry: None,
+            tool_ctx: &ctx,
+            skill_registry: None,
+            agent_id: None,
+            agent_tools: None,
+            agent_disallowed_tools: None,
+            agent_skills: None,
+            dynamic_sections: vec![],
+            append_section: None,
+            agent_registry: None,
+        };
+        assert!(config.agent_registry.is_none());
+    }
+
+    #[test]
+    fn test_workspace_build_config_with_agent_registry() {
+        use crate::agent::registry::AgentRegistry;
+        use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+        use crate::session::bootstrap::loader::BootstrapMode;
+
+        let agent_reg = Arc::new(AgentRegistry::new(30));
+        agent_reg.populate(vec![ResolvedAgentConfig {
+            id: "test-agent".into(),
+            name: "test-agent".into(),
+            parent_id: None,
+            model: None,
+            workspace: None,
+            agent_dir: None,
+            bootstrap_mode: BootstrapMode::Minimal,
+            skills: vec![],
+            tools: vec![],
+            disallowed_tools: vec![],
+            subagents: Default::default(),
+            source: ConfigSource::User,
+        }]);
+
+        let ctx = ToolContext {
+            agent_id: "test-agent".to_string(),
+            workdir: None,
+            session_id: None,
+            call_id: None,
+            session: None,
+        };
+        let config = WorkspaceBuildConfig {
+            bootstrap_files: vec![],
+            tool_registry: None,
+            tool_ctx: &ctx,
+            skill_registry: None,
+            agent_id: Some("test-agent"),
+            agent_tools: None,
+            agent_disallowed_tools: None,
+            agent_skills: None,
+            dynamic_sections: vec![],
+            append_section: None,
+            agent_registry: Some(agent_reg),
+        };
+        assert!(config.agent_registry.is_some());
+        assert_eq!(config.agent_id, Some("test-agent"));
+    }
+
+    #[test]
+    fn test_agent_registry_query_bootstrap_mode_minimal() {
+        use crate::agent::registry::AgentRegistry;
+        use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+        use crate::session::bootstrap::loader::BootstrapMode;
+
+        let agent_reg = Arc::new(AgentRegistry::new(30));
+        agent_reg.populate(vec![ResolvedAgentConfig {
+            id: "minimal-agent".into(),
+            name: "minimal-agent".into(),
+            parent_id: None,
+            model: None,
+            workspace: None,
+            agent_dir: None,
+            bootstrap_mode: BootstrapMode::Minimal,
+            skills: vec![],
+            tools: vec![],
+            disallowed_tools: vec![],
+            subagents: Default::default(),
+            source: ConfigSource::User,
+        }]);
+
+        // Verify the registry can be queried for bootstrap mode
+        let mode = agent_reg.query_bootstrap_mode("minimal-agent");
+        assert_eq!(mode, Some(BootstrapMode::Minimal));
+    }
+
+    #[test]
+    fn test_agent_registry_query_bootstrap_mode_full() {
+        use crate::agent::registry::AgentRegistry;
+        use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+        use crate::session::bootstrap::loader::BootstrapMode;
+
+        let agent_reg = Arc::new(AgentRegistry::new(30));
+        agent_reg.populate(vec![ResolvedAgentConfig {
+            id: "full-agent".into(),
+            name: "full-agent".into(),
+            parent_id: None,
+            model: None,
+            workspace: None,
+            agent_dir: None,
+            bootstrap_mode: BootstrapMode::Full,
+            skills: vec![],
+            tools: vec![],
+            disallowed_tools: vec![],
+            subagents: Default::default(),
+            source: ConfigSource::User,
+        }]);
+
+        let mode = agent_reg.query_bootstrap_mode("full-agent");
+        assert_eq!(mode, Some(BootstrapMode::Full));
+    }
+
+    #[test]
+    fn test_agent_registry_query_bootstrap_mode_not_found() {
+        use crate::agent::registry::AgentRegistry;
+
+        let agent_reg = Arc::new(AgentRegistry::new(30));
+        let mode = agent_reg.query_bootstrap_mode("missing-agent");
+        assert_eq!(mode, None);
+    }
 }

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -165,6 +165,55 @@ pub struct WorkspaceBuildConfig<'a> {
 /// and `config.agent_id` are set, the builder queries the AgentRegistry
 /// for the agent's bootstrap mode and loads files automatically
 /// (design-doc query path: System Prompt → AgentRegistry).
+/// Push the SkillListingSection into `sections` when a skill registry
+/// is available and produces a non-empty listing.
+fn push_skill_listing_section(
+    sections: &mut Vec<Section>,
+    skill_registry: &Option<Arc<RwLock<Option<DiskSkillRegistry>>>>,
+    agent_id: Option<&str>,
+    agent_skills: Option<&[String]>,
+) {
+    let Some(lock) = skill_registry else {
+        return;
+    };
+    let Ok(g) = lock.read() else {
+        return;
+    };
+    let Some(reg) = g.as_ref() else {
+        return;
+    };
+    let listing = reg.generate_listing(agent_id, agent_skills);
+    if !listing.is_empty() {
+        sections.push(Section::SkillListingSection(listing));
+    }
+}
+
+/// Resolve bootstrap files: use pre-loaded files, or query AgentRegistry
+/// for the bootstrap mode and load them on the fly.
+fn resolve_bootstrap_files(
+    root: &Path,
+    config: &WorkspaceBuildConfig<'_>,
+) -> Vec<(String, String)> {
+    if !config.bootstrap_files.is_empty() {
+        return config.bootstrap_files.clone();
+    }
+    let Some(registry) = config.agent_registry.as_ref() else {
+        return config.bootstrap_files.clone();
+    };
+    let Some(agent_id) = config.agent_id else {
+        return config.bootstrap_files.clone();
+    };
+    registry
+        .query_bootstrap_mode(agent_id)
+        .map(|mode| {
+            load_bootstrap_files(root, mode)
+                .unwrap_or_default()
+                .into_iter()
+                .collect()
+        })
+        .unwrap_or_else(|| config.bootstrap_files.clone())
+}
+
 pub async fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     config: WorkspaceBuildConfig<'_>,
@@ -172,25 +221,7 @@ pub async fn build_from_workspace<P: AsRef<Path>>(
     let root = workspace_root.as_ref();
     let mut sections: Vec<Section> = Vec::new();
 
-    // Resolve bootstrap files: use pre-loaded files, or query AgentRegistry
-    // for the bootstrap mode and load them on the fly.
-    let resolved_bootstrap_files = if config.bootstrap_files.is_empty() {
-        if let (Some(registry), Some(agent_id)) = (config.agent_registry.as_ref(), config.agent_id)
-        {
-            if let Some(mode) = registry.query_bootstrap_mode(agent_id) {
-                load_bootstrap_files(root, mode)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .collect()
-            } else {
-                config.bootstrap_files.clone()
-            }
-        } else {
-            config.bootstrap_files.clone()
-        }
-    } else {
-        config.bootstrap_files.clone()
-    };
+    let resolved_bootstrap_files = resolve_bootstrap_files(root, &config);
 
     // RoleSection from bootstrap files (skip MEMORY.md)
     let role: String = resolved_bootstrap_files
@@ -226,16 +257,12 @@ pub async fn build_from_workspace<P: AsRef<Path>>(
         sections.push(Section::ToolsSection(String::new()));
     }
     // SkillListingSection
-    if let Some(lock) = config.skill_registry {
-        if let Ok(g) = lock.read() {
-            if let Some(reg) = g.as_ref() {
-                let listing = reg.generate_listing(config.agent_id, config.agent_skills.as_deref());
-                if !listing.is_empty() {
-                    sections.push(Section::SkillListingSection(listing));
-                }
-            }
-        }
-    }
+    push_skill_listing_section(
+        &mut sections,
+        &config.skill_registry,
+        config.agent_id,
+        config.agent_skills.as_deref(),
+    );
     sections.extend(config.dynamic_sections);
     build_system_prompt(sections, config.append_section)
 }

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -4,6 +4,8 @@
 
 use super::sections::{get_cached_section, load_cached_file_section, read_file_section, Section};
 use super::tools_section::build_tools_section;
+use crate::agent::registry::AgentRegistry;
+use crate::session::bootstrap::loader::load_bootstrap_files;
 use crate::skills::DiskSkillRegistry;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -118,6 +120,10 @@ use crate::tools::{ToolContext, ToolRegistry};
 pub struct WorkspaceBuildConfig<'a> {
     /// Bootstrap files as (filename, content) pairs, in display order.
     /// Provided by `load_bootstrap_files`.
+    ///
+    /// When empty and `agent_registry` + `agent_id` are set, the builder
+    /// queries the AgentRegistry for the bootstrap mode and loads files
+    /// automatically (design-doc query path).
     pub bootstrap_files: Vec<(String, String)>,
     /// Tool registry for generating the ToolsSection.
     pub tool_registry: Option<&'a ToolRegistry>,
@@ -144,9 +150,21 @@ pub struct WorkspaceBuildConfig<'a> {
     pub dynamic_sections: Vec<Section>,
     /// Content to append at the end of the prompt.
     pub append_section: Option<String>,
+    /// Optional AgentRegistry reference for direct bootstrap mode queries.
+    ///
+    /// When set alongside `agent_id`, the builder can query the AgentRegistry
+    /// for the agent's bootstrap mode configuration, fulfilling the
+    /// design-doc query path: System Prompt → AgentRegistry.get(agent_id)
+    /// → bootstrap_mode.
+    pub agent_registry: Option<Arc<AgentRegistry>>,
 }
 
 /// Build a system prompt from a workspace directory.
+///
+/// When `config.bootstrap_files` is empty and `config.agent_registry`
+/// and `config.agent_id` are set, the builder queries the AgentRegistry
+/// for the agent's bootstrap mode and loads files automatically
+/// (design-doc query path: System Prompt → AgentRegistry).
 pub async fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     config: WorkspaceBuildConfig<'_>,
@@ -154,9 +172,28 @@ pub async fn build_from_workspace<P: AsRef<Path>>(
     let root = workspace_root.as_ref();
     let mut sections: Vec<Section> = Vec::new();
 
+    // Resolve bootstrap files: use pre-loaded files, or query AgentRegistry
+    // for the bootstrap mode and load them on the fly.
+    let resolved_bootstrap_files = if config.bootstrap_files.is_empty() {
+        if let (Some(registry), Some(agent_id)) = (config.agent_registry.as_ref(), config.agent_id)
+        {
+            if let Some(mode) = registry.query_bootstrap_mode(agent_id) {
+                load_bootstrap_files(root, mode)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect()
+            } else {
+                config.bootstrap_files.clone()
+            }
+        } else {
+            config.bootstrap_files.clone()
+        }
+    } else {
+        config.bootstrap_files.clone()
+    };
+
     // RoleSection from bootstrap files (skip MEMORY.md)
-    let role: String = config
-        .bootstrap_files
+    let role: String = resolved_bootstrap_files
         .iter()
         .filter(|(n, _)| n != "MEMORY.md")
         .map(|(_, c)| c.as_str())

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -159,14 +159,24 @@ pub struct WorkspaceBuildConfig<'a> {
     pub agent_registry: Option<Arc<AgentRegistry>>,
 }
 
-/// Build a system prompt from a workspace directory.
+// --- Private helpers -------------------------------------------------------
+
+/// Build the RoleSection from bootstrap files.
 ///
-/// When `config.bootstrap_files` is empty and `config.agent_registry`
-/// and `config.agent_id` are set, the builder queries the AgentRegistry
-/// for the agent's bootstrap mode and loads files automatically
-/// (design-doc query path: System Prompt → AgentRegistry).
-/// Push the SkillListingSection into `sections` when a skill registry
-/// is available and produces a non-empty listing.
+/// Filters out `MEMORY.md` entries (handled separately by the
+/// MemorySection path), concatenates the remaining bootstrap file
+/// contents, and pushes a `RoleSection` if any content exists.
+fn build_role_section(sections: &mut Vec<Section>, bootstrap_files: &[(String, String)]) {
+    let role: String = bootstrap_files
+        .iter()
+        .filter(|(n, _)| n != "MEMORY.md")
+        .map(|(_, c)| c.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if !role.is_empty() {
+        sections.push(Section::RoleSection(role));
+    }
+}
 fn push_skill_listing_section(
     sections: &mut Vec<Section>,
     skill_registry: &Option<Arc<RwLock<Option<DiskSkillRegistry>>>>,
@@ -214,6 +224,15 @@ fn resolve_bootstrap_files(
         .unwrap_or_else(|| config.bootstrap_files.clone())
 }
 
+/// Build a system prompt from a workspace directory.
+///
+/// When `config.bootstrap_files` is empty and `config.agent_registry`
+/// and `config.agent_id` are set, the builder queries the AgentRegistry
+/// for the agent's bootstrap mode and loads files automatically
+/// (design-doc query path: System Prompt → AgentRegistry).
+///
+/// Push the SkillListingSection into `sections` when a skill registry
+/// is available and produces a non-empty listing.
 pub async fn build_from_workspace<P: AsRef<Path>>(
     workspace_root: P,
     config: WorkspaceBuildConfig<'_>,
@@ -222,17 +241,7 @@ pub async fn build_from_workspace<P: AsRef<Path>>(
     let mut sections: Vec<Section> = Vec::new();
 
     let resolved_bootstrap_files = resolve_bootstrap_files(root, &config);
-
-    // RoleSection from bootstrap files (skip MEMORY.md)
-    let role: String = resolved_bootstrap_files
-        .iter()
-        .filter(|(n, _)| n != "MEMORY.md")
-        .map(|(_, c)| c.as_str())
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    if !role.is_empty() {
-        sections.push(Section::RoleSection(role));
-    }
+    build_role_section(&mut sections, &resolved_bootstrap_files);
     // MemorySection — skip if workspace_root is missing/empty
     if root.exists() && root.is_dir() {
         let memory_path = root.join("MEMORY.md");

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -42,7 +42,7 @@ pub async fn build_tools_section(
         (agent_tools, agent_disallowed_tools)
     } else {
         // Query AgentRegistry directly (design-doc query path).
-        registry.query_agent_tools_config(&ctx.agent_id).await
+        registry.query_agent_tools_config(&ctx.agent_id)
     };
 
     // 3. Build the prompt-generation context from the names + the existing

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -36,20 +36,29 @@ pub async fn build_tools_section(
     let descriptors = registry.list_descriptors(ctx).await;
     let available_tool_names: Vec<String> = descriptors.into_iter().map(|d| d.name).collect();
 
-    // 2. Build the prompt-generation context from the names + the existing
+    // 2. Resolve agent-level tool filtering.
+    //    Priority: explicit parameters > AgentRegistry query.
+    let (tools, disallowed_tools) = if agent_tools.is_some() || agent_disallowed_tools.is_some() {
+        (agent_tools, agent_disallowed_tools)
+    } else {
+        // Query AgentRegistry directly (design-doc query path).
+        registry.query_agent_tools_config(&ctx.agent_id).await
+    };
+
+    // 3. Build the prompt-generation context from the names + the existing
     //    execution context, including agent-level tool filtering.
     let prompt_ctx = PromptGenerationContext {
         agent_id: ctx.agent_id.clone(),
         workdir: ctx.workdir.clone(),
         available_tool_names,
-        tools: agent_tools,
-        disallowed_tools: agent_disallowed_tools,
+        tools,
+        disallowed_tools,
     };
 
-    // 3. Acquire the registry lock again and render the section.
+    // 4. Acquire the registry lock again and render the section.
     let content = registry.build_tools_section(&prompt_ctx).await;
 
-    // 4. If the spawn tool is available, append task writing guidance.
+    // 5. If the spawn tool is available, append task writing guidance.
     let content = if prompt_ctx
         .available_tool_names
         .iter()

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -317,7 +317,6 @@ impl Tool for SessionsSpawnTool {
             Some(id) => self
                 .agent_registry
                 .get(id)
-                .await
                 .and_then(|c| c.subagents.model.clone()),
             None => None,
         };

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! 支持注册、查询、列表操作，内部使用 `tokio::sync::RwLock` 保证并发安全。
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::agent::registry::AgentRegistry;
 use crate::tools::{PromptGenerationContext, Tool, ToolContext, ToolDescriptor, ToolError};
@@ -54,7 +54,7 @@ pub struct ToolRegistry {
     /// When set, allows querying agent-level tool filtering configuration
     /// directly from the AgentRegistry, fulfilling the design-doc query path:
     ///   Tools Registry → AgentRegistry.get(agent_id) → tools / disallowed_tools
-    agent_registry: tokio::sync::RwLock<Option<Arc<AgentRegistry>>>,
+    agent_registry: OnceLock<Arc<AgentRegistry>>,
 }
 
 impl std::fmt::Debug for ToolRegistry {
@@ -73,13 +73,16 @@ impl ToolRegistry {
     /// Set the AgentRegistry reference for direct config queries.
     ///
     /// Called during daemon initialization after the AgentRegistry is created.
-    pub async fn set_agent_registry(&self, registry: Arc<AgentRegistry>) {
-        *self.agent_registry.write().await = Some(registry);
+    /// Panics if called more than once.
+    pub fn set_agent_registry(&self, registry: Arc<AgentRegistry>) {
+        self.agent_registry
+            .set(registry)
+            .expect("AgentRegistry already set on ToolRegistry");
     }
 
     /// Get the current AgentRegistry reference, if set.
-    pub async fn get_agent_registry(&self) -> Option<Arc<AgentRegistry>> {
-        self.agent_registry.read().await.clone()
+    pub fn get_agent_registry(&self) -> Option<&Arc<AgentRegistry>> {
+        self.agent_registry.get()
     }
 
     /// Query agent-level tool filtering configuration from the AgentRegistry.
@@ -87,28 +90,20 @@ impl ToolRegistry {
     /// Returns `(tools, disallowed_tools)` extracted from the agent's
     /// `ResolvedAgentConfig`. When the agent is not found or the AgentRegistry
     /// is not set, returns `(None, None)` (no filtering — all tools allowed).
-    pub async fn query_agent_tools_config(
+    pub fn query_agent_tools_config(
         &self,
         agent_id: &str,
     ) -> (Option<Vec<String>>, Option<Vec<String>>) {
-        let guard = self.agent_registry.read().await;
-        let Some(registry) = guard.as_ref() else {
+        let Some(registry) = self.agent_registry.get() else {
             return (None, None);
         };
         let Some(config) = registry.get(agent_id) else {
             return (None, None);
         };
-        let tools = if config.tools.is_empty() || config.tools == ["*"] {
-            None
-        } else {
-            Some(config.tools.clone())
-        };
-        let disallowed_tools = if config.disallowed_tools.is_empty() {
-            None
-        } else {
-            Some(config.disallowed_tools.clone())
-        };
-        (tools, disallowed_tools)
+        (
+            config.effective_tools(),
+            config.effective_disallowed_tools(),
+        )
     }
 
     /// Format a single group into a section line, returning (output, new_total_len).
@@ -167,7 +162,7 @@ impl ToolRegistry {
     pub fn new() -> Self {
         Self {
             tools: tokio::sync::RwLock::new(std::collections::HashMap::new()),
-            agent_registry: tokio::sync::RwLock::new(None),
+            agent_registry: OnceLock::new(),
         }
     }
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use crate::agent::registry::AgentRegistry;
 use crate::tools::{PromptGenerationContext, Tool, ToolContext, ToolDescriptor, ToolError};
 
 use serde_json::Value;
@@ -48,6 +49,12 @@ const TOOLS_SECTION_MAX_LEN: usize = 15000;
 /// read-write lock so that all operations are async-safe.
 pub struct ToolRegistry {
     tools: tokio::sync::RwLock<std::collections::HashMap<String, Arc<dyn Tool>>>,
+    /// Optional reference to the AgentRegistry for direct config queries.
+    ///
+    /// When set, allows querying agent-level tool filtering configuration
+    /// directly from the AgentRegistry, fulfilling the design-doc query path:
+    ///   Tools Registry → AgentRegistry.get(agent_id) → tools / disallowed_tools
+    agent_registry: tokio::sync::RwLock<Option<Arc<AgentRegistry>>>,
 }
 
 impl std::fmt::Debug for ToolRegistry {
@@ -63,6 +70,47 @@ impl Default for ToolRegistry {
 }
 
 impl ToolRegistry {
+    /// Set the AgentRegistry reference for direct config queries.
+    ///
+    /// Called during daemon initialization after the AgentRegistry is created.
+    pub async fn set_agent_registry(&self, registry: Arc<AgentRegistry>) {
+        *self.agent_registry.write().await = Some(registry);
+    }
+
+    /// Get the current AgentRegistry reference, if set.
+    pub async fn get_agent_registry(&self) -> Option<Arc<AgentRegistry>> {
+        self.agent_registry.read().await.clone()
+    }
+
+    /// Query agent-level tool filtering configuration from the AgentRegistry.
+    ///
+    /// Returns `(tools, disallowed_tools)` extracted from the agent's
+    /// `ResolvedAgentConfig`. When the agent is not found or the AgentRegistry
+    /// is not set, returns `(None, None)` (no filtering — all tools allowed).
+    pub async fn query_agent_tools_config(
+        &self,
+        agent_id: &str,
+    ) -> (Option<Vec<String>>, Option<Vec<String>>) {
+        let guard = self.agent_registry.read().await;
+        let Some(registry) = guard.as_ref() else {
+            return (None, None);
+        };
+        let Some(config) = registry.get(agent_id) else {
+            return (None, None);
+        };
+        let tools = if config.tools.is_empty() || config.tools == ["*"] {
+            None
+        } else {
+            Some(config.tools.clone())
+        };
+        let disallowed_tools = if config.disallowed_tools.is_empty() {
+            None
+        } else {
+            Some(config.disallowed_tools.clone())
+        };
+        (tools, disallowed_tools)
+    }
+
     /// Format a single group into a section line, returning (output, new_total_len).
     /// Returns None if truncation was triggered.
     ///
@@ -119,6 +167,7 @@ impl ToolRegistry {
     pub fn new() -> Self {
         Self {
             tools: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+            agent_registry: tokio::sync::RwLock::new(None),
         }
     }
 

--- a/src/tools/registry_tests.rs
+++ b/src/tools/registry_tests.rs
@@ -496,3 +496,147 @@ async fn test_build_tools_section_empty() {
     let section = reg.build_tools_section(&ctx).await;
     assert!(section.is_empty());
 }
+
+// ---- AgentRegistry query path tests ----
+// Tests for ToolRegistry's ability to query AgentRegistry directly
+// for tools configuration, per design-doc query path.
+
+use crate::agent::registry::AgentRegistry;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::session::bootstrap::loader::BootstrapMode;
+use std::sync::Arc;
+
+fn make_agent_config(
+    id: &str,
+    tools: Vec<String>,
+    disallowed_tools: Vec<String>,
+) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: None,
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools,
+        disallowed_tools,
+        subagents: Default::default(),
+        source: ConfigSource::User,
+    }
+}
+
+#[tokio::test]
+async fn test_set_and_get_agent_registry() {
+    let reg = ToolRegistry::new();
+    assert!(reg.get_agent_registry().await.is_none());
+
+    let arc_reg = Arc::new(AgentRegistry::new(30));
+    reg.set_agent_registry(Arc::clone(&arc_reg)).await;
+
+    let returned = reg.get_agent_registry().await.unwrap();
+    assert!(Arc::ptr_eq(&returned, &arc_reg));
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_not_set() {
+    let reg = ToolRegistry::new();
+    // No agent registry set — should return (None, None)
+    let (tools, disallowed) = reg.query_agent_tools_config("any-agent").await;
+    assert_eq!(tools, None);
+    assert_eq!(disallowed, None);
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_agent_not_found() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("nonexistent").await;
+    assert_eq!(tools, None);
+    assert_eq!(disallowed, None);
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_with_tools_whitelist() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-1",
+        vec!["Read".into(), "Write".into()],
+        vec![],
+    )]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-1").await;
+    assert_eq!(tools, Some(vec!["Read".into(), "Write".into()]));
+    assert_eq!(disallowed, None);
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_with_disallowed() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-2",
+        vec![],
+        vec!["Bash".into(), "Write".into()],
+    )]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-2").await;
+    assert_eq!(tools, None);
+    assert_eq!(disallowed, Some(vec!["Bash".into(), "Write".into()]));
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_wildcard() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-wild",
+        vec!["*".into()],
+        vec![],
+    )]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-wild").await;
+    // ["*"] should be treated as no filtering (None)
+    assert_eq!(tools, None);
+    assert_eq!(disallowed, None);
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_empty_tools() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config("agent-empty", vec![], vec![])]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-empty").await;
+    // Empty tools = no filtering
+    assert_eq!(tools, None);
+    assert_eq!(disallowed, None);
+}
+
+#[tokio::test]
+async fn test_query_agent_tools_config_both_lists() {
+    let reg = ToolRegistry::new();
+    let agent_reg = Arc::new(AgentRegistry::new(30));
+    agent_reg.populate(vec![make_agent_config(
+        "agent-both",
+        vec!["Read".into(), "Write".into(), "Edit".into()],
+        vec!["Write".into()],
+    )]);
+    reg.set_agent_registry(agent_reg).await;
+
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-both").await;
+    assert_eq!(
+        tools,
+        Some(vec!["Read".into(), "Write".into(), "Edit".into()])
+    );
+    assert_eq!(disallowed, Some(vec!["Write".into()]));
+}

--- a/src/tools/registry_tests.rs
+++ b/src/tools/registry_tests.rs
@@ -527,41 +527,41 @@ fn make_agent_config(
     }
 }
 
-#[tokio::test]
-async fn test_set_and_get_agent_registry() {
+#[test]
+fn test_set_and_get_agent_registry() {
     let reg = ToolRegistry::new();
-    assert!(reg.get_agent_registry().await.is_none());
+    assert!(reg.get_agent_registry().is_none());
 
     let arc_reg = Arc::new(AgentRegistry::new(30));
-    reg.set_agent_registry(Arc::clone(&arc_reg)).await;
+    reg.set_agent_registry(Arc::clone(&arc_reg));
 
-    let returned = reg.get_agent_registry().await.unwrap();
-    assert!(Arc::ptr_eq(&returned, &arc_reg));
+    let returned = reg.get_agent_registry().unwrap();
+    assert!(Arc::ptr_eq(returned, &arc_reg));
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_not_set() {
+#[test]
+fn test_query_agent_tools_config_not_set() {
     let reg = ToolRegistry::new();
     // No agent registry set — should return (None, None)
-    let (tools, disallowed) = reg.query_agent_tools_config("any-agent").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("any-agent");
     assert_eq!(tools, None);
     assert_eq!(disallowed, None);
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_agent_not_found() {
+#[test]
+fn test_query_agent_tools_config_agent_not_found() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("nonexistent").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("nonexistent");
     assert_eq!(tools, None);
     assert_eq!(disallowed, None);
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_with_tools_whitelist() {
+#[test]
+fn test_query_agent_tools_config_with_tools_whitelist() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![make_agent_config(
@@ -569,15 +569,15 @@ async fn test_query_agent_tools_config_with_tools_whitelist() {
         vec!["Read".into(), "Write".into()],
         vec![],
     )]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("agent-1").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-1");
     assert_eq!(tools, Some(vec!["Read".into(), "Write".into()]));
     assert_eq!(disallowed, None);
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_with_disallowed() {
+#[test]
+fn test_query_agent_tools_config_with_disallowed() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![make_agent_config(
@@ -585,15 +585,15 @@ async fn test_query_agent_tools_config_with_disallowed() {
         vec![],
         vec!["Bash".into(), "Write".into()],
     )]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("agent-2").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-2");
     assert_eq!(tools, None);
     assert_eq!(disallowed, Some(vec!["Bash".into(), "Write".into()]));
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_wildcard() {
+#[test]
+fn test_query_agent_tools_config_wildcard() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![make_agent_config(
@@ -601,29 +601,29 @@ async fn test_query_agent_tools_config_wildcard() {
         vec!["*".into()],
         vec![],
     )]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("agent-wild").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-wild");
     // ["*"] should be treated as no filtering (None)
     assert_eq!(tools, None);
     assert_eq!(disallowed, None);
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_empty_tools() {
+#[test]
+fn test_query_agent_tools_config_empty_tools() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![make_agent_config("agent-empty", vec![], vec![])]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("agent-empty").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-empty");
     // Empty tools = no filtering
     assert_eq!(tools, None);
     assert_eq!(disallowed, None);
 }
 
-#[tokio::test]
-async fn test_query_agent_tools_config_both_lists() {
+#[test]
+fn test_query_agent_tools_config_both_lists() {
     let reg = ToolRegistry::new();
     let agent_reg = Arc::new(AgentRegistry::new(30));
     agent_reg.populate(vec![make_agent_config(
@@ -631,9 +631,9 @@ async fn test_query_agent_tools_config_both_lists() {
         vec!["Read".into(), "Write".into(), "Edit".into()],
         vec!["Write".into()],
     )]);
-    reg.set_agent_registry(agent_reg).await;
+    reg.set_agent_registry(agent_reg);
 
-    let (tools, disallowed) = reg.query_agent_tools_config("agent-both").await;
+    let (tools, disallowed) = reg.query_agent_tools_config("agent-both");
     assert_eq!(
         tools,
         Some(vec!["Read".into(), "Write".into(), "Edit".into()])

--- a/tests/builder_skill_listing_tests.rs
+++ b/tests/builder_skill_listing_tests.rs
@@ -64,6 +64,7 @@ async fn test_build_from_workspace_skill_listing_injected() {
             agent_skills: None,
             dynamic_sections: vec![],
             append_section: None,
+            agent_registry: None,
         },
     )
     .await;
@@ -115,6 +116,7 @@ async fn test_build_from_workspace_no_skill_info_no_section() {
             agent_skills: None,
             dynamic_sections: vec![],
             append_section: None,
+            agent_registry: None,
         },
     )
     .await;
@@ -155,6 +157,7 @@ async fn test_build_from_workspace_empty_listing_no_section() {
             agent_skills: None,
             dynamic_sections: vec![],
             append_section: None,
+            agent_registry: None,
         },
     )
     .await;
@@ -196,6 +199,7 @@ async fn test_build_from_workspace_skill_section_not_duplicated() {
             agent_skills: None,
             dynamic_sections: vec![],
             append_section: None,
+            agent_registry: None,
         },
     )
     .await;

--- a/tests/e2e_agent_registry_tests.rs
+++ b/tests/e2e_agent_registry_tests.rs
@@ -33,20 +33,20 @@ async fn test_populate_then_get() {
     let registry = create_registry(30);
     let configs = vec![make_config("agent-a"), make_config("agent-b")];
 
-    registry.populate(configs).await;
+    registry.populate(configs);
 
     // Hit: agent-a should be found
-    let a = registry.get("agent-a").await;
+    let a = registry.get("agent-a");
     assert!(a.is_some(), "agent-a should be found after populate");
     assert_eq!(a.unwrap().id, "agent-a");
 
     // Hit: agent-b should be found
-    let b = registry.get("agent-b").await;
+    let b = registry.get("agent-b");
     assert!(b.is_some(), "agent-b should be found after populate");
     assert_eq!(b.unwrap().id, "agent-b");
 
     // Miss: nonexistent agent returns None
-    let missing = registry.get("nonexistent").await;
+    let missing = registry.get("nonexistent");
     assert!(
         missing.is_none(),
         "querying a missing id should return None"
@@ -59,20 +59,20 @@ async fn test_hot_reload_replaces_data() {
     let registry = create_registry(30);
 
     // Populate with initial data.
-    registry.populate(vec![make_config("old-agent")]).await;
+    registry.populate(vec![make_config("old-agent")]);
     assert!(
-        registry.get("old-agent").await.is_some(),
+        registry.get("old-agent").is_some(),
         "old-agent should exist before reload"
     );
 
     // Hot-reload with new set that excludes old-agent.
-    registry.reload_config(vec![make_config("new-agent")]).await;
+    registry.reload_config(vec![make_config("new-agent")]);
 
     assert!(
-        registry.get("old-agent").await.is_none(),
+        registry.get("old-agent").is_none(),
         "old-agent should be gone after reload"
     );
-    let new = registry.get("new-agent").await;
+    let new = registry.get("new-agent");
     assert!(new.is_some(), "new-agent should be present after reload");
     assert_eq!(new.unwrap().id, "new-agent");
 }
@@ -82,25 +82,21 @@ async fn test_hot_reload_replaces_data() {
 async fn test_hot_reload_partial_overlap() {
     let registry = create_registry(30);
 
-    registry
-        .populate(vec![make_config("keep"), make_config("drop")])
-        .await;
+    registry.populate(vec![make_config("keep"), make_config("drop")]);
 
     // Reload with "keep" retained, "drop" removed, "added" new.
-    registry
-        .reload_config(vec![make_config("keep"), make_config("added")])
-        .await;
+    registry.reload_config(vec![make_config("keep"), make_config("added")]);
 
     assert!(
-        registry.get("keep").await.is_some(),
+        registry.get("keep").is_some(),
         "'keep' should survive reload"
     );
     assert!(
-        registry.get("drop").await.is_none(),
+        registry.get("drop").is_none(),
         "'drop' should be removed by reload"
     );
     assert!(
-        registry.get("added").await.is_some(),
+        registry.get("added").is_some(),
         "'added' should be present after reload"
     );
 }
@@ -110,10 +106,10 @@ async fn test_hot_reload_partial_overlap() {
 async fn test_populate_empty() {
     let registry = create_registry(30);
 
-    registry.populate(vec![]).await;
+    registry.populate(vec![]);
 
     assert!(
-        registry.get("anything").await.is_none(),
+        registry.get("anything").is_none(),
         "empty populate should leave registry empty"
     );
 }
@@ -128,9 +124,9 @@ async fn test_populate_duplicate_id_last_wins() {
     let mut second = make_config("dup-agent");
     second.name = "second".to_string();
 
-    registry.populate(vec![first, second]).await;
+    registry.populate(vec![first, second]);
 
-    let agent = registry.get("dup-agent").await;
+    let agent = registry.get("dup-agent");
     assert!(agent.is_some(), "dup-agent should exist");
     assert_eq!(
         agent.unwrap().name,
@@ -145,7 +141,7 @@ async fn test_registry_starts_empty() {
     let registry = create_registry(30);
 
     assert!(
-        registry.get("any-id").await.is_none(),
+        registry.get("any-id").is_none(),
         "newly created registry should have no configs"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -134,29 +134,29 @@ async fn test_agent_registry_config_query() {
     ];
 
     // Populate registry with all configs
-    registry.populate(configs).await;
+    registry.populate(configs);
 
     // Verify each config is stored correctly
-    let parent = registry.get("parent-agent").await;
+    let parent = registry.get("parent-agent");
     assert!(parent.is_some());
     let parent = parent.unwrap();
     assert_eq!(parent.id, "parent-agent");
     assert!(parent.parent_id.is_none());
 
-    let child = registry.get("child-agent").await;
+    let child = registry.get("child-agent");
     assert!(child.is_some());
     let child = child.unwrap();
     assert_eq!(child.id, "child-agent");
     assert_eq!(child.parent_id.as_deref(), Some("parent-agent"));
 
-    let grandchild = registry.get("grandchild-agent").await;
+    let grandchild = registry.get("grandchild-agent");
     assert!(grandchild.is_some());
     let grandchild = grandchild.unwrap();
     assert_eq!(grandchild.id, "grandchild-agent");
     assert_eq!(grandchild.parent_id.as_deref(), Some("child-agent"));
 
     // Verify non-existent agent returns None
-    assert!(registry.get("unknown-agent").await.is_none());
+    assert!(registry.get("unknown-agent").is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -182,11 +182,11 @@ async fn test_config_loading_drives_agent_creation() {
         .iter()
         .map(|id| make_resolved_config(id, None))
         .collect();
-    registry.populate(configs).await;
+    registry.populate(configs);
 
     // Verify each agent is stored correctly via get
     for agent_id in provider.agents() {
-        let agent = registry.get(agent_id).await;
+        let agent = registry.get(agent_id);
         assert!(
             agent.is_some(),
             "agent '{}' should exist in registry",
@@ -278,9 +278,9 @@ async fn test_skill_with_permission_engine_integration() {
     // Populate registry with a test agent config
     let registry: SharedAgentRegistry = create_registry(30);
     let configs = vec![make_resolved_config("test-agent", None)];
-    registry.populate(configs).await;
+    registry.populate(configs);
 
-    let agent = registry.get("test-agent").await.unwrap();
+    let agent = registry.get("test-agent").unwrap();
     let agent_id = agent.id.clone();
 
     // Query exec permission: should be denied (no exec rule)


### PR DESCRIPTION
feat: align AgentRegistry implementation with design doc API contract

Fix 4 must-fix discrepancies between docs/design/agent/agent-registry.md and code:

1. Skills Registry now queries AgentRegistry directly for agent skills whitelist
2. Tools Registry now queries AgentRegistry directly for tools config
3. System Prompt builder now queries AgentRegistry for bootstrap mode
4. get() returns Option<&ResolvedAgentConfig> via DashMap (replaces async RwLock)

Additional improvements:
- Split impl blocks to stay under 100-line limit
- Extract build_role_section to keep build_from_workspace under 50 lines
- Fix hard-limit violations (impl block size, function body size)
- 32 new unit tests covering reference validity, concurrent safety, and downstream query paths

Source: CI
Type: refactor
