### PR TITLE
refactor: rename AgentRegistry::reload_config() to reload()

### DIFF
--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -79,7 +79,7 @@ fn test_get_not_found() {
 }
 
 #[test]
-fn test_reload_config() {
+fn test_reload() {
     let registry = AgentRegistry::new(30);
 
     // Populate with old data.
@@ -90,7 +90,7 @@ fn test_reload_config() {
     );
 
     // Reload with new data that does NOT include old-agent.
-    registry.reload_config(vec![make_config("new-agent")]);
+    registry.reload(vec![make_config("new-agent")]);
 
     assert!(
         registry.get("old-agent").is_none(),
@@ -115,13 +115,13 @@ fn test_populate_empty() {
 }
 
 #[test]
-fn test_reload_config_preserves_existing() {
+fn test_reload_preserves_existing() {
     let registry = AgentRegistry::new(30);
 
     registry.populate(vec![make_config("keep"), make_config("drop")]);
 
     // Reload: only "keep" and a new agent "added" exist.
-    registry.reload_config(vec![make_config("keep"), make_config("added")]);
+    registry.reload(vec![make_config("keep"), make_config("added")]);
 
     assert!(
         registry.get("keep").is_some(),
@@ -184,7 +184,7 @@ fn test_get_reference_sees_reload_data() {
     // Reload with new config
     let mut new_cfg = make_config("old");
     new_cfg.skills = vec!["updated-skill".into()];
-    registry.reload_config(vec![new_cfg]);
+    registry.reload(vec![new_cfg]);
 
     // Reference should see updated data
     let old = registry.get("old").expect("old should exist after reload");
@@ -289,7 +289,7 @@ fn test_concurrent_get_and_reload() {
             let configs: Vec<_> = (0..10)
                 .map(|j| make_config(&format!("reload-{}-{}", i, j)))
                 .collect();
-            reg_write.reload_config(configs);
+            reg_write.reload(configs);
         }
     }));
 

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -53,7 +53,7 @@ impl AgentRegistry {
     }
 
     /// Replace all stored configs with the given set (hot-reload).
-    pub fn reload_config(&self, configs: Vec<ResolvedAgentConfig>) {
+    pub fn reload(&self, configs: Vec<ResolvedAgentConfig>) {
         self.configs.clear();
         for cfg in configs {
             self.configs.insert(cfg.id.clone(), cfg);

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -98,7 +98,7 @@ async fn reload_agents_with_log(
     }
     // Sync the new configs into AgentRegistry (design-doc hot-reload path).
     let configs: Vec<_> = cm.agents().into_values().collect();
-    agent_registry.reload_config(configs);
+    agent_registry.reload(configs);
 }
 
 /// Handle a single changed file path: reload agents or the matching section.

--- a/tests/e2e_agent_registry_tests.rs
+++ b/tests/e2e_agent_registry_tests.rs
@@ -1,7 +1,7 @@
 //! E2E integration tests for Agent Registry.
 //!
 //! Exercises the public entry point `create_registry` → `populate` → `get` →
-//! `reload_config` lifecycle, simulating daemon startup fill, runtime query,
+//! `reload` lifecycle, simulating daemon startup fill, runtime query,
 //! and config hot-reload.
 
 use closeclaw::agent::config::SubagentsConfig;
@@ -66,7 +66,7 @@ async fn test_hot_reload_replaces_data() {
     );
 
     // Hot-reload with new set that excludes old-agent.
-    registry.reload_config(vec![make_config("new-agent")]);
+    registry.reload(vec![make_config("new-agent")]);
 
     assert!(
         registry.get("old-agent").is_none(),
@@ -85,7 +85,7 @@ async fn test_hot_reload_partial_overlap() {
     registry.populate(vec![make_config("keep"), make_config("drop")]);
 
     // Reload with "keep" retained, "drop" removed, "added" new.
-    registry.reload_config(vec![make_config("keep"), make_config("added")]);
+    registry.reload(vec![make_config("keep"), make_config("added")]);
 
     assert!(
         registry.get("keep").is_some(),


### PR DESCRIPTION
将 AgentRegistry::reload_config() 重命名为 reload()，使代码与设计文档保持一致。

设计文档上游模块关系表描述 "Daemon 调用 `reload()` 更新注册表"，但代码中方法名为 `reload_config()`。
按核心原则 5（文档有 → 代码必须有；不一致 → 改代码），修改代码向文档对齐。

变更内容：
- 重命名 `src/agent/registry/mod.rs` 中 `reload_config` → `reload`
- 更新 `src/daemon/config_reload.rs` 中的调用方
- 更新 `src/agent/registry/config_tests.rs` 中的测试函数名和调用（5处）

Source: CI
Type: refactor
