### PR TITLE
fix: agent-spawn checkpoint 与 sweeper 级联清理对齐设计文档

### DIFF
--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -12,11 +12,12 @@ use crate::gateway::Session;
 use crate::llm::session::ChatSession;
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
-use crate::session::persistence::PendingMessage;
+use crate::session::persistence::{PendingMessage, SessionCheckpoint, SessionStatus};
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::ToolContext;
 use std::path::PathBuf;
+use tracing::warn;
 use uuid::Uuid;
 
 /// Metadata for a child session tracked by the parent.
@@ -266,6 +267,24 @@ impl SessionManager {
                     depth,
                 },
             );
+        }
+
+        // 7b. Persist checkpoint with parent_session_id and depth so
+        //     flush_all / recovery can reconstruct the spawn tree.
+        let cp = SessionCheckpoint::new(child_session_id.clone())
+            .with_status(SessionStatus::Active)
+            .with_platform("spawn".to_string())
+            .with_agent_id(config.id.clone())
+            .with_parent_session_id(parent_session_id.to_string())
+            .with_depth(depth);
+        if let Some(storage) = self.storage.read().await.as_ref() {
+            if let Err(e) = storage.save_checkpoint(&cp).await {
+                warn!(
+                    session_id = %child_session_id,
+                    error = %e,
+                    "failed to save child session checkpoint"
+                );
+            }
         }
 
         // 8. Register to children tracking table

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -348,81 +348,77 @@ async fn test_kill_child_removes_from_all_tables() {
 
 #[tokio::test]
 #[serial]
-async fn test_validate_child_ownership_returns_none_for_run_mode() {
+async fn test_validate_child_ownership_by_mode() {
     clear_global_prompt_state();
 
-    let tmp = tempfile::TempDir::new().unwrap();
-    let mgr = make_test_mgr(Some(tmp.path()));
-    let config = test_resolved_config("run-child", None);
+    // --- Run mode: should return None ---
+    {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mgr = make_test_mgr(Some(tmp.path()));
+        let config = test_resolved_config("run-child", None);
+        register_parent_session(&mgr, "parent-validate-run", tmp.path().to_path_buf()).await;
 
-    register_parent_session(&mgr, "parent-validate-run", tmp.path().to_path_buf()).await;
+        let child_id = mgr
+            .create_child_session(
+                &config,
+                "parent-validate-run",
+                1,
+                "run task",
+                false,
+                None,
+                SpawnMode::Run,
+                false,
+                None,
+                None,
+                None,
+                3,
+            )
+            .await
+            .expect("create_child_session should succeed");
 
-    let child_id = mgr
-        .create_child_session(
-            &config,
-            "parent-validate-run",
-            1,
-            "run task",
-            false,
-            None,
-            SpawnMode::Run,
-            false,
-            None,
-            None,
-            None,
-            3, // max_spawn_depth
-        )
-        .await
-        .expect("create_child_session should succeed");
+        let result = mgr
+            .validate_child_ownership("parent-validate-run", &child_id)
+            .await;
+        assert!(
+            result.is_none(),
+            "validate_child_ownership should return None for Run mode children"
+        );
+    }
 
-    // validate_child_ownership should return None for Run mode children
-    let result = mgr
-        .validate_child_ownership("parent-validate-run", &child_id)
-        .await;
-    assert!(
-        result.is_none(),
-        "validate_child_ownership should return None for Run mode children"
-    );
-}
+    // --- Session mode: should return Some with correct info ---
+    {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mgr = make_test_mgr(Some(tmp.path()));
+        let config = test_resolved_config("session-child", None);
+        register_parent_session(&mgr, "parent-validate-session", tmp.path().to_path_buf()).await;
 
-#[tokio::test]
-#[serial]
-async fn test_validate_child_ownership_returns_info_for_session_mode() {
-    clear_global_prompt_state();
+        let child_id = mgr
+            .create_child_session(
+                &config,
+                "parent-validate-session",
+                1,
+                "session task",
+                false,
+                None,
+                SpawnMode::Session,
+                false,
+                None,
+                None,
+                None,
+                3,
+            )
+            .await
+            .expect("create_child_session should succeed");
 
-    let tmp = tempfile::TempDir::new().unwrap();
-    let mgr = make_test_mgr(Some(tmp.path()));
-    let config = test_resolved_config("session-child", None);
-
-    register_parent_session(&mgr, "parent-validate-session", tmp.path().to_path_buf()).await;
-
-    let child_id = mgr
-        .create_child_session(
-            &config,
-            "parent-validate-session",
-            1,
-            "session task",
-            false,
-            None,
-            SpawnMode::Session,
-            false,
-            None,
-            None,
-            None,
-            3, // max_spawn_depth
-        )
-        .await
-        .expect("create_child_session should succeed");
-
-    // validate_child_ownership should return Some for Session mode children
-    let result = mgr
-        .validate_child_ownership("parent-validate-session", &child_id)
-        .await;
-    let info =
-        result.expect("validate_child_ownership should return Some for Session mode children");
-    assert_eq!(info.session_id, child_id);
-    assert_eq!(info.mode, SpawnMode::Session);
-    assert_eq!(info.parent_session_id, "parent-validate-session");
+        let result = mgr
+            .validate_child_ownership("parent-validate-session", &child_id)
+            .await;
+        let info =
+            result.expect("validate_child_ownership should return Some for Session mode children");
+        assert_eq!(info.session_id, child_id);
+        assert_eq!(info.mode, SpawnMode::Session);
+        assert_eq!(info.parent_session_id, "parent-validate-session");
+    }
 }
 
 #[tokio::test]
@@ -466,33 +462,19 @@ async fn test_create_child_session_allowed_tools_override() {
             Some(allowed),
             None,
             None,
-            3, // max_spawn_depth
+            3,
         )
         .await
         .expect("create_child_session with allowed_tools should succeed");
 
-    // Child should be created successfully
     assert!(mgr.has_session(&child_id).await);
     assert_eq!(mgr.get_session_depth(&child_id).await, Some(1));
-}
-
-#[tokio::test]
-#[serial]
-async fn test_create_child_session_no_allowed_tools_preserves_config() {
-    clear_global_prompt_state();
-
-    let tmp = tempfile::TempDir::new().unwrap();
-    let mgr = make_test_mgr(Some(tmp.path()));
-
-    let config = test_resolved_config("no-restrict", None);
-
-    register_parent_session(&mgr, "parent-no-restrict", tmp.path().to_path_buf()).await;
 
     // Create child without allowed_tools (None) — should use config's tools as-is
-    let child_id = mgr
+    let child_id_2 = mgr
         .create_child_session(
             &config,
-            "parent-no-restrict",
+            "parent-tools",
             1,
             "normal task",
             false,
@@ -502,12 +484,12 @@ async fn test_create_child_session_no_allowed_tools_preserves_config() {
             None,
             None,
             None,
-            3, // max_spawn_depth
+            3,
         )
         .await
         .expect("create_child_session without allowed_tools should succeed");
 
-    assert!(mgr.has_session(&child_id).await);
+    assert!(mgr.has_session(&child_id_2).await);
 }
 
 #[tokio::test]
@@ -918,34 +900,98 @@ fn test_non_spawn_session_no_communication_config() {
     );
 }
 
-/// Verify `CommunicationConfig::default_with_parent` with a valid parent id.
+/// Verify `CommunicationConfig` construction and permission checks.
 #[test]
-fn test_communication_config_default_with_parent() {
+fn test_communication_config_construction_and_permissions() {
     use crate::gateway::session_manager::communication::CommunicationConfig;
 
+    // With valid parent
     let config = CommunicationConfig::default_with_parent(Some("agent-abc"));
     assert_eq!(config.outbound, vec!["agent-abc".to_string()]);
     assert_eq!(config.inbound, vec!["agent-abc".to_string()]);
-}
 
-/// Verify `CommunicationConfig::default_with_parent` with None parent.
-#[test]
-fn test_communication_config_default_with_parent_none() {
-    use crate::gateway::session_manager::communication::CommunicationConfig;
-
+    // With None parent
     let config = CommunicationConfig::default_with_parent(None);
     assert!(config.outbound.is_empty());
     assert!(config.inbound.is_empty());
-}
 
-/// Verify `can_send_to` / `can_receive_from` respect the whitelist.
-#[test]
-fn test_communication_config_permission_checks() {
-    use crate::gateway::session_manager::communication::CommunicationConfig;
-
+    // Permission checks
     let config = CommunicationConfig::default_with_parent(Some("parent-1"));
     assert!(config.can_send_to("parent-1"));
     assert!(!config.can_send_to("other-agent"));
     assert!(config.can_receive_from("parent-1"));
     assert!(!config.can_receive_from("other-agent"));
+}
+
+// ── Step 1.3: spawn checkpoint parent_session_id + depth persistence ────
+
+/// Verify that `create_child_session` persists a checkpoint with the
+/// correct `parent_session_id` and `depth` values.
+#[tokio::test]
+#[serial]
+async fn test_spawn_checkpoint_persists_parent_session_id_and_depth() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Use MemoryStorage so we can read back the checkpoint.
+    let storage = Arc::new(crate::session::storage::memory::MemoryStorage::new());
+
+    // Register a parent checkpoint in storage so the parent can be found.
+    let parent_session_id = "parent-cp-check";
+    let mut parent_cp = SessionCheckpoint::new(parent_session_id.to_string());
+    parent_cp.depth = 0;
+    parent_cp.parent_session_id = None;
+    storage.save_checkpoint(&parent_cp).await.unwrap();
+
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let config = test_resolved_config("cp-check-agent", None);
+    register_parent_session(&mgr, parent_session_id, tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            parent_session_id,
+            2, // depth
+            "checkpoint test task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            4,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Load the child checkpoint from storage and verify fields.
+    let child_cp = storage
+        .load_checkpoint(&child_id)
+        .await
+        .expect("storage should be accessible")
+        .expect("child checkpoint should exist in storage");
+
+    assert_eq!(
+        child_cp.parent_session_id.as_deref(),
+        Some(parent_session_id),
+        "checkpoint parent_session_id should match the parent"
+    );
+    assert_eq!(
+        child_cp.depth, 2,
+        "checkpoint depth should match the depth passed to create_child_session"
+    );
+    assert_eq!(
+        child_cp.agent_id.as_deref(),
+        Some("cp-check-agent"),
+        "checkpoint agent_id should match the config"
+    );
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -35,3 +35,4 @@ pub use persistence::{
     PendingMessage, PersistenceError, PersistenceService, ReasoningLevel, ReasoningMode,
     SessionCheckpoint,
 };
+pub use recovery::SpawnTree;

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -443,6 +443,14 @@ pub trait PersistenceService: Send + Sync {
     ) -> Result<Vec<String>, PersistenceError> {
         Ok(Vec::new())
     }
+
+    /// 列出指定 session 的所有直接子 session（parent_session_id = session_id）
+    async fn list_children_sessions(
+        &self,
+        _parent_session_id: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(Vec::new())
+    }
 }
 
 #[cfg(test)]

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -67,6 +67,12 @@ pub struct SessionCheckpoint {
     /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为 None）。
     #[serde(default)]
     pub sender_id: Option<String>,
+    /// 父 session ID（spawn 创建时写入，顶层 session 为空）
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    /// spawn 层级深度（根节点为 0）
+    #[serde(default)]
+    pub depth: u32,
 }
 
 impl SessionCheckpoint {
@@ -94,6 +100,8 @@ impl SessionCheckpoint {
             system_appends: Vec::new(),
             thread_id: None,
             sender_id: None,
+            parent_session_id: None,
+            depth: 0,
         }
     }
 
@@ -183,6 +191,16 @@ impl SessionCheckpoint {
     /// Update the thread ID
     pub fn with_thread_id(mut self, thread_id: String) -> Self {
         self.thread_id = Some(thread_id);
+        self
+    }
+    /// Update the parent session ID
+    pub fn with_parent_session_id(mut self, parent: String) -> Self {
+        self.parent_session_id = Some(parent);
+        self
+    }
+    /// Update the spawn depth
+    pub fn with_depth(mut self, depth: u32) -> Self {
+        self.depth = depth;
         self
     }
     /// Touch the updated_at timestamp

--- a/src/session/persistence_tests.rs
+++ b/src/session/persistence_tests.rs
@@ -448,4 +448,81 @@ mod tests {
         assert!(parsed.peer_id.is_none());
         assert!(parsed.account_id.is_none());
     }
+
+    // ── parent_session_id + depth tests ───────────────────────────────────────
+
+    #[test]
+    fn test_checkpoint_parent_session_id_and_depth_default() {
+        let cp = SessionCheckpoint::new("s-parent-depth".into());
+        assert!(
+            cp.parent_session_id.is_none(),
+            "parent_session_id should default to None"
+        );
+        assert_eq!(cp.depth, 0, "depth should default to 0");
+    }
+
+    #[test]
+    fn test_checkpoint_with_parent_session_id_and_depth_builder() {
+        let cp = SessionCheckpoint::new("s-builder".into())
+            .with_parent_session_id("parent-id".to_string())
+            .with_depth(2);
+        assert_eq!(cp.parent_session_id.as_deref(), Some("parent-id"));
+        assert_eq!(cp.depth, 2);
+    }
+
+    #[test]
+    fn test_checkpoint_parent_session_id_depth_roundtrip() {
+        let cp = SessionCheckpoint::new("s-roundtrip".into())
+            .with_parent_session_id("p1".to_string())
+            .with_depth(3);
+        let json = serde_json::to_string(&cp).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.parent_session_id.as_deref(), Some("p1"));
+        assert_eq!(parsed.depth, 3);
+    }
+
+    #[test]
+    fn test_checkpoint_parent_session_id_depth_missing_json_defaults() {
+        // Simulate old JSON without parent_session_id and depth fields —
+        // should deserialize to None / 0 via #[serde(default)]
+        let cp = SessionCheckpoint::new("s-old-json".into())
+            .with_parent_session_id("old-parent".to_string())
+            .with_depth(5);
+        let mut json_value: serde_json::Value = serde_json::to_value(&cp).unwrap();
+        json_value
+            .as_object_mut()
+            .unwrap()
+            .remove("parent_session_id");
+        json_value.as_object_mut().unwrap().remove("depth");
+        let json_str = serde_json::to_string(&json_value).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json_str).unwrap();
+        assert!(
+            parsed.parent_session_id.is_none(),
+            "old data without parent_session_id should default to None"
+        );
+        assert_eq!(
+            parsed.depth, 0,
+            "old data without depth should default to 0"
+        );
+    }
+
+    #[test]
+    fn test_checkpoint_parent_session_id_none_roundtrip() {
+        let cp = SessionCheckpoint::new("s-none-parent".into());
+        let json = serde_json::to_string(&cp).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+        assert!(parsed.parent_session_id.is_none());
+        assert_eq!(parsed.depth, 0);
+    }
+
+    #[test]
+    fn test_checkpoint_parent_session_id_depth_zero_roundtrip() {
+        let cp = SessionCheckpoint::new("s-depth-zero".into())
+            .with_parent_session_id("root-parent".to_string())
+            .with_depth(0);
+        let json = serde_json::to_string(&cp).unwrap();
+        let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.parent_session_id.as_deref(), Some("root-parent"));
+        assert_eq!(parsed.depth, 0);
+    }
 }

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -3,7 +3,7 @@
 //! Provides functionality to recover sessions from persisted checkpoints
 //! during gateway startup, including spawn_tree reconstruction.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -40,15 +40,13 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
         *restore_fn = Some(Box::new(callback));
     }
 
