### PR TITLE
fix: align agent-spawn validation order, cascade cleanup, and termination timing with design doc

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -40,6 +40,21 @@ pub struct SpawnController {
     session_manager: Arc<SessionManager>,
 }
 
+/// Internal result from resolving parent depth and max spawn budget.
+struct ResolvedParentDepth {
+    parent_depth: u32,
+    parent_effective_budget: u32,
+}
+
+/// Internal result from resolving target agent configuration.
+struct ResolvedTarget {
+    target_id: Option<String>,
+    max_children: u32,
+    allow_agents: Vec<String>,
+    require_agent_id: bool,
+    target_config: Option<ResolvedAgentConfig>,
+}
+
 impl SpawnController {
     pub fn new(config_manager: Arc<ConfigManager>, session_manager: Arc<SessionManager>) -> Self {
         Self {
@@ -58,25 +73,77 @@ impl SpawnController {
         parent_session_id: &str,
         target_agent_id: Option<&str>,
     ) -> Result<SpawnValidationResult, SpawnError> {
-        // 1. Get parent depth — no lock needed, only reads runtime state.
+        // ① Depth check — read parent depth + config, validate budget.
+        let parent = self.resolve_parent_depth(parent_session_id).await?;
+
+        // ② AgentId fallback + config resolution (single lock block).
+        let resolved = self
+            .resolve_target_config(parent_session_id, target_agent_id)
+            .await?;
+
+        // ③ Concurrency check.
+        self.check_concurrency(parent_session_id, resolved.max_children)
+            .await?;
+
+        // ④ Whitelist check.
+        if let Some(ref tid) = resolved.target_id {
+            self.check_whitelist(tid, &resolved.allow_agents)?;
+        }
+
+        // ⑤ require_agent_id check — must come after concurrency/whitelist.
+        if resolved.require_agent_id && resolved.target_id.is_none() {
+            return Err(SpawnError::AgentIdRequired);
+        }
+        let target_id = resolved.target_id.ok_or(SpawnError::AgentIdRequired)?;
+
+        // ⑥ Compute effective_max_spawn_depth for the child.
+        let child_max_spawn_depth = resolved
+            .target_config
+            .as_ref()
+            .map(|c| c.subagents.max_spawn_depth)
+            .unwrap_or(1);
+        let effective_max =
+            child_max_spawn_depth.min(parent.parent_effective_budget.saturating_sub(1));
+        let child_depth = parent.parent_depth + 1;
+        if child_depth > effective_max {
+            return Err(SpawnError::DepthExceeded {
+                current: child_depth,
+                max: effective_max,
+            });
+        }
+
+        let config = resolved
+            .target_config
+            .ok_or(SpawnError::ConfigNotFound(target_id))?;
+        Ok(SpawnValidationResult {
+            config,
+            effective_max_spawn_depth: effective_max,
+        })
+    }
+
+    // ------------------------------------------------------------------
+    // Private helpers
+    // ------------------------------------------------------------------
+
+    /// Resolve the parent session's depth and maximum spawn budget.
+    /// Reads the parent agent config to get `max_spawn_depth`, then
+    /// compares with `get_effective_max_spawn_depth` from session manager.
+    async fn resolve_parent_depth(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<ResolvedParentDepth, SpawnError> {
         let parent_depth = self
             .session_manager
             .get_session_depth(parent_session_id)
             .await
             .unwrap_or(0);
 
-        // 2. Determine parent agent_id from session manager.
         let parent_agent_id = self
             .session_manager
             .get_chat_id(parent_session_id)
             .await
             .unwrap_or_default();
 
-        // 3. Depth check FIRST — design doc requires depth to be evaluated
-        //    before agentId resolution.  We read the parent's max_spawn_depth
-        //    from the config (read lock held only for the lookup, dropped
-        //    immediately).  This ensures depth=0 always returns DepthExceeded
-        //    rather than falling through to AgentIdRequired.
         let parent_max_spawn_depth = {
             let agents = self
                 .config_manager
@@ -102,11 +169,29 @@ impl SpawnController {
             });
         }
 
-        // 4. Load parent config and resolve target_id under the lock.
-        // ConfigManager.agents uses std::sync::RwLock, whose read guard is
-        // !Send. We must not hold it across an .await, so all lock-scoped
-        // work is performed inside this block and the guard is dropped
-        // before any await below.
+        Ok(ResolvedParentDepth {
+            parent_depth,
+            parent_effective_budget,
+        })
+    }
+
+    /// Resolve the target agent configuration under a single lock block.
+    /// Handles the agentId fallback: if no `target_agent_id` is provided,
+    /// falls back to the parent config's `default_child_agent`.
+    async fn resolve_target_config(
+        &self,
+        parent_session_id: &str,
+        target_agent_id: Option<&str>,
+    ) -> Result<ResolvedTarget, SpawnError> {
+        let parent_agent_id = self
+            .session_manager
+            .get_chat_id(parent_session_id)
+            .await
+            .unwrap_or_default();
+
+        // Single lock acquisition — agentId fallback + parent config read.
+        // ConfigManager.agents uses std::sync::RwLock whose read guard is
+        // !Send. All lock-scoped work must complete before any .await.
         let (target_id, max_children, allow_agents, require_agent_id, target_config) = {
             let agents = self
                 .config_manager
@@ -127,7 +212,6 @@ impl SpawnController {
                         sc.allow_agents.clone(),
                     )
                 } else {
-                    // No parent config found — use design-doc defaults
                     (
                         target_agent_id.map(|s| s.to_string()),
                         false,
@@ -136,9 +220,6 @@ impl SpawnController {
                     )
                 };
 
-            // Pre-clone the target config so we don't need the lock after
-            // this block.  target_id may be None here (require_agent_id is
-            // checked later per the design-doc order).
             let target_config = target_id.as_ref().and_then(|id| agents.get(id).cloned());
 
             (
@@ -149,9 +230,22 @@ impl SpawnController {
                 target_config,
             )
         };
-        // Lock guard dropped — safe to .await below.
 
-        // 5. Concurrency check (design doc ②)
+        Ok(ResolvedTarget {
+            target_id,
+            max_children,
+            allow_agents,
+            require_agent_id,
+            target_config,
+        })
+    }
+
+    /// Check that the parent has not reached its maximum concurrent children.
+    async fn check_concurrency(
+        &self,
+        parent_session_id: &str,
+        max_children: u32,
+    ) -> Result<(), SpawnError> {
         let active = self
             .session_manager
             .count_active_children(parent_session_id)
@@ -162,43 +256,16 @@ impl SpawnController {
                 max: max_children,
             });
         }
+        Ok(())
+    }
 
-        // 6. Whitelist check (design doc ③)
-        if let Some(ref tid) = target_id {
-            if !allow_agents.iter().any(|a| a == "*" || a == tid) {
-                return Err(SpawnError::AgentNotAllowed {
-                    agent_id: tid.clone(),
-                });
-            }
-        }
-
-        // 7. require_agent_id check (design doc ④) — must come after
-        //    concurrency and whitelist checks, not before.
-        if require_agent_id && target_id.is_none() {
-            return Err(SpawnError::AgentIdRequired);
-        }
-        let target_id = target_id.ok_or(SpawnError::AgentIdRequired)?;
-
-        // 8. Compute effective_max_spawn_depth for the child and return.
-        //    depth was already validated in step 3 (parent budget != 0);
-        //    now verify child_depth <= effective_max.
-        let child_max_spawn_depth = target_config
-            .as_ref()
-            .map(|c| c.subagents.max_spawn_depth)
-            .unwrap_or(1);
-        let effective_max = child_max_spawn_depth.min(parent_effective_budget.saturating_sub(1));
-        let child_depth = parent_depth + 1;
-        if child_depth > effective_max {
-            return Err(SpawnError::DepthExceeded {
-                current: child_depth,
-                max: effective_max,
+    /// Check that the target agent is in the parent's allowlist.
+    fn check_whitelist(&self, target_id: &str, allow_agents: &[String]) -> Result<(), SpawnError> {
+        if !allow_agents.iter().any(|a| a == "*" || a == target_id) {
+            return Err(SpawnError::AgentNotAllowed {
+                agent_id: target_id.to_string(),
             });
         }
-
-        let config = target_config.ok_or(SpawnError::ConfigNotFound(target_id))?;
-        Ok(SpawnValidationResult {
-            config,
-            effective_max_spawn_depth: effective_max,
-        })
+        Ok(())
     }
 }

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -103,20 +103,12 @@ impl SpawnController {
         }
         let target_id = resolved.target_id.ok_or(SpawnError::AgentIdRequired)?;
 
-        // ⑦ Compute effective_max_spawn_depth for the child.
-        let child_max_depth = resolved
-            .target_config
-            .as_ref()
-            .map(|c| c.subagents.max_spawn_depth)
-            .unwrap_or(1);
-        let effective_max = child_max_depth.min(parent.parent_effective_budget.saturating_sub(1));
-        let child_depth = parent.parent_depth + 1;
-        if child_depth > effective_max {
-            return Err(SpawnError::DepthExceeded {
-                current: child_depth,
-                max: effective_max,
-            });
-        }
+        // ⑦ Compute effective_max_spawn_depth and validate child depth.
+        let effective_max = self.compute_effective_max_depth(
+            parent.parent_depth,
+            parent.parent_effective_budget,
+            resolved.target_config.as_ref(),
+        )?;
 
         let config = resolved
             .target_config
@@ -125,6 +117,29 @@ impl SpawnController {
             config,
             effective_max_spawn_depth: effective_max,
         })
+    }
+
+    /// Compute the effective maximum spawn depth for a child session.
+    ///
+    /// Returns `Err(DepthExceeded)` if the child would exceed the budget.
+    fn compute_effective_max_depth(
+        &self,
+        parent_depth: u32,
+        parent_effective_budget: u32,
+        target_config: Option<&ResolvedAgentConfig>,
+    ) -> Result<u32, SpawnError> {
+        let child_max_depth = target_config
+            .map(|c| c.subagents.max_spawn_depth)
+            .unwrap_or(1);
+        let effective_max = child_max_depth.min(parent_effective_budget.saturating_sub(1));
+        let child_depth = parent_depth + 1;
+        if child_depth > effective_max {
+            return Err(SpawnError::DepthExceeded {
+                current: child_depth,
+                max: effective_max,
+            });
+        }
+        Ok(effective_max)
     }
 
     // ------------------------------------------------------------------

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -102,12 +102,12 @@ impl SpawnController {
             });
         }
 
