### PR TITLE
feat: align agent-spawn with design doc — depth budget propagation, kill all-mode, cascade termination

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,3 +7,7 @@ pub mod spawn;
 #[cfg(test)]
 #[path = "spawn_tests.rs"]
 mod spawn_tests;
+
+#[cfg(test)]
+#[path = "spawn_budget_tests.rs"]
+mod spawn_budget_tests;

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -127,12 +127,29 @@ impl SpawnController {
             )
         };
 
-        // 6. Depth check — effective max = min(child.max_spawn_depth, parent.max_spawn_depth - 1)
+        // 6. Depth check — read the parent's effective budget from
+        //    its checkpoint (persisted by create_child_session).  For
+        //    root sessions or legacy checkpoints without the field,
+        //    fall back to the config value.
+        let parent_effective_budget = self
+            .session_manager
+            .get_effective_max_spawn_depth(parent_session_id)
+            .await
+            .unwrap_or(max_spawn_depth);
+
+        if parent_effective_budget == 0 {
+            return Err(SpawnError::DepthExceeded {
+                current: parent_depth + 1,
+                max: 0,
+            });
+        }
+
+        // effective = min(child.max_spawn_depth, parent_effective_budget - 1)
         let child_max_spawn_depth = target_config
             .as_ref()
             .map(|c| c.subagents.max_spawn_depth)
             .unwrap_or(1);