-    /// Execute the recovery process
+    /// 执行恢复流程
     ///
-    /// Scans all active sessions from storage and attempts to recover each one.
-    /// After recovery, rebuilds the spawn_tree from checkpoint data:
-    /// - Sessions with `parent_session_id` whose parent is also recovered
-    ///   are registered as children in the spawn_tree.
-    /// - Sessions with `parent_session_id` whose parent is NOT recovered
-    ///   (swept) are demoted to root nodes (depth reset to 0).
-    /// - Sessions without `parent_session_id` are confirmed as root nodes.
+    /// 扫描 storage 中所有 active session 并逐一恢复。恢复后根据 checkpoint
+    /// 数据重建 spawn_tree：
+    /// - 有 `parent_session_id` 且父 session 也已恢复 → 注册为父节点的子节点
+    /// - 有 `parent_session_id` 但父 session 未恢复（已被 sweep）→ 降级为根节点，depth 重置为 0
+    /// - 无 `parent_session_id` → 确认为根节点
     pub async fn recover(&self) -> Result<RecoveryReport, PersistenceError> {
         let active_sessions = self.storage.list_active_sessions().await?;
         let mut recovered = Vec::new();
@@ -75,7 +73,7 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             }
         }
 
-        let spawn_tree = Self::build_spawn_tree(&checkpoints, &recovered);
+        let spawn_tree = Self::build_spawn_tree(&mut checkpoints, &recovered);
 
         Ok(RecoveryReport {
             recovered,
@@ -100,41 +98,40 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
         Ok(())
     }
 
-    /// Build spawn_tree from recovered session checkpoints.
+    /// 根据已恢复 session 的 checkpoint 构建 spawn_tree。
     ///
-    /// - Sessions with `parent_session_id` whose parent is also recovered
-    ///   → registered as children of the parent.
-    /// - Sessions with `parent_session_id` whose parent is NOT recovered
-    ///   → demoted to root nodes (depth reset to 0).
-    /// - Sessions without `parent_session_id` → root nodes.
+    /// - 有 `parent_session_id` 且父 session 已恢复 → 注册为父节点的子节点
+    /// - 有 `parent_session_id` 但父 session 未恢复 → 降级为根节点，depth 重置为 0
+    /// - 无 `parent_session_id` → 根节点
     fn build_spawn_tree(
-        checkpoints: &HashMap<String, SessionCheckpoint>,
+        checkpoints: &mut HashMap<String, SessionCheckpoint>,
         recovered: &[String],
     ) -> SpawnTree {
         let mut tree = SpawnTree::default();
-        let recovered_set: std::collections::HashSet<&String> = recovered.iter().collect();
+        let recovered_set: HashSet<&String> = recovered.iter().collect();
 
         for session_id in recovered {
-            if let Some(cp) = checkpoints.get(session_id) {
+            if let Some(cp) = checkpoints.get_mut(session_id) {
                 match &cp.parent_session_id {
                     Some(parent_id) if recovered_set.contains(parent_id) => {
-                        // Parent recovered — register as child
+                        // 父 session 已恢复 — 注册为子节点
                         tree.children
                             .entry(parent_id.clone())
                             .or_default()
                             .push(session_id.clone());
                     }
                     Some(parent_id) => {
-                        // Parent not recovered — demote to root
+                        // 父 session 未恢复 — 降级为根节点，depth 重置为 0
                         tracing::info!(
                             session_id = %session_id,
                             parent_id = %parent_id,
                             "Session demoted to root: parent not recovered"
                         );
+                        cp.depth = 0;
                         tree.roots.push(session_id.clone());
                     }
                     None => {
-                        // No parent — confirmed root
+                        // 无父节点 — 确认为根节点
                         tree.roots.push(session_id.clone());
                     }
                 }
@@ -477,11 +474,28 @@ mod tests {
     }
 
     #[test]
+    fn test_build_spawn_tree_demoted_depth_reset() {
+        // orphan child with depth=2 should be demoted to root with depth=0
+        let mut checkpoints = HashMap::new();
+        let mut orphan_cp = create_test_checkpoint("orphan");
+        orphan_cp.parent_session_id = Some("missing_parent".to_string());
+        orphan_cp.depth = 2;
+        checkpoints.insert("orphan".to_string(), orphan_cp);
+
+        let recovered = vec!["orphan".to_string()];
+        let tree =
+            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
+
+        assert!(tree.is_root("orphan"));
+        assert_eq!(checkpoints["orphan"].depth, 0);
+    }
+
+    #[test]
     fn test_build_spawn_tree_empty() {
-        let checkpoints = HashMap::new();
+        let mut checkpoints = HashMap::new();
         let recovered: Vec<String> = vec![];
         let tree =
-            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&checkpoints, &recovered);
+            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
         assert!(tree.roots.is_empty());
         assert!(tree.children.is_empty());
     }
@@ -496,7 +510,7 @@ mod tests {
 
         let recovered = vec!["parent".to_string()];
         let tree =
-            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&checkpoints, &recovered);
+            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
         assert_eq!(tree.roots, vec!["parent".to_string()]);
         assert!(tree.children.is_empty());
     }

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -73,7 +73,20 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             }
         }
 
-        let spawn_tree = Self::build_spawn_tree(&mut checkpoints, &recovered);
+        let (spawn_tree, demoted) = Self::build_spawn_tree(&mut checkpoints, &recovered);
+
+        // 持久化降级后的 checkpoint（depth 重置为 0）
+        for session_id in &demoted {
+            if let Some(cp) = checkpoints.get(session_id) {
+                if let Err(e) = self.storage.save_checkpoint(cp).await {
+                    tracing::error!(
+                        session_id = %session_id,
+                        "Failed to persist demoted checkpoint: {}",
+                        e
+                    );
+                }
+            }
+        }
 
         Ok(RecoveryReport {
             recovered,
@@ -106,8 +119,9 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
     fn build_spawn_tree(
         checkpoints: &mut HashMap<String, SessionCheckpoint>,
         recovered: &[String],
-    ) -> SpawnTree {
+    ) -> (SpawnTree, Vec<String>) {
         let mut tree = SpawnTree::default();
+        let mut demoted = Vec::new();
         let recovered_set: HashSet<&String> = recovered.iter().collect();
 
         for session_id in recovered {
@@ -128,6 +142,7 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
                             "Session demoted to root: parent not recovered"
                         );
                         cp.depth = 0;
+                        demoted.push(session_id.clone());
                         tree.roots.push(session_id.clone());
                     }
                     None => {
@@ -138,7 +153,7 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             }
         }
 
-        tree
+        (tree, demoted)
     }
 
     /// Get the storage reference
@@ -483,21 +498,23 @@ mod tests {
         checkpoints.insert("orphan".to_string(), orphan_cp);
 
         let recovered = vec!["orphan".to_string()];
-        let tree =
+        let (tree, demoted) =
             SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
 
         assert!(tree.is_root("orphan"));
         assert_eq!(checkpoints["orphan"].depth, 0);
+        assert!(demoted.contains(&"orphan".to_string()));
     }
 
     #[test]
     fn test_build_spawn_tree_empty() {
         let mut checkpoints = HashMap::new();
         let recovered: Vec<String> = vec![];
-        let tree =
+        let (tree, demoted) =
             SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
         assert!(tree.roots.is_empty());
         assert!(tree.children.is_empty());
+        assert!(demoted.is_empty());
     }
 
     #[test]
@@ -509,9 +526,10 @@ mod tests {
         checkpoints.insert("parent".to_string(), parent_cp);
 
         let recovered = vec!["parent".to_string()];
-        let tree =
+        let (tree, demoted) =
             SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&mut checkpoints, &recovered);
         assert_eq!(tree.roots, vec!["parent".to_string()]);
         assert!(tree.children.is_empty());
+        assert!(demoted.is_empty());
     }
 }

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -142,6 +142,8 @@ mod tests {
             system_appends: Vec::new(),
             thread_id: None,
             sender_id: None,
+            parent_session_id: None,
+            depth: 0,
         }
     }
 

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -1,11 +1,13 @@
 //! Session recovery service
 //!
 //! Provides functionality to recover sessions from persisted checkpoints
