### PR TITLE
refactor: remove unused heartbeat_timeout_secs from AgentRegistry and merge redundant methods

### DIFF
--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -7,7 +7,7 @@ use crate::session::bootstrap::BootstrapMode;
 
 #[test]
 fn test_new_construction() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     // After construction the config map must be empty.
     assert!(
         registry.get("any-id").is_none(),
@@ -17,7 +17,7 @@ fn test_new_construction() {
 
 #[test]
 fn test_new_with_graceful_shutdown() {
-    let registry = AgentRegistry::new_with_graceful_shutdown(30);
+    let registry = AgentRegistry::new_with_graceful_shutdown();
     // Must construct successfully and start empty.
     assert!(
         registry.get("any-id").is_none(),
@@ -55,7 +55,7 @@ fn make_config(id: &str) -> ResolvedAgentConfig {
 
 #[test]
 fn test_populate_and_get() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     let configs = vec![make_config("agent-a"), make_config("agent-b")];
 
     registry.populate(configs);
@@ -71,7 +71,7 @@ fn test_populate_and_get() {
 
 #[test]
 fn test_get_not_found() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     registry.populate(vec![make_config("existing")]);
 
     let result = registry.get("nonexistent");
@@ -80,7 +80,7 @@ fn test_get_not_found() {
 
 #[test]
 fn test_reload() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
 
     // Populate with old data.
     registry.populate(vec![make_config("old-agent")]);
@@ -103,7 +103,7 @@ fn test_reload() {
 
 #[test]
 fn test_populate_empty() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
 
     // Should not panic on empty input.
     registry.populate(vec![]);
@@ -116,7 +116,7 @@ fn test_populate_empty() {
 
 #[test]
 fn test_reload_preserves_existing() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
 
     registry.populate(vec![make_config("keep"), make_config("drop")]);
 
@@ -141,7 +141,7 @@ fn test_reload_preserves_existing() {
 
 #[test]
 fn test_get_returns_valid_reference() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     registry.populate(vec![make_config("agent-1")]);
 
     // The DashMap Ref implements Deref<Target = ResolvedAgentConfig>,
@@ -157,7 +157,7 @@ fn test_get_returns_valid_reference() {
 
 #[test]
 fn test_get_reference_sees_populated_data() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     let mut cfg = make_config("agent-x");
     cfg.skills = vec!["skill-a".into(), "skill-b".into()];
     cfg.tools = vec!["tool-1".into()];
@@ -172,7 +172,7 @@ fn test_get_reference_sees_populated_data() {
 
 #[test]
 fn test_get_reference_sees_reload_data() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     registry.populate(vec![make_config("old")]);
 
     // Verify old data is visible through reference
@@ -195,7 +195,7 @@ fn test_get_reference_sees_reload_data() {
 
 #[test]
 fn test_query_bootstrap_mode_full() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     let mut cfg = make_config("agent-full");
     cfg.bootstrap_mode = BootstrapMode::Full;
     registry.populate(vec![cfg]);
@@ -206,7 +206,7 @@ fn test_query_bootstrap_mode_full() {
 
 #[test]
 fn test_query_bootstrap_mode_minimal() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     let mut cfg = make_config("agent-minimal");
     cfg.bootstrap_mode = BootstrapMode::Minimal;
     registry.populate(vec![cfg]);
@@ -217,7 +217,7 @@ fn test_query_bootstrap_mode_minimal() {
 
 #[test]
 fn test_query_bootstrap_mode_not_found() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     registry.populate(vec![make_config("existing")]);
 
     let mode = registry.query_bootstrap_mode("nonexistent");
@@ -226,7 +226,7 @@ fn test_query_bootstrap_mode_not_found() {
 
 #[test]
 fn test_query_bootstrap_mode_empty_registry() {
-    let registry = AgentRegistry::new(30);
+    let registry = AgentRegistry::new();
     let mode = registry.query_bootstrap_mode("any-id");
     assert_eq!(mode, None);
 }
@@ -238,7 +238,7 @@ fn test_concurrent_get_and_populate() {
     use std::sync::Arc;
     use std::thread;
 
-    let registry = Arc::new(AgentRegistry::new(30));
+    let registry = Arc::new(AgentRegistry::new());
 
     // Spawn threads that read and write concurrently
     let mut handles = vec![];
@@ -277,7 +277,7 @@ fn test_concurrent_get_and_reload() {
     use std::sync::Arc;
     use std::thread;
 
-    let registry = Arc::new(AgentRegistry::new(30));
+    let registry = Arc::new(AgentRegistry::new());
     registry.populate(vec![make_config("initial")]);
 
     let mut handles = vec![];
@@ -315,7 +315,7 @@ fn test_concurrent_query_bootstrap_mode() {
     use std::sync::Arc;
     use std::thread;
 
-    let registry = Arc::new(AgentRegistry::new(30));
+    let registry = Arc::new(AgentRegistry::new());
     let mut cfg_full = make_config("full-agent");
     cfg_full.bootstrap_mode = BootstrapMode::Full;
     let mut cfg_min = make_config("min-agent");

--- a/src/agent/registry/config_tests.rs
+++ b/src/agent/registry/config_tests.rs
@@ -16,19 +16,9 @@ fn test_new_construction() {
 }
 
 #[test]
-fn test_new_with_graceful_shutdown() {
-    let registry = AgentRegistry::new_with_graceful_shutdown();
-    // Must construct successfully and start empty.
-    assert!(
-        registry.get("any-id").is_none(),
-        "registry created via new_with_graceful_shutdown should have no configs"
-    );
-}
-
-#[test]
 fn test_default_trait() {
     let registry = AgentRegistry::default();
-    // Default() delegates to new_with_graceful_shutdown, should be empty.
+    // Default() delegates to new(), should be empty.
     assert!(
         registry.get("any-id").is_none(),
         "default registry should have no configs"

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -18,18 +18,13 @@ pub struct AgentRegistry {
 
 impl Default for AgentRegistry {
     fn default() -> Self {
-        Self::new_with_graceful_shutdown()
+        Self::new()
     }
 }
 
 impl AgentRegistry {
     /// Create a new registry.
     pub fn new() -> Self {
-        Self::new_with_graceful_shutdown()
-    }
-
-    /// Create a new registry with graceful shutdown configuration.
-    pub fn new_with_graceful_shutdown() -> Self {
         Self {
             configs: DashMap::new(),
         }

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -18,18 +18,18 @@ pub struct AgentRegistry {
 
 impl Default for AgentRegistry {
     fn default() -> Self {
-        Self::new_with_graceful_shutdown(30)
+        Self::new_with_graceful_shutdown()
     }
 }
 
 impl AgentRegistry {
     /// Create a new registry.
-    pub fn new(_heartbeat_timeout_secs: i64) -> Self {
-        Self::new_with_graceful_shutdown(30)
+    pub fn new() -> Self {
+        Self::new_with_graceful_shutdown()
     }
 
     /// Create a new registry with graceful shutdown configuration.
-    pub fn new_with_graceful_shutdown(_heartbeat_timeout_secs: i64) -> Self {
+    pub fn new_with_graceful_shutdown() -> Self {
         Self {
             configs: DashMap::new(),
         }
@@ -77,8 +77,8 @@ impl AgentRegistry {
 pub type SharedAgentRegistry = Arc<AgentRegistry>;
 
 /// Create a new shared agent registry
-pub fn create_registry(heartbeat_timeout_secs: i64) -> SharedAgentRegistry {
-    Arc::new(AgentRegistry::new(heartbeat_timeout_secs))
+pub fn create_registry() -> SharedAgentRegistry {
+    Arc::new(AgentRegistry::new())
 }
 
 #[cfg(test)]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -163,7 +163,7 @@ impl Daemon {
             sweeper_for_task.run(sweeper_rx).await;
         });
         info!("ArchiveSweeper spawned");
-        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
         info!("Agent registry initialized",);
         let gateway_config = GatewayConfig {
             name: "closeclaw".to_string(),

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -298,7 +298,7 @@ async fn test_find_or_create_with_tool_registry() {
             .expect("failed to create ConfigManager for test"),
     );
     let spawn_controller = Arc::new(SpawnController::new(Arc::clone(&cfg_mgr), Arc::clone(&mgr)));
-    let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+    let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
     let builtin_ctx = Arc::new(BuiltinToolContext {
         config_manager: Arc::clone(&cfg_mgr),
         agent_registry,

--- a/src/skills/disk/registry_tests/mod.rs
+++ b/src/skills/disk/registry_tests/mod.rs
@@ -457,7 +457,7 @@ fn test_set_agent_registry_and_accessor() {
     let mut r = DiskSkillRegistry::new(vec![]);
     assert!(r.agent_registry().is_none());
 
-    let arc_reg = Arc::new(AgentRegistry::new(30));
+    let arc_reg = Arc::new(AgentRegistry::new());
     r.set_agent_registry(Arc::clone(&arc_reg));
     assert!(r.agent_registry().is_some());
     // The returned Arc should point to the same registry
@@ -468,7 +468,7 @@ fn test_set_agent_registry_and_accessor() {
 #[test]
 fn test_generate_listing_for_agent_with_whitelist() {
     // Agent has skills whitelist ["foo", "bar"]
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-1",
         vec!["foo".into(), "bar".into()],
@@ -490,7 +490,7 @@ fn test_generate_listing_for_agent_with_whitelist() {
 #[test]
 fn test_generate_listing_for_agent_agent_not_found() {
     // Agent not in registry — should show all skills (no whitelist)
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![]);
 
     let mut r = DiskSkillRegistry::new(vec![
@@ -507,7 +507,7 @@ fn test_generate_listing_for_agent_agent_not_found() {
 #[test]
 fn test_generate_listing_for_agent_wildcard_whitelist() {
     // Agent skills = ["*"] means show all
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config("agent-wild", vec!["*".into()])]);
 
     let mut r = DiskSkillRegistry::new(vec![
@@ -524,7 +524,7 @@ fn test_generate_listing_for_agent_wildcard_whitelist() {
 #[test]
 fn test_generate_listing_for_agent_empty_skills() {
     // Agent skills = [] means show all (no filtering)
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config("agent-empty", vec![])]);
 
     let mut r = DiskSkillRegistry::new(vec![
@@ -556,7 +556,7 @@ fn test_generate_listing_for_agent_no_registry_set() {
 fn test_generate_listing_fallback_to_agent_registry() {
     // When no explicit whitelist is passed, generate_listing should
     // fall back to AgentRegistry lookup.
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config("agent-fb", vec!["skill-a".into()])]);
 
     let mut r = DiskSkillRegistry::new(vec![
@@ -574,7 +574,7 @@ fn test_generate_listing_fallback_to_agent_registry() {
 #[test]
 fn test_generate_listing_explicit_whitelist_overrides_registry() {
     // When explicit whitelist is provided, AgentRegistry is not used
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config("agent-ov", vec!["skill-a".into()])]);
 
     let mut r = DiskSkillRegistry::new(vec![
@@ -592,7 +592,7 @@ fn test_generate_listing_explicit_whitelist_overrides_registry() {
 #[test]
 fn test_generate_listing_for_agent_user_invocable_filter() {
     // user_invocable: false skills should still be excluded
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-inv",
         vec!["visible".into(), "hidden".into()],

--- a/src/system_prompt/builder.rs
+++ b/src/system_prompt/builder.rs
@@ -385,7 +385,7 @@ mod tests {
         use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
         use crate::session::bootstrap::loader::BootstrapMode;
 
-        let agent_reg = Arc::new(AgentRegistry::new(30));
+        let agent_reg = Arc::new(AgentRegistry::new());
         agent_reg.populate(vec![ResolvedAgentConfig {
             id: "test-agent".into(),
             name: "test-agent".into(),
@@ -431,7 +431,7 @@ mod tests {
         use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
         use crate::session::bootstrap::loader::BootstrapMode;
 
-        let agent_reg = Arc::new(AgentRegistry::new(30));
+        let agent_reg = Arc::new(AgentRegistry::new());
         agent_reg.populate(vec![ResolvedAgentConfig {
             id: "minimal-agent".into(),
             name: "minimal-agent".into(),
@@ -458,7 +458,7 @@ mod tests {
         use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
         use crate::session::bootstrap::loader::BootstrapMode;
 
-        let agent_reg = Arc::new(AgentRegistry::new(30));
+        let agent_reg = Arc::new(AgentRegistry::new());
         agent_reg.populate(vec![ResolvedAgentConfig {
             id: "full-agent".into(),
             name: "full-agent".into(),
@@ -482,7 +482,7 @@ mod tests {
     fn test_agent_registry_query_bootstrap_mode_not_found() {
         use crate::agent::registry::AgentRegistry;
 
-        let agent_reg = Arc::new(AgentRegistry::new(30));
+        let agent_reg = Arc::new(AgentRegistry::new());
         let mode = agent_reg.query_bootstrap_mode("missing-agent");
         assert_eq!(mode, None);
     }

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -125,7 +125,7 @@ mod tests {
             Arc::clone(&cfg_mgr),
             Arc::clone(&session_manager),
         ));
-        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+        let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
         (spawn_controller, session_manager, cfg_mgr, agent_registry)
     }
 

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -536,7 +536,7 @@ async fn test_external_permissions_used() {
 
     let pe = Arc::new(make_permission_engine());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
-    let ar = Arc::new(AgentRegistry::new(30));
+    let ar = Arc::new(AgentRegistry::new());
     let tool = SessionsSpawnTool::new(controller, sm, pe.clone(), cm.clone(), ar);
 
     // Insert parent effective permissions into the engine cache.
@@ -767,7 +767,7 @@ async fn test_fully_denied_silent_return_no_session_created() {
 
     let pe = Arc::new(make_permission_engine());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
-    let ar = Arc::new(AgentRegistry::new(30));
+    let ar = Arc::new(AgentRegistry::new());
     let tool = SessionsSpawnTool::new(controller, sm.clone(), pe.clone(), cm.clone(), ar);
 
     // Parent has all-allow effective permissions in cache.

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -69,7 +69,7 @@ fn make_tool() -> SessionsSpawnTool {
     let sm = Arc::new(make_session_manager());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
     let pe = Arc::new(make_permission_engine());
-    let ar = Arc::new(crate::agent::registry::AgentRegistry::new(30));
+    let ar = Arc::new(crate::agent::registry::AgentRegistry::new());
     SessionsSpawnTool::new(controller, sm, pe, cm, ar)
 }
 

--- a/src/tools/registry_tests.rs
+++ b/src/tools/registry_tests.rs
@@ -532,7 +532,7 @@ fn test_set_and_get_agent_registry() {
     let reg = ToolRegistry::new();
     assert!(reg.get_agent_registry().is_none());
 
-    let arc_reg = Arc::new(AgentRegistry::new(30));
+    let arc_reg = Arc::new(AgentRegistry::new());
     reg.set_agent_registry(Arc::clone(&arc_reg));
 
     let returned = reg.get_agent_registry().unwrap();
@@ -551,7 +551,7 @@ fn test_query_agent_tools_config_not_set() {
 #[test]
 fn test_query_agent_tools_config_agent_not_found() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![]);
     reg.set_agent_registry(agent_reg);
 
@@ -563,7 +563,7 @@ fn test_query_agent_tools_config_agent_not_found() {
 #[test]
 fn test_query_agent_tools_config_with_tools_whitelist() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-1",
         vec!["Read".into(), "Write".into()],
@@ -579,7 +579,7 @@ fn test_query_agent_tools_config_with_tools_whitelist() {
 #[test]
 fn test_query_agent_tools_config_with_disallowed() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-2",
         vec![],
@@ -595,7 +595,7 @@ fn test_query_agent_tools_config_with_disallowed() {
 #[test]
 fn test_query_agent_tools_config_wildcard() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-wild",
         vec!["*".into()],
@@ -612,7 +612,7 @@ fn test_query_agent_tools_config_wildcard() {
 #[test]
 fn test_query_agent_tools_config_empty_tools() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config("agent-empty", vec![], vec![])]);
     reg.set_agent_registry(agent_reg);
 
@@ -625,7 +625,7 @@ fn test_query_agent_tools_config_empty_tools() {
 #[test]
 fn test_query_agent_tools_config_both_lists() {
     let reg = ToolRegistry::new();
-    let agent_reg = Arc::new(AgentRegistry::new(30));
+    let agent_reg = Arc::new(AgentRegistry::new());
     agent_reg.populate(vec![make_agent_config(
         "agent-both",
         vec!["Read".into(), "Write".into(), "Edit".into()],

--- a/tests/e2e_agent_registry_tests.rs
+++ b/tests/e2e_agent_registry_tests.rs
@@ -30,7 +30,7 @@ fn make_config(id: &str) -> ResolvedAgentConfig {
 /// Startup fill → query hit and miss.
 #[tokio::test]
 async fn test_populate_then_get() {
-    let registry = create_registry(30);
+    let registry = create_registry();
     let configs = vec![make_config("agent-a"), make_config("agent-b")];
 
     registry.populate(configs);
@@ -56,7 +56,7 @@ async fn test_populate_then_get() {
 /// Hot-reload: old data cleared, new data effective.
 #[tokio::test]
 async fn test_hot_reload_replaces_data() {
-    let registry = create_registry(30);
+    let registry = create_registry();
 
     // Populate with initial data.
     registry.populate(vec![make_config("old-agent")]);
@@ -80,7 +80,7 @@ async fn test_hot_reload_replaces_data() {
 /// Hot-reload: shared agents survive, removed agents gone, added agents appear.
 #[tokio::test]
 async fn test_hot_reload_partial_overlap() {
-    let registry = create_registry(30);
+    let registry = create_registry();
 
     registry.populate(vec![make_config("keep"), make_config("drop")]);
 
@@ -104,7 +104,7 @@ async fn test_hot_reload_partial_overlap() {
 /// Empty populate does not panic.
 #[tokio::test]
 async fn test_populate_empty() {
-    let registry = create_registry(30);
+    let registry = create_registry();
 
     registry.populate(vec![]);
 
@@ -117,7 +117,7 @@ async fn test_populate_empty() {
 /// Populate with duplicate IDs: the last entry wins.
 #[tokio::test]
 async fn test_populate_duplicate_id_last_wins() {
-    let registry = create_registry(30);
+    let registry = create_registry();
 
     let mut first = make_config("dup-agent");
     first.name = "first".to_string();
@@ -138,7 +138,7 @@ async fn test_populate_duplicate_id_last_wins() {
 /// Registry starts empty after create_registry.
 #[tokio::test]
 async fn test_registry_starts_empty() {
-    let registry = create_registry(30);
+    let registry = create_registry();
 
     assert!(
         registry.get("any-id").is_none(),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -124,7 +124,7 @@ fn make_resolved_config(id: &str, parent_id: Option<&str>) -> ResolvedAgentConfi
 
 #[tokio::test]
 async fn test_agent_registry_config_query() {
-    let registry: SharedAgentRegistry = create_registry(30);
+    let registry: SharedAgentRegistry = create_registry();
 
     // Build configs with parent-child relationships via parent_id
     let configs = vec![
@@ -166,7 +166,7 @@ async fn test_agent_registry_config_query() {
 
 #[tokio::test]
 async fn test_config_loading_drives_agent_creation() {
-    let registry: SharedAgentRegistry = create_registry(30);
+    let registry: SharedAgentRegistry = create_registry();
 
     // Simulate agents.json config (registration list of agent IDs)
     let json = r#"{
@@ -276,7 +276,7 @@ async fn test_skill_with_permission_engine_integration() {
     let perm_skill = closeclaw::skills::builtin::PermissionSkill::with_engine(engine.clone());
 
     // Populate registry with a test agent config
-    let registry: SharedAgentRegistry = create_registry(30);
+    let registry: SharedAgentRegistry = create_registry();
     let configs = vec![make_resolved_config("test-agent", None)];
     registry.populate(configs);
 


### PR DESCRIPTION
Remove unused `heartbeat_timeout_secs` parameter from `AgentRegistry` constructors (`new()`, `new_with_graceful_shutdown()`, `create_registry()`). The parameter was always ignored (prefixed with `_`), contradicting the design doc's description of AgentRegistry as a pure data store with no lifecycle management.

Additionally, merge the redundant `new_with_graceful_shutdown()` method into `new()`, simplifying the public API surface.

- All callers updated to use the new zero-argument constructors
- `Default` impl updated accordingly
- 2125 tests pass, clippy clean, fmt clean

Source: design doc docs/design/agent/agent-registry.md
Type: refactor