-        // 4-8. Load parent config and resolve the target id under the lock.
+        // 4. Load parent config and resolve target_id under the lock.
         // ConfigManager.agents uses std::sync::RwLock, whose read guard is
         // !Send. We must not hold it across an .await, so all lock-scoped
         // work is performed inside this block and the guard is dropped
         // before any await below.
-        let (target_id, max_children, allow_agents, target_config) = {
+        let (target_id, max_children, allow_agents, require_agent_id, target_config) = {
             let agents = self
                 .config_manager
                 .agents
@@ -136,23 +136,22 @@ impl SpawnController {
                     )
                 };
 
-            // 4a. agentId fallback already done above via or_else(default_child_agent).
+            // Pre-clone the target config so we don't need the lock after
+            // this block.  target_id may be None here (require_agent_id is
+            // checked later per the design-doc order).
+            let target_config = target_id.as_ref().and_then(|id| agents.get(id).cloned());
 
-            // 5. require_agent_id check
-            if require_agent_id && target_id.is_none() {
-                return Err(SpawnError::AgentIdRequired);
-            }
-
-            let target_id = target_id.ok_or(SpawnError::AgentIdRequired)?;
-
-            // Pre-clone the target config so we don't need the lock after this block.
-            let target_config = agents.get(&target_id).cloned();
-
-            (target_id, max_children, allow_agents, target_config)
+            (
+                target_id,
+                max_children,
+                allow_agents,
+                require_agent_id,
+                target_config,
+            )
         };
+        // Lock guard dropped — safe to .await below.
 
-        // 6. Concurrency check
-        // No lock held here — safe to await.
+        // 5. Concurrency check (design doc ②)
         let active = self
             .session_manager
             .count_active_children(parent_session_id)
@@ -164,14 +163,23 @@ impl SpawnController {
             });
         }
 