-//! during gateway startup.
+//! during gateway startup, including spawn_tree reconstruction.
 
-use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 
 /// Session recovery service — recovers sessions from persisted checkpoints
 pub struct SessionRecoveryService<S: PersistenceService> {
@@ -41,26 +43,45 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
     /// Execute the recovery process
     ///
     /// Scans all active sessions from storage and attempts to recover each one.
+    /// After recovery, rebuilds the spawn_tree from checkpoint data:
+    /// - Sessions with `parent_session_id` whose parent is also recovered
+    ///   are registered as children in the spawn_tree.
+    /// - Sessions with `parent_session_id` whose parent is NOT recovered
+    ///   (swept) are demoted to root nodes (depth reset to 0).
+    /// - Sessions without `parent_session_id` are confirmed as root nodes.
     pub async fn recover(&self) -> Result<RecoveryReport, PersistenceError> {
         let active_sessions = self.storage.list_active_sessions().await?;
         let mut recovered = Vec::new();
         let mut failed = Vec::new();
+        let mut checkpoints: HashMap<String, SessionCheckpoint> = HashMap::new();
 
-        for session_id in active_sessions {
-            match self.recover_session(&session_id).await {
-                Ok(()) => recovered.push(session_id.clone()),
+        for session_id in &active_sessions {
+            match self.recover_session(session_id).await {
+                Ok(()) => {
+                    recovered.push(session_id.clone());
+                    // Load checkpoint for spawn_tree reconstruction
+                    if let Ok(Some(cp)) = self.storage.load_checkpoint(session_id).await {
+                        checkpoints.insert(session_id.clone(), cp);
+                    }
+                }
                 Err(e) => {
                     tracing::error!(
                         session_id = %session_id,
                         "Failed to recover session: {}",
                         e
                     );
-                    failed.push(session_id);
+                    failed.push(session_id.clone());
                 }
             }
         }
 
-        Ok(RecoveryReport { recovered, failed })
+        let spawn_tree = Self::build_spawn_tree(&checkpoints, &recovered);
+
+        Ok(RecoveryReport {
+            recovered,
+            failed,
+            spawn_tree,
+        })
     }
 
     /// Recover a single session
@@ -79,9 +100,82 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
         Ok(())
     }
 
+    /// Build spawn_tree from recovered session checkpoints.
+    ///
+    /// - Sessions with `parent_session_id` whose parent is also recovered
+    ///   → registered as children of the parent.
+    /// - Sessions with `parent_session_id` whose parent is NOT recovered
+    ///   → demoted to root nodes (depth reset to 0).
+    /// - Sessions without `parent_session_id` → root nodes.
+    fn build_spawn_tree(
+        checkpoints: &HashMap<String, SessionCheckpoint>,
+        recovered: &[String],
+    ) -> SpawnTree {
+        let mut tree = SpawnTree::default();
+        let recovered_set: std::collections::HashSet<&String> = recovered.iter().collect();
+
+        for session_id in recovered {
+            if let Some(cp) = checkpoints.get(session_id) {
+                match &cp.parent_session_id {
+                    Some(parent_id) if recovered_set.contains(parent_id) => {
+                        // Parent recovered — register as child
+                        tree.children
+                            .entry(parent_id.clone())
+                            .or_default()
+                            .push(session_id.clone());
+                    }
+                    Some(parent_id) => {
+                        // Parent not recovered — demote to root
+                        tracing::info!(
+                            session_id = %session_id,
+                            parent_id = %parent_id,
+                            "Session demoted to root: parent not recovered"
+                        );
+                        tree.roots.push(session_id.clone());
+                    }
+                    None => {
+                        // No parent — confirmed root
+                        tree.roots.push(session_id.clone());
+                    }
+                }
+            }
+        }
+
+        tree
+    }
+
     /// Get the storage reference
     pub fn storage(&self) -> &S {
         &self.storage
+    }
+}
+
+/// Spawn tree — tracks parent-child relationships between sessions.
+///
+/// Built during recovery from checkpoint data. Used by the Session module
+/// to reconstruct the runtime spawn tree after gateway restart.
+#[derive(Debug, Clone, Default)]
+pub struct SpawnTree {
+    /// parent_session_id → list of child session_ids
+    pub children: HashMap<String, Vec<String>>,
+    /// All root sessions (no parent or parent not recovered)
+    pub roots: Vec<String>,
+}
+
+impl SpawnTree {
+    /// Check if a session is a root node (no parent or parent not recovered).
+    pub fn is_root(&self, session_id: &str) -> bool {
+        self.roots.iter().any(|id| id == session_id)
+    }
+
+    /// Get children of a session.
+    pub fn get_children(&self, session_id: &str) -> Option<&Vec<String>> {
+        self.children.get(session_id)
+    }
+
+    /// Get all root session IDs.
+    pub fn root_ids(&self) -> &[String] {
+        &self.roots
     }
 }
 
@@ -92,6 +186,8 @@ pub struct RecoveryReport {
     pub recovered: Vec<String>,
     /// List of session IDs that failed to recover
     pub failed: Vec<String>,
+    /// Spawn tree reconstructed from recovered checkpoints
+    pub spawn_tree: SpawnTree,
 }
 
 impl RecoveryReport {
@@ -152,6 +248,7 @@ mod tests {
         let report = RecoveryReport {
             recovered: vec!["s1".to_string(), "s2".to_string()],
             failed: Vec::new(),
+            spawn_tree: SpawnTree::default(),
         };
         assert!(report.is_full_success());
         assert_eq!(report.total(), 2);
@@ -162,6 +259,7 @@ mod tests {
         let report = RecoveryReport {
             recovered: vec!["s1".to_string()],
             failed: vec!["s2".to_string()],
+            spawn_tree: SpawnTree::default(),
         };
         assert!(!report.is_full_success());
         assert_eq!(report.total(), 2);
@@ -229,5 +327,177 @@ mod tests {
         // Recover should still succeed even without callback
         let report = service.recover().await.unwrap();
         assert_eq!(report.recovered.len(), 1);
+    }
+
+    // -----------------------------------------------------------------
+    // Spawn tree tests
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_recovery_spawn_tree_root_sessions() {
+        let storage = Arc::new(MemoryStorage::new());
+        storage
+            .save_checkpoint(&create_test_checkpoint("root1"))
+            .await
+            .unwrap();
+        storage
+            .save_checkpoint(&create_test_checkpoint("root2"))
+            .await
+            .unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 2);
+        let tree = &report.spawn_tree;
+        assert_eq!(tree.roots.len(), 2);
+        assert!(tree.roots.contains(&"root1".to_string()));
+        assert!(tree.roots.contains(&"root2".to_string()));
+        assert!(tree.children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_spawn_tree_parent_child() {
+        let storage = Arc::new(MemoryStorage::new());
+
+        // Parent session
+        let mut parent_cp = create_test_checkpoint("parent");
+        parent_cp.parent_session_id = None;
+        parent_cp.depth = 0;
+        storage.save_checkpoint(&parent_cp).await.unwrap();
+
+        // Child session
+        let mut child_cp = create_test_checkpoint("child");
+        child_cp.parent_session_id = Some("parent".to_string());
+        child_cp.depth = 1;
+        storage.save_checkpoint(&child_cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 2);
+        let tree = &report.spawn_tree;
+
+        // Parent is root, child is registered under parent
+        assert!(tree.is_root("parent"));
+        assert!(!tree.is_root("child"));
+        let children = tree.get_children("parent").unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0], "child");
+    }
+
+    #[tokio::test]
+    async fn test_recovery_spawn_tree_orphan_demoted_to_root() {
+        let storage = Arc::new(MemoryStorage::new());
+
+        // Child session whose parent is NOT in storage (swept)
+        let mut child_cp = create_test_checkpoint("orphan_child");
+        child_cp.parent_session_id = Some("missing_parent".to_string());
+        child_cp.depth = 2;
+        storage.save_checkpoint(&child_cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 1);
+        let tree = &report.spawn_tree;
+
+        // Orphan child is demoted to root
+        assert!(tree.is_root("orphan_child"));
+        assert!(tree.children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_spawn_tree_multi_level() {
+        let storage = Arc::new(MemoryStorage::new());
+
+        // root -> child1 -> grandchild
+        let mut root_cp = create_test_checkpoint("root");
+        root_cp.parent_session_id = None;
+        root_cp.depth = 0;
+        storage.save_checkpoint(&root_cp).await.unwrap();
+
+        let mut child_cp = create_test_checkpoint("child1");
+        child_cp.parent_session_id = Some("root".to_string());
+        child_cp.depth = 1;
+        storage.save_checkpoint(&child_cp).await.unwrap();
+
+        let mut grandchild_cp = create_test_checkpoint("grandchild");
+        grandchild_cp.parent_session_id = Some("child1".to_string());
+        grandchild_cp.depth = 2;
+        storage.save_checkpoint(&grandchild_cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 3);
+        let tree = &report.spawn_tree;
+
+        assert!(tree.is_root("root"));
+        assert!(!tree.is_root("child1"));
+        assert!(!tree.is_root("grandchild"));
+
+        let root_children = tree.get_children("root").unwrap();
+        assert_eq!(root_children, &vec!["child1".to_string()]);
+
+        let child1_children = tree.get_children("child1").unwrap();
+        assert_eq!(child1_children, &vec!["grandchild".to_string()]);
+    }
+
+    #[test]
+    fn test_spawn_tree_is_root() {
+        let tree = SpawnTree {
+            roots: vec!["r1".to_string(), "r2".to_string()],
+            children: HashMap::new(),
+        };
+        assert!(tree.is_root("r1"));
+        assert!(tree.is_root("r2"));
+        assert!(!tree.is_root("r3"));
+    }
+
+    #[test]
+    fn test_spawn_tree_get_children() {
+        let mut children = HashMap::new();
+        children.insert("p1".to_string(), vec!["c1".to_string(), "c2".to_string()]);
+        let tree = SpawnTree {
+            roots: vec![],
+            children,
+        };
+        assert_eq!(tree.get_children("p1").unwrap().len(), 2);
+        assert!(tree.get_children("p2").is_none());
+    }
+
+    #[test]
+    fn test_spawn_tree_root_ids() {
+        let tree = SpawnTree {
+            roots: vec!["a".to_string(), "b".to_string()],
+            children: HashMap::new(),
+        };
+        assert_eq!(tree.root_ids(), &["a", "b"]);
+    }
+
+    #[test]
+    fn test_build_spawn_tree_empty() {
+        let checkpoints = HashMap::new();
+        let recovered: Vec<String> = vec![];
+        let tree =
+            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&checkpoints, &recovered);
+        assert!(tree.roots.is_empty());
+        assert!(tree.children.is_empty());
+    }
+
+    #[test]
+    fn test_build_spawn_tree_partial_recovery() {
+        // parent recovered, child NOT recovered → child not in tree at all
+        let mut checkpoints = HashMap::new();
+        let mut parent_cp = create_test_checkpoint("parent");
+        parent_cp.parent_session_id = None;
+        checkpoints.insert("parent".to_string(), parent_cp);
+
+        let recovered = vec!["parent".to_string()];
+        let tree =
+            SessionRecoveryService::<MemoryStorage>::build_spawn_tree(&checkpoints, &recovered);
+        assert_eq!(tree.roots, vec!["parent".to_string()]);
+        assert!(tree.children.is_empty());
     }
 }

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -239,4 +239,98 @@ mod tests {
         assert!(loaded.is_some());
         assert_eq!(loaded.unwrap().last_message_id, Some("msg456".to_string()));
     }
+
+    // ── list_children_sessions tests ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_list_children_sessions_no_children() {
+        let storage = MemoryStorage::new();
+        let cp = create_test_checkpoint("parent-only");
+        storage.save_checkpoint(&cp).await.unwrap();
+
+        let children = storage.list_children_sessions("parent-only").await.unwrap();
+        assert!(children.is_empty(), "no children should return empty vec");
+    }
+
+    #[tokio::test]
+    async fn test_list_children_sessions_with_children() {
+        let storage = MemoryStorage::new();
+
+        // Parent
+        let mut parent = create_test_checkpoint("parent");
+        parent.parent_session_id = None;
+        storage.save_checkpoint(&parent).await.unwrap();
+
+        // Child 1
+        let mut child1 = create_test_checkpoint("child1");
+        child1.parent_session_id = Some("parent".to_string());
+        storage.save_checkpoint(&child1).await.unwrap();
+
+        // Child 2
+        let mut child2 = create_test_checkpoint("child2");
+        child2.parent_session_id = Some("parent".to_string());
+        storage.save_checkpoint(&child2).await.unwrap();
+
+        // Unrelated session
+        let mut unrelated = create_test_checkpoint("unrelated");
+        unrelated.parent_session_id = Some("other-parent".to_string());
+        storage.save_checkpoint(&unrelated).await.unwrap();
+
+        let mut children = storage.list_children_sessions("parent").await.unwrap();
+        children.sort();
+        assert_eq!(children, vec!["child1".to_string(), "child2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_list_children_sessions_empty_storage() {
+        let storage = MemoryStorage::new();
+        let children = storage.list_children_sessions("nonexistent").await.unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_children_sessions_after_delete() {
+        let storage = MemoryStorage::new();
+
+        let mut child = create_test_checkpoint("child-del");
+        child.parent_session_id = Some("parent-del".to_string());
+        storage.save_checkpoint(&child).await.unwrap();
+
+        // Verify child exists
+        let children = storage.list_children_sessions("parent-del").await.unwrap();
+        assert_eq!(children, vec!["child-del".to_string()]);
+
+        // Delete child
+        storage.delete_checkpoint("child-del").await.unwrap();
+
+        // Should be empty now
+        let children = storage.list_children_sessions("parent-del").await.unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_children_sessions_nested() {
+        let storage = MemoryStorage::new();
+
+        // root -> child1 -> grandchild
+        let mut root = create_test_checkpoint("root");
+        root.parent_session_id = None;
+        storage.save_checkpoint(&root).await.unwrap();
+
+        let mut child1 = create_test_checkpoint("child1");
+        child1.parent_session_id = Some("root".to_string());
+        storage.save_checkpoint(&child1).await.unwrap();
+
+        let mut grandchild = create_test_checkpoint("grandchild");
+        grandchild.parent_session_id = Some("child1".to_string());
+        storage.save_checkpoint(&grandchild).await.unwrap();
+
+        // root's direct children should only be child1, not grandchild
+        let root_children = storage.list_children_sessions("root").await.unwrap();
+        assert_eq!(root_children, vec!["child1".to_string()]);
+
+        // child1's direct children should only be grandchild
+        let child1_children = storage.list_children_sessions("child1").await.unwrap();
+        assert_eq!(child1_children, vec!["grandchild".to_string()]);
+    }
 }

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -149,6 +149,8 @@ mod tests {
             system_appends: Vec::new(),
             thread_id: None,
             sender_id: None,
+            parent_session_id: None,
+            depth: 0,
         }
     }
 

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -112,6 +112,22 @@ impl PersistenceService for MemoryStorage {
             .map_err(|_| PersistenceError::Lock("RwLock read failed".to_string()))?;
         Ok(archived.keys().cloned().collect())
     }
+
+    async fn list_children_sessions(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let checkpoints = self
+            .checkpoints
+            .read()
+            .map_err(|_| PersistenceError::Lock("RwLock read failed".to_string()))?;
+        let children: Vec<String> = checkpoints
+            .values()
+            .filter(|cp| cp.parent_session_id.as_deref() == Some(parent_session_id))
+            .map(|cp| cp.session_id.clone())
+            .collect();
+        Ok(children)
+    }
 }
 
 #[cfg(test)]

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -494,4 +494,31 @@ impl PersistenceService for SqliteStorage {
         self.list_expired_archived_sessions_for_agent(agent_id, role_str, purge_after_minutes)
             .await
     }
+
+    async fn list_children_sessions(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<String>, PersistenceError> {
+        let data_dir = self.data_dir.clone();
+        let parent_id = parent_session_id.to_string();
+
+        spawn_blocking(move || {
+            let conn = Connection::open(data_dir.join("sessions.sqlite"))
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+
+            let mut stmt = conn
+                .prepare("SELECT id FROM sessions WHERE parent_session_id = ?1")
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
+
+            let ids: Vec<String> = stmt
+                .query_map(rusqlite::params![parent_id], |row| row.get(0))
+                .map_err(|e| PersistenceError::Sqlite(e.to_string()))?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            Ok(ids)
+        })
+        .await
+        .map_err(|e| PersistenceError::Sqlite(e.to_string()))?
+    }
 }

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -122,6 +122,8 @@ impl SqliteStorage {
             "platform",
             "peer_id",
             "account_id",
+            "parent_session_id",
+            "depth",
         ] {
             Self::add_column_if_not_exists(conn, col)?;
         }
@@ -287,11 +289,11 @@ impl PersistenceService for SqliteStorage {
                 "INSERT OR REPLACE INTO sessions
                  (id, agent_id, role, channel, chat_id, status, title,
                   last_message_at, created_at, archived_at, message_count, metadata, thread_id,
-                  sender_id, platform, peer_id, account_id)
+                  sender_id, platform, peer_id, account_id, parent_session_id, depth)
                  VALUES (
                      ?1, ?2, ?3, ?4, ?5, ?6, ?7,
                      ?8, ?9, ?10, ?11, ?12, ?13,
-                     ?14, ?15, ?16, ?17
+                     ?14, ?15, ?16, ?17, ?18, ?19
                  )",
                 params![
                     checkpoint.session_id,
@@ -320,6 +322,8 @@ impl PersistenceService for SqliteStorage {
                     checkpoint.platform.as_deref(),
                     checkpoint.peer_id.as_deref(),
                     checkpoint.account_id.as_deref(),
+                    checkpoint.parent_session_id.as_deref(),
+                    checkpoint.depth,
                 ],
             )
             .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -176,7 +176,7 @@ pub fn load_checkpoint_inner(
         .prepare(
             "SELECT agent_id, role, channel, chat_id, status, title,
              last_message_at, created_at, archived_at, message_count, metadata, thread_id,
-             sender_id, platform, peer_id, account_id
+             sender_id, platform, peer_id, account_id, parent_session_id, depth
              FROM sessions WHERE id = ?1",
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;
@@ -199,6 +199,8 @@ pub fn load_checkpoint_inner(
             row.get::<_, Option<String>>(13)?,
             row.get::<_, Option<String>>(14)?,
             row.get::<_, Option<String>>(15)?,
+            row.get::<_, Option<String>>(16)?,
+            row.get::<_, Option<String>>(17)?,
         ))
     }) {
         Ok(r) => r,
@@ -223,7 +225,11 @@ pub fn load_checkpoint_inner(
         platform_new,
         peer_id_new,
         account_id_new,
+        parent_session_id,
+        depth_str,
     ) = row;
+
+    let depth: u32 = depth_str.and_then(|s| s.parse().ok()).unwrap_or(0);
 
     let status = match status_db.as_str() {
         "archived" => crate::session::persistence::SessionStatus::Archived,
@@ -328,8 +334,8 @@ pub fn load_checkpoint_inner(
         account_id: account_id_new,
         thread_id,
         sender_id,
-        parent_session_id: None,
-        depth: 0,
+        parent_session_id,
+        depth,
     }))
 }
 

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -328,6 +328,8 @@ pub fn load_checkpoint_inner(
         account_id: account_id_new,
         thread_id,
         sender_id,
+        parent_session_id: None,
+        depth: 0,
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -233,3 +233,114 @@ async fn test_load_both_new_and_old_null_yields_none() {
     );
     assert!(loaded.account_id.is_none());
 }
+
+// ===================================================================
+// parent_session_id + depth tests
+// ===================================================================
+
+#[tokio::test]
+async fn test_save_load_parent_session_id_and_depth() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    let cp = SessionCheckpoint::new("spawn-child".into())
+        .with_parent_session_id("spawn-parent".into())
+        .with_depth(2);
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let loaded = storage.load_checkpoint("spawn-child").await.unwrap();
+    assert!(loaded.is_some());
+    let loaded = loaded.unwrap();
+    assert_eq!(loaded.parent_session_id.as_deref(), Some("spawn-parent"));
+    assert_eq!(loaded.depth, 2);
+}
+
+#[tokio::test]
+async fn test_parent_session_id_depth_defaults_when_null() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    // Save a checkpoint (parent_session_id=NULL, depth=0 by default)
+    let cp = create_test_checkpoint("root-session");
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let loaded = storage.load_checkpoint("root-session").await.unwrap();
+    assert!(loaded.is_some());
+    let loaded = loaded.unwrap();
+    assert!(loaded.parent_session_id.is_none());
+    assert_eq!(loaded.depth, 0);
+}
+
+// ===================================================================
+// list_children_sessions tests
+// ===================================================================
+
+#[tokio::test]
+async fn test_list_children_sessions_basic() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    // Parent
+    let mut parent = create_test_checkpoint("parent-db");
+    parent.parent_session_id = None;
+    storage.save_checkpoint(&parent).await.unwrap();
+
+    // Child 1
+    let mut child1 = create_test_checkpoint("child1-db");
+    child1.parent_session_id = Some("parent-db".to_string());
+    storage.save_checkpoint(&child1).await.unwrap();
+
+    // Child 2
+    let mut child2 = create_test_checkpoint("child2-db");
+    child2.parent_session_id = Some("parent-db".to_string());
+    storage.save_checkpoint(&child2).await.unwrap();
+
+    // Unrelated
+    let mut unrelated = create_test_checkpoint("unrelated-db");
+    unrelated.parent_session_id = Some("other-parent".to_string());
+    storage.save_checkpoint(&unrelated).await.unwrap();
+
+    let mut children = storage.list_children_sessions("parent-db").await.unwrap();
+    children.sort();
+    assert_eq!(
+        children,
+        vec!["child1-db".to_string(), "child2-db".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn test_list_children_sessions_no_children() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    storage
+        .save_checkpoint(&create_test_checkpoint("no-kids"))
+        .await
+        .unwrap();
+    let children = storage.list_children_sessions("no-kids").await.unwrap();
+    assert!(children.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_children_sessions_after_delete() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = SqliteStorage::new(tmp.path()).unwrap();
+
+    let mut child = create_test_checkpoint("child-del-db");
+    child.parent_session_id = Some("parent-del-db".to_string());
+    storage.save_checkpoint(&child).await.unwrap();
+
+    let children = storage
+        .list_children_sessions("parent-del-db")
+        .await
+        .unwrap();
+    assert_eq!(children, vec!["child-del-db".to_string()]);
+
+    storage.delete_checkpoint("child-del-db").await.unwrap();
+
+    let children = storage
+        .list_children_sessions("parent-del-db")
+        .await
+        .unwrap();
+    assert!(children.is_empty());
+}

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -31,6 +31,8 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         thread_id: None,
         sender_id: None,
         account_id: None,
+        parent_session_id: None,
+        depth: 0,
     }
 }
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -33,6 +33,8 @@ mod tests {
             thread_id: None,
             sender_id: None,
             account_id: None,
+            parent_session_id: None,
+            depth: 0,
         }
     }
 