-        let effective_max = child_max_spawn_depth.min(max_spawn_depth.saturating_sub(1));
+        let effective_max = child_max_spawn_depth.min(parent_effective_budget.saturating_sub(1));
         let child_depth = parent_depth + 1;
         if child_depth > effective_max {
             return Err(SpawnError::DepthExceeded {

--- a/src/agent/spawn_budget_tests.rs
+++ b/src/agent/spawn_budget_tests.rs
@@ -1,0 +1,894 @@
+//! Unit tests for spawn depth budget propagation, kill all-mode, and
+//! cascade termination (Step 1.5).
+
+use std::sync::Arc;
+
+use crate::agent::config::SubagentsConfig;
+use crate::agent::spawn::{SpawnController, SpawnError};
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::config::ConfigManager;
+use crate::gateway::session_manager::{ChildSessionInfo, SpawnMode};
+use crate::gateway::{DmScope, GatewayConfig, SessionManager};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{PersistenceService, SessionCheckpoint};
+use crate::session::storage::memory::MemoryStorage;
+use crate::session::ReasoningLevel;
+
+// ---------------------------------------------------------------------------
+// Helpers (duplicated from spawn_tests.rs to keep this file self-contained)
+// ---------------------------------------------------------------------------
+
+fn test_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    }
+}
+
+fn make_config_manager() -> ConfigManager {
+    let tmp = tempfile::tempdir().expect("tempdir should be created");
+    ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed")
+}
+
+fn make_agent(id: &str, subagents: SubagentsConfig) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents,
+        source: ConfigSource::User,
+    }
+}
+
+async fn setup_parent_session(mgr: &SessionManager, agent_id: &str) -> String {
+    let msg = crate::gateway::Message {
+        id: format!("msg-{}", agent_id),
+        from: "user".to_string(),
+        to: agent_id.to_string(),
+        content: "hi".to_string(),
+        channel: "test-channel".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+        thread_id: None,
+    };
+    mgr.find_or_create("test-channel", &msg, None)
+        .await
+        .expect("find_or_create should succeed")
+}
+
+fn inject_agents(cm: &ConfigManager, agents: Vec<(&str, ResolvedAgentConfig)>) {
+    let mut map = cm.agents.write().expect("agents RwLock poisoned");
+    for (id, cfg) in agents {
+        map.insert(id.to_string(), cfg);
+    }
+}
+
+fn make_session_manager_with_memory_storage() -> (Arc<SessionManager>, Arc<MemoryStorage>) {
+    let storage = Arc::new(MemoryStorage::new());
+    let mgr = Arc::new(SessionManager::new(
+        &test_config(),
+        Some(storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    (mgr, storage)
+}
+
+async fn save_checkpoint_with_budget(
+    storage: &MemoryStorage,
+    session_id: &str,
+    depth: u32,
+    effective_budget: Option<u32>,
+    parent_session_id: Option<&str>,
+) {
+    let mut cp = SessionCheckpoint::new(session_id.to_string())
+        .with_depth(depth)
+        .with_effective_max_spawn_depth(effective_budget);
+    if let Some(pid) = parent_session_id {
+        cp = cp.with_parent_session_id(pid.to_string());
+    }
+    storage.save_checkpoint(&cp).await.unwrap();
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Step 1.5: Depth budget propagation tests
+// ══════════════════════════════════════════════════════════════════════
+
+/// Multi-level depth budget propagation:
+/// root(maxSpawnDepth=3) → child1(maxSpawnDepth=5, effective=2)
+/// → child2 rejected (child_depth=2 > effective_max=1)
+#[tokio::test]
+async fn test_depth_budget_propagation_multilevel() {
+    let cm = Arc::new(make_config_manager());
+    let (sm, mem_storage) = make_session_manager_with_memory_storage();
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    // Root: maxSpawnDepth=3
+    let mut root_sub = SubagentsConfig::default();
+    root_sub.max_spawn_depth = 3;
+    let root = make_agent("root", root_sub);
+    let root_id = setup_parent_session(&sm, "root").await;
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(3), None).await;
+
+    // child1: maxSpawnDepth=5 — effective = min(5, 3-1) = 2
+    let mut child1_sub = SubagentsConfig::default();
+    child1_sub.max_spawn_depth = 5;
+    let child1 = make_agent("child1", child1_sub);
+    inject_agents(&cm, vec![("root", root), ("child1", child1)]);
+
+    let result1 = controller
+        .validate(&root_id, Some("child1"))
+        .await
+        .expect("should pass: effective=2, child_depth=1");
+    assert_eq!(result1.effective_max_spawn_depth, 2);
+
+    // Simulate child1 created with effective budget = 2
+    let child1_session_id = "child1-session-id";
+    sm.sessions.write().await.insert(
+        child1_session_id.to_string(),
+        crate::gateway::Session {
+            id: child1_session_id.to_string(),
+            agent_id: "child1".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    sm.register_child(
+        &root_id,
+        ChildSessionInfo {
+            session_id: child1_session_id.to_string(),
+            parent_session_id: root_id.to_string(),
+            agent_id: "child1".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child1_session_id, 1, Some(2), Some(&root_id)).await;
+
+    // child2: maxSpawnDepth=5 — effective = min(5, 2-1) = 1
+    // child_depth=2 > effective_max=1 → DepthExceeded (correct behavior)
+    let mut child2_sub = SubagentsConfig::default();
+    child2_sub.max_spawn_depth = 5;
+    let child2 = make_agent("child2", child2_sub);
+    inject_agents(&cm, vec![("child2", child2)]);
+
+    let err = controller
+        .validate(child1_session_id, Some("child2"))
+        .await
+        .expect_err("should reject: child_depth=2 > effective_max=1");
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 2);
+            assert_eq!(max, 1);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+/// Spawn rejected when effective budget ≤ 0.
+/// root(maxSpawnDepth=3) → child1(effective=1) → child2(effective=0) rejected
+#[tokio::test]
+async fn test_depth_budget_rejected_when_effective_zero() {
+    let cm = Arc::new(make_config_manager());
+    let (sm, mem_storage) = make_session_manager_with_memory_storage();
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut root_sub = SubagentsConfig::default();
+    root_sub.max_spawn_depth = 3;
+    let root = make_agent("root", root_sub);
+    let root_id = setup_parent_session(&sm, "root").await;
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(3), None).await;
+
+    // child1 at depth=1, effective budget=1 (only allows one more level)
+    let mut child1_sub = SubagentsConfig::default();
+    child1_sub.max_spawn_depth = 1;
+    let child1 = make_agent("child1", child1_sub);
+    inject_agents(&cm, vec![("root", root), ("child1", child1)]);
+
+    // First spawn succeeds
+    let result = controller
+        .validate(&root_id, Some("child1"))
+        .await
+        .expect("should pass: effective=1, child_depth=1");
+    assert_eq!(result.effective_max_spawn_depth, 1);
+
+    // Simulate child1 created with effective budget = 1
+    let child1_session_id = "child1-budget-zero";
+    sm.sessions.write().await.insert(
+        child1_session_id.to_string(),
+        crate::gateway::Session {
+            id: child1_session_id.to_string(),
+            agent_id: "child1".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    sm.register_child(
+        &root_id,
+        ChildSessionInfo {
+            session_id: child1_session_id.to_string(),
+            parent_session_id: root_id.to_string(),
+            agent_id: "child1".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child1_session_id, 1, Some(1), Some(&root_id)).await;
+
+    // child2 attempt: effective = min(1, 1-1) = 0, child_depth=2 > 0 → reject
+    let mut child2_sub = SubagentsConfig::default();
+    child2_sub.max_spawn_depth = 1;
+    let child2 = make_agent("child2", child2_sub);
+    inject_agents(&cm, vec![("child2", child2)]);
+
+    let err = controller
+        .validate(child1_session_id, Some("child2"))
+        .await
+        .expect_err("should reject: effective_max=0, child_depth=2 > 0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 2);
+            assert_eq!(max, 0);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+/// Child maxSpawnDepth narrows via min: parent has large budget but
+/// child's config limits it.
+#[tokio::test]
+async fn test_depth_budget_child_narrows_via_min() {
+    let cm = Arc::new(make_config_manager());
+    let (sm, mem_storage) = make_session_manager_with_memory_storage();
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    let mut root_sub = SubagentsConfig::default();
+    root_sub.max_spawn_depth = 5;
+    let root = make_agent("root", root_sub);
+    let root_id = setup_parent_session(&sm, "root").await;
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(5), None).await;
+
+    // child: maxSpawnDepth=2 — effective = min(2, 5-1) = 2
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 2;
+    let child = make_agent("narrow-child", child_sub);
+    inject_agents(&cm, vec![("root", root), ("narrow-child", child)]);
+
+    let result = controller
+        .validate(&root_id, Some("narrow-child"))
+        .await
+        .expect("should pass: effective=2, child_depth=1");
+    assert_eq!(result.effective_max_spawn_depth, 2);
+    assert_eq!(result.config.id, "narrow-child");
+
+    // Simulate child created with effective budget = 2
+    let child_session_id = "narrow-child-session";
+    sm.sessions.write().await.insert(
+        child_session_id.to_string(),
+        crate::gateway::Session {
+            id: child_session_id.to_string(),
+            agent_id: "narrow-child".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    sm.register_child(
+        &root_id,
+        ChildSessionInfo {
+            session_id: child_session_id.to_string(),
+            parent_session_id: root_id.to_string(),
+            agent_id: "narrow-child".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child_session_id, 1, Some(2), Some(&root_id)).await;
+
+    // grandchild: maxSpawnDepth=5 — effective = min(5, 2-1) = 1
+    // child_depth=2 > effective_max=1 → DepthExceeded (budget exhausted)
+    let mut grandchild_sub = SubagentsConfig::default();
+    grandchild_sub.max_spawn_depth = 5;
+    let grandchild = make_agent("grandchild", grandchild_sub);
+    inject_agents(&cm, vec![("grandchild", grandchild)]);
+
+    let err = controller
+        .validate(child_session_id, Some("grandchild"))
+        .await
+        .expect_err("should reject: child_depth=2 > effective_max=1");
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 2);
+            assert_eq!(max, 1);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+/// Verify effective budget read from checkpoint vs config fallback.
+#[tokio::test]
+async fn test_depth_budget_checkpoint_vs_config_fallback() {
+    let cm = Arc::new(make_config_manager());
+    let (sm, mem_storage) = make_session_manager_with_memory_storage();
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    // Root: maxSpawnDepth=3
+    let mut root_sub = SubagentsConfig::default();
+    root_sub.max_spawn_depth = 3;
+    let root = make_agent("root", root_sub);
+    let root_id = setup_parent_session(&sm, "root").await;
+    // NO checkpoint saved → config fallback (3) is used
+
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 1;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("root", root), ("child", child)]);
+
+    // Fallback: effective = min(1, 3-1) = 1
+    let result = controller
+        .validate(&root_id, Some("child"))
+        .await
+        .expect("should pass with config fallback");
+    assert_eq!(result.effective_max_spawn_depth, 1);
+
+    // Now save a checkpoint with effective budget = 1
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(1), None).await;
+
+    // effective = min(1, 1-1) = 0, child_depth=1 > 0 → DepthExceeded
+    let err = controller
+        .validate(&root_id, Some("child"))
+        .await
+        .expect_err("should reject: checkpoint budget=1, effective=0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 1);
+            assert_eq!(max, 0);
+        }
+        other => panic!("expected DepthExceeded, got {:?}", other),
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Step 1.5: Kill all-mode tests
+// ══════════════════════════════════════════════════════════════════════
+
+/// Kill a run-mode child session — should succeed and clean up all tables.
+#[tokio::test]
+async fn test_kill_run_mode_child_succeeds() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MemoryStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let parent_id = "parent-run-kill";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+
+    let child_id = "run-child-to-kill";
+    let child_cs = crate::llm::session::ConversationSession::new(
+        child_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let child_arc = std::sync::Arc::new(tokio::sync::RwLock::new(child_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(child_id.to_string(), child_arc);
+    mgr.sessions.write().await.insert(
+        child_id.to_string(),
+        crate::gateway::Session {
+            id: child_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed for run-mode child");
+
+    assert!(!mgr.has_session(child_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+}
+
+/// Kill a session-mode child session — should succeed (regression test).
+#[tokio::test]
+async fn test_kill_session_mode_child_succeeds() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MemoryStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let parent_id = "parent-session-kill";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+
+    let child_id = "session-child-to-kill";
+    let child_cs = crate::llm::session::ConversationSession::new(
+        child_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let child_arc = std::sync::Arc::new(tokio::sync::RwLock::new(child_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(child_id.to_string(), child_arc);
+    mgr.sessions.write().await.insert(
+        child_id.to_string(),
+        crate::gateway::Session {
+            id: child_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed for session-mode child");
+
+    assert!(!mgr.has_session(child_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Step 1.5: Cascade termination on parent finish_llm
+// ══════════════════════════════════════════════════════════════════════
+
+/// Simulate the cascade termination pattern from finish_llm:
+/// list_active_child_ids → kill_child for each → all removed.
+#[tokio::test]
+async fn test_cascade_terminate_all_children_simulation() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MemoryStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let parent_id = "parent-cascade";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+
+    // Create 3 children (2 run, 1 session)
+    let children: Vec<(&str, SpawnMode)> = vec![
+        ("child-a", SpawnMode::Run),
+        ("child-b", SpawnMode::Session),
+        ("child-c", SpawnMode::Run),
+    ];
+    for (child_id, mode) in &children {
+        let cs = crate::llm::session::ConversationSession::new(
+            child_id.to_string(),
+            "test-model".to_string(),
+            tmp.path().to_path_buf(),
+        );
+        let arc = std::sync::Arc::new(tokio::sync::RwLock::new(cs));
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert(child_id.to_string(), arc);
+        mgr.sessions.write().await.insert(
+            child_id.to_string(),
+            crate::gateway::Session {
+                id: child_id.to_string(),
+                agent_id: "child-agent".to_string(),
+                channel: "spawn".to_string(),
+                created_at: 0,
+                depth: 1,
+            },
+        );
+        mgr.register_child(
+            parent_id,
+            ChildSessionInfo {
+                session_id: child_id.to_string(),
+                parent_session_id: parent_id.to_string(),
+                agent_id: "child-agent".to_string(),
+                depth: 1,
+                mode: mode.clone(),
+            },
+        )
+        .await;
+    }
+
+    assert_eq!(mgr.count_active_children(parent_id).await, 3);
+
+    // Simulate finish_llm cascade pattern
+    let child_ids = mgr.list_active_child_ids(parent_id).await;
+    assert_eq!(child_ids.len(), 3);
+    for child_id in &child_ids {
+        mgr.kill_child(parent_id, child_id)
+            .await
+            .expect("kill_child should succeed in cascade");
+    }
+
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+    for (child_id, _) in &children {
+        assert!(!mgr.has_session(child_id).await);
+        assert!(mgr.get_conversation_session(child_id).await.is_none());
+    }
+}
+
+/// When a parent session has no children, finish_llm cascade is a no-op.
+#[tokio::test]
+async fn test_cascade_terminate_no_children_noop() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MemoryStorage::new());
+    let mgr = SessionManager::new(
+        &test_config(),
+        Some(storage),
+        Some(tmp.path().to_path_buf()),
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    );
+
+    let parent_id = "parent-no-children";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+
+    let child_ids = mgr.list_active_child_ids(parent_id).await;
+    assert_eq!(child_ids.len(), 0);
+    for child_id in &child_ids {
+        mgr.kill_child(parent_id, child_id)
+            .await
+            .expect("should not reach here");
+    }
+    assert!(mgr.get_conversation_session(parent_id).await.is_some());
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Step 1.5: effective_max_spawn_depth persistence roundtrip
+// ══════════════════════════════════════════════════════════════════════
+
+/// Verify effective_max_spawn_depth round-trips through checkpoint
+/// serialization (JSON serde).
+#[test]
+fn test_effective_max_spawn_depth_roundtrip() {
+    // With value
+    let cp = SessionCheckpoint::new("rt1".to_string()).with_effective_max_spawn_depth(Some(3));
+    let json = serde_json::to_string(&cp).unwrap();
+    let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.effective_max_spawn_depth, Some(3));
+
+    // Without value
+    let cp2 = SessionCheckpoint::new("rt2".to_string());
+    let json2 = serde_json::to_string(&cp2).unwrap();
+    let parsed2: SessionCheckpoint = serde_json::from_str(&json2).unwrap();
+    assert_eq!(parsed2.effective_max_spawn_depth, None);
+
+    // Missing field in old JSON → defaults to None
+    let mut json_val = serde_json::to_value(&cp).unwrap();
+    json_val
+        .as_object_mut()
+        .unwrap()
+        .remove("effective_max_spawn_depth");
+    let old_json_str = serde_json::to_string(&json_val).unwrap();
+    let parsed_old: SessionCheckpoint = serde_json::from_str(&old_json_str).unwrap();
+    assert_eq!(parsed_old.effective_max_spawn_depth, None);
+}
+
+/// Verify get_effective_max_spawn_depth reads from checkpoint correctly.
+#[tokio::test]
+async fn test_get_effective_max_spawn_depth_from_checkpoint() {
+    let (sm, mem_storage) = make_session_manager_with_memory_storage();
+
+    // No checkpoint → returns None
+    assert_eq!(sm.get_effective_max_spawn_depth("nonexistent").await, None);
+
+    // Save checkpoint with budget
+    save_checkpoint_with_budget(&mem_storage, "s1", 0, Some(5), None).await;
+    assert_eq!(sm.get_effective_max_spawn_depth("s1").await, Some(5));
+
+    // Save checkpoint without budget
+    save_checkpoint_with_budget(&mem_storage, "s2", 0, None, None).await;
+    assert_eq!(sm.get_effective_max_spawn_depth("s2").await, None);
+}
+
+/// Verify validate_child_ownership works for both modes without
+/// the old SpawnMode::Session filter.
+#[tokio::test]
+async fn test_validate_child_ownership_all_modes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (sm, _) = make_session_manager_with_memory_storage();
+
+    let parent_id = "parent-ownership";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    sm.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+
+    // Register run-mode child
+    let run_child = "run-ownership-child";
+    sm.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: run_child.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // Register session-mode child
+    let session_child = "session-ownership-child";
+    sm.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: session_child.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // Both should be found by validate_child_ownership
+    let run_info = sm.validate_child_ownership(parent_id, run_child).await;
+    assert!(run_info.is_some());
+    assert_eq!(run_info.unwrap().mode, SpawnMode::Run);
+
+    let session_info = sm.validate_child_ownership(parent_id, session_child).await;
+    assert!(session_info.is_some());
+    assert_eq!(session_info.unwrap().mode, SpawnMode::Session);
+
+    // Unknown child should return None
+    let unknown = sm
+        .validate_child_ownership(parent_id, "unknown-child")
+        .await;
+    assert!(unknown.is_none());
+}
+
+/// Verify kill_child cascades token to grandchild sessions
+/// (parent → child → grandchild, kill child cascade-stops grandchild token).
+#[tokio::test]
+async fn test_kill_child_cascades_to_grandchild() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (mgr, _) = make_session_manager_with_memory_storage();
+
+    let parent_id = "parent-kill-cascade";
+    let parent_cs = crate::llm::session::ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let parent_arc = std::sync::Arc::new(tokio::sync::RwLock::new(parent_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), parent_arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+
+    // Create child with a grandchild registered under it
+    let child_id = "child-kill-cascade";
+    let child_cs = crate::llm::session::ConversationSession::new(
+        child_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let child_arc = std::sync::Arc::new(tokio::sync::RwLock::new(child_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(child_id.to_string(), child_arc.clone());
+    mgr.sessions.write().await.insert(
+        child_id.to_string(),
+        crate::gateway::Session {
+            id: child_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // Register grandchild under child
+    let grandchild_id = "grandchild-kill-cascade";
+    let gc_cs = crate::llm::session::ConversationSession::new(
+        grandchild_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    let gc_arc = std::sync::Arc::new(tokio::sync::RwLock::new(gc_cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(grandchild_id.to_string(), gc_arc.clone());
+    mgr.sessions.write().await.insert(
+        grandchild_id.to_string(),
+        crate::gateway::Session {
+            id: grandchild_id.to_string(),
+            agent_id: "grandchild-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 2,
+        },
+    );
+    mgr.register_child(
+        child_id,
+        ChildSessionInfo {
+            session_id: grandchild_id.to_string(),
+            parent_session_id: child_id.to_string(),
+            agent_id: "grandchild-agent".to_string(),
+            depth: 2,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // Register grandchild handle in child's ConversationSession
+    child_arc
+        .read()
+        .await
+        .register_child_handle(grandchild_id, std::sync::Arc::downgrade(&gc_arc));
+
+    // Verify initial state
+    assert_eq!(mgr.count_active_children(parent_id).await, 1);
+    assert_eq!(mgr.count_active_children(child_id).await, 1);
+    assert!(mgr.has_session(grandchild_id).await);
+
+    // Kill the child — grandchild token is cascade-stopped
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    // Child should be removed
+    assert!(!mgr.has_session(child_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+    // Grandchild token is cascade-stopped but remains in session tables
+    // (table cleanup is the parent's responsibility via kill_child or sweeper)
+    assert!(
+        mgr.has_session(grandchild_id).await,
+        "grandchild session remains in sessions table after parent kill"
+    );
+}

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -50,6 +50,23 @@ impl SessionMessageHandler {
             output_tx,
         )
         .await;
+
+        // Cascade-terminate active child sessions (design-doc §级联终止).
+        // When the parent session completes its LLM turn, any child
+        // sessions still alive in the `children` table are stopped and
+        // cleaned up. Reuses the existing `kill_child` which already
+        // performs cascade stop + table cleanup.
+        let child_ids = session_manager.list_active_child_ids(session_id).await;
+        for child_id in child_ids {
+            if let Err(e) = session_manager.kill_child(session_id, &child_id).await {
+                tracing::warn!(
+                    parent_id = session_id,
+                    child_id,
+                    error = %e,
+                    "failed to cascade-kill child session"
+                );
+            }
+        }
     }
 
     async fn clear_busy_and_send(

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -46,10 +46,36 @@ impl SessionManager {
         sessions.get(session_id).map(|s| s.depth)
     }
 
+    /// Get the effective max spawn depth budget for a session.
+    ///
+    /// Reads from the session's checkpoint (persisted by `create_child_session`).
+    /// Returns `None` if the session has no stored effective budget (e.g. root
+    /// sessions created before Step 1.1, or when storage is unavailable).
+    pub async fn get_effective_max_spawn_depth(&self, session_id: &str) -> Option<u32> {
+        let storage = self.storage.read().await;
+        let storage = storage.as_ref()?;
+        match storage.load_checkpoint(session_id).await {
+            Ok(Some(cp)) => cp.effective_max_spawn_depth,
+            _ => None,
+        }
+    }
+
     /// Count active (non-completed) child sessions for a parent.
     pub async fn count_active_children(&self, parent_id: &str) -> usize {
         let children = self.children.read().await;
         children.get(parent_id).map(|v| v.len()).unwrap_or(0)
+    }
+
+    /// List all active child session IDs for a parent.
+    ///
+    /// Returns a cloned snapshot so the caller does not hold the
+    /// `children` lock across await points.
+    pub(crate) async fn list_active_child_ids(&self, parent_id: &str) -> Vec<String> {
+        let children = self.children.read().await;
+        children
+            .get(parent_id)
+            .map(|list| list.iter().map(|info| info.session_id.clone()).collect())
+            .unwrap_or_default()
     }
 
     /// Register a child session under its parent. Called after child session creation.
@@ -276,7 +302,8 @@ impl SessionManager {
             .with_platform("spawn".to_string())
             .with_agent_id(config.id.clone())
             .with_parent_session_id(parent_session_id.to_string())
-            .with_depth(depth);
+            .with_depth(depth)
+            .with_effective_max_spawn_depth(Some(max_spawn_depth));
         if let Some(storage) = self.storage.read().await.as_ref() {
             if let Err(e) = storage.save_checkpoint(&cp).await {
                 warn!(
@@ -407,9 +434,8 @@ impl SessionManager {
         Ok(PathBuf::from("/tmp"))
     }
 
-    /// Validate that a child session is owned by the given parent and
-    /// was spawned in `Session` mode (persistent). Returns the child
-    /// info on success, `None` otherwise.
+    /// Validate that a child session is owned by the given parent.
+    /// Returns the child info on success, `None` otherwise.
     ///
     /// Pure read operation — does not hold the children lock across
     /// any await point.
@@ -421,10 +447,7 @@ impl SessionManager {
         let children = self.children.read().await;
         children
             .get(parent_id)
-            .and_then(|list| {
-                list.iter()
-                    .find(|info| info.session_id == child_id && info.mode == SpawnMode::Session)
-            })
+            .and_then(|list| list.iter().find(|info| info.session_id == child_id))
             .cloned()
     }
 

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -351,7 +351,7 @@ async fn test_kill_child_removes_from_all_tables() {
 async fn test_validate_child_ownership_by_mode() {
     clear_global_prompt_state();
 
-    // --- Run mode: should return None ---
+    // --- Run mode: should return Some with correct info ---
     {
         let tmp = tempfile::TempDir::new().unwrap();
         let mgr = make_test_mgr(Some(tmp.path()));
@@ -379,13 +379,14 @@ async fn test_validate_child_ownership_by_mode() {
         let result = mgr
             .validate_child_ownership("parent-validate-run", &child_id)
             .await;
-        assert!(
-            result.is_none(),
-            "validate_child_ownership should return None for Run mode children"
-        );
+        let info =
+            result.expect("validate_child_ownership should return Some for Run mode children");
+        assert_eq!(info.session_id, child_id);
+        assert_eq!(info.mode, SpawnMode::Run);
+        assert_eq!(info.parent_session_id, "parent-validate-run");
     }
 
-    // --- Session mode: should return Some with correct info ---
+    // --- Session mode: should still return Some with correct info ---
     {
         let tmp = tempfile::TempDir::new().unwrap();
         let mgr = make_test_mgr(Some(tmp.path()));

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -73,6 +73,13 @@ pub struct SessionCheckpoint {
     /// spawn 层级深度（根节点为 0）
     #[serde(default)]
     pub depth: u32,
+    /// 有效最大 spawn 深度预算（沿 spawn 链传播）
+    ///
+    /// 根 agent 的有效预算 = maxSpawnDepth；
+    /// 子 agent 的有效预算 = min(子.maxSpawnDepth, 父.有效预算 - 1)。
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON。
+    #[serde(default)]
+    pub effective_max_spawn_depth: Option<u32>,
 }
 
 impl SessionCheckpoint {
@@ -102,6 +109,7 @@ impl SessionCheckpoint {
             sender_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         }
     }
 
@@ -201,6 +209,11 @@ impl SessionCheckpoint {
     /// Update the spawn depth
     pub fn with_depth(mut self, depth: u32) -> Self {
         self.depth = depth;
+        self
+    }
+    /// Update the effective max spawn depth
+    pub fn with_effective_max_spawn_depth(mut self, depth: Option<u32>) -> Self {
+        self.effective_max_spawn_depth = depth;
         self
     }
     /// Touch the updated_at timestamp

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -252,6 +252,7 @@ mod tests {
             sender_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         }
     }
 

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -167,6 +167,7 @@ mod tests {
             sender_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         }
     }
 

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -336,6 +336,7 @@ pub fn load_checkpoint_inner(
         sender_id,
         parent_session_id,
         depth,
+        effective_max_spawn_depth: None,
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -33,6 +33,7 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         account_id: None,
         parent_session_id: None,
         depth: 0,
+        effective_max_spawn_depth: None,
     }
 }
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -35,6 +35,7 @@ mod tests {
             account_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         }
     }
 
@@ -395,6 +396,7 @@ mod tests {
             account_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -437,6 +439,7 @@ mod tests {
             account_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -479,6 +482,7 @@ mod tests {
             account_id: None,
             parent_session_id: None,
             depth: 0,
+            effective_max_spawn_depth: None,
         };
         storage.save_checkpoint(&checkpoint).await?;
 

--- a/src/tools/builtin/sessions_kill.rs
+++ b/src/tools/builtin/sessions_kill.rs
@@ -7,10 +7,10 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-/// Tool that kills a persistent child session by stopping it (cascade)
+/// Tool that kills a child session by stopping it (cascade)
 /// and removing it from all tracking tables.
 ///
-/// Only works on `mode=session` children owned by the calling parent.
+/// Works on any mode (run / session) children owned by the calling parent.
 pub struct SessionsKillTool {
     session_manager: Arc<SessionManager>,
 }
@@ -37,9 +37,10 @@ impl Tool for SessionsKillTool {
     }
 
     fn detail(&self) -> String {
-        "Kill a persistent (mode=session) child session by triggering a cascading \
+        "Kill a child session by triggering a cascading \
          stop (cancels in-flight LLM requests and tool processes), then removing \
          it from all tracking tables. The archive is preserved. \
+         Supports any mode (run / session). \
          Requires the child to be owned by the calling parent session."
             .to_string()
     }


### PR DESCRIPTION
Align agent-spawn implementation with design doc `docs/design/agent/agent-spawn.md` by fixing 3 must-fix gaps:

**Depth budget propagation**: Child session effective spawn depth is now calculated as `min(child.max_spawn_depth, parent.effective_budget - 1)` and propagated through the spawn chain via a new `effective_max_spawn_depth` checkpoint field. Previously each agent re-derived depth from its own config, allowing spawn when depth should be blocked.

**Kill all modes**: `sessions_kill` now supports both `run` and `session` mode child sessions. Previously only `session` mode was allowed, contradicting the design doc requirement.

**Cascade termination on parent finish**: When a parent session completes via `finish_llm`, all active child sessions are automatically terminated. Previously only the sweeper timeout cleanup triggered cascade.

Source: CI
Type: feat