-        // 7. Whitelist check
-        if !allow_agents.iter().any(|a| a == "*" || a == &target_id) {
-            return Err(SpawnError::AgentNotAllowed {
-                agent_id: target_id,
-            });
+        // 6. Whitelist check (design doc ③)
+        if let Some(ref tid) = target_id {
+            if !allow_agents.iter().any(|a| a == "*" || a == tid) {
+                return Err(SpawnError::AgentNotAllowed {
+                    agent_id: tid.clone(),
+                });
+            }
         }
 
-        // 8. Compute effective_max_spawn_depth for the child and return result.
+        // 7. require_agent_id check (design doc ④) — must come after
+        //    concurrency and whitelist checks, not before.
+        if require_agent_id && target_id.is_none() {
+            return Err(SpawnError::AgentIdRequired);
+        }
+        let target_id = target_id.ok_or(SpawnError::AgentIdRequired)?;
+
+        // 8. Compute effective_max_spawn_depth for the child and return.
         //    depth was already validated in step 3 (parent budget != 0);
         //    now verify child_depth <= effective_max.
         let child_max_spawn_depth = target_config

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -58,26 +58,56 @@ impl SpawnController {
         parent_session_id: &str,
         target_agent_id: Option<&str>,
     ) -> Result<SpawnValidationResult, SpawnError> {
-        // 1. Get parent depth
+        // 1. Get parent depth — no lock needed, only reads runtime state.
         let parent_depth = self
             .session_manager
             .get_session_depth(parent_session_id)
             .await
             .unwrap_or(0);
 
-        // 2. Determine parent agent_id from session manager
+        // 2. Determine parent agent_id from session manager.
         let parent_agent_id = self
             .session_manager
             .get_chat_id(parent_session_id)
             .await
             .unwrap_or_default();
 
-        // 3-5. Load parent config and resolve the target id under the lock.
+        // 3. Depth check FIRST — design doc requires depth to be evaluated
+        //    before agentId resolution.  We read the parent's max_spawn_depth
+        //    from the config (read lock held only for the lookup, dropped
+        //    immediately).  This ensures depth=0 always returns DepthExceeded
+        //    rather than falling through to AgentIdRequired.
+        let parent_max_spawn_depth = {
+            let agents = self
+                .config_manager
+                .agents
+                .read()
+                .expect("RwLock for agents was poisoned");
+            agents
+                .get(&parent_agent_id)
+                .map(|pc| pc.subagents.max_spawn_depth)
+                .unwrap_or(1u32)
+        };
+
+        let parent_effective_budget = self
+            .session_manager
+            .get_effective_max_spawn_depth(parent_session_id)
+            .await
+            .unwrap_or(parent_max_spawn_depth);
+
+        if parent_effective_budget == 0 {
+            return Err(SpawnError::DepthExceeded {
+                current: parent_depth + 1,
+                max: 0,
+            });
+        }
+
+        // 4-8. Load parent config and resolve the target id under the lock.
         // ConfigManager.agents uses std::sync::RwLock, whose read guard is
         // !Send. We must not hold it across an .await, so all lock-scoped
         // work is performed inside this block and the guard is dropped
         // before any await below.
-        let (target_id, max_spawn_depth, max_children, allow_agents, target_config) = {
+        let (target_id, max_children, allow_agents, target_config) = {
             let agents = self
                 .config_manager
                 .agents
@@ -85,7 +115,7 @@ impl SpawnController {
                 .expect("RwLock for agents was poisoned");
             let parent_config = agents.get(&parent_agent_id);
 
-            let (target_id, require_agent_id, max_spawn_depth, max_children, allow_agents) =
+            let (target_id, require_agent_id, max_children, allow_agents) =
                 if let Some(pc) = parent_config {
                     let sc = &pc.subagents;
                     (
@@ -93,7 +123,6 @@ impl SpawnController {
                             .map(|s| s.to_string())
                             .or_else(|| sc.default_child_agent.clone()),
                         sc.require_agent_id,
-                        sc.max_spawn_depth,
                         sc.max_children,
                         sc.allow_agents.clone(),
                     )
@@ -102,13 +131,14 @@ impl SpawnController {
                     (
                         target_agent_id.map(|s| s.to_string()),
                         false,
-                        1u32,
                         5u32,
                         vec!["*".to_string()],
                     )
                 };
 
-            // 5. Check require_agent_id
+            // 4a. agentId fallback already done above via or_else(default_child_agent).
+
+            // 5. require_agent_id check
             if require_agent_id && target_id.is_none() {
                 return Err(SpawnError::AgentIdRequired);
             }
@@ -118,33 +148,32 @@ impl SpawnController {
             // Pre-clone the target config so we don't need the lock after this block.
             let target_config = agents.get(&target_id).cloned();
 
-            (
-                target_id,
-                max_spawn_depth,
-                max_children,
-                allow_agents,
-                target_config,
-            )
+            (target_id, max_children, allow_agents, target_config)
         };
 
-        // 6. Depth check — read the parent's effective budget from
-        //    its checkpoint (persisted by create_child_session).  For
-        //    root sessions or legacy checkpoints without the field,
-        //    fall back to the config value.
-        let parent_effective_budget = self
+        // 6. Concurrency check
+        // No lock held here — safe to await.
+        let active = self
             .session_manager
-            .get_effective_max_spawn_depth(parent_session_id)
-            .await
-            .unwrap_or(max_spawn_depth);
-
-        if parent_effective_budget == 0 {
-            return Err(SpawnError::DepthExceeded {
-                current: parent_depth + 1,
-                max: 0,
+            .count_active_children(parent_session_id)
+            .await;
+        if active as u32 >= max_children {
+            return Err(SpawnError::MaxChildrenReached {
+                current: active,
+                max: max_children,
             });
         }
 
-        // effective = min(child.max_spawn_depth, parent_effective_budget - 1)
+        // 7. Whitelist check
+        if !allow_agents.iter().any(|a| a == "*" || a == &target_id) {
+            return Err(SpawnError::AgentNotAllowed {
+                agent_id: target_id,
+            });
+        }
+
+        // 8. Compute effective_max_spawn_depth for the child and return result.
+        //    depth was already validated in step 3 (parent budget != 0);
+        //    now verify child_depth <= effective_max.
         let child_max_spawn_depth = target_config
             .as_ref()
             .map(|c| c.subagents.max_spawn_depth)
@@ -158,27 +187,6 @@ impl SpawnController {
             });
         }
 
-        // 7. Concurrency check
-        // No lock held here — safe to await.
-        let active = self
-            .session_manager
-            .count_active_children(parent_session_id)
-            .await;
-        if active as u32 >= max_children {
-            return Err(SpawnError::MaxChildrenReached {
-                current: active,
-                max: max_children,
-            });
-        }
-
-        // 8. Whitelist check
-        if !allow_agents.iter().any(|a| a == "*" || a == &target_id) {
-            return Err(SpawnError::AgentNotAllowed {
-                agent_id: target_id,
-            });
-        }
-
-        // 9. Return validation result with effective max spawn depth
         let config = target_config.ok_or(SpawnError::ConfigNotFound(target_id))?;
         Ok(SpawnValidationResult {
             config,

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -80,22 +80,22 @@ impl SpawnController {
         // ① Depth check.
         let parent = self.resolve_parent_depth(parent_session_id).await?;
 
-        // ② Read parent config for concurrency/whitelist fields.
-        let parent_cfg = self.read_parent_config(parent_session_id).await?;
-
-        // ③ Concurrency check.
-        self.check_concurrency(parent_session_id, parent_cfg.max_children)
-            .await?;
-
-        // ④ Whitelist check (on raw target_agent_id, before fallback).
-        if let Some(tid) = target_agent_id {
-            self.check_whitelist(tid, &parent_cfg.allow_agents)?;
-        }
-
-        // ⑤ AgentId fallback + target config resolution.
+        // ② AgentId fallback + target config resolution.
         let resolved = self
             .resolve_target_config(parent_session_id, target_agent_id)
             .await?;
+
+        // ③ Read parent config for concurrency/whitelist/requireAgentId.
+        let parent_cfg = self.read_parent_config(parent_session_id).await?;
+
+        // ④ Concurrency check.
+        self.check_concurrency(parent_session_id, parent_cfg.max_children)
+            .await?;
+
+        // ⑤ Whitelist check (on resolved target_id, after fallback).
+        if let Some(ref tid) = resolved.target_id {
+            self.check_whitelist(tid, &parent_cfg.allow_agents)?;
+        }
 
         // ⑥ require_agent_id check — must come after concurrency/whitelist.
         if parent_cfg.require_agent_id && resolved.target_id.is_none() {

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -78,15 +78,22 @@ impl SpawnController {
         target_agent_id: Option<&str>,
     ) -> Result<SpawnValidationResult, SpawnError> {
         // ① Depth check.
-        let parent = self.resolve_parent_depth(parent_session_id).await?;
+        let parent_agent_id = self
+            .session_manager
+            .get_chat_id(parent_session_id)
+            .await
+            .unwrap_or_default();
+        let parent = self
+            .resolve_parent_depth(parent_session_id, &parent_agent_id)
+            .await?;
 
         // ② AgentId fallback + target config resolution.
         let resolved = self
-            .resolve_target_config(parent_session_id, target_agent_id)
+            .resolve_target_config(&parent_agent_id, target_agent_id)
             .await?;
 
         // ③ Read parent config for concurrency/whitelist/requireAgentId.
-        let parent_cfg = self.read_parent_config(parent_session_id).await?;
+        let parent_cfg = self.read_parent_config(&parent_agent_id).await?;
 
         // ④ Concurrency check.
         self.check_concurrency(parent_session_id, parent_cfg.max_children)
@@ -152,18 +159,13 @@ impl SpawnController {
     async fn resolve_parent_depth(
         &self,
         parent_session_id: &str,
+        parent_agent_id: &str,
     ) -> Result<ResolvedParentDepth, SpawnError> {
         let parent_depth = self
             .session_manager
             .get_session_depth(parent_session_id)
             .await
             .unwrap_or(0);
-
-        let parent_agent_id = self
-            .session_manager
-            .get_chat_id(parent_session_id)
-            .await
-            .unwrap_or_default();
 
         let parent_max_spawn_depth = {
             let agents = self
@@ -172,7 +174,7 @@ impl SpawnController {
                 .read()
                 .expect("RwLock for agents was poisoned");
             agents
-                .get(&parent_agent_id)
+                .get(parent_agent_id)
                 .map(|pc| pc.subagents.max_spawn_depth)
                 .unwrap_or(1u32)
         };
@@ -201,21 +203,15 @@ impl SpawnController {
     /// [`Self::resolve_target_config`].
     async fn read_parent_config(
         &self,
-        parent_session_id: &str,
+        parent_agent_id: &str,
     ) -> Result<ParentSpawnConfig, SpawnError> {
-        let parent_agent_id = self
-            .session_manager
-            .get_chat_id(parent_session_id)
-            .await
-            .unwrap_or_default();
-
         let agents = self
             .config_manager
             .agents
             .read()
             .expect("RwLock for agents was poisoned");
 
-        Ok(match agents.get(&parent_agent_id) {
+        Ok(match agents.get(parent_agent_id) {
             Some(pc) => {
                 let sc = &pc.subagents;
                 ParentSpawnConfig {
@@ -237,22 +233,16 @@ impl SpawnController {
     /// falls back to the parent config's `default_child_agent`.
     async fn resolve_target_config(
         &self,
-        parent_session_id: &str,
+        parent_agent_id: &str,
         target_agent_id: Option<&str>,
     ) -> Result<ResolvedTarget, SpawnError> {
-        let parent_agent_id = self
-            .session_manager
-            .get_chat_id(parent_session_id)
-            .await
-            .unwrap_or_default();
-
         let (target_id, target_config) = {
             let agents = self
                 .config_manager
                 .agents
                 .read()
                 .expect("RwLock for agents was poisoned");
-            let parent_config = agents.get(&parent_agent_id);
+            let parent_config = agents.get(parent_agent_id);
 
             let target_id = target_agent_id
                 .map(|s| s.to_string())

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -46,12 +46,16 @@ struct ResolvedParentDepth {
     parent_effective_budget: u32,
 }
 
-/// Internal result from resolving target agent configuration.
-struct ResolvedTarget {
-    target_id: Option<String>,
+/// Parent agent config fields needed for concurrency/whitelist checks.
+struct ParentSpawnConfig {
     max_children: u32,
     allow_agents: Vec<String>,
     require_agent_id: bool,
+}
+
+/// Result from resolving target agent configuration (agentId fallback).
+struct ResolvedTarget {
+    target_id: Option<String>,
     target_config: Option<ResolvedAgentConfig>,
 }
 
@@ -73,37 +77,39 @@ impl SpawnController {
         parent_session_id: &str,
         target_agent_id: Option<&str>,
     ) -> Result<SpawnValidationResult, SpawnError> {
-        // ① Depth check — read parent depth + config, validate budget.
+        // ① Depth check.
         let parent = self.resolve_parent_depth(parent_session_id).await?;
 
-        // ② AgentId fallback + config resolution (single lock block).
+        // ② Read parent config for concurrency/whitelist fields.
+        let parent_cfg = self.read_parent_config(parent_session_id).await?;
+
+        // ③ Concurrency check.
+        self.check_concurrency(parent_session_id, parent_cfg.max_children)
+            .await?;
+
+        // ④ Whitelist check (on raw target_agent_id, before fallback).
+        if let Some(tid) = target_agent_id {
+            self.check_whitelist(tid, &parent_cfg.allow_agents)?;
+        }
+
+        // ⑤ AgentId fallback + target config resolution.
         let resolved = self
             .resolve_target_config(parent_session_id, target_agent_id)
             .await?;
 
-        // ③ Concurrency check.
-        self.check_concurrency(parent_session_id, resolved.max_children)
-            .await?;
-
-        // ④ Whitelist check.
-        if let Some(ref tid) = resolved.target_id {
-            self.check_whitelist(tid, &resolved.allow_agents)?;
-        }
-
-        // ⑤ require_agent_id check — must come after concurrency/whitelist.
-        if resolved.require_agent_id && resolved.target_id.is_none() {
+        // ⑥ require_agent_id check — must come after concurrency/whitelist.
+        if parent_cfg.require_agent_id && resolved.target_id.is_none() {
             return Err(SpawnError::AgentIdRequired);
         }
         let target_id = resolved.target_id.ok_or(SpawnError::AgentIdRequired)?;
 
-        // ⑥ Compute effective_max_spawn_depth for the child.
-        let child_max_spawn_depth = resolved
+        // ⑦ Compute effective_max_spawn_depth for the child.
+        let child_max_depth = resolved
             .target_config
             .as_ref()
             .map(|c| c.subagents.max_spawn_depth)
             .unwrap_or(1);
-        let effective_max =
-            child_max_spawn_depth.min(parent.parent_effective_budget.saturating_sub(1));
+        let effective_max = child_max_depth.min(parent.parent_effective_budget.saturating_sub(1));
         let child_depth = parent.parent_depth + 1;
         if child_depth > effective_max {
             return Err(SpawnError::DepthExceeded {
@@ -175,6 +181,42 @@ impl SpawnController {
         })
     }
 
+    /// Read parent agent config fields needed for concurrency/whitelist checks.
+    /// Does NOT perform agentId fallback — that happens later in
+    /// [`Self::resolve_target_config`].
+    async fn read_parent_config(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<ParentSpawnConfig, SpawnError> {
+        let parent_agent_id = self
+            .session_manager
+            .get_chat_id(parent_session_id)
+            .await
+            .unwrap_or_default();
+
+        let agents = self
+            .config_manager
+            .agents
+            .read()
+            .expect("RwLock for agents was poisoned");
+
+        Ok(match agents.get(&parent_agent_id) {
+            Some(pc) => {
+                let sc = &pc.subagents;
+                ParentSpawnConfig {
+                    max_children: sc.max_children,
+                    allow_agents: sc.allow_agents.clone(),
+                    require_agent_id: sc.require_agent_id,
+                }
+            }
+            None => ParentSpawnConfig {
+                max_children: 5u32,
+                allow_agents: vec!["*".to_string()],
+                require_agent_id: false,
+            },
+        })
+    }
+
     /// Resolve the target agent configuration under a single lock block.
     /// Handles the agentId fallback: if no `target_agent_id` is provided,
     /// falls back to the parent config's `default_child_agent`.
@@ -189,10 +231,7 @@ impl SpawnController {
             .await
             .unwrap_or_default();
 
-        // Single lock acquisition — agentId fallback + parent config read.
-        // ConfigManager.agents uses std::sync::RwLock whose read guard is
-        // !Send. All lock-scoped work must complete before any .await.
-        let (target_id, max_children, allow_agents, require_agent_id, target_config) = {
+        let (target_id, target_config) = {
             let agents = self
                 .config_manager
                 .agents
@@ -200,42 +239,17 @@ impl SpawnController {
                 .expect("RwLock for agents was poisoned");
             let parent_config = agents.get(&parent_agent_id);
 
-            let (target_id, require_agent_id, max_children, allow_agents) =
-                if let Some(pc) = parent_config {
-                    let sc = &pc.subagents;
-                    (
-                        target_agent_id
-                            .map(|s| s.to_string())
-                            .or_else(|| sc.default_child_agent.clone()),
-                        sc.require_agent_id,
-                        sc.max_children,
-                        sc.allow_agents.clone(),
-                    )
-                } else {
-                    (
-                        target_agent_id.map(|s| s.to_string()),
-                        false,
-                        5u32,
-                        vec!["*".to_string()],
-                    )
-                };
+            let target_id = target_agent_id
+                .map(|s| s.to_string())
+                .or_else(|| parent_config.and_then(|pc| pc.subagents.default_child_agent.clone()));
 
             let target_config = target_id.as_ref().and_then(|id| agents.get(id).cloned());
 
-            (
-                target_id,
-                max_children,
-                allow_agents,
-                require_agent_id,
-                target_config,
-            )
+            (target_id, target_config)
         };
 
         Ok(ResolvedTarget {
             target_id,
-            max_children,
-            allow_agents,
-            require_agent_id,
             target_config,
         })
     }

--- a/src/agent/spawn_budget_tests.rs
+++ b/src/agent/spawn_budget_tests.rs
@@ -885,10 +885,19 @@ async fn test_kill_child_cascades_to_grandchild() {
     assert!(!mgr.has_session(child_id).await);
     assert!(mgr.get_conversation_session(child_id).await.is_none());
     assert_eq!(mgr.count_active_children(parent_id).await, 0);
-    // Grandchild token is cascade-stopped but remains in session tables
-    // (table cleanup is the parent's responsibility via kill_child or sweeper)
+    // Grandchild is recursively cleaned up — all tracking tables are
+    // purged (per design doc §级联 Kill: from deepest to shallowest).
     assert!(
-        mgr.has_session(grandchild_id).await,
-        "grandchild session remains in sessions table after parent kill"
+        !mgr.has_session(grandchild_id).await,
+        "grandchild session should be recursively removed after parent kill"
+    );
+    assert!(
+        mgr.get_conversation_session(grandchild_id).await.is_none(),
+        "grandchild conversation_session should be removed after parent kill"
+    );
+    assert_eq!(
+        mgr.count_active_children(child_id).await,
+        0,
+        "grandchild entry should be removed from children table"
     );
 }

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -662,77 +662,45 @@ async fn setup_kill_test_session(
     );
 }
 
+/// Macro to register a session and its parent-child relationship in one call.
+/// Each invocation stays compact (2 lines) even after `cargo fmt`.
+macro_rules! register_child {
+    ($mgr:expr, $tmp:expr, $parent:expr, $child:expr, $agent:expr, $depth:expr, $mode:expr) => {
+        setup_kill_test_session($mgr, $tmp, $child, $agent, $depth).await;
+        $mgr.register_child(
+            $parent,
+            ChildSessionInfo {
+                session_id: $child.to_string(),
+                parent_session_id: $parent.to_string(),
+                agent_id: $agent.to_string(),
+                depth: $depth,
+                mode: $mode,
+            },
+        )
+        .await;
+    };
+}
+
 /// Kill a child with multiple descendants (grandchild + great-grandchild)
 /// and verify no orphan entries remain in any tracking table.
 /// This is the key Step 1.2 multi-level cascade test.
+#[rustfmt::skip]
 #[tokio::test]
 async fn test_kill_child_cascades_removes_all_orphans_multilevel() {
     let tmp = tempfile::TempDir::new().unwrap();
     let mgr = make_session_manager();
 
     let parent_id = "parent-kill-multi";
-    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
-
     let child_id = "child-multi";
     let grandchild_a_id = "grandchild-a-multi";
     let grandchild_b_id = "grandchild-b-multi";
     let great_grandchild_id = "great-grandchild-multi";
 
-    // parent → child
-    setup_kill_test_session(&mgr, &tmp, child_id, "child-agent", 1).await;
-    mgr.register_child(
-        parent_id,
-        ChildSessionInfo {
-            session_id: child_id.to_string(),
-            parent_session_id: parent_id.to_string(),
-            agent_id: "child-agent".to_string(),
-            depth: 1,
-            mode: SpawnMode::Session,
-        },
-    )
-    .await;
-
-    // child → grandchild_a
-    setup_kill_test_session(&mgr, &tmp, grandchild_a_id, "gc-a-agent", 2).await;
-    mgr.register_child(
-        child_id,
-        ChildSessionInfo {
-            session_id: grandchild_a_id.to_string(),
-            parent_session_id: child_id.to_string(),
-            agent_id: "gc-a-agent".to_string(),
-            depth: 2,
-            mode: SpawnMode::Run,
-        },
-    )
-    .await;
-
-    // grandchild_a → great-grandchild
-    setup_kill_test_session(&mgr, &tmp, great_grandchild_id, "ggc-agent", 3).await;
-    mgr.register_child(
-        grandchild_a_id,
-        ChildSessionInfo {
-            session_id: great_grandchild_id.to_string(),
-            parent_session_id: grandchild_a_id.to_string(),
-            agent_id: "ggc-agent".to_string(),
-            depth: 3,
-            mode: SpawnMode::Run,
-        },
-    )
-    .await;
-
-    // child → grandchild_b
-    setup_kill_test_session(&mgr, &tmp, grandchild_b_id, "gc-b-agent", 2).await;
-    mgr.register_child(
-        child_id,
-        ChildSessionInfo {
-            session_id: grandchild_b_id.to_string(),
-            parent_session_id: child_id.to_string(),
-            agent_id: "gc-b-agent".to_string(),
-            depth: 2,
-            mode: SpawnMode::Session,
-        },
-    )
-    .await;
+    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
+    register_child!(&mgr, &tmp, parent_id, child_id, "child-agent", 1, SpawnMode::Session);
+    register_child!(&mgr, &tmp, child_id, grandchild_a_id, "gc-a-agent", 2, SpawnMode::Run);
+    register_child!(&mgr, &tmp, grandchild_a_id, great_grandchild_id, "ggc-agent", 3, SpawnMode::Run);
+    register_child!(&mgr, &tmp, child_id, grandchild_b_id, "gc-b-agent", 2, SpawnMode::Session);
 
     // Verify initial state
     assert_eq!(mgr.count_active_children(parent_id).await, 1);
@@ -754,18 +722,9 @@ async fn test_kill_child_cascades_removes_all_orphans_multilevel() {
     assert!(!mgr.has_session(grandchild_b_id).await);
     assert!(!mgr.has_session(great_grandchild_id).await);
     assert!(mgr.get_conversation_session(child_id).await.is_none());
-    assert!(mgr
-        .get_conversation_session(grandchild_a_id)
-        .await
-        .is_none());
-    assert!(mgr
-        .get_conversation_session(grandchild_b_id)
-        .await
-        .is_none());
-    assert!(mgr
-        .get_conversation_session(great_grandchild_id)
-        .await
-        .is_none());
+    assert!(mgr.get_conversation_session(grandchild_a_id).await.is_none());
+    assert!(mgr.get_conversation_session(grandchild_b_id).await.is_none());
+    assert!(mgr.get_conversation_session(great_grandchild_id).await.is_none());
     assert_eq!(mgr.count_active_children(parent_id).await, 0);
     assert_eq!(mgr.count_active_children(child_id).await, 0);
     assert_eq!(mgr.count_active_children(grandchild_a_id).await, 0);

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -699,7 +699,11 @@ async fn test_kill_child_cascades_removes_all_orphans_multilevel() {
     setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
     register_child!(&mgr, &tmp, parent_id, child_id, "child-agent", 1, SpawnMode::Session);
     register_child!(&mgr, &tmp, child_id, grandchild_a_id, "gc-a-agent", 2, SpawnMode::Run);
-    register_child!(&mgr, &tmp, grandchild_a_id, great_grandchild_id, "ggc-agent", 3, SpawnMode::Run);
+    register_child!(
+        &mgr, &tmp,
+        grandchild_a_id, great_grandchild_id,
+        "ggc-agent", 3, SpawnMode::Run
+    );
     register_child!(&mgr, &tmp, child_id, grandchild_b_id, "gc-b-agent", 2, SpawnMode::Session);
 
     // Verify initial state

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -585,3 +585,47 @@ async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
         other => panic!("expected DepthExceeded, got {:?}", other),
     }
 }
+
+// ── Step 1.1: depth-before-agentId order verification ────────────────────
+
+/// Verify that when depth=0 AND requireAgentId=true AND no agentId is passed,
+/// the validation returns `DepthExceeded` rather than `AgentIdRequired`.
+///
+/// This is the key behavioral difference the refactoring is meant to fix:
+/// the design doc requires depth check to execute before agentId resolution.
+#[tokio::test]
+async fn test_validate_depth_before_agent_id_required() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    // max_spawn_depth=0 (depth check will reject) AND require_agent_id=true
+    // (would also reject if depth check didn't run first).
+    let mut sub = SubagentsConfig::default();
+    sub.max_spawn_depth = 0;
+    sub.require_agent_id = true;
+    sub.default_child_agent = None;
+    let parent = make_agent("parent", sub);
+    inject_agents(&cm, vec![("parent", parent)]);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    // Pass None for agent_id — without the refactoring this would return
+    // AgentIdRequired (because require_agent_id is checked before depth).
+    // After the refactoring, depth check runs first → DepthExceeded.
+    let err = controller
+        .validate(&parent_id, None)
+        .await
+        .expect_err("should reject when depth=0");
+
+    match err {
+        SpawnError::DepthExceeded { current, max } => {
+            assert_eq!(current, 1);
+            assert_eq!(max, 0);
+        }
+        other => panic!(
+            "expected DepthExceeded (depth checked before agentId), got {:?}",
+            other
+        ),
+    }
+}

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -629,3 +629,272 @@ async fn test_validate_depth_before_agent_id_required() {
         ),
     }
 }
+
+// ── Step 1.2: multi-level cascade kill — no orphan entries ────────────
+
+/// Helper to create a minimal ConversationSession + register it in a
+/// SessionManager for cascade-kill tests.
+async fn setup_kill_test_session(
+    mgr: &crate::gateway::SessionManager,
+    tmp: &tempfile::TempDir,
+    session_id: &str,
+    agent_id: &str,
+    depth: u32,
+) {
+    let cs = crate::llm::session::ConversationSession::new(
+        session_id.to_string(),
+        "test-model".to_string(),
+        tmp.path().to_path_buf(),
+    );
+    mgr.conversation_sessions.write().await.insert(
+        session_id.to_string(),
+        std::sync::Arc::new(tokio::sync::RwLock::new(cs)),
+    );
+    mgr.sessions.write().await.insert(
+        session_id.to_string(),
+        crate::gateway::Session {
+            id: session_id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth,
+        },
+    );
+}
+
+/// Kill a child with multiple descendants (grandchild + great-grandchild)
+/// and verify no orphan entries remain in any tracking table.
+/// This is the key Step 1.2 multi-level cascade test.
+#[tokio::test]
+async fn test_kill_child_cascades_removes_all_orphans_multilevel() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_session_manager();
+
+    let parent_id = "parent-kill-multi";
+    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
+
+    let child_id = "child-multi";
+    let grandchild_a_id = "grandchild-a-multi";
+    let grandchild_b_id = "grandchild-b-multi";
+    let great_grandchild_id = "great-grandchild-multi";
+
+    // parent → child
+    setup_kill_test_session(&mgr, &tmp, child_id, "child-agent", 1).await;
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // child → grandchild_a
+    setup_kill_test_session(&mgr, &tmp, grandchild_a_id, "gc-a-agent", 2).await;
+    mgr.register_child(
+        child_id,
+        ChildSessionInfo {
+            session_id: grandchild_a_id.to_string(),
+            parent_session_id: child_id.to_string(),
+            agent_id: "gc-a-agent".to_string(),
+            depth: 2,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // grandchild_a → great-grandchild
+    setup_kill_test_session(&mgr, &tmp, great_grandchild_id, "ggc-agent", 3).await;
+    mgr.register_child(
+        grandchild_a_id,
+        ChildSessionInfo {
+            session_id: great_grandchild_id.to_string(),
+            parent_session_id: grandchild_a_id.to_string(),
+            agent_id: "ggc-agent".to_string(),
+            depth: 3,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // child → grandchild_b
+    setup_kill_test_session(&mgr, &tmp, grandchild_b_id, "gc-b-agent", 2).await;
+    mgr.register_child(
+        child_id,
+        ChildSessionInfo {
+            session_id: grandchild_b_id.to_string(),
+            parent_session_id: child_id.to_string(),
+            agent_id: "gc-b-agent".to_string(),
+            depth: 2,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // Verify initial state
+    assert_eq!(mgr.count_active_children(parent_id).await, 1);
+    assert_eq!(mgr.count_active_children(child_id).await, 2);
+    assert_eq!(mgr.count_active_children(grandchild_a_id).await, 1);
+    assert!(mgr.has_session(child_id).await);
+    assert!(mgr.has_session(grandchild_a_id).await);
+    assert!(mgr.has_session(grandchild_b_id).await);
+    assert!(mgr.has_session(great_grandchild_id).await);
+
+    // Kill child — should recursively clean up all descendants
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    // ALL descendants removed — no orphans
+    assert!(!mgr.has_session(child_id).await);
+    assert!(!mgr.has_session(grandchild_a_id).await);
+    assert!(!mgr.has_session(grandchild_b_id).await);
+    assert!(!mgr.has_session(great_grandchild_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert!(mgr
+        .get_conversation_session(grandchild_a_id)
+        .await
+        .is_none());
+    assert!(mgr
+        .get_conversation_session(grandchild_b_id)
+        .await
+        .is_none());
+    assert!(mgr
+        .get_conversation_session(great_grandchild_id)
+        .await
+        .is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+    assert_eq!(mgr.count_active_children(child_id).await, 0);
+    assert_eq!(mgr.count_active_children(grandchild_a_id).await, 0);
+}
+
+/// Verify that kill_child on a child with no descendants is a clean removal.
+#[tokio::test]
+async fn test_kill_child_no_descendants_clean_removal() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_session_manager();
+
+    let parent_id = "parent-no-desc";
+    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
+
+    let child_id = "lone-child";
+    setup_kill_test_session(&mgr, &tmp, child_id, "child-agent", 1).await;
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(!mgr.has_session(child_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+}
+
+// ── Step 1.3: children survive across parent turns ────────────────────
+
+/// Verify that session-mode children registered under a parent are NOT
+/// prematurely removed without an explicit kill. This test validates the
+/// Step 1.3 design invariant: cascade termination only occurs on parent
+/// session end or timeout, not on each finish_llm turn.
+#[tokio::test]
+async fn test_session_child_survives_without_explicit_kill() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_session_manager();
+
+    let parent_id = "parent-survive";
+    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
+
+    let child_id = "surviving-child";
+    setup_kill_test_session(&mgr, &tmp, child_id, "child-agent", 1).await;
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // Simulate multiple parent turns — child should remain alive
+    for turn in 0..3 {
+        assert!(
+            mgr.has_session(child_id).await,
+            "child should survive turn {}",
+            turn
+        );
+        assert!(
+            mgr.get_conversation_session(child_id).await.is_some(),
+            "child conversation session should survive turn {}",
+            turn
+        );
+        assert_eq!(
+            mgr.count_active_children(parent_id).await,
+            1,
+            "child count should remain 1 at turn {}",
+            turn
+        );
+    }
+
+    // Only after explicit kill should the child be removed
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(!mgr.has_session(child_id).await);
+    assert!(mgr.get_conversation_session(child_id).await.is_none());
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+}
+
+/// Verify that run-mode children also survive without explicit kill
+/// (cascade was removed from finish_llm, so run-mode children are only
+/// cleaned up by the sweeper or explicit kill).
+#[tokio::test]
+async fn test_run_child_survives_without_explicit_kill() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_session_manager();
+
+    let parent_id = "parent-run-survive";
+    setup_kill_test_session(&mgr, &tmp, parent_id, "parent-agent", 0).await;
+
+    let child_id = "run-surviving-child";
+    setup_kill_test_session(&mgr, &tmp, child_id, "child-agent", 1).await;
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // Verify child is alive
+    assert!(mgr.has_session(child_id).await);
+    assert_eq!(mgr.count_active_children(parent_id).await, 1);
+
+    // Explicit kill removes it
+    mgr.kill_child(parent_id, child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(!mgr.has_session(child_id).await);
+    assert_eq!(mgr.count_active_children(parent_id).await, 0);
+}

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -764,6 +764,73 @@ async fn test_kill_child_no_descendants_clean_removal() {
 
 // ── Step 1.3: children survive across parent turns ────────────────────
 
+/// When no target_agent_id is provided and default_child_agent resolves
+/// to an agent not in the allowlist, the whitelist check should reject it.
+#[tokio::test]
+async fn test_validate_default_child_agent_blocked_by_whitelist() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    // Parent has default_child_agent="fallback-child" but allowlist
+    // only allows "allowed-agent" — fallback should be blocked.
+    let mut sub = SubagentsConfig::default();
+    sub.default_child_agent = Some("fallback-child".to_string());
+    sub.allow_agents = vec!["allowed-agent".to_string()];
+    sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", sub);
+    let fallback_child = make_agent("fallback-child", SubagentsConfig::default());
+    inject_agents(
+        &cm,
+        vec![("parent", parent), ("fallback-child", fallback_child)],
+    );
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, None)
+        .await
+        .expect_err("should reject when default_child_agent not in allowlist");
+
+    match err {
+        SpawnError::AgentNotAllowed { agent_id } => {
+            assert_eq!(agent_id, "fallback-child");
+        }
+        other => panic!("expected AgentNotAllowed, got {:?}", other),
+    }
+}
+
+/// When no target_agent_id is provided and default_child_agent resolves
+/// to an agent in the allowlist, the whitelist check should pass.
+#[tokio::test]
+async fn test_validate_default_child_agent_allowed_by_whitelist() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller = SpawnController::new(cm.clone(), sm.clone());
+
+    // Parent has default_child_agent="allowed-child" and allowlist
+    // contains "allowed-child" — should pass.
+    let mut sub = SubagentsConfig::default();
+    sub.default_child_agent = Some("allowed-child".to_string());
+    sub.allow_agents = vec!["allowed-child".to_string()];
+    sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", sub);
+    let allowed_child = make_agent("allowed-child", SubagentsConfig::default());
+    inject_agents(
+        &cm,
+        vec![("parent", parent), ("allowed-child", allowed_child)],
+    );
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, None)
+        .await
+        .expect("validate should succeed for allowed default_child_agent");
+
+    assert_eq!(result.config.id, "allowed-child");
+}
+
 /// Verify that session-mode children registered under a parent are NOT
 /// prematurely removed without an explicit kill. This test validates the
 /// Step 1.3 design invariant: cascade termination only occurs on parent

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -159,17 +159,10 @@ impl Daemon {
                     )
                 }
             };
-        // Create ArchiveSweeper shutdown channel and spawn sweeper
+        // Create ArchiveSweeper shutdown channel (sweeper itself is
+        // created after SessionManager so it can cascade-terminate
+        // children on archive — design doc §生命周期联动).
         let (sweeper_tx, sweeper_rx) = watch::channel(());
-        let sweeper = Arc::new(ArchiveSweeper::new(
-            Arc::clone(&storage) as Arc<dyn PersistenceService>,
-            Arc::clone(&config_provider),
-        ));
-        let sweeper_for_task = Arc::clone(&sweeper);
-        tokio::spawn(async move {
-            sweeper_for_task.run(sweeper_rx).await;
-        });
-        info!("ArchiveSweeper spawned");
         let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
         info!("Agent registry initialized",);
         let gateway_config = GatewayConfig {
@@ -197,6 +190,22 @@ impl Daemon {
                 "failed to rebuild key_registry at startup — continuing"
             );
         }
+
+        // Create and spawn ArchiveSweeper with SessionManager so it can
+        // cascade-terminate children when archiving idle sessions.
+        let sweeper = Arc::new(
+            ArchiveSweeper::new(
+                Arc::clone(&storage) as Arc<dyn PersistenceService>,
+                Arc::clone(&config_provider),
+            )
+            .with_session_manager(Arc::clone(&session_manager)),
+        );
+        let sweeper_for_task = Arc::clone(&sweeper);
+        tokio::spawn(async move {
+            sweeper_for_task.run(sweeper_rx).await;
+        });
+        info!("ArchiveSweeper spawned");
+
         let gateway = Arc::new(gateway);
         // Wire the self-ref so `handle_inbound_message` can pass
         // a strong `Arc<Gateway>` into the streaming LLM path.

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -51,22 +51,14 @@ impl SessionMessageHandler {
         )
         .await;
 
-        // Cascade-terminate active child sessions (design-doc §级联终止).
-        // When the parent session completes its LLM turn, any child
-        // sessions still alive in the `children` table are stopped and
-        // cleaned up. Reuses the existing `kill_child` which already
-        // performs cascade stop + table cleanup.
-        let child_ids = session_manager.list_active_child_ids(session_id).await;
-        for child_id in child_ids {
-            if let Err(e) = session_manager.kill_child(session_id, &child_id).await {
-                tracing::warn!(
-                    parent_id = session_id,
-                    child_id,
-                    error = %e,
-                    "failed to cascade-kill child session"
-                );
-            }
-        }
+        // NOTE: Cascade-termination of child sessions is NOT done here.
+        // `finish_llm` is called after every LLM turn — cascading here
+        // would prematurely kill session-mode children that are designed
+        // to survive across turns. Cascade kill is handled by:
+        // - The sweeper (idle→archive path) for normal parent session end
+        // - `sessions_kill` tool for explicit parent-initiated kills
+        // - `ArchiveSweeper::cascade_archive_impl` for timeout cleanup
+        // See design-doc §生命周期联动 for the two correct trigger points.
     }
 
     async fn clear_busy_and_send(

--- a/src/gateway/session_manager/channel.rs
+++ b/src/gateway/session_manager/channel.rs
@@ -23,8 +23,18 @@ impl SessionManager {
     /// channel→session mapping. The old session is preserved in the
     /// sessions map for recovery but is no longer routed to by default.
     ///
+    /// Cascade-terminates all active children of the old session
+    /// before creating the new one (design doc §生命周期联动).
+    ///
     /// Returns the new session_id.
     pub async fn force_new_for_channel(&self, channel: &str, agent_id: &str) -> String {
+        // Cascade-kill children of the old session (if any) so they
+        // don't outlive the parent. Per design doc §生命周期联动:
+        // "父 session 正常结束: 所有仍活跃的子 session 被自动级联终止".
+        if let Some(old_id) = self.active_session_for_channel(channel).await {
+            self.cascade_kill_all_children(&old_id).await;
+        }
+
         // Generate a unique session id using the standard format
         let session_id = super::session_helpers::generate_session_id(agent_id);
         // Compute session_key for key_registry

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -481,19 +481,16 @@ impl SessionManager {
     /// table is traversed via BFS to discover all descendant session
     /// IDs before any removals, preventing lock-ordering issues.
     pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
-        // Verify the target child exists.
-        self.get_conversation_session(child_id)
-            .await
-            .ok_or_else(|| format!("child session not found: {}", child_id))?;
-
         // 1. Recursively collect all descendant session IDs via
         //    BFS on the `children` table.
         let descendant_ids = self.collect_descendant_ids(child_id).await;
 
-        // 2. Cascade-stop: cancel the token tree for the child
-        //    and all its descendants.
+        // 2. Get the child's conversation session, verify it exists,
+        //    and cascade-stop its token tree.
         if let Some(cs) = self.get_conversation_session(child_id).await {
             cs.read().await.stop(true).await;
+        } else {
+            return Err(format!("child session not found: {}", child_id));
         }
 
         // 3. Remove child + descendants from conversation_sessions.
@@ -595,8 +592,10 @@ impl SessionManager {
     /// Collect all descendant session IDs of a given session via BFS
     /// on the `children` table.
     ///
-    /// Returns session IDs in BFS order (shallowest first). The
-    /// caller is expected to process removals after calling this.
+    /// Returns session IDs in reverse BFS order (deepest first,
+    /// shallowest last) so that the caller removes leaves before
+    /// their parents — matching the design doc requirement to
+    /// "terminate from deepest to shallowest".
     async fn collect_descendant_ids(&self, session_id: &str) -> Vec<String> {
         let children = self.children.read().await;
         let mut result = Vec::new();
@@ -619,6 +618,8 @@ impl SessionManager {
             }
         }
 
+        // Reverse so deepest descendants come first.
+        result.reverse();
         result
     }
 }

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -468,23 +468,42 @@ impl SessionManager {
     /// remove it from `conversation_sessions`, `sessions`, and
     /// the parent's `children` tracking table. The archive is
     /// preserved (no purge).
+    ///
+    /// All descendants are also cleaned up recursively (per design
+    /// doc §级联 Kill — from deepest to shallowest). The `children`
+    /// table is traversed via BFS to discover all descendant session
+    /// IDs before any removals, preventing lock-ordering issues.
     pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
-        let cs = self
-            .get_conversation_session(child_id)
+        // Verify the target child exists.
+        self.get_conversation_session(child_id)
             .await
             .ok_or_else(|| format!("child session not found: {}", child_id))?;
 
-        // Cascade-stop: cancels the token tree and cleans up tool
-        // handles / child handles.
-        cs.read().await.stop(true).await;
+        // 1. Recursively collect all descendant session IDs via BFS
+        //    on the `children` table. This must happen before any
+        //    removals so we discover every descendant while the
+        //    tracking tables are still intact.
+        let descendant_ids = self.collect_descendant_ids(child_id).await;
 
-        // Remove from conversation_sessions.
+        // 2. Cascade-stop: cancels the token tree for the child and
+        //    all its descendants.  The cancel token tree (wired in
+        //    `create_child_session`) handles runtime cancellation;
+        //    we only need to clean up the tracking tables.
+        if let Some(cs) = self.get_conversation_session(child_id).await {
+            cs.read().await.stop(true).await;
+        }
+
+        // 3. Remove the child and all descendants from
+        //    conversation_sessions.
         {
             let mut conv_sessions = self.conversation_sessions.write().await;
             conv_sessions.remove(child_id);
+            for id in &descendant_ids {
+                conv_sessions.remove(id);
+            }
         }
 
-        // Unregister child handle from parent's ConversationSession.
+        // 4. Unregister child handle from parent's ConversationSession.
         {
             let conv_sessions = self.conversation_sessions.read().await;
             if let Some(parent_cs) = conv_sessions.get(parent_id) {
@@ -492,23 +511,73 @@ impl SessionManager {
             }
         }
 
-        // Remove from sessions.
+        // 5. Remove the child and all descendants from sessions.
         {
             let mut sessions = self.sessions.write().await;
             sessions.remove(child_id);
+            for id in &descendant_ids {
+                sessions.remove(id);
+            }
         }
 
-        // Remove from children tracking table.
+        // 6. Remove the child and all descendants from children
+        //    tracking table.  We also remove any entries where a
+        //    descendant acts as a parent of further descendants.
         {
             let mut children = self.children.write().await;
+            // Remove the direct child from parent's children list.
             if let Some(list) = children.get_mut(parent_id) {
                 list.retain(|info| info.session_id != child_id);
                 if list.is_empty() {
                     children.remove(parent_id);
                 }
             }
+            // Remove each descendant from its own parent's children
+            // list (grandchildren, great-grandchildren, etc.).
+            for id in &descendant_ids {
+                // Find and remove from the parent's list.
+                let parent = children
+                    .values_mut()
+                    .find(|list| list.iter().any(|info| info.session_id == *id));
+                if let Some(list) = parent {
+                    list.retain(|info| info.session_id != *id);
+                }
+                // Also remove the descendant's own children entry
+                // (if it had spawned further children).
+                children.remove(id);
+            }
         }
 
         Ok(())
+    }
+
+    /// Collect all descendant session IDs of a given session via BFS
+    /// on the `children` table.
+    ///
+    /// Returns session IDs in BFS order (shallowest first). The
+    /// caller is expected to process removals after calling this.
+    async fn collect_descendant_ids(&self, session_id: &str) -> Vec<String> {
+        let children = self.children.read().await;
+        let mut result = Vec::new();
+        let mut queue = std::collections::VecDeque::new();
+
+        // Seed the queue with the direct children of session_id.
+        if let Some(list) = children.get(session_id) {
+            for info in list {
+                queue.push_back(info.session_id.clone());
+            }
+        }
+
+        while let Some(current) = queue.pop_front() {
+            result.push(current.clone());
+            // Enqueue this session's own children (grandchildren).
+            if let Some(list) = children.get(&current) {
+                for info in list {
+                    queue.push_back(info.session_id.clone());
+                }
+            }
+        }
+
+        result
     }
 }

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -70,6 +70,7 @@ impl SessionManager {
     ///
     /// Returns a cloned snapshot so the caller does not hold the
     /// `children` lock across await points.
+    #[allow(dead_code)] // Used in spawn_budget_tests.rs for cascade simulation
     pub(crate) async fn list_active_child_ids(&self, parent_id: &str) -> Vec<String> {
         let children = self.children.read().await;
         children

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -529,6 +529,33 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Cascade-kill all active children of a session.
+    ///
+    /// Called when a parent session ends (via `/new`) or is archived
+    /// by the sweeper, per design doc §生命周期联动.
+    /// Iterates direct children and calls `kill_child` for each,
+    /// which recursively handles deeper descendants.
+    pub(crate) async fn cascade_kill_all_children(&self, parent_id: &str) {
+        // Snapshot child IDs to avoid holding the lock across kill calls.
+        let child_ids: Vec<String> = {
+            let children = self.children.read().await;
+            children
+                .get(parent_id)
+                .map(|list| list.iter().map(|i| i.session_id.clone()).collect())
+                .unwrap_or_default()
+        };
+        for child_id in child_ids {
+            if let Err(e) = self.kill_child(parent_id, &child_id).await {
+                tracing::warn!(
+                    parent = %parent_id,
+                    child = %child_id,
+                    error = %e,
+                    "cascade_kill_all_children: failed to kill child"
+                );
+            }
+        }
+    }
+
     /// Remove a direct child and all its descendants from the
     /// `children` tracking table.
     ///

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -94,9 +94,12 @@ impl SessionManager {
     ///
     /// Workflow:
     /// 1. Generate a new UUID-based session id.
-    /// 2. Resolve workspace path (3-level fallback: explicit arg → config → ensure subdir under self.workspace_dir).
+    /// 2. Resolve workspace path (3-level fallback: explicit
+    ///    arg → config → ensure subdir under parent workspace).
     /// 3. Pick bootstrap mode (Minimal if light_context, else config's mode).
-    /// 4. Build system prompt (mirrors `find_or_create` — load bootstrap files, build ToolContext, call `build_from_workspace`).
+    /// 4. Build system prompt (mirrors `find_or_create` —
+    ///    load bootstrap files, build ToolContext, call
+    ///    `build_from_workspace`).
     /// 5. Construct `ConversationSession` (with system prompt + default reasoning level).
     /// 6. Push `task` as the first pending message so the child picks it up.
     /// 7. Register the new child in `conversation_sessions` + `sessions` + `children` tables.
@@ -351,7 +354,10 @@ impl SessionManager {
              If you need to wait for sub-agent results, use the yield \
              mechanism to end your current turn.\n\
              **Behavioral constraints:**\n\
-             - Trust push-based completion notifications\n             - Do not call session query tools to check child agent status\n             - Execute the task directly; do not ask for confirmation \
+             - Trust push-based completion
+               notifications\n             - Do not call session query tools
+               to check child agent status\n             - Execute the task directly;
+               do not ask for confirmation \
                or suggest next steps — the parent agent handles that"
         );
         if depth < max_spawn_depth {
@@ -480,39 +486,34 @@ impl SessionManager {
             .await
             .ok_or_else(|| format!("child session not found: {}", child_id))?;
 
-        // 1. Recursively collect all descendant session IDs via BFS
-        //    on the `children` table. This must happen before any
-        //    removals so we discover every descendant while the
-        //    tracking tables are still intact.
+        // 1. Recursively collect all descendant session IDs via
+        //    BFS on the `children` table.
         let descendant_ids = self.collect_descendant_ids(child_id).await;
 
-        // 2. Cascade-stop: cancels the token tree for the child and
-        //    all its descendants.  The cancel token tree (wired in
-        //    `create_child_session`) handles runtime cancellation;
-        //    we only need to clean up the tracking tables.
+        // 2. Cascade-stop: cancel the token tree for the child
+        //    and all its descendants.
         if let Some(cs) = self.get_conversation_session(child_id).await {
             cs.read().await.stop(true).await;
         }
 
-        // 3. Remove the child and all descendants from
-        //    conversation_sessions.
+        // 3. Remove child + descendants from conversation_sessions.
         {
-            let mut conv_sessions = self.conversation_sessions.write().await;
-            conv_sessions.remove(child_id);
+            let mut cs = self.conversation_sessions.write().await;
+            cs.remove(child_id);
             for id in &descendant_ids {
-                conv_sessions.remove(id);
+                cs.remove(id);
             }
         }
 
-        // 4. Unregister child handle from parent's ConversationSession.
+        // 4. Unregister child handle from parent.
         {
-            let conv_sessions = self.conversation_sessions.read().await;
-            if let Some(parent_cs) = conv_sessions.get(parent_id) {
+            let cs = self.conversation_sessions.read().await;
+            if let Some(parent_cs) = cs.get(parent_id) {
                 parent_cs.read().await.unregister_child_handle(child_id);
             }
         }
 
-        // 5. Remove the child and all descendants from sessions.
+        // 5. Remove child + descendants from sessions.
         {
             let mut sessions = self.sessions.write().await;
             sessions.remove(child_id);
@@ -521,35 +522,47 @@ impl SessionManager {
             }
         }
 
-        // 6. Remove the child and all descendants from children
-        //    tracking table.  We also remove any entries where a
-        //    descendant acts as a parent of further descendants.
-        {
-            let mut children = self.children.write().await;
-            // Remove the direct child from parent's children list.
-            if let Some(list) = children.get_mut(parent_id) {
-                list.retain(|info| info.session_id != child_id);
-                if list.is_empty() {
-                    children.remove(parent_id);
-                }
-            }
-            // Remove each descendant from its own parent's children
-            // list (grandchildren, great-grandchildren, etc.).
-            for id in &descendant_ids {
-                // Find and remove from the parent's list.
-                let parent = children
-                    .values_mut()
-                    .find(|list| list.iter().any(|info| info.session_id == *id));
-                if let Some(list) = parent {
-                    list.retain(|info| info.session_id != *id);
-                }
-                // Also remove the descendant's own children entry
-                // (if it had spawned further children).
-                children.remove(id);
+        // 6. Remove child + descendants from children table.
+        self.remove_children_entries(parent_id, child_id, &descendant_ids)
+            .await;
+
+        Ok(())
+    }
+
+    /// Remove a direct child and all its descendants from the
+    /// `children` tracking table.
+    ///
+    /// Handles: (a) removing the direct child from `parent_id`'s
+    /// list, (b) removing each descendant from its own parent's
+    /// list, and (c) removing any entries where a descendant is
+    /// itself a parent of further descendants.
+    async fn remove_children_entries(
+        &self,
+        parent_id: &str,
+        child_id: &str,
+        descendant_ids: &[String],
+    ) {
+        let mut children = self.children.write().await;
+
+        // Remove the direct child from parent's children list.
+        if let Some(list) = children.get_mut(parent_id) {
+            list.retain(|info| info.session_id != child_id);
+            if list.is_empty() {
+                children.remove(parent_id);
             }
         }
 
-        Ok(())
+        // Remove each descendant from its own parent's list
+        // and clean up any sub-entries.
+        for id in descendant_ids {
+            let parent = children
+                .values_mut()
+                .find(|list| list.iter().any(|info| info.session_id == *id));
+            if let Some(list) = parent {
+                list.retain(|info| info.session_id != *id);
+            }
+            children.remove(id);
+        }
     }
 
     /// Collect all descendant session IDs of a given session via BFS

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -13,6 +13,7 @@ use tokio::time::Instant;
 use tracing::{error, info, warn};
 
 use crate::config::session::SessionConfigProvider;
+use crate::gateway::session_manager::SessionManager;
 use crate::session::persistence::{AgentRole, PersistenceError, PersistenceService};
 
 /// Errors that can occur during sweeper operations.
@@ -29,6 +30,9 @@ pub enum ArchiveSweeperError {
 pub struct ArchiveSweeper {
     storage: Arc<dyn PersistenceService>,
     config: Arc<dyn SessionConfigProvider>,
+    /// Optional runtime session manager for cleaning up child sessions
+    /// when archiving a parent (design doc §生命周期联动).
+    session_manager: Option<Arc<SessionManager>>,
 }
 
 impl ArchiveSweeper {
@@ -37,7 +41,18 @@ impl ArchiveSweeper {
         storage: Arc<dyn PersistenceService>,
         config: Arc<dyn SessionConfigProvider>,
     ) -> Self {
-        Self { storage, config }
+        Self {
+            storage,
+            config,
+            session_manager: None,
+        }
+    }
+
+    /// Attach a runtime [`SessionManager`] so the sweeper can
+    /// cascade-terminate children when archiving a parent session.
+    pub fn with_session_manager(mut self, sm: Arc<SessionManager>) -> Self {
+        self.session_manager = Some(sm);
+        self
     }
 
     /// Run the sweeper loop until `shutdown` signal is received.
@@ -97,6 +112,7 @@ impl ArchiveSweeper {
         // so panics propagate into catch_unwind.
         let storage = Arc::clone(&self.storage);
         let config = Arc::clone(&self.config);
+        let session_manager = self.session_manager.clone();
 
         let handle = tokio::task::spawn_blocking(move || {
             let runtime = tokio::runtime::Handle::current();
@@ -104,6 +120,7 @@ impl ArchiveSweeper {
                 runtime.block_on(Self::run_once_inner_impl(
                     Arc::clone(&storage),
                     Arc::clone(&config),
+                    session_manager,
                 ))
             }))
         });
@@ -132,6 +149,7 @@ impl ArchiveSweeper {
     async fn run_once_inner_impl(
         storage: Arc<dyn PersistenceService>,
         config: Arc<dyn SessionConfigProvider>,
+        session_manager: Option<Arc<SessionManager>>,
     ) -> Result<(), ArchiveSweeperError> {
         let agents = config.list_agents();
         if agents.is_empty() {
@@ -140,7 +158,14 @@ impl ArchiveSweeper {
 
         for agent_id in &agents {
             for role in [AgentRole::MainAgent, AgentRole::SubAgent] {
-                Self::sweep_agent_role(Arc::clone(&storage), config.as_ref(), agent_id, role).await;
+                Self::sweep_agent_role(
+                    Arc::clone(&storage),
+                    config.as_ref(),
+                    agent_id,
+                    role,
+                    session_manager.as_ref(),
+                )
+                .await;
             }
         }
 
@@ -153,6 +178,7 @@ impl ArchiveSweeper {
         config: &dyn SessionConfigProvider,
         agent_id: &str,
         role: AgentRole,
+        session_manager: Option<&Arc<SessionManager>>,
     ) {
         let cfg = config.session_config_for(agent_id, role);
 
@@ -163,7 +189,9 @@ impl ArchiveSweeper {
         {
             for sid in idle_ids {
                 let sid_err = sid.clone();
-                if let Err(e) = Self::cascade_archive_impl(Arc::clone(&storage), sid).await {
+                if let Err(e) =
+                    Self::cascade_archive_impl(Arc::clone(&storage), sid, session_manager).await
+                {
                     error!(session_id = %sid_err, %e, "failed to archive idle session");
                 }
             }
@@ -209,12 +237,24 @@ impl ArchiveSweeper {
 
     /// Cascade-terminate all descendants of `session_id` (deepest first),
     /// then archive the parent session.
+    ///
+    /// When a runtime [`SessionManager`] is available, also cleans up
+    /// child sessions from the runtime tracking tables (design doc
+    /// §生命周期联动: "父 session 超时清理: 级联终止所有子 session").
     async fn cascade_archive_impl(
         storage: Arc<dyn PersistenceService>,
         session_id: String,
+        session_manager: Option<&Arc<SessionManager>>,
     ) -> Result<(), ArchiveSweeperError> {
         // Recursively kill all descendants (deepest → shallowest)
         Self::cascade_kill_children(storage.as_ref(), &session_id).await?;
+
+        // Clean up runtime tracking tables if SessionManager is available.
+        // This terminates active child sessions and removes them from
+        // conversation_sessions / sessions / children tables.
+        if let Some(sm) = session_manager {
+            sm.cascade_kill_all_children(&session_id).await;
+        }
 
         // Now archive the parent session itself
         Self::archive_and_invalidate_impl(Arc::clone(&storage), session_id.clone()).await?;
@@ -668,7 +708,7 @@ mod tests {
         mem.add_checkpoint(child);
 
         let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_archive_impl(storage, "parent-archive".into())
+        ArchiveSweeper::cascade_archive_impl(storage, "parent-archive".into(), None)
             .await
             .unwrap();
 
@@ -687,7 +727,7 @@ mod tests {
         mem.add_checkpoint(SessionCheckpoint::new("solo-parent".into()));
 
         let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_archive_impl(storage, "solo-parent".into())
+        ArchiveSweeper::cascade_archive_impl(storage, "solo-parent".into(), None)
             .await
             .unwrap();
 

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -287,7 +287,11 @@ impl ArchiveSweeper {
         for (child_id, _) in all_descendants {
             storage.delete_checkpoint(&child_id).await?;
             storage.invalidate_session(&child_id).await?;
-            info!(parent = %parent_session_id, child = %child_id, "child session deleted and invalidated during cascade");
+            info!(
+                parent = %parent_session_id,
+                child = %child_id,
+                "child session deleted and invalidated during cascade"
+            );
         }
 
         Ok(())


### PR DESCRIPTION
Align agent-spawn implementation with design doc (3 must-fix discrepancies):

1. **Validation order**: Restructure `SpawnController::validate()` so depth check executes first (before agentId fallback and requireAgentId), matching design doc §验证顺序 ①→②→③→③a→④
2. **Cascade cleanup**: Add recursive removal of all descendant session tracking entries in `kill_child`, preventing orphan entries after cascade termination
3. **Cascade termination timing**: Remove premature cascade-kill from `finish_llm` (which ran on every LLM turn) and instead trigger cascade termination on parent session end and sweeper timeout, matching design doc §生命周期联动

Source: CI
Type: fix