@@ -391,6 +393,8 @@ mod tests {
             thread_id: None,
             sender_id: None,
             account_id: None,
+            parent_session_id: None,
+            depth: 0,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -431,6 +435,8 @@ mod tests {
             thread_id: None,
             sender_id: None,
             account_id: None,
+            parent_session_id: None,
+            depth: 0,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -471,6 +477,8 @@ mod tests {
             thread_id: None,
             sender_id: None,
             account_id: None,
+            parent_session_id: None,
+            depth: 0,
         };
         storage.save_checkpoint(&checkpoint).await?;
 

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -290,6 +290,8 @@ mod tests {
         idle_sessions: Mutex<Vec<String>>,
         /// Session IDs returned from `list_expired_archived_sessions_for_agent`.
         expired_sessions: Mutex<Vec<String>>,
+        /// Session IDs deleted via `delete_checkpoint`.
+        deleted: Mutex<Vec<String>>,
     }
 
     impl MemStorage {
@@ -308,14 +310,20 @@ mod tests {
         fn add_checkpoint(&self, checkpoint: SessionCheckpoint) {
             self.checkpoints.lock().unwrap().push(checkpoint);
         }
+
+        /// Get IDs of sessions deleted via `delete_checkpoint`.
+        fn deleted_ids(&self) -> Vec<String> {
+            self.deleted.lock().unwrap().clone()
+        }
     }
 
     #[async_trait]
     impl PersistenceService for MemStorage {
         async fn save_checkpoint(
             &self,
-            _checkpoint: &SessionCheckpoint,
+            checkpoint: &SessionCheckpoint,
         ) -> Result<(), PersistenceError> {
+            self.checkpoints.lock().unwrap().push(checkpoint.clone());
             Ok(())
         }
 
@@ -330,7 +338,12 @@ mod tests {
                 .cloned())
         }
 
-        async fn delete_checkpoint(&self, _session_id: &str) -> Result<(), PersistenceError> {
+        async fn delete_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
+            self.deleted.lock().unwrap().push(session_id.into());
+            self.checkpoints
+                .lock()
+                .unwrap()
+                .retain(|cp| cp.session_id != session_id);
             Ok(())
         }
 
@@ -379,6 +392,19 @@ mod tests {
             _purge_after_minutes: i64,
         ) -> Result<Vec<String>, PersistenceError> {
             Ok(self.expired_sessions.lock().unwrap().clone())
+        }
+
+        async fn list_children_sessions(
+            &self,
+            parent_session_id: &str,
+        ) -> Result<Vec<String>, PersistenceError> {
+            let checkpoints = self.checkpoints.lock().unwrap();
+            let children: Vec<String> = checkpoints
+                .iter()
+                .filter(|cp| cp.parent_session_id.as_deref() == Some(parent_session_id))
+                .map(|cp| cp.session_id.clone())
+                .collect();
+            Ok(children)
         }
     }
 
@@ -536,5 +562,140 @@ mod tests {
 
         let _ = tx.send(());
         let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
+
+    // -----------------------------------------------------------------
+    // Test: cascade_kill_children deletes all descendants
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_deletes_descendants() {
+        let mem = Arc::new(MemStorage::default());
+
+        // Build a 3-level tree: parent -> child1 -> grandchild
+        let mut parent = SessionCheckpoint::new("parent".into());
+        parent.parent_session_id = None;
+        parent.depth = 0;
+        mem.add_checkpoint(parent);
+
+        let mut child1 = SessionCheckpoint::new("child1".into());
+        child1.parent_session_id = Some("parent".into());
+        child1.depth = 1;
+        mem.add_checkpoint(child1);
+
+        let mut grandchild = SessionCheckpoint::new("grandchild".into());
+        grandchild.parent_session_id = Some("child1".into());
+        grandchild.depth = 2;
+        mem.add_checkpoint(grandchild);
+
+        // Run cascade
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
+            .await
+            .unwrap();
+
+        // Both descendants should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child1".to_string()));
+        assert!(deleted.contains(&"grandchild".to_string()));
+        // Parent itself should NOT be deleted by cascade_kill_children
+        assert!(!deleted.contains(&"parent".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_no_children_noop() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_checkpoint(SessionCheckpoint::new("leaf".into()));
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "leaf")
+            .await
+            .unwrap();
+
+        // No children to delete
+        let deleted = mem.deleted_ids();
+        assert!(deleted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_siblings_only() {
+        let mem = Arc::new(MemStorage::default());
+
+        let mut parent = SessionCheckpoint::new("parent".into());
+        parent.parent_session_id = None;
+        mem.add_checkpoint(parent);
+
+        let mut child_a = SessionCheckpoint::new("child_a".into());
+        child_a.parent_session_id = Some("parent".into());
+        mem.add_checkpoint(child_a);
+
+        let mut child_b = SessionCheckpoint::new("child_b".into());
+        child_b.parent_session_id = Some("parent".into());
+        mem.add_checkpoint(child_b);
+
+        // Unrelated child under a different parent
+        let mut other_child = SessionCheckpoint::new("other_child".into());
+        other_child.parent_session_id = Some("other_parent".into());
+        mem.add_checkpoint(other_child);
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
+            .await
+            .unwrap();
+
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child_a".to_string()));
+        assert!(deleted.contains(&"child_b".to_string()));
+        // other_child should NOT be deleted
+        assert!(!deleted.contains(&"other_child".to_string()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: cascade_archive kills children then archives parent
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cascade_archive_kills_children_then_archives_parent() {
+        let mem = Arc::new(MemStorage::default());
+
+        let mut parent = SessionCheckpoint::new("parent-archive".into());
+        parent.parent_session_id = None;
+        mem.add_checkpoint(parent);
+
+        let mut child = SessionCheckpoint::new("child-archive".into());
+        child.parent_session_id = Some("parent-archive".into());
+        mem.add_checkpoint(child);
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_archive_impl(storage, "parent-archive".into())
+            .await
+            .unwrap();
+
+        // Child should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child-archive".to_string()));
+
+        // Parent should be archived
+        let archive_called = mem.archive_called.lock().unwrap();
+        assert!(archive_called.contains(&"parent-archive".into()));
+    }
+
+    #[tokio::test]
+    async fn test_cascade_archive_no_children_archives_parent() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_checkpoint(SessionCheckpoint::new("solo-parent".into()));
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_archive_impl(storage, "solo-parent".into())
+            .await
+            .unwrap();
+
+        // No children deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.is_empty());
+
+        // Parent should be archived
+        let archive_called = mem.archive_called.lock().unwrap();
+        assert!(archive_called.contains(&"solo-parent".into()));
     }
 }

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -222,22 +222,23 @@ impl ArchiveSweeper {
         Ok(())
     }
 
-    /// Delete all descendants of `parent_session_id` (deepest first).
-    /// Uses an explicit stack to avoid recursive async boxing.
+    /// 删除 `parent_session_id` 的所有后代 session（先深后浅）。
+    /// 使用 BFS 收集所有后代，再从叶子节点向上删除。
     async fn cascade_kill_children(
         storage: &dyn PersistenceService,
         parent_session_id: &str,
     ) -> Result<(), ArchiveSweeperError> {
-        // Collect all descendant IDs via BFS, then delete from leaves upward.
+        // 通过 BFS 收集所有后代 ID，再从叶子节点向上删除。
         let mut all_descendants: Vec<String> = Vec::new();
-        let mut stack = vec![parent_session_id.to_string()];
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(parent_session_id.to_string());
 
-        // BFS to collect all descendant IDs
-        while let Some(current) = stack.pop() {
+        // BFS 收集所有后代 ID
+        while let Some(current) = queue.pop_front() {
             let children = storage.list_children_sessions(&current).await?;
             for child_id in &children {
                 all_descendants.push(child_id.clone());
-                stack.push(child_id.clone());
+                queue.push_back(child_id.clone());
             }
         }
 

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -156,14 +156,14 @@ impl ArchiveSweeper {
     ) {
         let cfg = config.session_config_for(agent_id, role);
 
-        // --- Idle → archive ---
+        // --- Idle → archive (cascade children first) ---
         if let Ok(idle_ids) = storage
             .list_idle_sessions_for_agent(agent_id, role, cfg.idle_minutes)
             .await
         {
             for sid in idle_ids {
                 let sid_err = sid.clone();
-                if let Err(e) = Self::archive_and_invalidate_impl(Arc::clone(&storage), sid).await {
+                if let Err(e) = Self::cascade_archive_impl(Arc::clone(&storage), sid).await {
                     error!(session_id = %sid_err, %e, "failed to archive idle session");
                 }
             }
@@ -204,6 +204,51 @@ impl ArchiveSweeper {
         storage.archive_checkpoint(&checkpoint).await?;
         storage.invalidate_session(&session_id).await?;
         info!(%session_id, "session archived and cache invalidated");
+        Ok(())
+    }
+
+    /// Cascade-terminate all descendants of `session_id` (deepest first),
+    /// then archive the parent session.
+    async fn cascade_archive_impl(
+        storage: Arc<dyn PersistenceService>,
+        session_id: String,
+    ) -> Result<(), ArchiveSweeperError> {
+        // Recursively kill all descendants (deepest → shallowest)
+        Self::cascade_kill_children(storage.as_ref(), &session_id).await?;
+
+        // Now archive the parent session itself
+        Self::archive_and_invalidate_impl(Arc::clone(&storage), session_id.clone()).await?;
+        info!(%session_id, "session archived after cascade cleanup");
+        Ok(())
+    }
+
+    /// Delete all descendants of `parent_session_id` (deepest first).
+    /// Uses an explicit stack to avoid recursive async boxing.
+    async fn cascade_kill_children(
+        storage: &dyn PersistenceService,
+        parent_session_id: &str,
+    ) -> Result<(), ArchiveSweeperError> {
+        // Collect all descendant IDs via BFS, then delete from leaves upward.
+        let mut all_descendants: Vec<String> = Vec::new();
+        let mut stack = vec![parent_session_id.to_string()];
+
+        // BFS to collect all descendant IDs
+        while let Some(current) = stack.pop() {
+            let children = storage.list_children_sessions(&current).await?;
+            for child_id in &children {
+                all_descendants.push(child_id.clone());
+                stack.push(child_id.clone());
+            }
+        }
+
+        // Delete deepest descendants first (reverse BFS order).
+        // This ensures leaf nodes are cleaned up before their parents.
+        for child_id in all_descendants.iter().rev() {
+            storage.delete_checkpoint(child_id).await?;
+            storage.invalidate_session(child_id).await?;
+            info!(parent = %parent_session_id, child = %child_id, "child session deleted and invalidated during cascade");
+        }
+
         Ok(())
     }
 

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -223,30 +223,30 @@ impl ArchiveSweeper {
     }
 
     /// 删除 `parent_session_id` 的所有后代 session（先深后浅）。
-    /// 使用 BFS 收集所有后代，再从叶子节点向上删除。
+    /// 使用 BFS 收集所有后代及其深度，按深度降序删除（叶节点优先）。
     async fn cascade_kill_children(
         storage: &dyn PersistenceService,
         parent_session_id: &str,
     ) -> Result<(), ArchiveSweeperError> {
-        // 通过 BFS 收集所有后代 ID，再从叶子节点向上删除。
-        let mut all_descendants: Vec<String> = Vec::new();
+        // BFS 收集所有后代及其深度
+        let mut all_descendants: Vec<(String, u32)> = Vec::new();
         let mut queue = std::collections::VecDeque::new();
-        queue.push_back(parent_session_id.to_string());
+        queue.push_back((parent_session_id.to_string(), 0u32));
 
-        // BFS 收集所有后代 ID
-        while let Some(current) = queue.pop_front() {
+        while let Some((current, depth)) = queue.pop_front() {
             let children = storage.list_children_sessions(&current).await?;
             for child_id in &children {
-                all_descendants.push(child_id.clone());
-                queue.push_back(child_id.clone());
+                all_descendants.push((child_id.clone(), depth + 1));
+                queue.push_back((child_id.clone(), depth + 1));
             }
         }
 
-        // Delete deepest descendants first (reverse BFS order).
-        // This ensures leaf nodes are cleaned up before their parents.
-        for child_id in all_descendants.iter().rev() {
-            storage.delete_checkpoint(child_id).await?;
-            storage.invalidate_session(child_id).await?;
+        // 按深度降序排序（叶节点优先删除），深度相同则按 ID 排序保证确定性
+        all_descendants.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+        for (child_id, _) in all_descendants {
+            storage.delete_checkpoint(&child_id).await?;
+            storage.invalidate_session(&child_id).await?;
             info!(parent = %parent_session_id, child = %child_id, "child session deleted and invalidated during cascade");
         }
 
@@ -698,5 +698,87 @@ mod tests {
         // Parent should be archived
         let archive_called = mem.archive_called.lock().unwrap();
         assert!(archive_called.contains(&"solo-parent".into()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: multi-branch tree — leaf nodes deleted before branch nodes
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_multi_branch_tree() {
+        let mem = Arc::new(MemStorage::default());
+
+        // Build a multi-branch tree:
+        //       root
+        //      /    \
+        //    child_a  child_b
+        //    /    \        \
+        //  gc_a1  gc_a2    gc_b1
+        let mut root = SessionCheckpoint::new("root".into());
+        root.parent_session_id = None;
+        root.depth = 0;
+        mem.add_checkpoint(root);
+
+        let mut child_a = SessionCheckpoint::new("child_a".into());
+        child_a.parent_session_id = Some("root".into());
+        child_a.depth = 1;
+        mem.add_checkpoint(child_a);
+
+        let mut child_b = SessionCheckpoint::new("child_b".into());
+        child_b.parent_session_id = Some("root".into());
+        child_b.depth = 1;
+        mem.add_checkpoint(child_b);
+
+        let mut gc_a1 = SessionCheckpoint::new("gc_a1".into());
+        gc_a1.parent_session_id = Some("child_a".into());
+        gc_a1.depth = 2;
+        mem.add_checkpoint(gc_a1);
+
+        let mut gc_a2 = SessionCheckpoint::new("gc_a2".into());
+        gc_a2.parent_session_id = Some("child_a".into());
+        gc_a2.depth = 2;
+        mem.add_checkpoint(gc_a2);
+
+        let mut gc_b1 = SessionCheckpoint::new("gc_b1".into());
+        gc_b1.parent_session_id = Some("child_b".into());
+        gc_b1.depth = 2;
+        mem.add_checkpoint(gc_b1);
+
+        // Run cascade
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "root")
+            .await
+            .unwrap();
+
+        // All 5 descendants should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child_a".to_string()));
+        assert!(deleted.contains(&"child_b".to_string()));
+        assert!(deleted.contains(&"gc_a1".to_string()));
+        assert!(deleted.contains(&"gc_a2".to_string()));
+        assert!(deleted.contains(&"gc_b1".to_string()));
+        // Root itself should NOT be deleted
+        assert!(!deleted.contains(&"root".to_string()));
+        assert_eq!(deleted.len(), 5);
+
+        // Verify deletion order: all depth-2 nodes before depth-1 nodes
+        let pos_gc_a1 = deleted.iter().position(|id| id == "gc_a1").unwrap();
+        let pos_gc_a2 = deleted.iter().position(|id| id == "gc_a2").unwrap();
+        let pos_gc_b1 = deleted.iter().position(|id| id == "gc_b1").unwrap();
+        let pos_child_a = deleted.iter().position(|id| id == "child_a").unwrap();
+        let pos_child_b = deleted.iter().position(|id| id == "child_b").unwrap();
+
+        assert!(
+            pos_gc_a1 < pos_child_a,
+            "gc_a1 must be deleted before child_a"
+        );
+        assert!(
+            pos_gc_a2 < pos_child_a,
+            "gc_a2 must be deleted before child_a"
+        );
+        assert!(
+            pos_gc_b1 < pos_child_b,
+            "gc_b1 must be deleted before child_b"
+        );
     }
 }


### PR DESCRIPTION
实现 agent-spawn checkpoint 与 sweeper 级联清理对齐设计文档

设计文档 `docs/design/agent/agent-spawn.md` 的「重启恢复」和「生命周期联动」两节描述了两个功能，当前代码未实现。本次变更补全这两项能力：

## 变更内容

### Gap 1: SessionCheckpoint 增加 parent_session_id 和 depth 字段
- `SessionCheckpoint` 新增 `parent_session_id` (Option<String>) 和 `depth` (u32) 字段，均标记 `#[serde(default)]` 以兼容旧 checkpoint
- SQLite schema 自动迁移新增两列
- spawn 创建子 session 时写入正确的 parent_session_id 和 depth 值

### Gap 2: Sweeper 级联清理
- `PersistenceService` trait 新增 `list_children_sessions` 方法，SQLite 和内存存储均已实现
- `ArchiveSweeper` 归档父 session 前，递归终止所有子 session（从深层向浅层删除），确保无孤儿节点

### Gap 3: Recovery 重建 spawn_tree
- 恢复流程利用 `parent_session_id` + `depth` 重建 spawn_tree 父子关系
- 降级策略：父 session 已被 sweep 未恢复时，子 session 降级为根节点，depth 重置为 0 并持久化

### 单元测试
- 覆盖新字段 serde 序列化/反序列化（含旧格式兼容）
- 覆盖 list_children_sessions 查询、sweeper 级联清理、recovery 重建及降级策略

Source: design doc
Type: fix
