### PR TITLE
feat: implement TerminalPlugin for CLI chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "tempfile",
+ "terminal_size",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -2521,6 +2522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ anyhow = "1.0"
 
 # Linux system APIs (seccomp, landlock)
 libc = "0.2"
+# Terminal size detection for dynamic width truncation
+terminal_size = "0.4"
 
 # HTTP client (rustls for TLS, no OpenSSL required)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,6 +1,6 @@
 //! CLI argument types for CloseClaw commands.
 
-use clap::Subcommand;
+use clap::{Args, Subcommand};
 
 #[derive(Subcommand)]
 pub enum AgentAction {
@@ -58,4 +58,12 @@ pub enum SkillAction {
         /// Skill name
         name: String,
     },
+}
+
+/// Interactive chat with an agent via the terminal.
+#[derive(Args)]
+pub struct ChatArgs {
+    /// Agent ID to chat with.
+    #[arg(short = 'a', long = "agent-id")]
+    pub agent_id: String,
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -8,9 +8,17 @@ use std::io::{self, BufRead, Write};
 use std::sync::Arc;
 
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
-use crate::im::terminal::TerminalPlugin;
+use crate::im::terminal::{current_uid, TerminalPlugin};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
+
+/// Why the REPL loop exited.
+enum ExitReason {
+    /// User typed quit/exit or /stop.
+    Quit,
+    /// unrecoverable error occurred.
+    Error(anyhow::Error),
+}
 
 /// Run the interactive chat REPL.
 ///
@@ -18,7 +26,23 @@ use crate::session::persistence::ReasoningLevel;
 /// 2. Create a session for the given `agent_id`.
 /// 3. Loop: read user input → route through gateway → print response.
 pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
-    // ── Gateway setup ─────────────────────────────────────────────────
+    let (gateway, session_manager) = build_gateway().await;
+    let session_id = create_session(&session_manager).await?;
+
+    println!("CloseClaw Chat — agent: {}", agent_id);
+    println!(
+        "Type your message and press Enter. Empty line to send. \
+         Type 'quit' or 'exit' to stop.\n"
+    );
+
+    match repl_loop(&gateway, &session_id).await {
+        ExitReason::Quit => Ok(()),
+        ExitReason::Error(e) => Err(e),
+    }
+}
+
+/// Build a [`Gateway`] with a [`TerminalPlugin`] registered.
+async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
     let gateway_config = GatewayConfig {
         name: "closeclaw-chat".to_string(),
         rate_limit_per_minute: 0,
@@ -39,138 +63,127 @@ pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
     let gateway = Arc::new(gateway);
     gateway.set_self_ref(Arc::clone(&gateway));
 
-    // Register the terminal plugin.
     let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());
     gateway.register_plugin(plugin).await;
 
-    // ── Create session ────────────────────────────────────────────────
-    let sender_id = get_user_id();
-    let peer_id = "cli";
-    let channel = "terminal";
+    (gateway, session_manager)
+}
 
+/// Create a session for the chat REPL.
+async fn create_session(session_manager: &SessionManager) -> anyhow::Result<String> {
+    let sender_id = current_uid();
     let message = crate::gateway::Message {
         id: format!("chat-{}", chrono::Utc::now().timestamp()),
-        from: sender_id.clone(),
-        to: peer_id.to_string(),
+        from: sender_id,
+        to: "cli".to_string(),
         content: String::new(),
-        channel: channel.to_string(),
+        channel: "terminal".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: Default::default(),
         thread_id: None,
     };
 
-    let session_id = session_manager
-        .find_or_create(channel, &message, None)
+    session_manager
+        .find_or_create("terminal", &message, None)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to create session: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("failed to create session: {}", e))
+}
 
