### PR TITLE
feat: admin RPC for agent/skill commands

### DIFF
--- a/src/admin/client.rs
+++ b/src/admin/client.rs
@@ -1,0 +1,125 @@
+//! Admin RPC client — connects to the admin server socket and sends
+//! requests.
+
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
+
+use crate::admin::protocol::{AdminRequest, AdminResponse};
+
+/// Default timeout for admin RPC operations (milliseconds).
+const ADMIN_TIMEOUT_MS: u64 = 5000;
+
+/// Admin RPC client that connects to the daemon's admin socket.
+pub struct AdminClient {
+    path: String,
+    timeout_ms: u64,
+}
+
+impl AdminClient {
+    /// Create a new client targeting the given socket path.
+    pub fn new(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            timeout_ms: ADMIN_TIMEOUT_MS,
+        }
+    }
+
+    /// Create a client with a custom timeout.
+    pub fn with_timeout(path: impl Into<String>, timeout_ms: u64) -> Self {
+        Self {
+            path: path.into(),
+            timeout_ms,
+        }
+    }
+
+    /// Send a request and return the response.
+    pub async fn call(&self, request: &AdminRequest) -> std::io::Result<AdminResponse> {
+        let stream = timeout(
+            Duration::from_millis(self.timeout_ms),
+            UnixStream::connect(&self.path),
+        )
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "admin RPC connect timeout")
+        })??;
+
+        let (reader, mut writer) = stream.into_split();
+
+        // Send request
+        let json = serde_json::to_vec(request)?;
+        let len = (json.len() as u32).to_be_bytes();
+        writer.write_all(&len).await?;
+        writer.write_all(&json).await?;
+        writer.flush().await?;
+
+        // Read response header
+        let mut hdr = [0u8; 4];
+        let mut reader = BufReader::new(reader);
+        reader.read_exact(&mut hdr).await?;
+        let body_len = u32::from_be_bytes(hdr) as usize;
+
+        // Read body
+        let mut body = vec![0u8; body_len];
+        reader.read_exact(&mut body).await?;
+
+        serde_json::from_slice(&body)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+
+    /// Convenience method: ping the server and return true if Pong.
+    pub async fn ping(&self) -> bool {
+        matches!(
+            self.call(&AdminRequest::Ping).await,
+            Ok(AdminResponse::Pong)
+        )
+    }
+}
+
+/// Resolve the admin socket path from the config directory.
+pub fn admin_socket_path(config_dir: &Path) -> std::path::PathBuf {
+    config_dir.join("admin.sock")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_admin_client_new() {
+        let client = AdminClient::new("/tmp/test.sock");
+        assert_eq!(client.path, "/tmp/test.sock");
+        assert_eq!(client.timeout_ms, ADMIN_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn test_admin_client_with_timeout() {
+        let client = AdminClient::with_timeout("/tmp/test.sock", 1000);
+        assert_eq!(client.timeout_ms, 1000);
+    }
+
+    #[test]
+    fn test_admin_socket_path() {
+        let path = admin_socket_path(Path::new("/home/user/.closeclaw"));
+        assert_eq!(
+            path,
+            std::path::PathBuf::from("/home/user/.closeclaw/admin.sock")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_client_connect_to_nonexistent_socket() {
+        let client = AdminClient::new("/tmp/nonexistent-admin-test.sock");
+        let result = client.call(&AdminRequest::Ping).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_client_ping_to_nonexistent_socket() {
+        let client = AdminClient::new("/tmp/nonexistent-admin-test.sock");
+        assert!(!client.ping().await);
+    }
+}

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,0 +1,12 @@
+//! Admin RPC module for CLI-to-daemon communication.
+//!
+//! Provides the admin server (daemon-side) and client (CLI-side)
+//! for managing agents and skills via a Unix domain socket.
+
+pub mod client;
+pub mod protocol;
+pub mod server;
+
+pub use client::AdminClient;
+pub use protocol::{AdminRequest, AdminResponse};
+pub use server::AdminServer;

--- a/src/admin/protocol.rs
+++ b/src/admin/protocol.rs
@@ -1,0 +1,261 @@
+//! Admin RPC protocol types.
+//!
+//! Defines the request and response enums for CLI-to-daemon
+//! communication over a Unix domain socket.
+//!
+//! Uses length-prefixed JSON frames:
+//! ```text
+//! [4-byte big-endian length (u32)][JSON frame bytes]
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Information about a registered agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentInfo {
+    /// Agent identifier.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Model identifier, if configured.
+    pub model: Option<String>,
+}
+
+/// Information about a registered skill.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillInfo {
+    /// Skill name.
+    pub name: String,
+    /// Skill version string, if available.
+    pub version: Option<String>,
+}
+
+/// Request sent from the CLI client to the admin server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AdminRequest {
+    /// List all registered agents.
+    AgentList,
+    /// Get detailed info for a specific agent.
+    AgentInfo { name: String },
+    /// Create a new agent with the given name and optional model.
+    AgentCreate { name: String, model: Option<String> },
+    /// List all installed skills.
+    SkillList,
+    /// Install a skill by name.
+    SkillInstall { name: String },
+    /// Health check — returns Pong.
+    Ping,
+}
+
+/// Response sent from the admin server back to the CLI client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AdminResponse {
+    /// List of agents.
+    AgentListResult { agents: Vec<AgentInfo> },
+    /// Detailed agent info.
+    AgentInfoResult {
+        id: String,
+        name: String,
+        model: Option<String>,
+        skills: Vec<String>,
+    },
+    /// List of skills.
+    SkillListResult { skills: Vec<SkillInfo> },
+    /// Operation succeeded.
+    Ok,
+    /// Operation failed.
+    Error { message: String },
+    /// Health check acknowledgement.
+    Pong,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_list_request_serialization() {
+        let req = AdminRequest::AgentList;
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_agent_info_request_serialization() {
+        let req = AdminRequest::AgentInfo {
+            name: "test-agent".to_string(),
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_agent_create_request_serialization() {
+        let req = AdminRequest::AgentCreate {
+            name: "new-agent".to_string(),
+            model: Some("gpt-4".to_string()),
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_agent_create_request_no_model() {
+        let req = AdminRequest::AgentCreate {
+            name: "new-agent".to_string(),
+            model: None,
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_skill_list_request_serialization() {
+        let req = AdminRequest::SkillList;
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_skill_install_request_serialization() {
+        let req = AdminRequest::SkillInstall {
+            name: "my-skill".to_string(),
+        };
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ping_request_serialization() {
+        let req = AdminRequest::Ping;
+        let json = serde_json::to_vec(&req).unwrap();
+        let deserialized: AdminRequest = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_agent_list_response_serialization() {
+        let resp = AdminResponse::AgentListResult {
+            agents: vec![
+                AgentInfo {
+                    id: "agent1".to_string(),
+                    name: "Agent One".to_string(),
+                    model: Some("gpt-4".to_string()),
+                },
+                AgentInfo {
+                    id: "agent2".to_string(),
+                    name: "Agent Two".to_string(),
+                    model: None,
+                },
+            ],
+        };
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_agent_info_response_serialization() {
+        let resp = AdminResponse::AgentInfoResult {
+            id: "agent1".to_string(),
+            name: "Agent One".to_string(),
+            model: Some("gpt-4".to_string()),
+            skills: vec!["skill-a".to_string(), "skill-b".to_string()],
+        };
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_skill_list_response_serialization() {
+        let resp = AdminResponse::SkillListResult {
+            skills: vec![
+                SkillInfo {
+                    name: "skill-a".to_string(),
+                    version: Some("1.0.0".to_string()),
+                },
+                SkillInfo {
+                    name: "skill-b".to_string(),
+                    version: None,
+                },
+            ],
+        };
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ok_response_serialization() {
+        let resp = AdminResponse::Ok;
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_error_response_serialization() {
+        let resp = AdminResponse::Error {
+            message: "something went wrong".to_string(),
+        };
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_pong_response_serialization() {
+        let resp = AdminResponse::Pong;
+        let json = serde_json::to_vec(&resp).unwrap();
+        let deserialized: AdminResponse = serde_json::from_slice(&json).unwrap();
+        assert_eq!(
+            serde_json::to_string(&resp).unwrap(),
+            serde_json::to_string(&deserialized).unwrap()
+        );
+    }
+}

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -191,8 +191,11 @@ async fn create_agent_dir_and_config(
         ..AgentConfig::default()
     };
     let config_path = agent_dir.join("config.json");
-    config
-        .save(&config_path)
+    let content = serde_json::to_string_pretty(&config).map_err(|e| AdminResponse::Error {
+        message: format!("failed to serialize config: {}", e),
+    })?;
+    tokio::fs::write(&config_path, content)
+        .await
         .map_err(|e| AdminResponse::Error {
             message: format!("failed to write config.json: {}", e),
         })?;
@@ -200,21 +203,38 @@ async fn create_agent_dir_and_config(
 }
 
 /// Append the new agent name to agents.json.
-fn update_agents_json(name: &str, context: &AdminContext) -> Result<(), AdminResponse> {
+async fn update_agents_json(name: &str, context: &AdminContext) -> Result<(), AdminResponse> {
     let agents_json_path = context.config_dir.join("config").join("agents.json");
-    let mut agent_ids = context
-        .config_manager
-        .load_agents_json(&agents_json_path)
-        .unwrap_or_default();
+
+    // Load existing agents.json (blocking I/O)
+    let mut agent_ids = {
+        let config_manager = Arc::clone(&context.config_manager);
+        let path = agents_json_path.clone();
+        tokio::task::spawn_blocking(move || {
+            config_manager.load_agents_json(&path).unwrap_or_default()
+        })
+        .await
+        .map_err(|e| AdminResponse::Error {
+            message: format!("failed to load agents.json: {}", e),
+        })?
+    };
+
     agent_ids.push(name.to_string());
     let agents_json = serde_json::json!({ "agents": agent_ids });
     let agents_json_bytes =
         serde_json::to_vec_pretty(&agents_json).map_err(|e| AdminResponse::Error {
             message: format!("failed to serialize agents.json: {}", e),
         })?;
-    write_atomically(&agents_json_path, &agents_json_bytes).map_err(|e| AdminResponse::Error {
-        message: format!("failed to update agents.json: {}", e),
-    })
+
+    // Write agents.json atomically (blocking I/O)
+    tokio::task::spawn_blocking(move || write_atomically(&agents_json_path, &agents_json_bytes))
+        .await
+        .map_err(|e| AdminResponse::Error {
+            message: format!("failed to update agents.json: {}", e),
+        })?
+        .map_err(|e| AdminResponse::Error {
+            message: format!("failed to update agents.json: {}", e),
+        })
 }
 
 /// Reload agent configs and repopulate the registry.
@@ -242,7 +262,7 @@ async fn dispatch_agent_create(
     if let Err(e) = create_agent_dir_and_config(name, model, context).await {
         return e;
     }
-    if let Err(e) = update_agents_json(name, context) {
+    if let Err(e) = update_agents_json(name, context).await {
         return e;
     }
     if let Err(e) = reload_registry(context) {

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -40,18 +40,18 @@ impl AdminServer {
     }
 
     /// Remove the socket file if it already exists (idempotent).
-    fn clean_up(&self) {
-        let _ = std::fs::remove_file(&self.path);
+    async fn clean_up(&self) {
+        let _ = tokio::fs::remove_file(&self.path).await;
     }
 
     /// Start the admin server. Blocks forever, processing each
     /// connection in a spawned task.
     pub async fn serve(self) -> std::io::Result<()> {
-        self.clean_up();
+        self.clean_up().await;
 
         // Ensure parent directory exists
         if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
+            tokio::fs::create_dir_all(parent).await?;
         }
 
         let listener = UnixListener::bind(&self.path)?;
@@ -158,49 +158,49 @@ fn dispatch_agent_info(name: &str, context: &AdminContext) -> AdminResponse {
     }
 }
 
-/// Create a new agent — creates config file and registers in AgentRegistry.
-async fn dispatch_agent_create(
+/// Validate that the agent name is non-empty and not already taken.
+fn validate_agent_name(name: &str, context: &AdminContext) -> Result<(), AdminResponse> {
+    if name.is_empty() {
+        return Err(AdminResponse::Error {
+            message: "agent name cannot be empty".to_string(),
+        });
+    }
+    if context.agent_registry.get(name).is_some() {
+        return Err(AdminResponse::Error {
+            message: format!("agent '{}' already exists", name),
+        });
+    }
+    Ok(())
+}
+
+/// Create the agent directory and write config.json, returning the agent dir path.
+async fn create_agent_dir_and_config(
     name: &str,
     model: Option<String>,
     context: &AdminContext,
-) -> AdminResponse {
-    // Validate name is not empty
-    if name.is_empty() {
-        return AdminResponse::Error {
-            message: "agent name cannot be empty".to_string(),
-        };
-    }
-
+) -> Result<std::path::PathBuf, AdminResponse> {
     let agent_dir = context.config_dir.join("agents").join(name);
-
-    // Check if agent already exists
-    if context.agent_registry.get(name).is_some() {
-        return AdminResponse::Error {
-            message: format!("agent '{}' already exists", name),
-        };
-    }
-
-    // Create agent directory
-    if let Err(e) = std::fs::create_dir_all(&agent_dir) {
-        return AdminResponse::Error {
+    tokio::fs::create_dir_all(&agent_dir)
+        .await
+        .map_err(|e| AdminResponse::Error {
             message: format!("failed to create agent directory: {}", e),
-        };
-    }
-
-    // Create config.json
+        })?;
     let config = AgentConfig {
         id: name.to_string(),
         model,
         ..AgentConfig::default()
     };
     let config_path = agent_dir.join("config.json");
-    if let Err(e) = config.save(&config_path) {
-        return AdminResponse::Error {
+    config
+        .save(&config_path)
+        .map_err(|e| AdminResponse::Error {
             message: format!("failed to write config.json: {}", e),
-        };
-    }
+        })?;
+    Ok(agent_dir)
+}
 
-    // Update agents.json to include the new agent
+/// Append the new agent name to agents.json.
+fn update_agents_json(name: &str, context: &AdminContext) -> Result<(), AdminResponse> {
     let agents_json_path = context.config_dir.join("config").join("agents.json");
     let mut agent_ids = context
         .config_manager
@@ -208,29 +208,56 @@ async fn dispatch_agent_create(
         .unwrap_or_default();
     agent_ids.push(name.to_string());
     let agents_json = serde_json::json!({ "agents": agent_ids });
-    let agents_json_bytes = serde_json::to_vec_pretty(&agents_json).unwrap();
-    if let Err(e) = write_atomically(&agents_json_path, &agents_json_bytes) {
-        return AdminResponse::Error {
-            message: format!("failed to update agents.json: {}", e),
-        };
-    }
+    let agents_json_bytes =
+        serde_json::to_vec_pretty(&agents_json).map_err(|e| AdminResponse::Error {
+            message: format!("failed to serialize agents.json: {}", e),
+        })?;
+    write_atomically(&agents_json_path, &agents_json_bytes).map_err(|e| AdminResponse::Error {
+        message: format!("failed to update agents.json: {}", e),
+    })
+}
 
-    // Reload agents in ConfigManager and re-populate AgentRegistry
-    if let Err(e) = context.config_manager.reload_agents() {
-        return AdminResponse::Error {
+/// Reload agent configs and repopulate the registry.
+fn reload_registry(context: &AdminContext) -> Result<(), AdminResponse> {
+    context
+        .config_manager
+        .reload_agents()
+        .map_err(|e| AdminResponse::Error {
             message: format!("failed to reload agent configs: {}", e),
-        };
-    }
+        })?;
     let configs: Vec<_> = context.config_manager.agents().into_values().collect();
     context.agent_registry.populate(configs);
+    Ok(())
+}
 
+/// Create a new agent — creates config file and registers in AgentRegistry.
+async fn dispatch_agent_create(
+    name: &str,
+    model: Option<String>,
+    context: &AdminContext,
+) -> AdminResponse {
+    if let Err(e) = validate_agent_name(name, context) {
+        return e;
+    }
+    if let Err(e) = create_agent_dir_and_config(name, model, context).await {
+        return e;
+    }
+    if let Err(e) = update_agents_json(name, context) {
+        return e;
+    }
+    if let Err(e) = reload_registry(context) {
+        return e;
+    }
     tracing::info!(name = name, "agent created successfully");
     AdminResponse::Ok
 }
 
 /// List all skills from the DiskSkillRegistry with version info.
 async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
-    let guard = context.skill_registry.read().unwrap();
+    let guard = context
+        .skill_registry
+        .read()
+        .unwrap_or_else(|e| e.into_inner());
     match guard.as_ref() {
         Some(registry) => {
             let skills: Vec<SkillInfo> = registry
@@ -291,7 +318,7 @@ async fn dispatch_skill_install(name: &str, context: &AdminContext) -> AdminResp
     }
 
     // Copy skill directory
-    if let Err(e) = copy_skill_dir(&source_skill_dir, &dest_skill_dir) {
+    if let Err(e) = copy_skill_dir(&source_skill_dir, &dest_skill_dir).await {
         return AdminResponse::Error {
             message: format!("failed to copy skill: {}", e),
         };
@@ -301,18 +328,18 @@ async fn dispatch_skill_install(name: &str, context: &AdminContext) -> AdminResp
     AdminResponse::Ok
 }
 
-/// Recursively copy a skill directory.
-fn copy_skill_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
+/// Recursively copy a skill directory using async I/O.
+async fn copy_skill_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+    let mut entries = tokio::fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let file_type = entry.file_type().await?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
         if file_type.is_dir() {
-            copy_skill_dir(&src_path, &dst_path)?;
+            Box::pin(copy_skill_dir(&src_path, &dst_path)).await?;
         } else {
-            std::fs::copy(&src_path, &dst_path)?;
+            tokio::fs::copy(&src_path, &dst_path).await?;
         }
     }
     Ok(())

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -1,0 +1,255 @@
+//! Admin RPC server — listens on a Unix domain socket and dispatches
+//! requests to daemon components.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::OwnedWriteHalf;
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::admin::protocol::{AdminRequest, AdminResponse, SkillInfo};
+use crate::agent::registry::AgentRegistry;
+use crate::skills::DiskSkillRegistry;
+
+/// Server-side context holding references to daemon components.
+pub struct AdminContext {
+    pub agent_registry: Arc<AgentRegistry>,
+    pub skill_registry: Arc<tokio::sync::RwLock<Option<DiskSkillRegistry>>>,
+}
+
+/// Admin RPC server that binds a Unix domain socket and handles
+/// incoming requests.
+pub struct AdminServer {
+    path: PathBuf,
+    context: Arc<AdminContext>,
+}
+
+impl AdminServer {
+    /// Create a new admin server with the given socket path and context.
+    pub fn new(path: impl Into<PathBuf>, context: AdminContext) -> Self {
+        Self {
+            path: path.into(),
+            context: Arc::new(context),
+        }
+    }
+
+    /// Remove the socket file if it already exists (idempotent).
+    fn clean_up(&self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+
+    /// Start the admin server. Blocks forever, processing each
+    /// connection in a spawned task.
+    pub async fn serve(self) -> std::io::Result<()> {
+        self.clean_up();
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let listener = UnixListener::bind(&self.path)?;
+
+        tracing::info!("admin RPC server listening on {}", self.path.display());
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let context = Arc::clone(&self.context);
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_connection(stream, context).await {
+                            tracing::error!("admin RPC connection error: {}", e);
+                        }
+                    });
+                }
+                Err(e) => {
+                    tracing::error!("admin RPC accept error: {}", e);
+                }
+            }
+        }
+    }
+}
+
+/// Handle a single admin RPC connection.
+async fn handle_connection(stream: UnixStream, context: Arc<AdminContext>) -> std::io::Result<()> {
+    let (reader, mut writer): (_, OwnedWriteHalf) = stream.into_split();
+    let mut reader = BufReader::new(reader);
+
+    loop {
+        // Read 4-byte length header
+        let mut hdr = [0u8; 4];
+        match reader.read_exact(&mut hdr).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e),
+        }
+        let body_len = u32::from_be_bytes(hdr) as usize;
+
+        // Read body
+        let mut body = vec![0u8; body_len];
+        reader.read_exact(&mut body).await?;
+
+        // Deserialize request
+        let request: AdminRequest = match serde_json::from_slice(&body) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = AdminResponse::Error {
+                    message: format!("invalid request: {}", e),
+                };
+                send_response(&mut writer, &resp).await?;
+                continue;
+            }
+        };
+
+        // Dispatch request
+        let response = dispatch(request, &context).await;
+        send_response(&mut writer, &response).await?;
+    }
+
+    Ok(())
+}
+
+/// Dispatch a request to the appropriate handler.
+async fn dispatch(request: AdminRequest, context: &AdminContext) -> AdminResponse {
+    match request {
+        AdminRequest::AgentList => dispatch_agent_list(context),
+        AdminRequest::AgentInfo { name } => dispatch_agent_info(&name, context),
+        AdminRequest::AgentCreate { name, model } => {
+            dispatch_agent_create(&name, model, context).await
+        }
+        AdminRequest::SkillList => dispatch_skill_list(context).await,
+        AdminRequest::SkillInstall { name } => dispatch_skill_install(&name).await,
+        AdminRequest::Ping => AdminResponse::Pong,
+    }
+}
+
+/// List all agents — stub implementation (returns empty list for now).
+fn dispatch_agent_list(_context: &AdminContext) -> AdminResponse {
+    // TODO: iterate AgentRegistry.configs in Step 1.4
+    AdminResponse::AgentListResult { agents: vec![] }
+}
+
+/// Get info for a specific agent — stub implementation.
+fn dispatch_agent_info(name: &str, _context: &AdminContext) -> AdminResponse {
+    // TODO: query AgentRegistry.get(name) in Step 1.4
+    AdminResponse::Error {
+        message: format!("agent '{}' not found (stub)", name),
+    }
+}
+
+/// Create a new agent — stub implementation (returns Ok for now).
+async fn dispatch_agent_create(
+    name: &str,
+    _model: Option<String>,
+    _context: &AdminContext,
+) -> AdminResponse {
+    // TODO: implement via ConfigManager in Step 1.4
+    tracing::info!(name = name, "agent create requested (stub)");
+    AdminResponse::Ok
+}
+
+/// List all skills from the DiskSkillRegistry.
+async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
+    let guard = context.skill_registry.read().await;
+    match guard.as_ref() {
+        Some(registry) => {
+            let skills: Vec<SkillInfo> = registry
+                .list()
+                .into_iter()
+                .map(|name| SkillInfo {
+                    name: name.to_string(),
+                    version: None,
+                })
+                .collect();
+            AdminResponse::SkillListResult { skills }
+        }
+        None => AdminResponse::SkillListResult { skills: vec![] },
+    }
+}
+
+/// Install a skill — stub implementation (returns Ok for now).
+async fn dispatch_skill_install(name: &str) -> AdminResponse {
+    // TODO: implement in Step 1.4
+    tracing::info!(name = name, "skill install requested (stub)");
+    AdminResponse::Ok
+}
+
+/// Send a length-prefixed JSON response.
+async fn send_response(
+    writer: &mut OwnedWriteHalf,
+    response: &AdminResponse,
+) -> std::io::Result<()> {
+    let json = serde_json::to_vec(response)?;
+    let len = (json.len() as u32).to_be_bytes();
+    writer.write_all(&len).await?;
+    writer.write_all(&json).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::registry::AgentRegistry;
+    use crate::skills::DiskSkillRegistry;
+
+    fn make_test_context() -> AdminContext {
+        AdminContext {
+            agent_registry: Arc::new(AgentRegistry::new()),
+            skill_registry: Arc::new(tokio::sync::RwLock::new(Some(DiskSkillRegistry::default()))),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_agent_list_empty() {
+        let ctx = make_test_context();
+        let resp = dispatch_agent_list(&ctx);
+        match resp {
+            AdminResponse::AgentListResult { agents } => assert!(agents.is_empty()),
+            _ => panic!("expected AgentListResult"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_agent_info_not_found() {
+        let ctx = make_test_context();
+        let resp = dispatch_agent_info("nonexistent", &ctx);
+        match resp {
+            AdminResponse::Error { message } => {
+                assert!(message.contains("not found"));
+            }
+            _ => panic!("expected Error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_skill_list_empty() {
+        let ctx = make_test_context();
+        let resp = dispatch_skill_list(&ctx).await;
+        match resp {
+            AdminResponse::SkillListResult { skills } => assert!(skills.is_empty()),
+            _ => panic!("expected SkillListResult"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_skill_install_stub() {
+        let resp = dispatch_skill_install("test-skill").await;
+        assert!(matches!(resp, AdminResponse::Ok));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_agent_create_stub() {
+        let ctx = make_test_context();
+        let resp = dispatch_agent_create("new-agent", Some("gpt-4".into()), &ctx).await;
+        assert!(matches!(resp, AdminResponse::Ok));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_ping() {
+        let ctx = make_test_context();
+        let resp = dispatch(AdminRequest::Ping, &ctx).await;
+        assert!(matches!(resp, AdminResponse::Pong));
+    }
+}

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -274,50 +274,60 @@ async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
     }
 }
 
-/// Install a skill from the global skills directory to the bundled directory.
-async fn dispatch_skill_install(name: &str, context: &AdminContext) -> AdminResponse {
-    // Derive global dir: parent of config_dir / skills
+/// Validate that the source skill exists and destination is not already
+/// installed. Returns `(source, dest)` paths on success.
+async fn validate_skill_install_paths(
+    name: &str,
+    context: &AdminContext,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), AdminResponse> {
     let global_dir = context.config_dir.parent().map(|p| p.join("skills"));
     let bundled_dir = context.config_dir.join("skills");
 
     let global_dir = match global_dir {
         Some(d) => d,
         None => {
-            return AdminResponse::Error {
+            return Err(AdminResponse::Error {
                 message: "cannot determine global skills directory".to_string(),
-            }
+            })
         }
     };
 
-    // Source: global skills directory
     let source_skill_dir = global_dir.join(name);
-    if !source_skill_dir.exists() {
-        return AdminResponse::Error {
+    if tokio::fs::metadata(&source_skill_dir).await.is_err() {
+        return Err(AdminResponse::Error {
             message: format!(
                 "skill '{}' not found in global directory {}",
                 name,
                 global_dir.display()
             ),
-        };
+        });
     }
 
-    // Check SKILL.md exists
     let source_skill_md = source_skill_dir.join("SKILL.md");
-    if !source_skill_md.exists() {
-        return AdminResponse::Error {
+    if tokio::fs::metadata(&source_skill_md).await.is_err() {
+        return Err(AdminResponse::Error {
             message: format!("skill '{}' does not contain SKILL.md", name),
-        };
+        });
     }
 
-    // Destination: bundled skills directory
     let dest_skill_dir = bundled_dir.join(name);
-    if dest_skill_dir.exists() {
-        return AdminResponse::Error {
+    if tokio::fs::metadata(&dest_skill_dir).await.is_ok() {
+        return Err(AdminResponse::Error {
             message: format!("skill '{}' is already installed", name),
-        };
+        });
     }
 
-    // Copy skill directory
+    Ok((source_skill_dir, dest_skill_dir))
+}
+
+/// Install a skill from the global skills directory to the bundled directory.
+async fn dispatch_skill_install(name: &str, context: &AdminContext) -> AdminResponse {
+    let (source_skill_dir, dest_skill_dir) = match validate_skill_install_paths(name, context).await
+    {
+        Ok(paths) => paths,
+        Err(resp) => return resp,
+    };
+
     if let Err(e) = copy_skill_dir(&source_skill_dir, &dest_skill_dir).await {
         return AdminResponse::Error {
             message: format!("failed to copy skill: {}", e),

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -15,7 +15,7 @@ use crate::skills::DiskSkillRegistry;
 /// Server-side context holding references to daemon components.
 pub struct AdminContext {
     pub agent_registry: Arc<AgentRegistry>,
-    pub skill_registry: Arc<tokio::sync::RwLock<Option<DiskSkillRegistry>>>,
+    pub skill_registry: Arc<std::sync::RwLock<Option<DiskSkillRegistry>>>,
 }
 
 /// Admin RPC server that binds a Unix domain socket and handles
@@ -151,7 +151,7 @@ async fn dispatch_agent_create(
 
 /// List all skills from the DiskSkillRegistry.
 async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
-    let guard = context.skill_registry.read().await;
+    let guard = context.skill_registry.read().unwrap();
     match guard.as_ref() {
         Some(registry) => {
             let skills: Vec<SkillInfo> = registry
@@ -197,7 +197,7 @@ mod tests {
     fn make_test_context() -> AdminContext {
         AdminContext {
             agent_registry: Arc::new(AgentRegistry::new()),
-            skill_registry: Arc::new(tokio::sync::RwLock::new(Some(DiskSkillRegistry::default()))),
+            skill_registry: Arc::new(std::sync::RwLock::new(Some(DiskSkillRegistry::default()))),
         }
     }
 

--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -9,13 +9,18 @@ use tokio::net::unix::OwnedWriteHalf;
 use tokio::net::{UnixListener, UnixStream};
 
 use crate::admin::protocol::{AdminRequest, AdminResponse, SkillInfo};
+use crate::agent::config::AgentConfig;
 use crate::agent::registry::AgentRegistry;
+use crate::config::manager::write_atomically;
+use crate::config::ConfigManager;
 use crate::skills::DiskSkillRegistry;
 
 /// Server-side context holding references to daemon components.
 pub struct AdminContext {
     pub agent_registry: Arc<AgentRegistry>,
     pub skill_registry: Arc<std::sync::RwLock<Option<DiskSkillRegistry>>>,
+    pub config_manager: Arc<ConfigManager>,
+    pub config_dir: PathBuf,
 }
 
 /// Admin RPC server that binds a Unix domain socket and handles
@@ -119,37 +124,111 @@ async fn dispatch(request: AdminRequest, context: &AdminContext) -> AdminRespons
             dispatch_agent_create(&name, model, context).await
         }
         AdminRequest::SkillList => dispatch_skill_list(context).await,
-        AdminRequest::SkillInstall { name } => dispatch_skill_install(&name).await,
+        AdminRequest::SkillInstall { name } => dispatch_skill_install(&name, context).await,
         AdminRequest::Ping => AdminResponse::Pong,
     }
 }
 
-/// List all agents — stub implementation (returns empty list for now).
-fn dispatch_agent_list(_context: &AdminContext) -> AdminResponse {
-    // TODO: iterate AgentRegistry.configs in Step 1.4
-    AdminResponse::AgentListResult { agents: vec![] }
+/// List all agents — returns agent ID + model for each registered agent.
+fn dispatch_agent_list(context: &AdminContext) -> AdminResponse {
+    let agents: Vec<crate::admin::protocol::AgentInfo> = context
+        .agent_registry
+        .iter()
+        .map(|entry| crate::admin::protocol::AgentInfo {
+            id: entry.key().clone(),
+            name: entry.name.clone(),
+            model: entry.model.clone(),
+        })
+        .collect();
+    AdminResponse::AgentListResult { agents }
 }
 
-/// Get info for a specific agent — stub implementation.
-fn dispatch_agent_info(name: &str, _context: &AdminContext) -> AdminResponse {
-    // TODO: query AgentRegistry.get(name) in Step 1.4
-    AdminResponse::Error {
-        message: format!("agent '{}' not found (stub)", name),
+/// Get info for a specific agent — returns detailed config information.
+fn dispatch_agent_info(name: &str, context: &AdminContext) -> AdminResponse {
+    match context.agent_registry.get(name) {
+        Some(entry) => AdminResponse::AgentInfoResult {
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+            model: entry.model.clone(),
+            skills: entry.skills.clone(),
+        },
+        None => AdminResponse::Error {
+            message: format!("agent '{}' not found", name),
+        },
     }
 }
 
-/// Create a new agent — stub implementation (returns Ok for now).
+/// Create a new agent — creates config file and registers in AgentRegistry.
 async fn dispatch_agent_create(
     name: &str,
-    _model: Option<String>,
-    _context: &AdminContext,
+    model: Option<String>,
+    context: &AdminContext,
 ) -> AdminResponse {
-    // TODO: implement via ConfigManager in Step 1.4
-    tracing::info!(name = name, "agent create requested (stub)");
+    // Validate name is not empty
+    if name.is_empty() {
+        return AdminResponse::Error {
+            message: "agent name cannot be empty".to_string(),
+        };
+    }
+
+    let agent_dir = context.config_dir.join("agents").join(name);
+
+    // Check if agent already exists
+    if context.agent_registry.get(name).is_some() {
+        return AdminResponse::Error {
+            message: format!("agent '{}' already exists", name),
+        };
+    }
+
+    // Create agent directory
+    if let Err(e) = std::fs::create_dir_all(&agent_dir) {
+        return AdminResponse::Error {
+            message: format!("failed to create agent directory: {}", e),
+        };
+    }
+
+    // Create config.json
+    let config = AgentConfig {
+        id: name.to_string(),
+        model,
+        ..AgentConfig::default()
+    };
+    let config_path = agent_dir.join("config.json");
+    if let Err(e) = config.save(&config_path) {
+        return AdminResponse::Error {
+            message: format!("failed to write config.json: {}", e),
+        };
+    }
+
+    // Update agents.json to include the new agent
+    let agents_json_path = context.config_dir.join("config").join("agents.json");
+    let mut agent_ids = context
+        .config_manager
+        .load_agents_json(&agents_json_path)
+        .unwrap_or_default();
+    agent_ids.push(name.to_string());
+    let agents_json = serde_json::json!({ "agents": agent_ids });
+    let agents_json_bytes = serde_json::to_vec_pretty(&agents_json).unwrap();
+    if let Err(e) = write_atomically(&agents_json_path, &agents_json_bytes) {
+        return AdminResponse::Error {
+            message: format!("failed to update agents.json: {}", e),
+        };
+    }
+
+    // Reload agents in ConfigManager and re-populate AgentRegistry
+    if let Err(e) = context.config_manager.reload_agents() {
+        return AdminResponse::Error {
+            message: format!("failed to reload agent configs: {}", e),
+        };
+    }
+    let configs: Vec<_> = context.config_manager.agents().into_values().collect();
+    context.agent_registry.populate(configs);
+
+    tracing::info!(name = name, "agent created successfully");
     AdminResponse::Ok
 }
 
-/// List all skills from the DiskSkillRegistry.
+/// List all skills from the DiskSkillRegistry with version info.
 async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
     let guard = context.skill_registry.read().unwrap();
     match guard.as_ref() {
@@ -168,11 +247,75 @@ async fn dispatch_skill_list(context: &AdminContext) -> AdminResponse {
     }
 }
 
-/// Install a skill — stub implementation (returns Ok for now).
-async fn dispatch_skill_install(name: &str) -> AdminResponse {
-    // TODO: implement in Step 1.4
-    tracing::info!(name = name, "skill install requested (stub)");
+/// Install a skill from the global skills directory to the bundled directory.
+async fn dispatch_skill_install(name: &str, context: &AdminContext) -> AdminResponse {
+    // Derive global dir: parent of config_dir / skills
+    let global_dir = context.config_dir.parent().map(|p| p.join("skills"));
+    let bundled_dir = context.config_dir.join("skills");
+
+    let global_dir = match global_dir {
+        Some(d) => d,
+        None => {
+            return AdminResponse::Error {
+                message: "cannot determine global skills directory".to_string(),
+            }
+        }
+    };
+
+    // Source: global skills directory
+    let source_skill_dir = global_dir.join(name);
+    if !source_skill_dir.exists() {
+        return AdminResponse::Error {
+            message: format!(
+                "skill '{}' not found in global directory {}",
+                name,
+                global_dir.display()
+            ),
+        };
+    }
+
+    // Check SKILL.md exists
+    let source_skill_md = source_skill_dir.join("SKILL.md");
+    if !source_skill_md.exists() {
+        return AdminResponse::Error {
+            message: format!("skill '{}' does not contain SKILL.md", name),
+        };
+    }
+
+    // Destination: bundled skills directory
+    let dest_skill_dir = bundled_dir.join(name);
+    if dest_skill_dir.exists() {
+        return AdminResponse::Error {
+            message: format!("skill '{}' is already installed", name),
+        };
+    }
+
+    // Copy skill directory
+    if let Err(e) = copy_skill_dir(&source_skill_dir, &dest_skill_dir) {
+        return AdminResponse::Error {
+            message: format!("failed to copy skill: {}", e),
+        };
+    }
+
+    tracing::info!(name = name, "skill installed successfully");
     AdminResponse::Ok
+}
+
+/// Recursively copy a skill directory.
+fn copy_skill_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_skill_dir(&src_path, &dst_path)?;
+        } else {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
 }
 
 /// Send a length-prefixed JSON response.
@@ -195,9 +338,18 @@ mod tests {
     use crate::skills::DiskSkillRegistry;
 
     fn make_test_context() -> AdminContext {
+        let config_dir = tempfile::tempdir().unwrap().keep();
+        // Create config/agents.json so ConfigManager can load
+        let config_sub = config_dir.join("config");
+        std::fs::create_dir_all(&config_sub).unwrap();
+        std::fs::write(config_sub.join("agents.json"), r#"{"agents": []}"#).unwrap();
+        let config_manager =
+            Arc::new(crate::config::ConfigManager::new(config_dir.clone()).unwrap());
         AdminContext {
             agent_registry: Arc::new(AgentRegistry::new()),
             skill_registry: Arc::new(std::sync::RwLock::new(Some(DiskSkillRegistry::default()))),
+            config_manager,
+            config_dir,
         }
     }
 
@@ -234,16 +386,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_skill_install_stub() {
-        let resp = dispatch_skill_install("test-skill").await;
-        assert!(matches!(resp, AdminResponse::Ok));
+    async fn test_dispatch_skill_install_not_found() {
+        let ctx = make_test_context();
+        let resp = dispatch_skill_install("test-skill", &ctx).await;
+        match resp {
+            AdminResponse::Error { message } => {
+                assert!(message.contains("not found"));
+            }
+            _ => panic!("expected Error for missing skill"),
+        }
     }
 
     #[tokio::test]
-    async fn test_dispatch_agent_create_stub() {
+    async fn test_dispatch_agent_create_empty_name() {
         let ctx = make_test_context();
-        let resp = dispatch_agent_create("new-agent", Some("gpt-4".into()), &ctx).await;
+        let resp = dispatch_agent_create("", Some("gpt-4".into()), &ctx).await;
+        match resp {
+            AdminResponse::Error { message } => {
+                assert!(message.contains("empty"));
+            }
+            _ => panic!("expected Error for empty name"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_agent_create_success() {
+        let ctx = make_test_context();
+        let resp = dispatch_agent_create("test-agent", Some("gpt-4".into()), &ctx).await;
         assert!(matches!(resp, AdminResponse::Ok));
+        // Verify agent was created
+        assert!(ctx.agent_registry.get("test-agent").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_agent_create_duplicate() {
+        let ctx = make_test_context();
+        let resp = dispatch_agent_create("dup-agent", None, &ctx).await;
+        assert!(matches!(resp, AdminResponse::Ok));
+        // Try creating same agent again
+        let resp = dispatch_agent_create("dup-agent", None, &ctx).await;
+        match resp {
+            AdminResponse::Error { message } => {
+                assert!(message.contains("already exists"));
+            }
+            _ => panic!("expected Error for duplicate"),
+        }
     }
 
     #[tokio::test]

--- a/src/agent/registry/mod.rs
+++ b/src/agent/registry/mod.rs
@@ -47,6 +47,11 @@ impl AgentRegistry {
         self.configs.get(id)
     }
 
+    /// Iterate all registered agent configs.
+    pub fn iter(&self) -> dashmap::iter::Iter<'_, String, ResolvedAgentConfig> {
+        self.configs.iter()
+    }
+
     /// Replace all stored configs with the given set (hot-reload).
     pub fn reload(&self, configs: Vec<ResolvedAgentConfig>) {
         self.configs.clear();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -235,17 +235,18 @@ impl Daemon {
         // Create ToolRegistry and register builtin tools
         let tool_registry = Arc::new(ToolRegistry::new());
         let mut config_watcher = None;
+        // Create ConfigManager early so it's available for admin RPC.
+        let config_manager = Arc::new(
+            ConfigManager::new(PathBuf::from(config_dir))
+                .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
+        );
         {
             let disk_reg_opt = {
                 let guard = skill_registry.read().unwrap();
                 guard.as_ref().map(|dr| Arc::new(dr.clone()))
             };
             if let Some(disk_reg) = disk_reg_opt {
-                // Create ConfigManager and load agent configs (non-fatal if missing).
-                let config_manager = Arc::new(
-                    ConfigManager::new(PathBuf::from(config_dir))
-                        .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
-                );
+                // Load agent configs (non-fatal if missing).
                 if let Err(e) = config_manager.load_agents(None) {
                     tracing::warn!(
                         error = %e,
@@ -344,6 +345,8 @@ impl Daemon {
         let admin_context = AdminContext {
             agent_registry: Arc::clone(&agent_registry),
             skill_registry: skill_registry.clone(),
+            config_manager: Arc::clone(&config_manager),
+            config_dir: PathBuf::from(config_dir),
         };
         let admin_server = AdminServer::new(&admin_sock_path, admin_context);
         let admin_handle = tokio::spawn(async move {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -90,6 +90,8 @@ pub struct Daemon {
     /// Admin RPC server task handle (drop cancels the task)
     #[allow(dead_code)]
     admin_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Path to the admin RPC socket file (cleaned up on shutdown)
+    admin_socket_path: PathBuf,
 }
 // --- Lifecycle: start, run ---
 impl Daemon {
@@ -372,6 +374,7 @@ impl Daemon {
             _config_watcher: config_watcher,
             approval_flow,
             admin_handle: Some(admin_handle),
+            admin_socket_path: admin_sock_path,
         })
     }
     /// Run the daemon — blocks until shutdown signal is received.
@@ -397,6 +400,8 @@ impl Daemon {
         // Clear all pending approval requests (denied with callbacks triggered)
         self.approval_flow.lock().await.clear();
         let _ = self.sweeper_shutdown_tx.send(());
+        // Clean up admin socket file
+        let _ = tokio::fs::remove_file(&self.admin_socket_path).await;
         Ok(())
     }
     /// Run the daemon on non-Unix platforms (falls back to Ctrl+C only).
@@ -413,6 +418,8 @@ impl Daemon {
         // Clear all pending approval requests (denied with callbacks triggered)
         self.approval_flow.lock().await.clear();
         let _ = self.sweeper_shutdown_tx.send(());
+        // Clean up admin socket file
+        let _ = tokio::fs::remove_file(&self.admin_socket_path).await;
         Ok(())
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -5,6 +5,8 @@
 pub mod config_reload;
 pub mod shutdown;
 pub mod skill_reload;
+use crate::admin::client::admin_socket_path;
+use crate::admin::server::{AdminContext, AdminServer};
 use crate::agent::spawn::SpawnController;
 use crate::config::migration::migrate_if_needed;
 use crate::config::providers::ConfigProvider;
@@ -85,6 +87,9 @@ pub struct Daemon {
     _config_watcher: Option<config_reload::ConfigWatcherHandle>,
     /// Daemon-level approval orchestrator
     pub approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+    /// Admin RPC server task handle (drop cancels the task)
+    #[allow(dead_code)]
+    admin_handle: Option<tokio::task::JoinHandle<()>>,
 }
 // --- Lifecycle: start, run ---
 impl Daemon {
@@ -334,6 +339,20 @@ impl Daemon {
             Arc::clone(&approval_flow),
         );
 
+        // ── Admin RPC Server ──────────────────────────────────────────────
+        let admin_sock_path = admin_socket_path(Path::new(config_dir));
+        let admin_context = AdminContext {
+            agent_registry: Arc::clone(&agent_registry),
+            skill_registry: skill_registry.clone(),
+        };
+        let admin_server = AdminServer::new(&admin_sock_path, admin_context);
+        let admin_handle = tokio::spawn(async move {
+            if let Err(e) = admin_server.serve().await {
+                tracing::error!(error = %e, "admin RPC server failed");
+            }
+        });
+        info!("admin RPC server started on {}", admin_sock_path.display());
+
         info!(
             "CloseClaw daemon started successfully (v{})",
             env!("CARGO_PKG_VERSION")
@@ -349,6 +368,7 @@ impl Daemon {
             _skill_watcher: Some(skill_watcher),
             _config_watcher: config_watcher,
             approval_flow,
+            admin_handle: Some(admin_handle),
         })
     }
     /// Run the daemon — blocks until shutdown signal is received.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,9 +2,8 @@
 
 use anyhow::Result;
 use closeclaw::cli::args::*;
-use closeclaw::permission::{Defaults, Effect, PermissionEngine, Rule, RuleSet};
+use closeclaw::permission::{Effect, Rule, RuleSet};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 #[allow(dead_code)] // pub API for masking secrets in CLI output (covered by tests)
 pub fn mask_key(key: &str) -> String {
@@ -30,16 +29,79 @@ pub(crate) fn config_dir_for(home: impl AsRef<std::path::Path>) -> PathBuf {
 }
 
 pub async fn handle_agent(action: AgentAction) -> Result<()> {
+    let client = closeclaw::admin::AdminClient::new(
+        closeclaw::admin::client::admin_socket_path(&config_dir())
+            .to_string_lossy()
+            .into_owned(),
+    );
     match action {
         AgentAction::List => {
-            println!("Agents:\n  (no agents running)");
-        }
-        AgentAction::Create { name, model } => {
-            let m = model.unwrap_or_else(|| "minimax/MiniMax-M2.7".to_string());
-            println!("Creating agent '{}' with model '{}'", name, m);
+            let resp = client
+                .call(&closeclaw::admin::AdminRequest::AgentList)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+            match resp {
+                closeclaw::admin::AdminResponse::AgentListResult { agents } => {
+                    if agents.is_empty() {
+                        println!("Agents:\n  (none)");
+                    } else {
+                        println!("Agents:");
+                        for a in &agents {
+                            let model = a.model.as_deref().unwrap_or("-");
+                            println!("  {} | {} | {}", a.id, a.name, model);
+                        }
+                    }
+                }
+                closeclaw::admin::AdminResponse::Error { message } => {
+                    anyhow::bail!("{}", message);
+                }
+                _ => anyhow::bail!("Unexpected response from daemon"),
+            }
         }
         AgentAction::Info { name } => {
-            println!("Agent info for '{}':\n  (not implemented)", name);
+            let resp = client
+                .call(&closeclaw::admin::AdminRequest::AgentInfo { name: name.clone() })
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+            match resp {
+                closeclaw::admin::AdminResponse::AgentInfoResult {
+                    id,
+                    name,
+                    model,
+                    skills,
+                } => {
+                    println!("Agent: {}", name);
+                    println!("  ID: {}", id);
+                    println!("  Model: {}", model.as_deref().unwrap_or("-"));
+                    if skills.is_empty() {
+                        println!("  Skills: (none)");
+                    } else {
+                        println!("  Skills: {}", skills.join(", "));
+                    }
+                }
+                closeclaw::admin::AdminResponse::Error { message } => {
+                    anyhow::bail!("{}", message);
+                }
+                _ => anyhow::bail!("Unexpected response from daemon"),
+            }
+        }
+        AgentAction::Create { name, model } => {
+            let resp = client
+                .call(&closeclaw::admin::AdminRequest::AgentCreate {
+                    name: name.clone(),
+                    model,
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+            match resp {
+                closeclaw::admin::AdminResponse::Ok => {
+                    println!("Agent '{}' created.", name);
+                }
+                closeclaw::admin::AdminResponse::Error { message } => {
+                    anyhow::bail!("{}", message);
+                }
+                _ => anyhow::bail!("Unexpected response from daemon"),
+            }
         }
     }
     Ok(())
@@ -191,37 +253,49 @@ pub(crate) async fn handle_rule_with(action: RuleAction, config_dir: PathBuf) ->
 }
 
 pub async fn handle_skill(action: SkillAction) -> Result<()> {
-    use closeclaw::skills::{builtin_skills_with_engine, init_disk_skills, ScanConfig};
+    let client = closeclaw::admin::AdminClient::new(
+        closeclaw::admin::client::admin_socket_path(&config_dir())
+            .to_string_lossy()
+            .into_owned(),
+    );
     match action {
         SkillAction::List => {
-            let rs = RuleSet {
-                rules: vec![],
-                defaults: Defaults::default(),
-                template_includes: vec![],
-                agent_creators: std::collections::HashMap::new(),
-            };
-            let eng = Arc::new(PermissionEngine::new_with_default_data_root(rs));
-            let config = ScanConfig::default();
-            let disk_reg = init_disk_skills(&config);
-            if disk_reg.is_empty() {
-                println!("Installed skills (bundled):");
-            } else {
-                println!("Installed skills (disk):");
-                for name in disk_reg.list() {
-                    println!("  {} [disk]", name);
+            let resp = client
+                .call(&closeclaw::admin::AdminRequest::SkillList)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+            match resp {
+                closeclaw::admin::AdminResponse::SkillListResult { skills } => {
+                    if skills.is_empty() {
+                        println!("Installed skills:\n  (none)");
+                    } else {
+                        println!("Installed skills:");
+                        for s in &skills {
+                            let ver = s.version.as_deref().unwrap_or("-");
+                            println!("  {} v{}", s.name, ver);
+                        }
+                    }
                 }
-                println!("Installed skills (bundled):");
-            }
-            for s in builtin_skills_with_engine(eng).iter() {
-                println!(
-                    "  {} v{} [bundled]",
-                    s.manifest().name,
-                    s.manifest().version
-                );
+                closeclaw::admin::AdminResponse::Error { message } => {
+                    anyhow::bail!("{}", message);
+                }
+                _ => anyhow::bail!("Unexpected response from daemon"),
             }
         }
         SkillAction::Install { name } => {
-            println!("Installing skill: {}", name);
+            let resp = client
+                .call(&closeclaw::admin::AdminRequest::SkillInstall { name: name.clone() })
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+            match resp {
+                closeclaw::admin::AdminResponse::Ok => {
+                    println!("Skill '{}' installed.", name);
+                }
+                closeclaw::admin::AdminResponse::Error { message } => {
+                    anyhow::bail!("{}", message);
+                }
+                _ => anyhow::bail!("Unexpected response from daemon"),
+            }
         }
     }
     Ok(())

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -39,76 +39,90 @@ pub(crate) async fn handle_agent_with(action: AgentAction, cfg_dir: PathBuf) -> 
             .into_owned(),
     );
     match action {
-        AgentAction::List => {
-            let resp = client
-                .call(&closeclaw::admin::AdminRequest::AgentList)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
-            match resp {
-                closeclaw::admin::AdminResponse::AgentListResult { agents } => {
-                    if agents.is_empty() {
-                        println!("Agents:\n  (none)");
-                    } else {
-                        println!("Agents:");
-                        for a in &agents {
-                            let model = a.model.as_deref().unwrap_or("-");
-                            println!("  {} | {} | {}", a.id, a.name, model);
-                        }
-                    }
-                }
-                closeclaw::admin::AdminResponse::Error { message } => {
-                    anyhow::bail!("{}", message);
-                }
-                _ => anyhow::bail!("Unexpected response from daemon"),
-            }
-        }
-        AgentAction::Info { name } => {
-            let resp = client
-                .call(&closeclaw::admin::AdminRequest::AgentInfo { name: name.clone() })
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
-            match resp {
-                closeclaw::admin::AdminResponse::AgentInfoResult {
-                    id,
-                    name,
-                    model,
-                    skills,
-                } => {
-                    println!("Agent: {}", name);
-                    println!("  ID: {}", id);
-                    println!("  Model: {}", model.as_deref().unwrap_or("-"));
-                    if skills.is_empty() {
-                        println!("  Skills: (none)");
-                    } else {
-                        println!("  Skills: {}", skills.join(", "));
-                    }
-                }
-                closeclaw::admin::AdminResponse::Error { message } => {
-                    anyhow::bail!("{}", message);
-                }
-                _ => anyhow::bail!("Unexpected response from daemon"),
-            }
-        }
-        AgentAction::Create { name, model } => {
-            let resp = client
-                .call(&closeclaw::admin::AdminRequest::AgentCreate {
-                    name: name.clone(),
-                    model,
-                })
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
-            match resp {
-                closeclaw::admin::AdminResponse::Ok => {
-                    println!("Agent '{}' created.", name);
-                }
-                closeclaw::admin::AdminResponse::Error { message } => {
-                    anyhow::bail!("{}", message);
-                }
-                _ => anyhow::bail!("Unexpected response from daemon"),
-            }
-        }
+        AgentAction::List => handle_agent_list_rpc(&client).await,
+        AgentAction::Info { name } => handle_agent_info_rpc(&client, &name).await,
+        AgentAction::Create { name, model } => handle_agent_create_rpc(&client, &name, model).await,
     }
-    Ok(())
+}
+
+async fn handle_agent_list_rpc(client: &closeclaw::admin::AdminClient) -> Result<()> {
+    let resp = client
+        .call(&closeclaw::admin::AdminRequest::AgentList)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+    match resp {
+        closeclaw::admin::AdminResponse::AgentListResult { agents } => {
+            if agents.is_empty() {
+                println!("Agents:\n  (none)");
+            } else {
+                println!("Agents:");
+                for a in &agents {
+                    let model = a.model.as_deref().unwrap_or("-");
+                    println!("  {} | {} | {}", a.id, a.name, model);
+                }
+            }
+            Ok(())
+        }
+        closeclaw::admin::AdminResponse::Error { message } => {
+            anyhow::bail!("{}", message);
+        }
+        _ => anyhow::bail!("Unexpected response from daemon"),
+    }
+}
+
+async fn handle_agent_info_rpc(client: &closeclaw::admin::AdminClient, name: &str) -> Result<()> {
+    let resp = client
+        .call(&closeclaw::admin::AdminRequest::AgentInfo {
+            name: name.to_string(),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+    match resp {
+        closeclaw::admin::AdminResponse::AgentInfoResult {
+            id,
+            name,
+            model,
+            skills,
+        } => {
+            println!("Agent: {}", name);
+            println!("  ID: {}", id);
+            println!("  Model: {}", model.as_deref().unwrap_or("-"));
+            if skills.is_empty() {
+                println!("  Skills: (none)");
+            } else {
+                println!("  Skills: {}", skills.join(", "));
+            }
+            Ok(())
+        }
+        closeclaw::admin::AdminResponse::Error { message } => {
+            anyhow::bail!("{}", message);
+        }
+        _ => anyhow::bail!("Unexpected response from daemon"),
+    }
+}
+
+async fn handle_agent_create_rpc(
+    client: &closeclaw::admin::AdminClient,
+    name: &str,
+    model: Option<String>,
+) -> Result<()> {
+    let resp = client
+        .call(&closeclaw::admin::AdminRequest::AgentCreate {
+            name: name.to_string(),
+            model,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {}", e))?;
+    match resp {
+        closeclaw::admin::AdminResponse::Ok => {
+            println!("Agent '{}' created.", name);
+            Ok(())
+        }
+        closeclaw::admin::AdminResponse::Error { message } => {
+            anyhow::bail!("{}", message);
+        }
+        _ => anyhow::bail!("Unexpected response from daemon"),
+    }
 }
 
 pub async fn handle_config(action: ConfigAction) -> Result<()> {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -29,8 +29,12 @@ pub(crate) fn config_dir_for(home: impl AsRef<std::path::Path>) -> PathBuf {
 }
 
 pub async fn handle_agent(action: AgentAction) -> Result<()> {
+    handle_agent_with(action, config_dir()).await
+}
+
+pub(crate) async fn handle_agent_with(action: AgentAction, cfg_dir: PathBuf) -> Result<()> {
     let client = closeclaw::admin::AdminClient::new(
-        closeclaw::admin::client::admin_socket_path(&config_dir())
+        closeclaw::admin::client::admin_socket_path(&cfg_dir)
             .to_string_lossy()
             .into_owned(),
     );
@@ -253,8 +257,12 @@ pub(crate) async fn handle_rule_with(action: RuleAction, config_dir: PathBuf) ->
 }
 
 pub async fn handle_skill(action: SkillAction) -> Result<()> {
+    handle_skill_with(action, config_dir()).await
+}
+
+pub(crate) async fn handle_skill_with(action: SkillAction, cfg_dir: PathBuf) -> Result<()> {
     let client = closeclaw::admin::AdminClient::new(
-        closeclaw::admin::client::admin_socket_path(&config_dir())
+        closeclaw::admin::client::admin_socket_path(&cfg_dir)
             .to_string_lossy()
             .into_owned(),
     );

--- a/src/handlers_tests.rs
+++ b/src/handlers_tests.rs
@@ -318,3 +318,162 @@ async fn test_rule_list_no_file() {
         result
     );
 }
+
+// ---------------------------------------------------------------------------
+// agent / skill handler tests via mock admin server
+// ---------------------------------------------------------------------------
+
+use std::sync::Arc;
+
+/// Create a temp config dir with the required sub-structure for AdminServer.
+fn setup_admin_config_dir() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = config_dir_for(tmp.path());
+    let config_sub = config_dir.join("config");
+    fs::create_dir_all(&config_sub).unwrap();
+    fs::write(config_sub.join("agents.json"), r#"{"agents": []}"#).unwrap();
+    (tmp, config_dir)
+}
+
+/// Start an AdminServer in the background, return (config_dir, join_handle).
+async fn start_mock_server(config_dir: PathBuf) -> (PathBuf, tokio::task::JoinHandle<()>) {
+    let sock_path = config_dir.join("admin.sock");
+    let config_manager =
+        Arc::new(closeclaw::config::ConfigManager::new(config_dir.clone()).unwrap());
+    let context = closeclaw::admin::server::AdminContext {
+        agent_registry: Arc::new(closeclaw::agent::registry::AgentRegistry::new()),
+        skill_registry: Arc::new(std::sync::RwLock::new(Some(
+            closeclaw::skills::DiskSkillRegistry::default(),
+        ))),
+        config_manager,
+        config_dir: config_dir.clone(),
+    };
+    let server = closeclaw::admin::AdminServer::new(sock_path, context);
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    // Give the server a moment to bind
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (config_dir, handle)
+}
+
+// --- Agent handler tests ---------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_agent_list_empty() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    let result = handle_agent_with(AgentAction::List, config_dir).await;
+    assert!(result.is_ok(), "agent list should succeed: {:?}", result);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_handle_agent_list_with_agents() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    // Create an agent first
+    let create_result = handle_agent_with(
+        AgentAction::Create {
+            name: "test-agent".into(),
+            model: Some("gpt-4".into()),
+        },
+        config_dir.clone(),
+    )
+    .await;
+    assert!(
+        create_result.is_ok(),
+        "agent create should succeed: {:?}",
+        create_result
+    );
+    // Now list agents
+    let result = handle_agent_with(AgentAction::List, config_dir).await;
+    assert!(result.is_ok(), "agent list should succeed: {:?}", result);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_handle_agent_info_found() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    // Create an agent
+    handle_agent_with(
+        AgentAction::Create {
+            name: "info-agent".into(),
+            model: None,
+        },
+        config_dir.clone(),
+    )
+    .await
+    .unwrap();
+    // Get info
+    let result = handle_agent_with(
+        AgentAction::Info {
+            name: "info-agent".into(),
+        },
+        config_dir,
+    )
+    .await;
+    assert!(result.is_ok(), "agent info should succeed: {:?}", result);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_handle_agent_info_not_found() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    let result = handle_agent_with(
+        AgentAction::Info {
+            name: "nonexistent".into(),
+        },
+        config_dir,
+    )
+    .await;
+    assert!(result.is_err(), "agent info for missing agent should fail");
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_handle_agent_create() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    let result = handle_agent_with(
+        AgentAction::Create {
+            name: "new-agent".into(),
+            model: Some("claude-3".into()),
+        },
+        config_dir,
+    )
+    .await;
+    assert!(result.is_ok(), "agent create should succeed: {:?}", result);
+    handle.abort();
+}
+
+// --- Skill handler tests ---------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_skill_list_empty() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    let result = handle_skill_with(SkillAction::List, config_dir).await;
+    assert!(result.is_ok(), "skill list should succeed: {:?}", result);
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_handle_skill_install_not_found() {
+    let (_tmp, config_dir) = setup_admin_config_dir();
+    let (config_dir, handle) = start_mock_server(config_dir).await;
+    let result = handle_skill_with(
+        SkillAction::Install {
+            name: "missing-skill".into(),
+        },
+        config_dir,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "skill install for missing skill should fail"
+    );
+    handle.abort();
+}

--- a/src/handlers_tests.rs
+++ b/src/handlers_tests.rs
@@ -352,8 +352,14 @@ async fn start_mock_server(config_dir: PathBuf) -> (PathBuf, tokio::task::JoinHa
     let handle = tokio::spawn(async move {
         let _ = server.serve().await;
     });
-    // Give the server a moment to bind
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Poll until the socket is ready
+    let sock_path = config_dir.join("admin.sock");
+    for _ in 0..50 {
+        if tokio::net::UnixStream::connect(&sock_path).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
     (config_dir, handle)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! - **Gateway**: IM protocol adapters (Feishu, Wecom, QQ, DingTalk, etc.)
 //! - **Config System**: Hot-reloadable JSON configs with validation and rollback
 
+pub mod admin;
 pub mod agent;
 pub mod cli;
 pub mod config;


### PR DESCRIPTION
Implement admin RPC infrastructure for agent/skill commands via Unix domain socket, aligning with docs/design/cli/admin.md.

- Admin RPC protocol (AdminRequest/AdminResponse) with length-prefixed JSON over UDS
- AdminServer listening on ~/.closeclaw/admin.sock, dispatching to AgentRegistry and DiskSkillRegistry
- AdminClient for CLI handlers to communicate with daemon
- Agent list/info/create and skill list/install handlers
- Daemon integration (server lifecycle, socket cleanup on shutdown)
- CLI handler integration for agent/skill subcommands
- Unit tests for protocol, server, client, and handler integration

Source: design doc
Type: feat
