### PR TITLE
fix: rebuild spawn_tree from checkpoints at startup

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -191,6 +191,14 @@ impl Daemon {
             );
         }
 
+        // Rebuild spawn_tree (children table) from persisted checkpoints at startup.
+        if let Err(e) = session_manager.rebuild_spawn_tree().await {
+            tracing::warn!(
+                error = %e,
+                "failed to rebuild spawn_tree at startup — continuing"
+            );
+        }
+
         // Create and spawn ArchiveSweeper with SessionManager so it can
         // cascade-terminate children when archiving idle sessions.
         let sweeper = Arc::new(

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -434,6 +434,8 @@ mod flush_tests;
 #[cfg(test)]
 mod model_priority_tests;
 #[cfg(test)]
+mod rebuild_spawn_tree_tests;
+#[cfg(test)]
 mod rebuild_tests;
 #[cfg(test)]
 mod resolve_tests;

--- a/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
+++ b/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
@@ -1,0 +1,98 @@
+//! Tests for `SessionManager::rebuild_spawn_tree`.
+//!
+//! These tests verify that `rebuild_spawn_tree` correctly reconstructs the
+//! in-memory children table from persisted `SessionCheckpoint`s.
+
+use super::tests::{make_test_mgr, test_config};
+use super::SessionManager;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{PersistenceService, SessionCheckpoint};
+use crate::session::ReasoningLevel;
+use std::sync::Arc;
+
+/// Helper: create a `SessionManager` with the given `MemoryStorage` and
+/// no workspace (avoids filesystem dependencies).
+fn make_mgr_with_storage(
+    storage: Arc<crate::session::storage::memory::MemoryStorage>,
+) -> SessionManager {
+    SessionManager::new(
+        &test_config(),
+        Some(storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    )
+}
+
+/// `rebuild_spawn_tree` basic: parent and child checkpoints stored;
+/// after rebuild the children table should contain the child under
+/// the parent with the correct fields.
+#[tokio::test]
+async fn test_rebuild_spawn_tree_basic() {
+    let storage = Arc::new(crate::session::storage::memory::MemoryStorage::new());
+
+    // Parent checkpoint (root, no parent_session_id).
+    let mut parent_cp = SessionCheckpoint::new("parent-1".to_string());
+    parent_cp.depth = 0;
+    parent_cp.agent_id = Some("parent-agent".to_string());
+    parent_cp.parent_session_id = None;
+    storage.save_checkpoint(&parent_cp).await.unwrap();
+
+    // Child checkpoint (parent = parent-1).
+    let mut child_cp = SessionCheckpoint::new("child-1".to_string());
+    child_cp.depth = 1;
+    child_cp.agent_id = Some("child-agent".to_string());
+    child_cp.parent_session_id = Some("parent-1".to_string());
+    storage.save_checkpoint(&child_cp).await.unwrap();
+
+    let mgr = make_mgr_with_storage(storage);
+    mgr.rebuild_spawn_tree().await.unwrap();
+
+    // children table should have one entry under parent-1.
+    let count = mgr.count_active_children("parent-1").await;
+    assert_eq!(count, 1, "parent-1 should have exactly 1 child");
+
+    let children = mgr.children.read().await;
+    let list = children.get("parent-1").unwrap();
+    assert_eq!(list[0].session_id, "child-1");
+    assert_eq!(list[0].parent_session_id, "parent-1");
+    assert_eq!(list[0].agent_id, "child-agent");
+    assert_eq!(list[0].depth, 1);
+}
+
+/// `rebuild_spawn_tree` orphan: child's parent does not exist in storage.
+/// The child should NOT be registered in the children table (degraded to root).
+#[tokio::test]
+async fn test_rebuild_spawn_tree_orphan() {
+    let storage = Arc::new(crate::session::storage::memory::MemoryStorage::new());
+
+    // Only child checkpoint, no parent.
+    let mut child_cp = SessionCheckpoint::new("orphan-child".to_string());
+    child_cp.depth = 2;
+    child_cp.agent_id = Some("orphan-agent".to_string());
+    child_cp.parent_session_id = Some("nonexistent-parent".to_string());
+    storage.save_checkpoint(&child_cp).await.unwrap();
+
+    let mgr = make_mgr_with_storage(storage);
+    mgr.rebuild_spawn_tree().await.unwrap();
+
+    // children table should be empty — orphan degraded to root.
+    let children = mgr.children.read().await;
+    assert!(
+        children.is_empty(),
+        "orphan child should not appear in children table"
+    );
+}
+
+/// `rebuild_spawn_tree` no storage: returns Ok and children table stays empty.
+#[tokio::test]
+async fn test_rebuild_spawn_tree_no_storage() {
+    let mgr = make_test_mgr(None); // no storage
+    mgr.rebuild_spawn_tree().await.unwrap();
+
+    let children = mgr.children.read().await;
+    assert!(
+        children.is_empty(),
+        "children table should be empty without storage"
+    );
+}

--- a/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
+++ b/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
@@ -5,9 +5,11 @@
 
 use super::tests::{make_test_mgr, test_config};
 use super::SessionManager;
+use crate::gateway::Session;
 use crate::session::bootstrap::BootstrapMode;
-use crate::session::persistence::{PersistenceService, SessionCheckpoint};
+use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 use crate::session::ReasoningLevel;
+use chrono::Utc;
 use std::sync::Arc;
 
 /// Helper: create a `SessionManager` with the given `MemoryStorage` and
@@ -15,6 +17,17 @@ use std::sync::Arc;
 fn make_mgr_with_storage(
     storage: Arc<crate::session::storage::memory::MemoryStorage>,
 ) -> SessionManager {
+    SessionManager::new(
+        &test_config(),
+        Some(storage),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    )
+}
+
+/// Helper: create a `SessionManager` with any `PersistenceService` impl.
+fn make_mgr_with_persistence(storage: Arc<dyn PersistenceService>) -> SessionManager {
     SessionManager::new(
         &test_config(),
         Some(storage),
@@ -61,7 +74,8 @@ async fn test_rebuild_spawn_tree_basic() {
 }
 
 /// `rebuild_spawn_tree` orphan: child's parent does not exist in storage.
-/// The child should NOT be registered in the children table (degraded to root).
+/// The child should NOT be registered in the children table (degraded to root)
+/// and its depth should be reset to 0 in the sessions map.
 #[tokio::test]
 async fn test_rebuild_spawn_tree_orphan() {
     let storage = Arc::new(crate::session::storage::memory::MemoryStorage::new());
@@ -74,6 +88,20 @@ async fn test_rebuild_spawn_tree_orphan() {
     storage.save_checkpoint(&child_cp).await.unwrap();
 
     let mgr = make_mgr_with_storage(storage);
+
+    // Pre-populate the session in the sessions map with depth=2
+    // so we can verify it gets reset to 0 after rebuild.
+    mgr.sessions.write().await.insert(
+        "orphan-child".to_string(),
+        Session {
+            id: "orphan-child".to_string(),
+            agent_id: "orphan-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: Utc::now().timestamp(),
+            depth: 2,
+        },
+    );
+
     mgr.rebuild_spawn_tree().await.unwrap();
 
     // children table should be empty — orphan degraded to root.
@@ -82,6 +110,13 @@ async fn test_rebuild_spawn_tree_orphan() {
         children.is_empty(),
         "orphan child should not appear in children table"
     );
+
+    // Depth should be reset to 0 (degraded to root).
+    let sessions = mgr.sessions.read().await;
+    let orphan = sessions
+        .get("orphan-child")
+        .expect("orphan session should exist");
+    assert_eq!(orphan.depth, 0, "orphan depth should be reset to 0");
 }
 
 /// `rebuild_spawn_tree` no storage: returns Ok and children table stays empty.
@@ -94,5 +129,84 @@ async fn test_rebuild_spawn_tree_no_storage() {
     assert!(
         children.is_empty(),
         "children table should be empty without storage"
+    );
+}
+
+/// Mock persistence service that returns an error from `load_checkpoint`.
+struct FailingCheckpointStorage;
+
+#[async_trait::async_trait]
+impl PersistenceService for FailingCheckpointStorage {
+    async fn save_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn load_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Err(PersistenceError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "injected failure",
+        )))
+    }
+    async fn delete_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec!["session-a".to_string()])
+    }
+    async fn restore_checkpoint(
+        &self,
+        _: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Err(PersistenceError::Io(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "injected failure",
+        )))
+    }
+    async fn archive_checkpoint(&self, _: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec![])
+    }
+    async fn purge_checkpoint(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn invalidate_session(&self, _: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    async fn list_idle_sessions_for_agent(
+        &self,
+        _: &str,
+        _: crate::session::persistence::AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec![])
+    }
+    async fn list_expired_archived_sessions_for_agent(
+        &self,
+        _: &str,
+        _: crate::session::persistence::AgentRole,
+        _: i64,
+    ) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec![])
+    }
+}
+
+/// `rebuild_spawn_tree` checkpoint error: `load_checkpoint` returns `Err`
+/// for a session — should log a warning and skip that session without
+/// panicking.
+#[tokio::test]
+async fn test_rebuild_spawn_tree_checkpoint_error() {
+    let storage = Arc::new(FailingCheckpointStorage);
+    let mgr = make_mgr_with_persistence(storage);
+    // Should complete successfully — errors are logged and skipped.
+    mgr.rebuild_spawn_tree().await.unwrap();
+
+    let children = mgr.children.read().await;
+    assert!(
+        children.is_empty(),
+        "children table should be empty when checkpoint loading fails"
     );
 }

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -658,14 +658,35 @@ impl SessionManager {
         for session_id in &all_ids {
             let cp = match storage_arc.load_checkpoint(session_id).await {
                 Ok(Some(cp)) => cp,
-                _ => continue,
+                Ok(None) => {
+                    warn!(
+                        session_id = %session_id,
+                        "checkpoint returned None during spawn_tree rebuild, skipping"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        session_id = %session_id,
+                        error = %e,
+                        "failed to load checkpoint during spawn_tree rebuild, skipping"
+                    );
+                    continue;
+                }
             };
             let parent_id = match cp.parent_session_id.as_deref() {
                 Some(p) => p,
                 None => continue, // root node
             };
             if !known_ids.contains(parent_id) {
-                continue; // parent missing — orphan, degrade to root
+                // Parent missing — orphan session. Degrade to root by
+                // resetting depth to 0 so the spawn depth budget is
+                // not artificially compressed.
+                let mut sessions = self.sessions.write().await;
+                if let Some(s) = sessions.get_mut(session_id) {
+                    s.depth = 0;
+                }
+                continue;
             }
             self.register_child(
                 parent_id,
@@ -674,6 +695,10 @@ impl SessionManager {
                     parent_session_id: parent_id.to_string(),
                     agent_id: cp.agent_id.unwrap_or_default(),
                     depth: cp.depth,
+                    // All restored child sessions are treated as
+                    // persistent (Session) because run-mode sessions
+                    // that completed before shutdown are not expected
+                    // to appear in the checkpoint list.
                     mode: SpawnMode::Session,
                 },
             )

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -12,10 +12,13 @@ use crate::gateway::Session;
 use crate::llm::session::ChatSession;
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
-use crate::session::persistence::{PendingMessage, SessionCheckpoint, SessionStatus};
+use crate::session::persistence::{
+    PendingMessage, PersistenceError, SessionCheckpoint, SessionStatus,
+};
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::ToolContext;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use tracing::warn;
 use uuid::Uuid;
@@ -621,5 +624,64 @@ impl SessionManager {
         // Reverse so deepest descendants come first.
         result.reverse();
         result
+    }
+
+    /// Rebuild the spawn tree (children table) from persisted checkpoints.
+    ///
+    /// Called at startup after all sessions are restored. Iterates all
+    /// active + archived checkpoints and registers parent-child
+    /// relationships. Sessions whose parent has been swept are
+    /// silently skipped (degraded to root).
+    pub async fn rebuild_spawn_tree(&self) -> Result<(), PersistenceError> {
+        let storage_arc = {
+            let guard = self.storage.read().await;
+            match guard.as_ref() {
+                Some(s) => std::sync::Arc::clone(s),
+                None => return Ok(()),
+            }
+        };
+
+        // Collect all session_ids from active + archived.
+        let mut all_ids: Vec<String> = {
+            let active = storage_arc.list_active_sessions().await?;
+            let archived = storage_arc.list_archived_sessions().await?;
+            let mut ids = active;
+            ids.extend(archived);
+            ids
+        };
+        all_ids.sort();
+        all_ids.dedup();
+
+        let known_ids: HashSet<&str> = all_ids.iter().map(|s| s.as_str()).collect();
+        let mut rebuilt: u32 = 0;
+
+        for session_id in &all_ids {
+            let cp = match storage_arc.load_checkpoint(session_id).await {
+                Ok(Some(cp)) => cp,
+                _ => continue,
+            };
+            let parent_id = match cp.parent_session_id.as_deref() {
+                Some(p) => p,
+                None => continue, // root node
+            };
+            if !known_ids.contains(parent_id) {
+                continue; // parent missing — orphan, degrade to root
+            }
+            self.register_child(
+                parent_id,
+                ChildSessionInfo {
+                    session_id: session_id.clone(),
+                    parent_session_id: parent_id.to_string(),
+                    agent_id: cp.agent_id.unwrap_or_default(),
+                    depth: cp.depth,
+                    mode: SpawnMode::Session,
+                },
+            )
+            .await;
+            rebuilt += 1;
+        }
+
+        tracing::info!(rebuilt, "spawn_tree rebuilt from checkpoints");
+        Ok(())
     }
 }

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -654,6 +654,7 @@ impl SessionManager {
 
         let known_ids: HashSet<&str> = all_ids.iter().map(|s| s.as_str()).collect();
         let mut rebuilt: u32 = 0;
+        let mut orphan_ids: Vec<String> = Vec::new();
 
         for session_id in &all_ids {
             let cp = match storage_arc.load_checkpoint(session_id).await {
@@ -679,13 +680,10 @@ impl SessionManager {
                 None => continue, // root node
             };
             if !known_ids.contains(parent_id) {
-                // Parent missing — orphan session. Degrade to root by
-                // resetting depth to 0 so the spawn depth budget is
-                // not artificially compressed.
-                let mut sessions = self.sessions.write().await;
-                if let Some(s) = sessions.get_mut(session_id) {
-                    s.depth = 0;
-                }
+                // Parent missing — orphan session. Collect for batch
+                // depth reset after the loop to avoid acquiring the
+                // write lock per iteration.
+                orphan_ids.push(session_id.clone());
                 continue;
             }
             self.register_child(
@@ -704,6 +702,17 @@ impl SessionManager {
             )
             .await;
             rebuilt += 1;
+        }
+
+        // Batch-reset orphan session depths to 0 (degrade to root).
+        // Single write lock acquisition instead of per-orphan lock.
+        if !orphan_ids.is_empty() {
+            let mut sessions = self.sessions.write().await;
+            for orphan_id in &orphan_ids {
+                if let Some(s) = sessions.get_mut(orphan_id) {
+                    s.depth = 0;
+                }
+            }
         }
 
         tracing::info!(rebuilt, "spawn_tree rebuilt from checkpoints");


### PR DESCRIPTION
Add `rebuild_spawn_tree` to reconstruct the in-memory children table from persisted checkpoints at startup.

Previously, gateway restart left `spawn_tree.children` empty, causing `cascade_kill_all_children` and `count_active_children` to silently no-op on pre-existing child sessions. This fix iterates all active + archived checkpoints after session restore and re-registers parent-child relationships. Orphan sessions (whose parent was swept before shutdown) are degraded to root nodes with depth reset to 0.

Source: user
Type: fix