-    // Store agent_id as chat_id so send_outbound can resolve it.
-    // SessionManager stores agent_id in the Session struct; we need
-    // to ensure the session maps correctly. For the chat REPL the
-    // session's agent_id *is* the chat_id used by send_outbound.
-    // Since find_or_create computes the session from the message, and
-    // our message has `to = "cli"`, the session's agent_id will be set
-    // to the agent_id we pass. We need a small helper to set it.
-    // Actually, looking at SessionManager::find_or_create, the
-    // agent_id comes from the message routing — we need to make sure
-    // the session is associated with our agent_id. The simplest way is
-    // to store it in metadata and let the session router pick it up.
-    // For the terminal channel, we'll just note the agent_id for
-    // reference; the actual agent resolution happens in the LLM layer.
-
-    println!("CloseClaw Chat — agent: {}", agent_id);
-    println!(
-        "Type your message and press Enter. Empty line to send. Type 'quit' or 'exit' to stop.\n"
-    );
-
-    // ── REPL loop ─────────────────────────────────────────────────────
+/// Run the read-eval-print loop.
+///
+/// Returns [`ExitReason::Quit`] when the user exits normally, or
+/// [`ExitReason::Error`] on I/O failure.
+async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str) -> ExitReason {
+    let sender_id = current_uid();
     let stdin = io::stdin();
+
     loop {
-        // Prompt
         print!("> ");
-        io::stdout().flush().ok();
+        if io::stdout().flush().is_err() {
+            return ExitReason::Error(anyhow::anyhow!("failed to flush stdout"));
+        }
 
-        // Read lines until a blank line (message boundary) or EOF.
-        let mut lines = Vec::new();
-        let mut blank_seen = false;
-        for line in stdin.lock().lines() {
-            match line {
-                Ok(text) => {
-                    let trimmed = text.trim();
-                    // Exit commands
-                    if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit")
-                    {
-                        println!("Goodbye!");
-                        return Ok(());
-                    }
-                    // Slash stop command
-                    if trimmed.eq_ignore_ascii_case("/stop") {
-                        println!("Session stopped.");
-                        return Ok(());
-                    }
-                    // Blank line = message boundary
-                    if trimmed.is_empty() {
-                        if lines.is_empty() {
-                            // Empty input — skip
-                            print!("> ");
-                            io::stdout().flush().ok();
-                            continue;
-                        }
-                        blank_seen = true;
-                        break;
-                    }
-                    lines.push(text);
-                }
-                Err(e) => {
-                    eprintln!("Error reading input: {}", e);
-                    return Ok(());
-                }
+        let content = match read_user_input(&stdin) {
+            InputResult::Message(c) => c,
+            InputResult::Quit => {
+                println!("Goodbye!");
+                return ExitReason::Quit;
             }
-        }
+            InputResult::Empty => continue,
+            InputResult::Eof => {
+                println!("\nGoodbye!");
+                return ExitReason::Quit;
+            }
+            InputResult::IoError(e) => {
+                return ExitReason::Error(anyhow::anyhow!("read error: {}", e));
+            }
+        };
 
-        // EOF without content
-        if lines.is_empty() && !blank_seen {
-            println!("\nGoodbye!");
-            return Ok(());
-        }
-
-        let content = lines.join("\n");
-        if content.trim().is_empty() {
-            continue;
-        }
-
-        // ── Route through gateway ─────────────────────────────────────
         let result = gateway
-            .handle_inbound_message(&session_id, content, Some(&sender_id), channel)
+            .handle_inbound_message(session_id, content, Some(&sender_id), "terminal")
             .await;
 
-        match result {
-            Some(_handle_result) => {
-                // The response is rendered by TerminalPlugin and sent to
-                // stdout asynchronously. We just wait briefly to allow
-                // the streaming task to flush.
-                // Give the LLM call a moment to produce output.
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            }
-            None => {
-                eprintln!("(no response — session handler not configured)");
-            }
+        if result.is_none() {
+            eprintln!("(no response — session handler not configured)");
         }
 
-        println!(); // blank line between exchanges
+        // Allow the streaming response to flush to stdout.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        println!();
     }
 }
 
-/// Get a stable user ID for the terminal session.
-///
-/// Uses the system UID on Unix, or a fallback string.
-fn get_user_id() -> String {
-    #[cfg(unix)]
-    {
-        format!("uid-{}", unsafe { libc::getuid() })
+/// Result of reading one user input attempt.
+enum InputResult {
+    /// A non-empty message ready to send.
+    Message(String),
+    /// User typed quit, exit, or /stop.
+    Quit,
+    /// Blank input — prompt again.
+    Empty,
+    /// EOF reached (stdin closed).
+    Eof,
+    /// I/O error.
+    IoError(io::Error),
+}
+
+/// Read user input from stdin until a blank line (message boundary) or EOF.
+fn read_user_input(stdin: &io::Stdin) -> InputResult {
+    let mut lines = Vec::new();
+
+    for line in stdin.lock().lines() {
+        match line {
+            Ok(text) => {
+                let trimmed = text.trim();
+                if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit") {
+                    return InputResult::Quit;
+                }
+                if trimmed.eq_ignore_ascii_case("/stop") {
+                    println!("Session stopped.");
+                    return InputResult::Quit;
+                }
+                if trimmed.is_empty() {
+                    if lines.is_empty() {
+                        print!("> ");
+                        let _ = io::stdout().flush();
+                        continue;
+                    }
+                    break;
+                }
+                lines.push(text);
+            }
+            Err(e) => return InputResult::IoError(e),
+        }
     }
-    #[cfg(not(unix))]
-    {
-        "terminal-user".to_string()
+
+    if lines.is_empty() {
+        return InputResult::Eof;
+    }
+
+    let content = lines.join("\n");
+    if content.trim().is_empty() {
+        InputResult::Empty
+    } else {
+        InputResult::Message(content)
     }
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -8,7 +8,7 @@ use std::io::{self, BufRead, Write};
 use std::sync::Arc;
 
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
-use crate::im::terminal::{current_uid, TerminalPlugin};
+use crate::im::terminal::TerminalPlugin;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 
@@ -26,8 +26,9 @@ enum ExitReason {
 /// 2. Create a session for the given `agent_id`.
 /// 3. Loop: read user input → route through gateway → print response.
 pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
+    let sender_id = crate::im::terminal::current_uid();
     let (gateway, session_manager) = build_gateway().await;
-    let session_id = create_session(&session_manager).await?;
+    let session_id = create_session(&session_manager, agent_id, &sender_id).await?;
 
     println!("CloseClaw Chat — agent: {}", agent_id);
     println!(
@@ -35,7 +36,7 @@ pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
          Type 'quit' or 'exit' to stop.\n"
     );
 
-    match repl_loop(&gateway, &session_id).await {
+    match repl_loop(&gateway, &session_id, &sender_id).await {
         ExitReason::Quit => Ok(()),
         ExitReason::Error(e) => Err(e),
     }
@@ -70,12 +71,15 @@ async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
 }
 
 /// Create a session for the chat REPL.
-async fn create_session(session_manager: &SessionManager) -> anyhow::Result<String> {
-    let sender_id = current_uid();
+async fn create_session(
+    session_manager: &SessionManager,
+    agent_id: &str,
+    sender_id: &str,
+) -> anyhow::Result<String> {
     let message = crate::gateway::Message {
         id: format!("chat-{}", chrono::Utc::now().timestamp()),
-        from: sender_id,
-        to: "cli".to_string(),
+        from: sender_id.to_string(),
+        to: agent_id.to_string(),
         content: String::new(),
         channel: "terminal".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
@@ -93,8 +97,7 @@ async fn create_session(session_manager: &SessionManager) -> anyhow::Result<Stri
 ///
 /// Returns [`ExitReason::Quit`] when the user exits normally, or
 /// [`ExitReason::Error`] on I/O failure.
-async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str) -> ExitReason {
-    let sender_id = current_uid();
+async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str, sender_id: &str) -> ExitReason {
     let stdin = io::stdin();
 
     loop {
@@ -120,7 +123,7 @@ async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str) -> ExitReason {
         };
 
         let result = gateway
-            .handle_inbound_message(session_id, content, Some(&sender_id), "terminal")
+            .handle_inbound_message(session_id, content, Some(sender_id), "terminal")
             .await;
 
         if result.is_none() {

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -1,0 +1,176 @@
+//! Interactive chat REPL via the terminal channel.
+//!
+//! Creates a [`TerminalPlugin`], registers it with a minimal [`Gateway`],
+//! and runs a read-eval-print loop that routes user input through the
+//! full inbound/outbound message pipeline.
+
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+
+use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
+use crate::im::terminal::TerminalPlugin;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+
+/// Run the interactive chat REPL.
+///
+/// 1. Build a [`Gateway`] with a [`TerminalPlugin`] registered.
+/// 2. Create a session for the given `agent_id`.
+/// 3. Loop: read user input → route through gateway → print response.
+pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
+    // ── Gateway setup ─────────────────────────────────────────────────
+    let gateway_config = GatewayConfig {
+        name: "closeclaw-chat".to_string(),
+        rate_limit_per_minute: 0,
+        max_message_size: 16_384,
+        dm_scope: DmScope::PerChannelPeer,
+        ..Default::default()
+    };
+
+    let session_manager = Arc::new(SessionManager::new(
+        &gateway_config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+
+    let gateway = Gateway::new(gateway_config, Arc::clone(&session_manager));
+    let gateway = Arc::new(gateway);
+    gateway.set_self_ref(Arc::clone(&gateway));
+
+    // Register the terminal plugin.
+    let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());
+    gateway.register_plugin(plugin).await;
+
+    // ── Create session ────────────────────────────────────────────────
+    let sender_id = get_user_id();
+    let peer_id = "cli";
+    let channel = "terminal";
+
+    let message = crate::gateway::Message {
+        id: format!("chat-{}", chrono::Utc::now().timestamp()),
+        from: sender_id.clone(),
+        to: peer_id.to_string(),
+        content: String::new(),
+        channel: channel.to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+        metadata: Default::default(),
+        thread_id: None,
+    };
+
+    let session_id = session_manager
+        .find_or_create(channel, &message, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to create session: {}", e))?;
+
+    // Store agent_id as chat_id so send_outbound can resolve it.
+    // SessionManager stores agent_id in the Session struct; we need
+    // to ensure the session maps correctly. For the chat REPL the
+    // session's agent_id *is* the chat_id used by send_outbound.
+    // Since find_or_create computes the session from the message, and
+    // our message has `to = "cli"`, the session's agent_id will be set
+    // to the agent_id we pass. We need a small helper to set it.
+    // Actually, looking at SessionManager::find_or_create, the
+    // agent_id comes from the message routing — we need to make sure
+    // the session is associated with our agent_id. The simplest way is
+    // to store it in metadata and let the session router pick it up.
+    // For the terminal channel, we'll just note the agent_id for
+    // reference; the actual agent resolution happens in the LLM layer.
+
+    println!("CloseClaw Chat — agent: {}", agent_id);
+    println!(
+        "Type your message and press Enter. Empty line to send. Type 'quit' or 'exit' to stop.\n"
+    );
+
+    // ── REPL loop ─────────────────────────────────────────────────────
+    let stdin = io::stdin();
+    loop {
+        // Prompt
+        print!("> ");
+        io::stdout().flush().ok();
+
+        // Read lines until a blank line (message boundary) or EOF.
+        let mut lines = Vec::new();
+        let mut blank_seen = false;
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(text) => {
+                    let trimmed = text.trim();
+                    // Exit commands
+                    if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit")
+                    {
+                        println!("Goodbye!");
+                        return Ok(());
+                    }
+                    // Slash stop command
+                    if trimmed.eq_ignore_ascii_case("/stop") {
+                        println!("Session stopped.");
+                        return Ok(());
+                    }
+                    // Blank line = message boundary
+                    if trimmed.is_empty() {
+                        if lines.is_empty() {
+                            // Empty input — skip
+                            print!("> ");
+                            io::stdout().flush().ok();
+                            continue;
+                        }
+                        blank_seen = true;
+                        break;
+                    }
+                    lines.push(text);
+                }
+                Err(e) => {
+                    eprintln!("Error reading input: {}", e);
+                    return Ok(());
+                }
+            }
+        }
+
+        // EOF without content
+        if lines.is_empty() && !blank_seen {
+            println!("\nGoodbye!");
+            return Ok(());
+        }
+
+        let content = lines.join("\n");
+        if content.trim().is_empty() {
+            continue;
+        }
+
+        // ── Route through gateway ─────────────────────────────────────
+        let result = gateway
+            .handle_inbound_message(&session_id, content, Some(&sender_id), channel)
+            .await;
+
+        match result {
+            Some(_handle_result) => {
+                // The response is rendered by TerminalPlugin and sent to
+                // stdout asynchronously. We just wait briefly to allow
+                // the streaming task to flush.
+                // Give the LLM call a moment to produce output.
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            None => {
+                eprintln!("(no response — session handler not configured)");
+            }
+        }
+
+        println!(); // blank line between exchanges
+    }
+}
+
+/// Get a stable user ID for the terminal session.
+///
+/// Uses the system UID on Unix, or a fallback string.
+fn get_user_id() -> String {
+    #[cfg(unix)]
+    {
+        format!("uid-{}", unsafe { libc::getuid() })
+    }
+    #[cfg(not(unix))]
+    {
+        "terminal-user".to_string()
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 //! CLI Tool - closeclaw command-line interface
 
 pub mod args;
+pub mod chat;
 pub mod config_wizard;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -14,6 +14,7 @@ use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::config::ConfigManager;
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
+use crate::im::terminal::TerminalPlugin;
 use crate::renderer::feishu::FeishuRenderer;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{ReasoningHandler, SystemHandler, WorkdirHandler};
@@ -245,6 +246,7 @@ impl Daemon {
 
         info!("Gateway initialized");
         Self::init_feishu_plugin(config_dir, &gateway).await?;
+        Self::init_terminal_plugin(&gateway).await;
         let shutdown = shutdown::ShutdownHandle::new();
         info!("Shutdown coordinator initialized");
         // Initialize skill hot reload system
@@ -518,6 +520,16 @@ impl Daemon {
             info!("Feishu credentials not found in env — Feishu plugin not registered");
         }
         Ok(())
+    }
+
+    /// Initialize the terminal (CLI) IM plugin and register with Gateway.
+    ///
+    /// TerminalPlugin requires no credentials — it reads from stdin and writes
+    /// to stdout, so it is always registered when the daemon starts.
+    async fn init_terminal_plugin(gateway: &Arc<Gateway>) {
+        let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());
+        gateway.register_plugin(plugin).await;
+        info!("Terminal plugin registered");
     }
 }
 

--- a/src/im/mod.rs
+++ b/src/im/mod.rs
@@ -6,6 +6,9 @@ pub mod feishu;
 #[cfg(test)]
 pub mod feishu_tests;
 pub mod processor;
+pub mod terminal;
+#[cfg(test)]
+pub mod terminal_tests;
 pub use crate::im_adapter::AdapterError;
 pub use crate::im_adapter::IMPlugin;
 pub use crate::im_adapter::NormalizedMessage;

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -7,10 +7,14 @@
 
 use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
 use crate::im_adapter::normalized::NormalizedMessage;
+use crate::im_adapter::plugin::IMPlugin;
 use crate::im_adapter::renderer::{RenderedOutput, Renderer};
+use crate::im_adapter::AdapterError;
 use crate::llm::types::ContentBlock;
 use crate::processor_chain::DslParseResult;
-use std::io::{self, BufRead};
+use async_trait::async_trait;
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
@@ -605,4 +609,90 @@ fn current_timestamp() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i64
+}
+
+// ---------------------------------------------------------------------------
+// TerminalPlugin
+// ---------------------------------------------------------------------------
+
+/// Unified IM plugin for the terminal (CLI) channel.
+///
+/// Wraps [`TerminalAdapter`] (stdin input) and [`TerminalRenderer`] (ANSI
+/// output) behind the [`IMPlugin`] trait so the Gateway can route messages
+/// through the terminal channel just like any other platform.
+pub struct TerminalPlugin {
+    adapter: Arc<TerminalAdapter>,
+    renderer: Arc<TerminalRenderer>,
+}
+
+impl TerminalPlugin {
+    /// Create a new terminal plugin with auto-detected ANSI capability.
+    pub fn new() -> Self {
+        Self {
+            adapter: Arc::new(TerminalAdapter::new()),
+            renderer: Arc::new(TerminalRenderer::new()),
+        }
+    }
+
+    /// Create a terminal plugin with explicit ANSI mode.
+    ///
+    /// Useful for testing or forcing a specific output mode.
+    pub fn with_ansi(ansi: bool) -> Self {
+        Self {
+            adapter: Arc::new(TerminalAdapter::new()),
+            renderer: Arc::new(TerminalRenderer::with_ansi(ansi)),
+        }
+    }
+}
+
+impl Default for TerminalPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl IMPlugin for TerminalPlugin {
+    fn platform(&self) -> &str {
+        "terminal"
+    }
+
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        let adapter = self.adapter.clone();
+        let result = tokio::task::spawn_blocking(move || adapter.read_input())
+            .await
+            .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
+        Ok(result)
+    }
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        self.renderer.render(content_blocks, dsl_result)
+    }
+
+    async fn send(
+        &self,
+        output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+
+        let mut stdout = io::stdout();
+        Write::write_all(&mut stdout, text.as_bytes())
+            .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+        Write::flush(&mut stdout).map_err(|e| AdapterError::SendFailed(e.to_string()))?;
+        Ok(())
+    }
 }

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -1,13 +1,17 @@
-//! Terminal renderer — converts LLM [`ContentBlock`]s to ANSI-formatted text.
+//! Terminal channel — renderer and adapter for CLI chat.
 //!
-//! Detects terminal ANSI capability and falls back to plain text when
-//! unsupported. Handles all block types defined in the design doc:
-//! Text, Thinking, ToolUse, ToolResult, and unsupported placeholders.
+//! - [`TerminalRenderer`]: converts LLM [`ContentBlock`]s to ANSI-formatted
+//!   text. Detects terminal ANSI capability and falls back to plain text.
+//! - [`TerminalAdapter`]: reads user input from stdin, producing
+//!   [`NormalizedMessage`]s with blank-line-delimited message boundaries.
 
 use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
+use crate::im_adapter::normalized::NormalizedMessage;
 use crate::im_adapter::renderer::{RenderedOutput, Renderer};
 use crate::llm::types::ContentBlock;
 use crate::processor_chain::DslParseResult;
+use std::io::{self, BufRead};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
 // ANSI escape codes
@@ -512,4 +516,93 @@ impl Renderer for TerminalRenderer {
             payload,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// TerminalAdapter
+// ---------------------------------------------------------------------------
+
+/// Adapter that reads user input from stdin and produces
+/// [`NormalizedMessage`]s.
+///
+/// Messages are delimited by blank lines: a sequence of non-empty lines
+/// followed by an empty line forms one message. Trailing newlines within
+/// a message are preserved.
+#[derive(Debug, Clone, Default)]
+pub struct TerminalAdapter;
+
+impl TerminalAdapter {
+    /// Create a new adapter.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Read a single message from stdin.
+    ///
+    /// Collects lines until a blank line is encountered, then returns the
+    /// joined content as a [`NormalizedMessage`]. Returns `None` when the
+    /// input is empty or stdin is exhausted (EOF).
+    pub fn read_input(&self) -> Option<NormalizedMessage> {
+        let stdin = io::stdin();
+        let mut lines = Vec::new();
+
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(text) => {
+                    if text.trim().is_empty() {
+                        // Blank line → message boundary
+                        if lines.is_empty() {
+                            continue;
+                        }
+                        break;
+                    }
+                    lines.push(text);
+                }
+                Err(_) => break,
+            }
+        }
+
+        if lines.is_empty() {
+            return None;
+        }
+
+        let content = lines.join("\n");
+        Some(self.make_message(content))
+    }
+
+    /// Build a [`NormalizedMessage`] from raw text content.
+    fn make_message(&self, content: String) -> NormalizedMessage {
+        NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: current_uid(),
+            peer_id: "cli".to_string(),
+            content,
+            timestamp: current_timestamp(),
+            thread_id: None,
+            account_id: None,
+        }
+    }
+}
+
+/// Return the current user's system UID as a string.
+///
+/// On Unix, uses `libc::getuid()`. On other platforms, falls back to a
+/// static identifier.
+fn current_uid() -> String {
+    #[cfg(unix)]
+    {
+        unsafe { libc::getuid() }.to_string()
+    }
+    #[cfg(not(unix))]
+    {
+        "terminal-user".to_string()
+    }
+}
+
+/// Return the current Unix timestamp in seconds.
+fn current_timestamp() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
 }

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -109,37 +109,32 @@ fn check_line_pattern(line: &str) -> Option<String> {
     None
 }
 
+/// Apply ANSI code around `text` when `ansi` is true.
+fn apply_inline_styled_text(text: &str, ansi_code: &str, ansi: bool) -> String {
+    let mut out = String::new();
+    if ansi {
+        out.push_str(ansi_code);
+    }
+    out.push_str(text);
+    if ansi {
+        out.push_str(RESET);
+    }
+    out
+}
+
 /// Generic inline styling: applies ANSI codes or strips markdown markers.
 fn apply_inline_styling(spans: &[InlineSpan], ansi: bool) -> String {
     let mut out = String::new();
     for span in spans {
         match span {
             InlineSpan::Bold(text) => {
-                if ansi {
-                    out.push_str(BOLD);
-                }
-                out.push_str(text);
-                if ansi {
-                    out.push_str(RESET);
-                }
+                out.push_str(&apply_inline_styled_text(text, BOLD, ansi));
             }
             InlineSpan::Italic(text) => {
-                if ansi {
-                    out.push_str(ITALIC);
-                }
-                out.push_str(text);
-                if ansi {
-                    out.push_str(RESET);
-                }
+                out.push_str(&apply_inline_styled_text(text, ITALIC, ansi));
             }
             InlineSpan::Code(text) => {
-                if ansi {
-                    out.push_str(BOLD);
-                }
-                out.push_str(text);
-                if ansi {
-                    out.push_str(RESET);
-                }
+                out.push_str(&apply_inline_styled_text(text, BOLD, ansi));
             }
             InlineSpan::Link { text, url } => {
                 if ansi {

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -416,9 +416,8 @@ fn is_comment(trimmed: &str, language: &str) -> bool {
         || (matches!(
             language,
             "rust" | "go" | "javascript" | "typescript" | "c" | "cpp" | "java"
-        ) && trimmed.starts_with("//"))
+        ) && (trimmed.starts_with("//") || trimmed.starts_with("/*")))
         || (matches!(language, "haskell" | "lua") && trimmed.starts_with("--"))
-        || trimmed.starts_with("/*")
 }
 
 /// Check if a word is a keyword for the given language.

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -84,27 +84,40 @@ pub(crate) fn strip_ansi(text: &str) -> String {
 // Markdown → ANSI inline conversion
 // ---------------------------------------------------------------------------
 
-/// Apply inline ANSI formatting to a single line of markdown text.
-fn ansi_format_inline(line: &str) -> String {
-    if let Some(styled) = check_line_pattern(line) {
+/// Format a single line of markdown text.
+/// `ansi=true` applies ANSI styling; `ansi=false` strips markdown markers.
+fn format_line(line: &str, ansi: bool) -> String {
+    if let Some(styled) = check_line_pattern(line, ansi) {
         return styled;
     }
     let chars: Vec<char> = line.chars().collect();
     let spans = parse_inline_spans(&chars);
-    apply_inline_styling(&spans, true)
+    apply_inline_styling(&spans, ansi)
 }
 
 /// Check line-level patterns (heading, blockquote, hr).
-/// Returns styled string if matched, None otherwise.
-fn check_line_pattern(line: &str) -> Option<String> {
+/// Returns formatted string if matched, None otherwise.
+fn check_line_pattern(line: &str, ansi: bool) -> Option<String> {
     if let Some(rest) = line.strip_prefix("# ") {
-        return Some(format!("{}{}{}", BOLD, rest, RESET));
+        return Some(if ansi {
+            format!("{}{}{}", BOLD, rest, RESET)
+        } else {
+            rest.to_string()
+        });
     }
     if line.trim() == "---" {
-        return Some(format!("{}───{}", DIM, RESET));
+        return Some(if ansi {
+            format!("{}───{}", DIM, RESET)
+        } else {
+            "───".to_string()
+        });
     }
     if let Some(rest) = line.strip_prefix("> ") {
-        return Some(format!("{}│ {}{}", DIM, rest, RESET));
+        return Some(if ansi {
+            format!("{}│ {}{}", DIM, rest, RESET)
+        } else {
+            format!("│ {}", rest)
+        });
     }
     None
 }
@@ -567,69 +580,33 @@ fn is_c_keyword(word: &str) -> bool {
 // Markdown → ANSI block rendering
 // ---------------------------------------------------------------------------
 
-/// Convert markdown content to ANSI-formatted text.
-fn render_markdown_ansi(content: &str) -> String {
+/// Convert markdown content to text, with optional ANSI styling.
+fn render_markdown(content: &str, ansi: bool) -> String {
     let segments = parse_content_segments(content);
     let mut out = String::new();
 
     for seg in &segments {
         match seg {
             ContentSegment::Hr => {
-                out.push_str(&format!("{}───{}\n\n", DIM, RESET));
+                if ansi {
+                    out.push_str(&format!("{}───{}\n\n", DIM, RESET));
+                } else {
+                    out.push_str("───\n\n");
+                }
             }
             ContentSegment::CodeBlock { language, code } => {
                 out.push('\n');
-                out.push_str(&render_code_block(language, code, true));
+                out.push_str(&render_code_block(language, code, ansi));
                 out.push('\n');
             }
             ContentSegment::Markdown(line) => {
-                out.push_str(&ansi_format_inline(line));
+                out.push_str(&format_line(line, ansi));
                 out.push('\n');
             }
         }
     }
 
     out
-}
-
-/// Convert markdown content to plain text (no ANSI).
-fn render_markdown_plain(content: &str) -> String {
-    let segments = parse_content_segments(content);
-    let mut out = String::new();
-
-    for seg in &segments {
-        match seg {
-            ContentSegment::Hr => {
-                out.push_str("───\n\n");
-            }
-            ContentSegment::CodeBlock { language, code } => {
-                out.push('\n');
-                out.push_str(&render_code_block(language, code, false));
-                out.push('\n');
-            }
-            ContentSegment::Markdown(line) => {
-                // Strip markdown formatting markers for plain text
-                let stripped = strip_markdown(line);
-                out.push_str(&stripped);
-                out.push('\n');
-            }
-        }
-    }
-
-    out
-}
-
-/// Remove common markdown formatting markers for plain-text output.
-fn strip_markdown(line: &str) -> String {
-    if let Some(rest) = line.strip_prefix("# ") {
-        return rest.to_string();
-    }
-    if let Some(rest) = line.strip_prefix("> ") {
-        return format!("│ {}", rest);
-    }
-    let chars: Vec<char> = line.chars().collect();
-    let spans = parse_inline_spans(&chars);
-    apply_inline_styling(&spans, false)
 }
 
 // ---------------------------------------------------------------------------
@@ -670,13 +647,7 @@ impl TerminalRenderer {
     /// Render a single [`ContentBlock`] to text.
     fn render_block(&self, block: &ContentBlock) -> String {
         match block {
-            ContentBlock::Text(text) => {
-                if self.ansi {
-                    render_markdown_ansi(text)
-                } else {
-                    render_markdown_plain(text)
-                }
-            }
+            ContentBlock::Text(text) => render_markdown(text, self.ansi),
             ContentBlock::Thinking(text) => self.render_thinking(text),
             ContentBlock::ToolUse { name, input, .. } => self.render_tool_use(name, input),
             ContentBlock::ToolResult { content, .. } => self.render_tool_result(content),
@@ -764,9 +735,14 @@ impl Renderer for TerminalRenderer {
         }
 
         // Build the payload — the text content for stdout
+        let text = if self.ansi {
+            output_text
+        } else {
+            strip_ansi(&output_text)
+        };
         let payload = serde_json::json!({
             "content": {
-                "text": if self.ansi { output_text.clone() } else { strip_ansi(&output_text) }
+                "text": text
             }
         });
 

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -1,0 +1,515 @@
+//! Terminal renderer — converts LLM [`ContentBlock`]s to ANSI-formatted text.
+//!
+//! Detects terminal ANSI capability and falls back to plain text when
+//! unsupported. Handles all block types defined in the design doc:
+//! Text, Thinking, ToolUse, ToolResult, and unsupported placeholders.
+
+use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
+use crate::im_adapter::renderer::{RenderedOutput, Renderer};
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::DslParseResult;
+
+// ---------------------------------------------------------------------------
+// ANSI escape codes
+// ---------------------------------------------------------------------------
+
+/// ANSI style: bold
+pub(crate) const BOLD: &str = "\x1b[1m";
+/// ANSI style: dim
+pub(crate) const DIM: &str = "\x1b[2m";
+/// ANSI style: italic
+pub(crate) const ITALIC: &str = "\x1b[3m";
+/// ANSI reset all styles
+pub(crate) const RESET: &str = "\x1b[0m";
+
+// ---------------------------------------------------------------------------
+// ANSI capability detection
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if the current terminal supports ANSI escape sequences.
+///
+/// Checks the `TERM` environment variable for known ANSI-capable values
+/// (`xterm`, `screen`, `ansi`, `vt100`, `color`). On Windows, detects the
+/// Windows Terminal environment via `WT_SESSION`.
+fn supports_ansi() -> bool {
+    if std::env::var("WT_SESSION").is_ok() {
+        return true;
+    }
+    std::env::var("TERM")
+        .map(|term| {
+            let t = term.to_lowercase();
+            t.contains("xterm")
+                || t.contains("screen")
+                || t.contains("ansi")
+                || t.contains("vt100")
+                || t.contains("color")
+        })
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Plain-text fallback
+// ---------------------------------------------------------------------------
+
+/// Strip all ANSI escape sequences from `text`.
+pub(crate) fn strip_ansi(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // Skip until a control character (the final byte of the sequence)
+            for ch in chars.by_ref() {
+                if ch.is_ascii_alphabetic() || ch == 'm' {
+                    break;
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Markdown → ANSI inline conversion
+// ---------------------------------------------------------------------------
+
+/// Apply inline ANSI formatting to a single line of markdown text.
+fn ansi_format_inline(line: &str) -> String {
+    let mut out = String::with_capacity(line.len() * 2);
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Headings: lines starting with `# `
+        if i == 0 && line.starts_with("# ") {
+            out.push_str(BOLD);
+            out.push_str(&line[2..]);
+            out.push_str(RESET);
+            return out;
+        }
+
+        // Horizontal rule
+        if i == 0 && line.trim() == "---" {
+            return format!("{}───{}", DIM, RESET);
+        }
+
+        // Bold: **text**
+        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
+            if let Some(end) = find_double_star_end(&chars, i + 2) {
+                out.push_str(BOLD);
+                for c in &chars[i + 2..end] {
+                    out.push(*c);
+                }
+                out.push_str(RESET);
+                i = end + 2;
+                continue;
+            }
+        }
+
+        // Italic: *text*
+        if chars[i] == '*' && (i + 1 >= len || chars[i + 1] != '*') {
+            if let Some(end) = find_single_star_end(&chars, i + 1) {
+                out.push_str(ITALIC);
+                for c in &chars[i + 1..end] {
+                    out.push(*c);
+                }
+                out.push_str(RESET);
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // Inline code: `text`
+        if chars[i] == '`' {
+            if let Some(end) = find_char_end(&chars, i + 1, '`') {
+                let code_text: String = chars[i + 1..end].iter().collect();
+                out.push_str(BOLD);
+                out.push_str(&code_text);
+                out.push_str(RESET);
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // Link: [text](url) → "text (url)"
+        if chars[i] == '[' {
+            if let Some(bracket_end) = find_char_end(&chars, i + 1, ']') {
+                if bracket_end + 1 < len && chars[bracket_end + 1] == '(' {
+                    if let Some(paren_end) = find_char_end(&chars, bracket_end + 2, ')') {
+                        let link_text: String = chars[i + 1..bracket_end].iter().collect();
+                        let link_url: String = chars[bracket_end + 2..paren_end].iter().collect();
+                        out.push_str(&format!("{}{}{} ({})", BOLD, link_text, RESET, link_url));
+                        i = paren_end + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Blockquote: > text
+        if i == 0 && line.starts_with("> ") {
+            out.push_str(DIM);
+            out.push_str("│ ");
+            out.push_str(&line[2..]);
+            out.push_str(RESET);
+            return out;
+        }
+
+        out.push(chars[i]);
+        i += 1;
+    }
+
+    out
+}
+
+/// Find the closing `**` for bold starting at `start`.
+fn find_double_star_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i + 1 < chars.len() {
+        if chars[i] == '*' && chars[i + 1] == '*' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the closing `*` for italic starting at `start`, skipping `**`.
+fn find_single_star_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i < chars.len() {
+        if chars[i] == '*' {
+            // Skip over `**` so bold is handled elsewhere
+            if i + 1 < chars.len() && chars[i + 1] == '*' {
+                i += 2;
+                continue;
+            }
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find closing `ch` starting at `start`, not crossing newlines.
+fn find_char_end(chars: &[char], start: usize, ch: char) -> Option<usize> {
+    let mut i = start;
+    while i < chars.len() {
+        if chars[i] == ch {
+            return Some(i);
+        }
+        if chars[i] == '\n' {
+            return None;
+        }
+        i += 1;
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Code block rendering
+// ---------------------------------------------------------------------------
+
+/// Render a fenced code block with language annotation and line numbers.
+fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
+    let lines: Vec<&str> = code.lines().collect();
+    let line_width = format!("{}", lines.len()).len();
+    let mut out = String::new();
+
+    if ansi && !language.is_empty() {
+        out.push_str(&format!("{} {} {}\n", DIM, language, RESET));
+    } else if !language.is_empty() {
+        out.push_str(&format!("  {}\n", language));
+    }
+
+    for (i, line) in lines.iter().enumerate() {
+        let num = format!("{:>width$}", i + 1, width = line_width);
+        if ansi {
+            out.push_str(&format!("{} {} │ {}{}", DIM, num, RESET, line));
+        } else {
+            out.push_str(&format!("  {} │ {}", num, line));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Markdown → ANSI block rendering
+// ---------------------------------------------------------------------------
+
+/// Convert markdown content to ANSI-formatted text.
+fn render_markdown_ansi(content: &str) -> String {
+    let segments = parse_content_segments(content);
+    let mut out = String::new();
+
+    for seg in &segments {
+        match seg {
+            ContentSegment::Hr => {
+                out.push_str(&format!("{}───{}\n\n", DIM, RESET));
+            }
+            ContentSegment::CodeBlock { language, code } => {
+                out.push('\n');
+                out.push_str(&render_code_block(language, code, true));
+                out.push('\n');
+            }
+            ContentSegment::Markdown(line) => {
+                out.push_str(&ansi_format_inline(line));
+                out.push('\n');
+            }
+        }
+    }
+
+    out
+}
+
+/// Convert markdown content to plain text (no ANSI).
+fn render_markdown_plain(content: &str) -> String {
+    let segments = parse_content_segments(content);
+    let mut out = String::new();
+
+    for seg in &segments {
+        match seg {
+            ContentSegment::Hr => {
+                out.push_str("───\n\n");
+            }
+            ContentSegment::CodeBlock { language, code } => {
+                out.push('\n');
+                out.push_str(&render_code_block(language, code, false));
+                out.push('\n');
+            }
+            ContentSegment::Markdown(line) => {
+                // Strip markdown formatting markers for plain text
+                let stripped = strip_markdown(line);
+                out.push_str(&stripped);
+                out.push('\n');
+            }
+        }
+    }
+
+    out
+}
+
+/// Remove common markdown formatting markers for plain-text output.
+fn strip_markdown(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Heading markers
+        if i == 0 && line.starts_with("# ") {
+            out.push_str(&line[2..]);
+            return out;
+        }
+
+        // Bold: **text** → text
+        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
+            if let Some(end) = find_double_star_end(&chars, i + 2) {
+                for c in &chars[i + 2..end] {
+                    out.push(*c);
+                }
+                i = end + 2;
+                continue;
+            }
+        }
+
+        // Italic: *text* → text
+        if chars[i] == '*' && (i + 1 >= len || chars[i + 1] != '*') {
+            if let Some(end) = find_single_star_end(&chars, i + 1) {
+                for c in &chars[i + 1..end] {
+                    out.push(*c);
+                }
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // Inline code: `text` → text
+        if chars[i] == '`' {
+            if let Some(end) = find_char_end(&chars, i + 1, '`') {
+                for c in &chars[i + 1..end] {
+                    out.push(*c);
+                }
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // Link: [text](url) → text (url)
+        if chars[i] == '[' {
+            if let Some(bracket_end) = find_char_end(&chars, i + 1, ']') {
+                if bracket_end + 1 < len && chars[bracket_end + 1] == '(' {
+                    if let Some(paren_end) = find_char_end(&chars, bracket_end + 2, ')') {
+                        let link_text: String = chars[i + 1..bracket_end].iter().collect();
+                        let link_url: String = chars[bracket_end + 2..paren_end].iter().collect();
+                        out.push_str(&format!("{} ({})", link_text, link_url));
+                        i = paren_end + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Blockquote: > text → │ text
+        if i == 0 && line.starts_with("> ") {
+            out.push_str("│ ");
+            out.push_str(&line[2..]);
+            return out;
+        }
+
+        out.push(chars[i]);
+        i += 1;
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// TerminalRenderer
+// ---------------------------------------------------------------------------
+
+/// Renderer for the terminal (CLI) channel.
+///
+/// Converts LLM [`ContentBlock`]s into ANSI-formatted text suitable for
+/// stdout display. Detects terminal ANSI support and falls back to plain
+/// text when unavailable.
+#[derive(Debug, Clone)]
+pub struct TerminalRenderer {
+    ansi: bool,
+}
+
+impl Default for TerminalRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TerminalRenderer {
+    /// Create a new renderer that auto-detects ANSI capability.
+    pub fn new() -> Self {
+        Self {
+            ansi: supports_ansi(),
+        }
+    }
+
+    /// Create a renderer with explicit ANSI mode.
+    ///
+    /// Useful for testing or forcing a specific output mode.
+    pub fn with_ansi(ansi: bool) -> Self {
+        Self { ansi }
+    }
+
+    /// Render a single [`ContentBlock`] to text.
+    fn render_block(&self, block: &ContentBlock) -> String {
+        match block {
+            ContentBlock::Text(text) => {
+                if self.ansi {
+                    render_markdown_ansi(text)
+                } else {
+                    render_markdown_plain(text)
+                }
+            }
+            ContentBlock::Thinking(text) => self.render_thinking(text),
+            ContentBlock::ToolUse { name, input, .. } => self.render_tool_use(name, input),
+            ContentBlock::ToolResult { content, .. } => self.render_tool_result(content),
+        }
+    }
+
+    /// Render a Thinking block with boundary markers.
+    fn render_thinking(&self, text: &str) -> String {
+        if self.ansi {
+            format!(
+                "{}[Thinking]{}\n  {}{}{}[end of thinking]{}\n",
+                DIM, RESET, DIM, text, DIM, RESET
+            )
+        } else {
+            format!("[Thinking]\n  {}\n[end of thinking]\n", text)
+        }
+    }
+
+    /// Render a ToolUse block: `⚙ tool_name(args)`.
+    fn render_tool_use(&self, name: &str, input: &str) -> String {
+        if self.ansi {
+            format!(
+                "{}⚙ {}{}{}({}{}){}{}\n",
+                DIM, BOLD, name, RESET, DIM, input, DIM, RESET
+            )
+        } else {
+            format!("⚙ {}({})\n", name, input)
+        }
+    }
+
+    /// Render a ToolResult block, truncating at terminal width.
+    fn render_tool_result(&self, content: &str) -> String {
+        // Truncate at 120 characters with indicator
+        let max_width = 120;
+        let display = if content.len() > max_width {
+            format!("{}... (truncated)", &content[..max_width])
+        } else {
+            content.to_string()
+        };
+
+        if self.ansi {
+            format!("{}{}{}\n", DIM, display, RESET)
+        } else {
+            format!("{}\n", display)
+        }
+    }
+
+    /// Render DSL instructions as plain text prompts.
+    fn render_dsl(&self, dsl_result: &DslParseResult) -> String {
+        let mut out = String::new();
+        for inst in &dsl_result.instructions {
+            let label = match inst {
+                crate::processor_chain::dsl_parser::DslInstruction::Button { label, .. } => label,
+            };
+            out.push_str(&format!("[Button: {}]\n", label));
+        }
+        out
+    }
+}
+
+impl Renderer for TerminalRenderer {
+    fn platform(&self) -> &str {
+        "terminal"
+    }
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        let mut output_text = String::new();
+
+        for block in content_blocks {
+            let rendered = self.render_block(block);
+            output_text.push_str(&rendered);
+            output_text.push('\n');
+        }
+
+        // Append DSL prompts if present
+        if let Some(dsl) = dsl_result {
+            let dsl_text = self.render_dsl(dsl);
+            if !dsl_text.is_empty() {
+                output_text.push_str(&dsl_text);
+            }
+        }
+
+        // Build the payload — the text content for stdout
+        let payload = serde_json::json!({
+            "content": {
+                "text": if self.ansi { output_text.clone() } else { strip_ansi(&output_text) }
+            }
+        });
+
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload,
+        }
+    }
+}

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -25,6 +25,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(crate) const BOLD: &str = "\x1b[1m";
 /// ANSI style: dim
 pub(crate) const DIM: &str = "\x1b[2m";
+/// ANSI style: cyan
+pub(crate) const CYAN: &str = "\x1b[36m";
 /// ANSI style: italic
 pub(crate) const ITALIC: &str = "\x1b[3m";
 /// ANSI reset all styles
@@ -84,92 +86,188 @@ pub(crate) fn strip_ansi(text: &str) -> String {
 
 /// Apply inline ANSI formatting to a single line of markdown text.
 fn ansi_format_inline(line: &str) -> String {
-    let mut out = String::with_capacity(line.len() * 2);
+    if let Some(styled) = check_line_pattern(line) {
+        return styled;
+    }
     let chars: Vec<char> = line.chars().collect();
-    let len = chars.len();
+    let spans = parse_inline_spans(&chars);
+    apply_inline_styling(&spans, true)
+}
+
+/// Check line-level patterns (heading, blockquote, hr).
+/// Returns styled string if matched, None otherwise.
+fn check_line_pattern(line: &str) -> Option<String> {
+    if let Some(rest) = line.strip_prefix("# ") {
+        return Some(format!("{}{}{}", BOLD, rest, RESET));
+    }
+    if line.trim() == "---" {
+        return Some(format!("{}───{}", DIM, RESET));
+    }
+    if let Some(rest) = line.strip_prefix("> ") {
+        return Some(format!("{}│ {}{}", DIM, rest, RESET));
+    }
+    None
+}
+
+/// Generic inline styling: applies ANSI codes or strips markdown markers.
+fn apply_inline_styling(spans: &[InlineSpan], ansi: bool) -> String {
+    let mut out = String::new();
+    for span in spans {
+        match span {
+            InlineSpan::Bold(text) => {
+                if ansi {
+                    out.push_str(BOLD);
+                }
+                out.push_str(text);
+                if ansi {
+                    out.push_str(RESET);
+                }
+            }
+            InlineSpan::Italic(text) => {
+                if ansi {
+                    out.push_str(ITALIC);
+                }
+                out.push_str(text);
+                if ansi {
+                    out.push_str(RESET);
+                }
+            }
+            InlineSpan::Code(text) => {
+                if ansi {
+                    out.push_str(BOLD);
+                }
+                out.push_str(text);
+                if ansi {
+                    out.push_str(RESET);
+                }
+            }
+            InlineSpan::Link { text, url } => {
+                if ansi {
+                    out.push_str(&format!("{}{}{} ({})", BOLD, text, RESET, url));
+                } else {
+                    out.push_str(&format!("{} ({})", text, url));
+                }
+            }
+            InlineSpan::Text(text) => {
+                out.push_str(text);
+            }
+        }
+    }
+    out
+}
+
+/// Parsed inline markdown spans.
+enum InlineSpan {
+    Bold(String),
+    Italic(String),
+    Code(String),
+    Link { text: String, url: String },
+    Text(String),
+}
+
+/// Extract bold spans from chars starting at position.
+/// Returns (end_pos, Some(text)) if found, or (start, None).
+fn extract_bold(chars: &[char], start: usize) -> (usize, Option<String>) {
+    if start + 1 < chars.len() && chars[start] == '*' && chars[start + 1] == '*' {
+        if let Some(end) = find_double_star_end(chars, start + 2) {
+            let text: String = chars[start + 2..end].iter().collect();
+            return (end + 2, Some(text));
+        }
+    }
+    (start, None)
+}
+
+/// Extract italic spans from chars starting at position.
+fn extract_italic(chars: &[char], start: usize) -> (usize, Option<String>) {
+    if chars[start] == '*' && (start + 1 >= chars.len() || chars[start + 1] != '*') {
+        if let Some(end) = find_single_star_end(chars, start + 1) {
+            let text: String = chars[start + 1..end].iter().collect();
+            return (end + 1, Some(text));
+        }
+    }
+    (start, None)
+}
+
+/// Extract inline code spans from chars starting at position.
+fn extract_code(chars: &[char], start: usize) -> (usize, Option<String>) {
+    if chars[start] == '`' {
+        if let Some(end) = find_char_end(chars, start + 1, '`') {
+            let text: String = chars[start + 1..end].iter().collect();
+            return (end + 1, Some(text));
+        }
+    }
+    (start, None)
+}
+
+/// Extract link spans from chars starting at position.
+fn extract_link(chars: &[char], start: usize) -> (usize, Option<(String, String)>) {
+    if chars[start] == '[' {
+        let len = chars.len();
+        if let Some(bracket_end) = find_char_end(chars, start + 1, ']') {
+            if bracket_end + 1 < len && chars[bracket_end + 1] == '(' {
+                if let Some(paren_end) = find_char_end(chars, bracket_end + 2, ')') {
+                    let text: String = chars[start + 1..bracket_end].iter().collect();
+                    let url: String = chars[bracket_end + 2..paren_end].iter().collect();
+                    return (paren_end + 1, Some((text, url)));
+                }
+            }
+        }
+    }
+    (start, None)
+}
+
+/// Push accumulated plain text into spans if non-empty.
+fn flush_text(spans: &mut Vec<InlineSpan>, chars: &[char], start: usize, end: usize) {
+    if start < end {
+        let text: String = chars[start..end].iter().collect();
+        spans.push(InlineSpan::Text(text));
+    }
+}
+
+/// Parse inline markdown patterns into spans.
+fn parse_inline_spans(chars: &[char]) -> Vec<InlineSpan> {
+    let mut spans = Vec::new();
     let mut i = 0;
+    let mut text_start = 0;
+    let len = chars.len();
 
     while i < len {
-        // Headings: lines starting with `# `
-        if i == 0 && line.starts_with("# ") {
-            out.push_str(BOLD);
-            out.push_str(&line[2..]);
-            out.push_str(RESET);
-            return out;
+        let (new_i, bold_text) = extract_bold(chars, i);
+        if let Some(text) = bold_text {
+            flush_text(&mut spans, chars, text_start, i);
+            spans.push(InlineSpan::Bold(text));
+            i = new_i;
+            text_start = i;
+            continue;
         }
-
-        // Horizontal rule
-        if i == 0 && line.trim() == "---" {
-            return format!("{}───{}", DIM, RESET);
+        let (new_i, italic_text) = extract_italic(chars, i);
+        if let Some(text) = italic_text {
+            flush_text(&mut spans, chars, text_start, i);
+            spans.push(InlineSpan::Italic(text));
+            i = new_i;
+            text_start = i;
+            continue;
         }
-
-        // Bold: **text**
-        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
-            if let Some(end) = find_double_star_end(&chars, i + 2) {
-                out.push_str(BOLD);
-                for c in &chars[i + 2..end] {
-                    out.push(*c);
-                }
-                out.push_str(RESET);
-                i = end + 2;
-                continue;
-            }
+        let (new_i, code_text) = extract_code(chars, i);
+        if let Some(text) = code_text {
+            flush_text(&mut spans, chars, text_start, i);
+            spans.push(InlineSpan::Code(text));
+            i = new_i;
+            text_start = i;
+            continue;
         }
-
-        // Italic: *text*
-        if chars[i] == '*' && (i + 1 >= len || chars[i + 1] != '*') {
-            if let Some(end) = find_single_star_end(&chars, i + 1) {
-                out.push_str(ITALIC);
-                for c in &chars[i + 1..end] {
-                    out.push(*c);
-                }
-                out.push_str(RESET);
-                i = end + 1;
-                continue;
-            }
+        let (new_i, link_opt) = extract_link(chars, i);
+        if let Some((text, url)) = link_opt {
+            flush_text(&mut spans, chars, text_start, i);
+            spans.push(InlineSpan::Link { text, url });
+            i = new_i;
+            text_start = i;
+            continue;
         }
-
-        // Inline code: `text`
-        if chars[i] == '`' {
-            if let Some(end) = find_char_end(&chars, i + 1, '`') {
-                let code_text: String = chars[i + 1..end].iter().collect();
-                out.push_str(BOLD);
-                out.push_str(&code_text);
-                out.push_str(RESET);
-                i = end + 1;
-                continue;
-            }
-        }
-
-        // Link: [text](url) → "text (url)"
-        if chars[i] == '[' {
-            if let Some(bracket_end) = find_char_end(&chars, i + 1, ']') {
-                if bracket_end + 1 < len && chars[bracket_end + 1] == '(' {
-                    if let Some(paren_end) = find_char_end(&chars, bracket_end + 2, ')') {
-                        let link_text: String = chars[i + 1..bracket_end].iter().collect();
-                        let link_url: String = chars[bracket_end + 2..paren_end].iter().collect();
-                        out.push_str(&format!("{}{}{} ({})", BOLD, link_text, RESET, link_url));
-                        i = paren_end + 1;
-                        continue;
-                    }
-                }
-            }
-        }
-
-        // Blockquote: > text
-        if i == 0 && line.starts_with("> ") {
-            out.push_str(DIM);
-            out.push_str("│ ");
-            out.push_str(&line[2..]);
-            out.push_str(RESET);
-            return out;
-        }
-
-        out.push(chars[i]);
         i += 1;
     }
-
-    out
+    flush_text(&mut spans, chars, text_start, len);
+    spans
 }
 
 /// Find the closing `**` for bold starting at `start`.
@@ -189,7 +287,6 @@ fn find_single_star_end(chars: &[char], start: usize) -> Option<usize> {
     let mut i = start;
     while i < chars.len() {
         if chars[i] == '*' {
-            // Skip over `**` so bold is handled elsewhere
             if i + 1 < chars.len() && chars[i + 1] == '*' {
                 i += 2;
                 continue;
@@ -220,7 +317,8 @@ fn find_char_end(chars: &[char], start: usize, ch: char) -> Option<usize> {
 // Code block rendering
 // ---------------------------------------------------------------------------
 
-/// Render a fenced code block with language annotation and line numbers.
+/// Render a fenced code block with language annotation, line numbers,
+/// and optional syntax highlighting.
 fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
     let lines: Vec<&str> = code.lines().collect();
     let line_width = format!("{}", lines.len()).len();
@@ -235,7 +333,8 @@ fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
     for (i, line) in lines.iter().enumerate() {
         let num = format!("{:>width$}", i + 1, width = line_width);
         if ansi {
-            out.push_str(&format!("{} {} │ {}{}", DIM, num, RESET, line));
+            let highlighted = highlight_line(line, language);
+            out.push_str(&format!("{} {} │ {}{}", DIM, num, RESET, highlighted));
         } else {
             out.push_str(&format!("  {} │ {}", num, line));
         }
@@ -243,6 +342,231 @@ fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
     }
 
     out
+}
+
+/// ANSI color codes for syntax highlighting.
+const ANSI_KEYWORD: &str = "\x1b[35m";
+const ANSI_COMMENT: &str = "\x1b[90m";
+/// Highlight a string literal in source code.
+fn highlight_string(chars: &[char], start: usize, out: &mut String) -> usize {
+    let q = chars[start];
+    out.push(q);
+    let mut i = start + 1;
+    while i < chars.len() && chars[i] != q {
+        if chars[i] == '\\' {
+            out.push(chars[i]);
+            i += 1;
+            if i < chars.len() {
+                out.push(chars[i]);
+                i += 1;
+            }
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    if i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    i
+}
+
+/// Highlight a word — check for keywords and wrap in ANSI color.
+fn highlight_word(chars: &[char], start: usize, language: &str, out: &mut String) -> usize {
+    let mut i = start;
+    while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+        i += 1;
+    }
+    let word: String = chars[start..i].iter().collect();
+    if is_keyword(&word, language) {
+        out.push_str(ANSI_KEYWORD);
+        out.push_str(&word);
+        out.push_str(RESET);
+    } else {
+        out.push_str(&word);
+    }
+    i
+}
+
+/// Highlight keywords, strings, and comments in a code line.
+fn highlight_line(line: &str, language: &str) -> String {
+    let trimmed = line.trim_start();
+    if is_comment(trimmed, language) {
+        return format!("{}{}{}", ANSI_COMMENT, line, RESET);
+    }
+    let mut out = String::with_capacity(line.len() * 2);
+    let chars: Vec<char> = line.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+    while i < len {
+        if chars[i] == '"' || chars[i] == '\'' {
+            i = highlight_string(&chars, i, &mut out);
+        } else if chars[i].is_alphabetic() || chars[i] == '_' {
+            i = highlight_word(&chars, i, language, &mut out);
+        } else {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Check if a trimmed line is a comment.
+fn is_comment(trimmed: &str, language: &str) -> bool {
+    matches!(
+        language,
+        "python" | "ruby" | "bash" | "sh" | "yaml" | "toml"
+    ) && trimmed.starts_with('#')
+        || (matches!(
+            language,
+            "rust" | "go" | "javascript" | "typescript" | "c" | "cpp" | "java"
+        ) && trimmed.starts_with("//"))
+        || (matches!(language, "haskell" | "lua") && trimmed.starts_with("--"))
+        || trimmed.starts_with("/*")
+}
+
+/// Check if a word is a keyword for the given language.
+fn is_keyword(word: &str, language: &str) -> bool {
+    match language {
+        "rust" | "" => is_rust_keyword(word),
+        "python" => is_python_keyword(word),
+        "javascript" | "typescript" => is_js_keyword(word),
+        "go" => is_go_keyword(word),
+        "c" | "cpp" | "java" => is_c_keyword(word),
+        _ => false,
+    }
+}
+
+fn is_rust_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "fn" | "let"
+            | "mut"
+            | "pub"
+            | "mod"
+            | "use"
+            | "struct"
+            | "enum"
+            | "impl"
+            | "trait"
+            | "match"
+            | "if"
+            | "else"
+            | "for"
+            | "while"
+            | "loop"
+            | "return"
+            | "self"
+            | "Self"
+            | "super"
+            | "crate"
+            | "async"
+            | "await"
+            | "move"
+            | "ref"
+            | "type"
+            | "where"
+    )
+}
+
+fn is_python_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "def"
+            | "class"
+            | "import"
+            | "from"
+            | "return"
+            | "if"
+            | "else"
+            | "for"
+            | "while"
+            | "try"
+            | "except"
+            | "with"
+            | "as"
+            | "in"
+            | "not"
+            | "and"
+            | "or"
+            | "lambda"
+            | "yield"
+            | "print"
+    )
+}
+
+fn is_js_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "function"
+            | "const"
+            | "let"
+            | "var"
+            | "return"
+            | "if"
+            | "else"
+            | "for"
+            | "while"
+            | "class"
+            | "new"
+            | "this"
+            | "import"
+            | "export"
+            | "default"
+            | "switch"
+            | "case"
+            | "break"
+    )
+}
+
+fn is_go_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "func"
+            | "package"
+            | "import"
+            | "return"
+            | "if"
+            | "else"
+            | "for"
+            | "range"
+            | "struct"
+            | "interface"
+            | "type"
+            | "var"
+            | "const"
+            | "defer"
+            | "go"
+            | "select"
+            | "chan"
+            | "map"
+    )
+}
+
+fn is_c_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "int"
+            | "float"
+            | "double"
+            | "char"
+            | "void"
+            | "if"
+            | "else"
+            | "for"
+            | "while"
+            | "return"
+            | "class"
+            | "public"
+            | "private"
+            | "static"
+            | "new"
+            | "this"
+            | "switch"
+            | "case"
+            | "break"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -303,78 +627,15 @@ fn render_markdown_plain(content: &str) -> String {
 
 /// Remove common markdown formatting markers for plain-text output.
 fn strip_markdown(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let chars: Vec<char> = line.chars().collect();
-    let len = chars.len();
-    let mut i = 0;
-
-    while i < len {
-        // Heading markers
-        if i == 0 && line.starts_with("# ") {
-            out.push_str(&line[2..]);
-            return out;
-        }
-
-        // Bold: **text** → text
-        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
-            if let Some(end) = find_double_star_end(&chars, i + 2) {
-                for c in &chars[i + 2..end] {
-                    out.push(*c);
-                }
-                i = end + 2;
-                continue;
-            }
-        }
-
-        // Italic: *text* → text
-        if chars[i] == '*' && (i + 1 >= len || chars[i + 1] != '*') {
-            if let Some(end) = find_single_star_end(&chars, i + 1) {
-                for c in &chars[i + 1..end] {
-                    out.push(*c);
-                }
-                i = end + 1;
-                continue;
-            }
-        }
-
-        // Inline code: `text` → text
-        if chars[i] == '`' {
-            if let Some(end) = find_char_end(&chars, i + 1, '`') {
-                for c in &chars[i + 1..end] {
-                    out.push(*c);
-                }
-                i = end + 1;
-                continue;
-            }
-        }
-
-        // Link: [text](url) → text (url)
-        if chars[i] == '[' {
-            if let Some(bracket_end) = find_char_end(&chars, i + 1, ']') {
-                if bracket_end + 1 < len && chars[bracket_end + 1] == '(' {
-                    if let Some(paren_end) = find_char_end(&chars, bracket_end + 2, ')') {
-                        let link_text: String = chars[i + 1..bracket_end].iter().collect();
-                        let link_url: String = chars[bracket_end + 2..paren_end].iter().collect();
-                        out.push_str(&format!("{} ({})", link_text, link_url));
-                        i = paren_end + 1;
-                        continue;
-                    }
-                }
-            }
-        }
-
-        // Blockquote: > text → │ text
-        if i == 0 && line.starts_with("> ") {
-            out.push_str("│ ");
-            out.push_str(&line[2..]);
-            return out;
-        }
-
-        out.push(chars[i]);
-        i += 1;
+    if let Some(rest) = line.strip_prefix("# ") {
+        return rest.to_string();
     }
-
-    out
+    if let Some(rest) = line.strip_prefix("> ") {
+        return format!("│ {}", rest);
+    }
+    let chars: Vec<char> = line.chars().collect();
+    let spans = parse_inline_spans(&chars);
+    apply_inline_styling(&spans, false)
 }
 
 // ---------------------------------------------------------------------------
@@ -444,8 +705,8 @@ impl TerminalRenderer {
     fn render_tool_use(&self, name: &str, input: &str) -> String {
         if self.ansi {
             format!(
-                "{}⚙ {}{}{}({}{}){}{}\n",
-                DIM, BOLD, name, RESET, DIM, input, DIM, RESET
+                "{}⚙ {}{}{}{}({}{}){}{}\n",
+                DIM, BOLD, CYAN, name, RESET, DIM, input, DIM, RESET
             )
         } else {
             format!("⚙ {}({})\n", name, input)
@@ -454,10 +715,10 @@ impl TerminalRenderer {
 
     /// Render a ToolResult block, truncating at terminal width.
     fn render_tool_result(&self, content: &str) -> String {
-        // Truncate at 120 characters with indicator
-        let max_width = 120;
-        let display = if content.len() > max_width {
-            format!("{}... (truncated)", &content[..max_width])
+        let max_width = get_terminal_width();
+        let display = if content.chars().count() > max_width {
+            let truncated: String = content.chars().take(max_width).collect();
+            format!("{}... (truncated)", truncated)
         } else {
             content.to_string()
         };
@@ -588,13 +849,22 @@ impl TerminalAdapter {
     }
 }
 
+/// Return the terminal width in columns, falling back to 120.
+fn get_terminal_width() -> usize {
+    terminal_size::terminal_size()
+        .map(|(w, _)| w.0 as usize)
+        .unwrap_or(120)
+}
+
 /// Return the current user's system UID as a string.
 ///
 /// On Unix, uses `libc::getuid()`. On other platforms, falls back to a
 /// static identifier.
-fn current_uid() -> String {
+pub(crate) fn current_uid() -> String {
     #[cfg(unix)]
     {
+        // SAFETY: libc::getuid() is always safe — it reads the calling
+        // process's real user ID without side effects.
         unsafe { libc::getuid() }.to_string()
     }
     #[cfg(not(unix))]

--- a/src/im/terminal_tests.rs
+++ b/src/im/terminal_tests.rs
@@ -1,0 +1,500 @@
+#[cfg(test)]
+mod tests {
+    use crate::im::terminal::*;
+    use crate::im_adapter::renderer::Renderer;
+    use crate::llm::types::ContentBlock;
+
+    #[test]
+    fn test_platform() {
+        let r = TerminalRenderer::new();
+        assert_eq!(r.platform(), "terminal");
+    }
+
+    #[test]
+    fn test_render_text_plain() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("Hello world".into())];
+        let output = r.render(&blocks, None);
+        assert_eq!(output.msg_type, "text");
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Hello world"));
+        assert!(!text.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_render_text_ansi() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("**bold**".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(BOLD));
+        assert!(text.contains("bold"));
+    }
+
+    #[test]
+    fn test_render_thinking() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Thinking("reasoning here".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("[Thinking]"));
+        assert!(text.contains("reasoning here"));
+        assert!(text.contains("[end of thinking]"));
+    }
+
+    #[test]
+    fn test_render_tool_use() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::ToolUse {
+            id: "call_1".into(),
+            name: "web_search".into(),
+            input: r#"{"query":"rust"}"#.into(),
+        }];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("⚙"));
+        assert!(text.contains("web_search"));
+        assert!(text.contains("rust"));
+    }
+
+    #[test]
+    fn test_render_tool_result_truncation() {
+        let r = TerminalRenderer::with_ansi(false);
+        let long_content = "x".repeat(200);
+        let blocks = vec![ContentBlock::ToolResult {
+            tool_call_id: "call_1".into(),
+            content: long_content,
+        }];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("(truncated)"));
+        assert!(text.len() < 200);
+    }
+
+    #[test]
+    fn test_render_tool_result_short() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::ToolResult {
+            tool_call_id: "call_1".into(),
+            content: "ok".into(),
+        }];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("ok"));
+        assert!(!text.contains("(truncated)"));
+    }
+
+    #[test]
+    fn test_render_code_block() {
+        let r = TerminalRenderer::with_ansi(false);
+        let code = "fn main() {\n    println!(\"hi\");\n}";
+        let blocks = vec![ContentBlock::Text(format!("```rust\n{}\n```", code))];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("rust"));
+        assert!(text.contains("│"));
+        assert!(text.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_render_code_block_ansi() {
+        let r = TerminalRenderer::with_ansi(true);
+        let code = "let x = 1;";
+        let blocks = vec![ContentBlock::Text(format!("```js\n{}\n```", code))];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("js"));
+        assert!(text.contains("let x = 1;"));
+    }
+
+    #[test]
+    fn test_render_heading() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("# Title".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(BOLD));
+        assert!(text.contains("Title"));
+    }
+
+    #[test]
+    fn test_render_bold() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("This is **bold** text".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(BOLD));
+        assert!(text.contains("bold"));
+    }
+
+    #[test]
+    fn test_render_link() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text(
+            "[Rust](https://rust-lang.org) is great".into(),
+        )];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Rust"));
+        assert!(text.contains("https://rust-lang.org"));
+    }
+
+    #[test]
+    fn test_render_hr() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("---".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("───"));
+    }
+
+    #[test]
+    fn test_render_blockquote() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("> quote".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("│"));
+        assert!(text.contains("quote"));
+    }
+
+    #[test]
+    fn test_strip_ansi() {
+        let input = format!("{}hello{}", BOLD, RESET);
+        assert_eq!(strip_ansi(&input), "hello");
+    }
+
+    #[test]
+    fn test_strip_ansi_nested() {
+        let input = format!("{}{}nested{}", BOLD, DIM, RESET);
+        assert_eq!(strip_ansi(&input), "nested");
+    }
+
+    #[test]
+    fn test_render_thinking_plain() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Thinking("thinking text".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("[Thinking]"));
+        assert!(text.contains("thinking text"));
+        assert!(text.contains("[end of thinking]"));
+        assert!(!text.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_render_empty_blocks() {
+        let r = TerminalRenderer::with_ansi(true);
+        let output = r.render(&[], None);
+        assert_eq!(output.msg_type, "text");
+    }
+
+    #[test]
+    fn test_render_mixed_blocks() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![
+            ContentBlock::Text("Step 1".into()),
+            ContentBlock::ToolUse {
+                id: "c1".into(),
+                name: "exec".into(),
+                input: "ls".into(),
+            },
+            ContentBlock::ToolResult {
+                tool_call_id: "c1".into(),
+                content: "file.rs".into(),
+            },
+            ContentBlock::Text("Done".into()),
+        ];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Step 1"));
+        assert!(text.contains("exec"));
+        assert!(text.contains("file.rs"));
+        assert!(text.contains("Done"));
+    }
+
+    #[test]
+    fn test_render_tool_use_plain() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::ToolUse {
+            id: "call_2".into(),
+            name: "read_file".into(),
+            input: r#"{"path":"/tmp/x"}"#.into(),
+        }];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("read_file"));
+        assert!(!text.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_render_italic() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("use *italic* please".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(ITALIC));
+        assert!(text.contains("italic"));
+    }
+
+    #[test]
+    fn test_render_inline_code() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("use `println!` macro".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("println!"));
+    }
+
+    #[test]
+    fn test_render_code_block_no_language() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("```\nhello\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("│"));
+        assert!(text.contains("hello"));
+    }
+
+    #[test]
+    fn test_render_code_block_ansi_has_dim_header() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("```python\nprint(1)\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("python"));
+        assert!(text.contains(DIM));
+    }
+
+    #[test]
+    fn test_render_long_tool_result_not_truncated() {
+        let r = TerminalRenderer::with_ansi(false);
+        let short = "a".repeat(50);
+        let blocks = vec![ContentBlock::ToolResult {
+            tool_call_id: "c1".into(),
+            content: short.clone(),
+        }];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(&short));
+        assert!(!text.contains("(truncated)"));
+    }
+
+    #[test]
+    fn test_render_plain_text_strip_bold() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("**bold**".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("bold"));
+        assert!(!text.contains("**"));
+        assert!(!text.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_render_plain_text_strip_italic() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("*italic*".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("italic"));
+        assert!(!text.contains("*"));
+    }
+
+    #[test]
+    fn test_render_plain_text_link() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("[click](https://x.com)".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("click (https://x.com)"));
+    }
+
+    #[test]
+    fn test_render_plain_text_heading() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("# Hello".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Hello"));
+        assert!(!text.contains("#"));
+    }
+
+    #[test]
+    fn test_render_plain_text_blockquote() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("> quote".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("│ quote"));
+    }
+
+    #[test]
+    fn test_render_plain_text_hr() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("---".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("───"));
+    }
+
+    #[test]
+    fn test_render_plain_text_inline_code() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("use `foo` here".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("foo"));
+    }
+
+    #[test]
+    fn test_payload_is_json() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("test".into())];
+        let output = r.render(&blocks, None);
+        // payload should be valid JSON
+        let s = serde_json::to_string(&output.payload).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert!(parsed.get("content").is_some());
+    }
+}

--- a/src/im/terminal_tests.rs
+++ b/src/im/terminal_tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
     use crate::im::terminal::*;
-    use crate::im_adapter::renderer::Renderer;
+    use crate::im_adapter::plugin::IMPlugin;
+    use crate::im_adapter::renderer::{RenderedOutput, Renderer};
+    use crate::im_adapter::NormalizedMessage;
     use crate::llm::types::ContentBlock;
 
     #[test]
@@ -496,5 +498,280 @@ mod tests {
         let s = serde_json::to_string(&output.payload).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
         assert!(parsed.get("content").is_some());
+    }
+
+    // =========================================================================
+    // TerminalAdapter tests
+    // =========================================================================
+
+    #[test]
+    fn test_adapter_new() {
+        let _adapter = TerminalAdapter::new();
+    }
+
+    #[test]
+    fn test_read_input_returns_none_on_eof() {
+        let adapter = TerminalAdapter::new();
+        // stdin is empty in test environment -> EOF -> None
+        assert!(adapter.read_input().is_none());
+    }
+
+    #[test]
+    fn test_read_input_blank_lines_only_returns_none() {
+        let adapter = TerminalAdapter::new();
+        // Leading blank lines are skipped; with no content accumulated -> None
+        assert!(adapter.read_input().is_none());
+    }
+
+    #[test]
+    fn test_normalized_message_platform_and_peer() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: "hello".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        assert_eq!(msg.platform, "terminal");
+        assert_eq!(msg.peer_id, "cli");
+        assert_eq!(msg.content, "hello");
+    }
+
+    #[test]
+    fn test_normalized_message_optional_fields_none() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: "test".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        assert!(msg.thread_id.is_none());
+        assert!(msg.account_id.is_none());
+    }
+
+    #[test]
+    fn test_normalized_message_timestamp_is_reasonable() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: "test".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        // Timestamp is a valid Unix timestamp (after 2023)
+        assert!(msg.timestamp > 1672531200);
+    }
+
+    #[test]
+    fn test_normalized_message_serialization_roundtrip() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: "hello\nworld".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let deserialized: NormalizedMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.platform, "terminal");
+        assert_eq!(deserialized.content, "hello\nworld");
+    }
+
+    #[test]
+    fn test_normalized_message_empty_content() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: String::new(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        assert!(msg.content.is_empty());
+    }
+
+    #[test]
+    fn test_normalized_message_multiline_content() {
+        let msg = NormalizedMessage {
+            platform: "terminal".to_string(),
+            sender_id: "1000".to_string(),
+            peer_id: "cli".to_string(),
+            content: "line1\nline2\nline3".to_string(),
+            timestamp: 1700000000,
+            thread_id: None,
+            account_id: None,
+        };
+        let lines: Vec<&str> = msg.content.lines().collect();
+        assert_eq!(lines.len(), 3);
+    }
+
+    // =========================================================================
+    // TerminalPlugin tests
+    // =========================================================================
+
+    #[test]
+    fn test_plugin_platform_returns_terminal() {
+        let plugin = TerminalPlugin::new();
+        assert_eq!(plugin.platform(), "terminal");
+    }
+
+    #[test]
+    fn test_plugin_with_ansi_platform() {
+        let plugin = TerminalPlugin::with_ansi(true);
+        assert_eq!(plugin.platform(), "terminal");
+    }
+
+    #[test]
+    fn test_plugin_default() {
+        let plugin = TerminalPlugin::default();
+        assert_eq!(plugin.platform(), "terminal");
+    }
+
+    #[tokio::test]
+    async fn test_plugin_parse_inbound_eof() {
+        let plugin = TerminalPlugin::new();
+        let result = plugin.parse_inbound(b"").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_parse_inbound_none_with_ansi() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let result = plugin.parse_inbound(b"").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_plugin_render_delegates_to_renderer() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("hello world".into())];
+        let output = plugin.render(&blocks, None);
+        assert_eq!(output.msg_type, "text");
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("hello world"));
+    }
+
+    #[test]
+    fn test_plugin_render_with_ansi() {
+        let plugin = TerminalPlugin::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("**bold**".into())];
+        let output = plugin.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains(BOLD));
+    }
+
+    #[test]
+    fn test_plugin_render_empty_blocks() {
+        let plugin = TerminalPlugin::new();
+        let output = plugin.render(&[], None);
+        assert_eq!(output.msg_type, "text");
+    }
+
+    #[test]
+    fn test_plugin_render_mixed_content() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let blocks = vec![
+            ContentBlock::Text("first".into()),
+            ContentBlock::ToolUse {
+                id: "c1".into(),
+                name: "exec".into(),
+                input: "ls".into(),
+            },
+            ContentBlock::ToolResult {
+                tool_call_id: "c1".into(),
+                content: "ok".into(),
+            },
+        ];
+        let output = plugin.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("first"));
+        assert!(text.contains("exec"));
+        assert!(text.contains("ok"));
+    }
+
+    #[tokio::test]
+    async fn test_plugin_send_ok() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({
+                "content": { "text": "test output" }
+            }),
+        };
+        let result = plugin.send(&output, "cli", None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_send_empty_text() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({
+                "content": { "text": "" }
+            }),
+        };
+        let result = plugin.send(&output, "cli", None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_send_null_payload() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::Value::Null,
+        };
+        let result = plugin.send(&output, "cli", None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_send_missing_content_key() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({}),
+        };
+        let result = plugin.send(&output, "cli", None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_send_with_thread_id() {
+        let plugin = TerminalPlugin::with_ansi(false);
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({
+                "content": { "text": "thread reply" }
+            }),
+        };
+        let result = plugin.send(&output, "cli", Some("thread_123")).await;
+        assert!(result.is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ enum Commands {
         #[command(subcommand)]
         action: SkillAction,
     },
+    /// Interactive chat with an agent via the terminal.
+    Chat(ChatArgs),
     Run {
         #[arg(short, long, default_value = "")]
         config_dir: String,
@@ -56,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Config { action } => handle_config(action, cli.json).await?,
         Commands::Rule { action } => handle_rule(action, cli.json).await?,
         Commands::Skill { action } => handle_skill(action, cli.json).await?,
+        Commands::Chat(args) => closeclaw::cli::chat::run_chat(&args.agent_id).await?,
         Commands::Run { config_dir } => {
             let config_dir: PathBuf = if config_dir.is_empty() {
                 dirs::home_dir()


### PR DESCRIPTION
feat: implement TerminalPlugin for CLI chat

实现 TerminalPlugin（IMPlugin trait 的 terminal 渠道），包含 TerminalRenderer 和 TerminalAdapter，使终端输入输出接入完整的 Gateway 出入站消息链路。

主要变更：
- TerminalRenderer：ANSI 渲染，支持 Text/Thinking/ToolUse/ToolResult 等 ContentBlock
- TerminalAdapter：stdin 读取，空行分隔消息边界
- TerminalPlugin：IMPlugin trait 完整实现
- CLI chat 子命令：`closeclaw chat --agent-id <id>` REPL 循环
- Daemon 集成：启动时自动注册 TerminalPlugin
- 单元测试覆盖所有渲染分支和 adapter 逻辑

Source: user
Type: feat
