### PR TITLE
feat: wire ProcessorRegistry, SlashDispatcher, SessionMessageHandler into chat Gateway

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -1,16 +1,32 @@
 //! Interactive chat REPL via the terminal channel.
 //!
-//! Creates a [`TerminalPlugin`], registers it with a minimal [`Gateway`],
-//! and runs a read-eval-print loop that routes user input through the
-//! full inbound/outbound message pipeline.
+//! Creates a [`TerminalPlugin`], registers it with a [`Gateway`] configured
+//! with a [`ProcessorRegistry`], [`SlashDispatcher`], and
+//! [`SessionMessageHandler`], and runs a read-eval-print loop that routes
+//! user input through the full inbound/outbound message pipeline.
 
 use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::config::providers::{ConfigProvider, CredentialsProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::terminal::TerminalPlugin;
+use crate::llm::anthropic::AnthropicProvider;
+use crate::llm::fallback::{FallbackClient, ModelEntry};
+use crate::llm::minimax::MiniMaxProvider;
+use crate::llm::openai::OpenAIProvider;
+use crate::llm::unified_fallback::{ChainEntry, UnifiedFallbackClient};
+use crate::llm::LLMRegistry;
+use crate::processor_chain::content_normalizer::ContentNormalizer;
+use crate::processor_chain::dsl_parser::DslParser;
+use crate::processor_chain::raw_log_processor::{RawLogConfig, RawLogProcessor};
+use crate::processor_chain::ProcessorRegistry;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
+use crate::slash::dispatcher::SlashDispatcher;
+use crate::slash::registry::HandlerRegistry;
+use crate::slash::{ClearHandler, HelpHandler, NewSessionHandler, StatusHandler, StopHandler};
 
 /// Why the REPL loop exited.
 enum ExitReason {
@@ -42,7 +58,8 @@ pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
     }
 }
 
-/// Build a [`Gateway`] with a [`TerminalPlugin`] registered.
+/// Build a [`Gateway`] with [`ProcessorRegistry`], [`SlashDispatcher`],
+/// and [`SessionMessageHandler`] configured.
 async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
     let gateway_config = GatewayConfig {
         name: "closeclaw-chat".to_string(),
@@ -60,14 +77,224 @@ async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
         ReasoningLevel::default(),
     ));
 
-    let gateway = Gateway::new(gateway_config, Arc::clone(&session_manager));
+    // ── Processor Registry ─────────────────────────────────────────────
+    let processor_registry = Arc::new(build_processor_registry(&gateway_config));
+
+    let gateway = Gateway::with_processor_registry(
+        gateway_config,
+        Arc::clone(&session_manager),
+        processor_registry,
+    );
+
+    // ── Slash Dispatcher ───────────────────────────────────────────────
+    let slash_registry = Arc::new(HandlerRegistry::new());
+    slash_registry.register(Arc::new(ClearHandler::new(Arc::clone(&session_manager))));
+    let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
+    slash_registry.register(Arc::new(help_handler));
+    slash_registry.register(Arc::new(NewSessionHandler));
+    slash_registry.register(Arc::new(StopHandler));
+    slash_registry.register(Arc::new(StatusHandler::new(Arc::clone(&session_manager))));
+    let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
+
+    // ── Session Message Handler ────────────────────────────────────────
+    let session_handler = build_session_handler(Arc::clone(&session_manager)).await;
+    let gateway = if let Some(handler) = session_handler {
+        gateway.with_session_handler(Arc::new(handler))
+    } else {
+        gateway
+    };
+
     let gateway = Arc::new(gateway);
     gateway.set_self_ref(Arc::clone(&gateway));
+
+    // Inject slash dispatcher after Arc wrapping (async method).
+    gateway.set_slash_dispatcher(slash_dispatcher).await;
 
     let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());
     gateway.register_plugin(plugin).await;
 
     (gateway, session_manager)
+}
+
+/// Build a [`ProcessorRegistry`] with inbound [`RawLogProcessor`] and
+/// [`ContentNormalizer`], outbound [`DslParser`].
+fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegistry {
+    let mut registry = ProcessorRegistry::default();
+
+    // Inbound: RawLogProcessor (if raw_log_dir is configured)
+    if let Some(ref dir) = config.raw_log_dir {
+        let raw_log_config = RawLogConfig {
+            enabled: true,
+            dir: dir.clone(),
+            retention_days: 7,
+        };
+        let processor =
+            RawLogProcessor::new(raw_log_config).expect("RawLogProcessor initialization failed");
+        registry.register(Arc::new(processor));
+    }
+
+    // Inbound: ContentNormalizer
+    registry.register(Arc::new(ContentNormalizer::new()));
+
+    // Outbound: DslParser
+    registry.register(Arc::new(DslParser));
+
+    registry
+}
+
+/// Initialize the LLM registry from credentials files or environment variables.
+async fn init_llm_registry() -> Arc<LLMRegistry> {
+    let registry = Arc::new(LLMRegistry::new());
+
+    // Determine config directory
+    let config_dir = dirs::home_dir()
+        .map(|h| h.join(".closeclaw"))
+        .unwrap_or_else(|| PathBuf::from(".closeclaw"));
+
+    // Load credentials from config/credentials/ directory
+    let creds_dir = config_dir.join(CredentialsProvider::config_path());
+    let creds_provider = match CredentialsProvider::load_from_dir(&creds_dir) {
+        Ok(cp) => cp,
+        Err(e) => {
+            tracing::warn!(
+                "failed to load credentials from '{}': {}",
+                creds_dir.display(),
+                e
+            );
+            CredentialsProvider::default()
+        }
+    };
+
+    // Register OpenAI provider
+    let openai_key = creds_provider
+        .get_api_key("openai")
+        .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+        .filter(|k| !k.is_empty());
+    if let Some(api_key) = openai_key {
+        let provider: Arc<dyn crate::llm::provider::Provider> =
+            Arc::new(OpenAIProvider::new(api_key));
+        registry.register("openai".to_string(), provider).await;
+    }
+
+    // Register Anthropic provider
+    let anthropic_key = creds_provider
+        .get_api_key("anthropic")
+        .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+        .filter(|k| !k.is_empty());
+    if let Some(api_key) = anthropic_key {
+        let provider: Arc<dyn crate::llm::provider::Provider> =
+            Arc::new(AnthropicProvider::new(api_key));
+        registry.register("anthropic".to_string(), provider).await;
+    }
+
+    // Register MiniMax provider
+    let minimax_key = creds_provider
+        .get_api_key("minimax")
+        .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
+        .filter(|k| !k.is_empty());
+    if let Some(api_key) = minimax_key {
+        let provider: Arc<dyn crate::llm::provider::Provider> =
+            Arc::new(MiniMaxProvider::new(api_key));
+        registry.register("minimax".to_string(), provider).await;
+    }
+
+    registry
+}
+
+/// Build the fallback chain from environment variables or defaults.
+///
+/// Reads `CLOSECLAW_FALLBACK_CHAIN` (comma-separated `provider/model` pairs)
+/// or falls back to a reasonable default.
+fn build_fallback_chain() -> Vec<ModelEntry> {
+    if let Ok(chain_str) = std::env::var("CLOSECLAW_FALLBACK_CHAIN") {
+        return chain_str
+            .split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                let (provider, model) = s.split_once('/')?;
+                Some(ModelEntry {
+                    provider: provider.to_string(),
+                    model: model.to_string(),
+                })
+            })
+            .collect();
+    }
+
+    // Default fallback chain
+    vec![
+        ModelEntry {
+            provider: "openai".to_string(),
+            model: "gpt-4o".to_string(),
+        },
+        ModelEntry {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4-20250514".to_string(),
+        },
+    ]
+}
+
+/// Build a [`SessionMessageHandler`] with LLM clients.
+///
+/// Returns `None` if no LLM providers are configured.
+async fn build_session_handler(
+    session_manager: Arc<SessionManager>,
+) -> Option<crate::gateway::session_handler::SessionMessageHandler> {
+    let llm_registry = init_llm_registry().await;
+    let fallback_chain = build_fallback_chain();
+
+    // Filter chain to only include providers that are registered
+    let available_providers = llm_registry.list().await;
+    let valid_chain: Vec<ModelEntry> = fallback_chain
+        .into_iter()
+        .filter(|e| available_providers.contains(&e.provider))
+        .collect();
+
+    if valid_chain.is_empty() {
+        tracing::warn!("no LLM providers configured — session handler not installed");
+        return None;
+    }
+
+    let fallback_client = Arc::new(FallbackClient::new(
+        Arc::clone(&llm_registry),
+        valid_chain.clone(),
+    ));
+
+    // Build UnifiedFallbackClient chain entries
+    let cooldown = Arc::new(crate::llm::retry::CooldownManager::new());
+    let unified_chain: Vec<ChainEntry> = valid_chain
+        .iter()
+        .filter_map(|entry| {
+            let protocol = Arc::new(crate::llm::protocol::OpenAiProtocol::default());
+            let interpreter_registry = crate::llm::interpreter::InterpreterRegistry::new(vec![]);
+            let plugin_pipeline = crate::llm::plugin::PluginPipeline::new();
+            let provider = {
+                let rt = tokio::runtime::Handle::current();
+                rt.block_on(llm_registry.get(&entry.provider))
+            }?;
+            let client = Arc::new(crate::llm::client::UnifiedChatClient::new(
+                provider,
+                protocol,
+                interpreter_registry,
+                plugin_pipeline,
+                Arc::new(crate::llm::cache_adapter::NoopCacheAdapter),
+            ));
+            Some(ChainEntry {
+                provider_id: entry.provider.clone(),
+                model_id: entry.model.clone(),
+                client,
+            })
+        })
+        .collect();
+
+    let unified_fallback_client = Arc::new(UnifiedFallbackClient::new(unified_chain, cooldown));
+
+    let (output_tx, _output_rx) = tokio::sync::mpsc::channel(64);
+    Some(crate::gateway::session_handler::SessionMessageHandler::new(
+        session_manager,
+        fallback_client,
+        output_tx,
+        unified_fallback_client,
+    ))
 }
 
 /// Create a session for the chat REPL.

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -78,37 +78,18 @@ pub(crate) async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
         ReasoningLevel::default(),
     ));
 
-    // ── Processor Registry ─────────────────────────────────────────────
     let processor_registry = Arc::new(build_processor_registry(&gateway_config));
-
     let gateway = Gateway::with_processor_registry(
         gateway_config,
         Arc::clone(&session_manager),
         processor_registry,
     );
 
-    // ── Slash Dispatcher ───────────────────────────────────────────────
-    let slash_registry = Arc::new(HandlerRegistry::new());
-    slash_registry.register(Arc::new(ClearHandler::new(Arc::clone(&session_manager))));
-    let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
-    slash_registry.register(Arc::new(help_handler));
-    slash_registry.register(Arc::new(NewSessionHandler));
-    slash_registry.register(Arc::new(StopHandler));
-    slash_registry.register(Arc::new(StatusHandler::new(Arc::clone(&session_manager))));
-    let slash_dispatcher = Arc::new(SlashDispatcher::from_shared(slash_registry));
+    let slash_dispatcher = build_slash_dispatcher(Arc::clone(&session_manager));
 
-    // ── Session Message Handler ────────────────────────────────────────
-    let session_handler = build_session_handler(Arc::clone(&session_manager)).await;
-    let gateway = if let Some(handler) = session_handler {
-        gateway.with_session_handler(Arc::new(handler))
-    } else {
-        gateway
-    };
-
+    let gateway = attach_session_handler(gateway, Arc::clone(&session_manager)).await;
     let gateway = Arc::new(gateway);
     gateway.set_self_ref(Arc::clone(&gateway));
-
-    // Inject slash dispatcher after Arc wrapping (async method).
     gateway.set_slash_dispatcher(slash_dispatcher).await;
 
     let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());
@@ -143,18 +124,13 @@ pub(crate) fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegis
     registry
 }
 
-/// Initialize the LLM registry from credentials files or environment variables.
-async fn init_llm_registry() -> Arc<LLMRegistry> {
-    let registry = Arc::new(LLMRegistry::new());
-
-    // Determine config directory
+/// Load credentials from the config directory, falling back to defaults.
+fn load_credentials_provider() -> CredentialsProvider {
     let config_dir = dirs::home_dir()
         .map(|h| h.join(".closeclaw"))
         .unwrap_or_else(|| PathBuf::from(".closeclaw"));
-
-    // Load credentials from config/credentials/ directory
     let creds_dir = config_dir.join(CredentialsProvider::config_path());
-    let creds_provider = match CredentialsProvider::load_from_dir(&creds_dir) {
+    match CredentialsProvider::load_from_dir(&creds_dir) {
         Ok(cp) => cp,
         Err(e) => {
             tracing::warn!(
@@ -164,40 +140,93 @@ async fn init_llm_registry() -> Arc<LLMRegistry> {
             );
             CredentialsProvider::default()
         }
-    };
-
-    // Register OpenAI provider
-    let openai_key = creds_provider
-        .get_api_key("openai")
-        .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-        .filter(|k| !k.is_empty());
-    if let Some(api_key) = openai_key {
-        let provider: Arc<dyn crate::llm::provider::Provider> =
-            Arc::new(OpenAIProvider::new(api_key));
-        registry.register("openai".to_string(), provider).await;
     }
+}
 
-    // Register Anthropic provider
-    let anthropic_key = creds_provider
-        .get_api_key("anthropic")
-        .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
-        .filter(|k| !k.is_empty());
-    if let Some(api_key) = anthropic_key {
-        let provider: Arc<dyn crate::llm::provider::Provider> =
-            Arc::new(AnthropicProvider::new(api_key));
-        registry.register("anthropic".to_string(), provider).await;
+/// Filter the fallback chain to only include registered providers.
+async fn filter_valid_chain(
+    llm_registry: &LLMRegistry,
+    fallback_chain: Vec<ModelEntry>,
+) -> Option<Vec<ModelEntry>> {
+    let available = llm_registry.list().await;
+    let valid: Vec<ModelEntry> = fallback_chain
+        .into_iter()
+        .filter(|e| available.contains(&e.provider))
+        .collect();
+    if valid.is_empty() {
+        tracing::warn!("no LLM providers configured — session handler not installed");
+        return None;
     }
+    Some(valid)
+}
 
-    // Register MiniMax provider
-    let minimax_key = creds_provider
-        .get_api_key("minimax")
-        .or_else(|| std::env::var("MINIMAX_API_KEY").ok())
-        .filter(|k| !k.is_empty());
-    if let Some(api_key) = minimax_key {
-        let provider: Arc<dyn crate::llm::provider::Provider> =
-            Arc::new(MiniMaxProvider::new(api_key));
-        registry.register("minimax".to_string(), provider).await;
+/// Build a [`SlashDispatcher`] with core command handlers.
+fn build_slash_dispatcher(session_manager: Arc<SessionManager>) -> Arc<SlashDispatcher> {
+    let slash_registry = Arc::new(HandlerRegistry::new());
+    slash_registry.register(Arc::new(ClearHandler::new(Arc::clone(&session_manager))));
+    let help_handler = HelpHandler::new(Arc::clone(&slash_registry));
+    slash_registry.register(Arc::new(help_handler));
+    slash_registry.register(Arc::new(NewSessionHandler));
+    slash_registry.register(Arc::new(StopHandler));
+    slash_registry.register(Arc::new(StatusHandler::new(Arc::clone(&session_manager))));
+    Arc::new(SlashDispatcher::from_shared(slash_registry))
+}
+
+/// Attach a [`SessionMessageHandler`] to the gateway if LLM providers are available.
+async fn attach_session_handler(gateway: Gateway, session_manager: Arc<SessionManager>) -> Gateway {
+    match build_session_handler(session_manager).await {
+        Some(handler) => gateway.with_session_handler(Arc::new(handler)),
+        None => gateway,
     }
+}
+
+/// Register a single LLM provider if credentials are available.
+async fn try_register_provider(
+    registry: &LLMRegistry,
+    name: &str,
+    creds_provider: &CredentialsProvider,
+    env_var: &str,
+    create_fn: impl FnOnce(String) -> Arc<dyn crate::llm::provider::Provider>,
+) {
+    let key = creds_provider
+        .get_api_key(name)
+        .or_else(|| std::env::var(env_var).ok())
+        .filter(|k| !k.is_empty());
+    if let Some(api_key) = key {
+        let provider = create_fn(api_key);
+        registry.register(name.to_string(), provider).await;
+    }
+}
+
+/// Initialize the LLM registry from credentials files or environment variables.
+async fn init_llm_registry() -> Arc<LLMRegistry> {
+    let registry = Arc::new(LLMRegistry::new());
+    let creds_provider = load_credentials_provider();
+
+    try_register_provider(
+        &registry,
+        "openai",
+        &creds_provider,
+        "OPENAI_API_KEY",
+        |k| Arc::new(OpenAIProvider::new(k)),
+    )
+    .await;
+    try_register_provider(
+        &registry,
+        "anthropic",
+        &creds_provider,
+        "ANTHROPIC_API_KEY",
+        |k| Arc::new(AnthropicProvider::new(k)),
+    )
+    .await;
+    try_register_provider(
+        &registry,
+        "minimax",
+        &creds_provider,
+        "MINIMAX_API_KEY",
+        |k| Arc::new(MiniMaxProvider::new(k)),
+    )
+    .await;
 
     registry
 }
@@ -234,6 +263,40 @@ fn build_fallback_chain() -> Vec<ModelEntry> {
     ]
 }
 
+/// Build [`ChainEntry`] items by resolving providers asynchronously.
+async fn build_unified_chain(
+    llm_registry: &LLMRegistry,
+    valid_chain: &[ModelEntry],
+) -> Vec<ChainEntry> {
+    let mut providers = Vec::new();
+    for entry in valid_chain {
+        if let Some(provider) = llm_registry.get(&entry.provider).await {
+            providers.push((entry, provider));
+        }
+    }
+
+    providers
+        .into_iter()
+        .map(|(entry, provider)| {
+            let protocol = Arc::new(crate::llm::protocol::OpenAiProtocol::default());
+            let interpreter_registry = crate::llm::interpreter::InterpreterRegistry::new(vec![]);
+            let plugin_pipeline = crate::llm::plugin::PluginPipeline::new();
+            let client = Arc::new(crate::llm::client::UnifiedChatClient::new(
+                provider,
+                protocol,
+                interpreter_registry,
+                plugin_pipeline,
+                Arc::new(crate::llm::cache_adapter::NoopCacheAdapter),
+            ));
+            ChainEntry {
+                provider_id: entry.provider.clone(),
+                model_id: entry.model.clone(),
+                client,
+            }
+        })
+        .collect()
+}
+
 /// Build a [`SessionMessageHandler`] with LLM clients.
 ///
 /// Returns `None` if no LLM providers are configured.
@@ -242,51 +305,14 @@ async fn build_session_handler(
 ) -> Option<crate::gateway::session_handler::SessionMessageHandler> {
     let llm_registry = init_llm_registry().await;
     let fallback_chain = build_fallback_chain();
-
-    // Filter chain to only include providers that are registered
-    let available_providers = llm_registry.list().await;
-    let valid_chain: Vec<ModelEntry> = fallback_chain
-        .into_iter()
-        .filter(|e| available_providers.contains(&e.provider))
-        .collect();
-
-    if valid_chain.is_empty() {
-        tracing::warn!("no LLM providers configured — session handler not installed");
-        return None;
-    }
+    let valid_chain = filter_valid_chain(&llm_registry, fallback_chain).await?;
 
     let fallback_client = Arc::new(FallbackClient::new(
         Arc::clone(&llm_registry),
         valid_chain.clone(),
     ));
-
-    // Build UnifiedFallbackClient chain entries
     let cooldown = Arc::new(crate::llm::retry::CooldownManager::new());
-    let unified_chain: Vec<ChainEntry> = valid_chain
-        .iter()
-        .filter_map(|entry| {
-            let protocol = Arc::new(crate::llm::protocol::OpenAiProtocol::default());
-            let interpreter_registry = crate::llm::interpreter::InterpreterRegistry::new(vec![]);
-            let plugin_pipeline = crate::llm::plugin::PluginPipeline::new();
-            let provider = {
-                let rt = tokio::runtime::Handle::current();
-                rt.block_on(llm_registry.get(&entry.provider))
-            }?;
-            let client = Arc::new(crate::llm::client::UnifiedChatClient::new(
-                provider,
-                protocol,
-                interpreter_registry,
-                plugin_pipeline,
-                Arc::new(crate::llm::cache_adapter::NoopCacheAdapter),
-            ));
-            Some(ChainEntry {
-                provider_id: entry.provider.clone(),
-                model_id: entry.model.clone(),
-                client,
-            })
-        })
-        .collect();
-
+    let unified_chain = build_unified_chain(&llm_registry, &valid_chain).await;
     let unified_fallback_client = Arc::new(UnifiedFallbackClient::new(unified_chain, cooldown));
 
     let (output_tx, _output_rx) = tokio::sync::mpsc::channel(64);

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -5,13 +5,14 @@
 //! [`SessionMessageHandler`], and runs a read-eval-print loop that routes
 //! user input through the full inbound/outbound message pipeline.
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::providers::{ConfigProvider, CredentialsProvider};
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::terminal::TerminalPlugin;
+use crate::im_adapter::plugin::IMPlugin;
 use crate::llm::anthropic::AnthropicProvider;
 use crate::llm::fallback::{FallbackClient, ModelEntry};
 use crate::llm::minimax::MiniMaxProvider;
@@ -325,7 +326,7 @@ async fn create_session(
 /// Returns [`ExitReason::Quit`] when the user exits normally, or
 /// [`ExitReason::Error`] on I/O failure.
 async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str, sender_id: &str) -> ExitReason {
-    let stdin = io::stdin();
+    let plugin = TerminalPlugin::new();
 
     loop {
         print!("> ");
@@ -333,21 +334,26 @@ async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str, sender_id: &str) ->
             return ExitReason::Error(anyhow::anyhow!("failed to flush stdout"));
         }
 
-        let content = match read_user_input(&stdin) {
-            InputResult::Message(c) => c,
-            InputResult::Quit => {
-                println!("Goodbye!");
-                return ExitReason::Quit;
-            }
-            InputResult::Empty => continue,
-            InputResult::Eof => {
-                println!("\nGoodbye!");
-                return ExitReason::Quit;
-            }
-            InputResult::IoError(e) => {
-                return ExitReason::Error(anyhow::anyhow!("read error: {}", e));
+        let message = match plugin.parse_inbound(&[]).await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => continue,
+            Err(e) => {
+                return ExitReason::Error(anyhow::anyhow!("input error: {}", e));
             }
         };
+
+        let content = message.content;
+        let trimmed = content.trim();
+
+        if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit") {
+            println!("Goodbye!");
+            return ExitReason::Quit;
+        }
+        if trimmed.eq_ignore_ascii_case("/stop") {
+            println!("Session stopped.");
+            println!("Goodbye!");
+            return ExitReason::Quit;
+        }
 
         let result = gateway
             .handle_inbound_message(session_id, content, Some(sender_id), "terminal")
@@ -360,60 +366,5 @@ async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str, sender_id: &str) ->
         // Allow the streaming response to flush to stdout.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         println!();
-    }
-}
-
-/// Result of reading one user input attempt.
-enum InputResult {
-    /// A non-empty message ready to send.
-    Message(String),
-    /// User typed quit, exit, or /stop.
-    Quit,
-    /// Blank input — prompt again.
-    Empty,
-    /// EOF reached (stdin closed).
-    Eof,
-    /// I/O error.
-    IoError(io::Error),
-}
-
-/// Read user input from stdin until a blank line (message boundary) or EOF.
-fn read_user_input(stdin: &io::Stdin) -> InputResult {
-    let mut lines = Vec::new();
-
-    for line in stdin.lock().lines() {
-        match line {
-            Ok(text) => {
-                let trimmed = text.trim();
-                if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit") {
-                    return InputResult::Quit;
-                }
-                if trimmed.eq_ignore_ascii_case("/stop") {
-                    println!("Session stopped.");
-                    return InputResult::Quit;
-                }
-                if trimmed.is_empty() {
-                    if lines.is_empty() {
-                        print!("> ");
-                        let _ = io::stdout().flush();
-                        continue;
-                    }
-                    break;
-                }
-                lines.push(text);
-            }
-            Err(e) => return InputResult::IoError(e),
-        }
-    }
-
-    if lines.is_empty() {
-        return InputResult::Eof;
-    }
-
-    let content = lines.join("\n");
-    if content.trim().is_empty() {
-        InputResult::Empty
-    } else {
-        InputResult::Message(content)
     }
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -61,7 +61,7 @@ pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
 
 /// Build a [`Gateway`] with [`ProcessorRegistry`], [`SlashDispatcher`],
 /// and [`SessionMessageHandler`] configured.
-async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
+pub(crate) async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
     let gateway_config = GatewayConfig {
         name: "closeclaw-chat".to_string(),
         rate_limit_per_minute: 0,
@@ -119,7 +119,7 @@ async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
 
 /// Build a [`ProcessorRegistry`] with inbound [`RawLogProcessor`] and
 /// [`ContentNormalizer`], outbound [`DslParser`].
-fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegistry {
+pub(crate) fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegistry {
     let mut registry = ProcessorRegistry::default();
 
     // Inbound: RawLogProcessor (if raw_log_dir is configured)

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -1,0 +1,202 @@
+//! Unit tests for the interactive chat REPL.
+//!
+//! Verifies that `build_gateway()` produces a [`Gateway`] with the expected
+//! configuration (processor registry, slash dispatcher, session handler) and
+//! that the TerminalAdapter quit/exit detection logic works correctly.
+
+use crate::gateway::{GatewayConfig, SessionManager};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use std::sync::Arc;
+
+use super::chat::{build_gateway, build_processor_registry};
+
+// ── Processor Registry tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_build_processor_registry_has_inbound_and_outbound() {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        ..Default::default()
+    };
+    let registry = build_processor_registry(&config);
+
+    // ContentNormalizer (inbound) + DslParser (outbound)
+    assert!(registry.inbound_len() > 0, "expected inbound processors");
+    assert!(registry.outbound_len() > 0, "expected outbound processors");
+}
+
+#[tokio::test]
+async fn test_build_processor_registry_inbound_count() {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        ..Default::default()
+    };
+    let registry = build_processor_registry(&config);
+
+    // Without raw_log_dir: 1 inbound (ContentNormalizer)
+    assert_eq!(registry.inbound_len(), 1);
+}
+
+#[tokio::test]
+async fn test_build_processor_registry_outbound_count() {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        ..Default::default()
+    };
+    let registry = build_processor_registry(&config);
+
+    // 1 outbound (DslParser)
+    assert_eq!(registry.outbound_len(), 1);
+}
+
+#[tokio::test]
+async fn test_build_processor_registry_with_raw_log() {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        raw_log_dir: Some(std::path::PathBuf::from("/tmp/test-raw-log")),
+        ..Default::default()
+    };
+    let registry = build_processor_registry(&config);
+
+    // With raw_log_dir: 2 inbound (RawLogProcessor + ContentNormalizer)
+    assert_eq!(registry.inbound_len(), 2);
+    assert_eq!(registry.outbound_len(), 1);
+}
+
+// ── Gateway build tests ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_build_gateway_has_processor_registry() {
+    let (gateway, _session_manager) = build_gateway().await;
+
+    let (inbound, outbound) = gateway.processor_registry_len();
+    assert!(inbound > 0, "expected inbound processors in gateway");
+    assert!(outbound > 0, "expected outbound processors in gateway");
+}
+
+#[tokio::test]
+async fn test_build_gateway_has_slash_dispatcher() {
+    let (gateway, _session_manager) = build_gateway().await;
+
+    assert!(
+        gateway.has_slash_dispatcher().await,
+        "expected slash dispatcher to be configured"
+    );
+}
+
+#[tokio::test]
+async fn test_build_gateway_slash_help_dispatchable() {
+    use crate::slash::dispatcher::SlashDispatcher;
+
+    let slash_registry = Arc::new(crate::slash::registry::HandlerRegistry::new());
+    let session_manager = Arc::new(SessionManager::new(
+        &GatewayConfig {
+            name: "test".to_string(),
+            ..Default::default()
+        },
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    slash_registry.register(Arc::new(crate::slash::ClearHandler::new(Arc::clone(
+        &session_manager,
+    ))));
+    let help_handler = crate::slash::HelpHandler::new(Arc::clone(&slash_registry));
+    slash_registry.register(Arc::new(help_handler));
+    slash_registry.register(Arc::new(crate::slash::NewSessionHandler));
+    slash_registry.register(Arc::new(crate::slash::StopHandler));
+    slash_registry.register(Arc::new(crate::slash::StatusHandler::new(Arc::clone(
+        &session_manager,
+    ))));
+
+    let dispatcher = SlashDispatcher::from_shared(slash_registry);
+
+    // Verify all core handlers are registered
+    assert!(
+        dispatcher.get_handler("help").is_some(),
+        "expected /help handler to be registered"
+    );
+    assert!(
+        dispatcher.get_handler("stop").is_some(),
+        "expected /stop handler to be registered"
+    );
+    assert!(
+        dispatcher.get_handler("status").is_some(),
+        "expected /status handler to be registered"
+    );
+    assert!(
+        dispatcher.get_handler("clear").is_some(),
+        "expected /clear handler to be registered"
+    );
+    assert!(
+        dispatcher.get_handler("new").is_some(),
+        "expected /new handler to be registered"
+    );
+}
+
+// ── Session Message Handler test ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_build_gateway_has_session_handler() {
+    let (gateway, _session_manager) = build_gateway().await;
+
+    // Session handler depends on LLM providers being configured.
+    // In test environments, providers may not be available, so we
+    // verify the gateway was built successfully and the accessor works.
+    let has = gateway.has_session_handler().await;
+    tracing::info!("session_handler present: {}", has);
+}
+
+// ── TerminalAdapter / REPL quit/exit detection ──────────────────────────────
+
+/// Replicate the quit/exit detection logic from the REPL loop for unit testing.
+fn is_quit_command(content: &str) -> bool {
+    let trimmed = content.trim();
+    trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit")
+}
+
+fn is_stop_command(content: &str) -> bool {
+    let trimmed = content.trim();
+    trimmed.eq_ignore_ascii_case("/stop")
+}
+
+#[test]
+fn test_quit_detection_exact() {
+    assert!(is_quit_command("quit"));
+    assert!(is_quit_command("exit"));
+}
+
+#[test]
+fn test_quit_detection_case_insensitive() {
+    assert!(is_quit_command("Quit"));
+    assert!(is_quit_command("QUIT"));
+    assert!(is_quit_command("Exit"));
+    assert!(is_quit_command("EXIT"));
+    assert!(is_quit_command("qUit"));
+}
+
+#[test]
+fn test_quit_detection_with_whitespace() {
+    assert!(is_quit_command("  quit  "));
+    assert!(is_quit_command("\texit\n"));
+}
+
+#[test]
+fn test_quit_detection_non_quit() {
+    assert!(!is_quit_command("hello"));
+    assert!(!is_quit_command("quitting"));
+    assert!(!is_quit_command("exit_now"));
+    assert!(!is_quit_command(""));
+    assert!(!is_quit_command("/stop"));
+}
+
+#[test]
+fn test_stop_detection() {
+    assert!(is_stop_command("/stop"));
+    assert!(is_stop_command("/Stop"));
+    assert!(is_stop_command("  /stop  "));
+    assert!(!is_stop_command("stop"));
+    assert!(!is_stop_command("/stopextra"));
+}

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -52,9 +52,10 @@ async fn test_build_processor_registry_outbound_count() {
 
 #[tokio::test]
 async fn test_build_processor_registry_with_raw_log() {
+    let tmp = tempfile::TempDir::new().unwrap();
     let config = GatewayConfig {
         name: "test".to_string(),
-        raw_log_dir: Some(std::path::PathBuf::from("/tmp/test-raw-log")),
+        raw_log_dir: Some(tmp.path().to_path_buf()),
         ..Default::default()
     };
     let registry = build_processor_registry(&config);
@@ -142,11 +143,13 @@ async fn test_build_gateway_slash_help_dispatchable() {
 async fn test_build_gateway_has_session_handler() {
     let (gateway, _session_manager) = build_gateway().await;
 
-    // Session handler depends on LLM providers being configured.
-    // In test environments, providers may not be available, so we
-    // verify the gateway was built successfully and the accessor works.
+    // In test environments without LLM providers, session handler
+    // should not be installed.
     let has = gateway.has_session_handler().await;
-    tracing::info!("session_handler present: {}", has);
+    assert!(
+        !has,
+        "session handler should not be present without LLM providers"
+    );
 }
 
 // ── TerminalAdapter / REPL quit/exit detection ──────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,3 +3,6 @@
 pub mod args;
 pub mod chat;
 pub mod config_wizard;
+
+#[cfg(test)]
+mod chat_tests;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -228,6 +228,24 @@ impl Gateway {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn processor_registry_len(&self) -> (usize, usize) {
+        self.processor_registry
+            .as_ref()
+            .map(|r| (r.inbound_len(), r.outbound_len()))
+            .unwrap_or((0, 0))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn has_slash_dispatcher(&self) -> bool {
+        self.slash_dispatcher.read().await.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn has_session_handler(&self) -> bool {
+        self.session_handler.is_some()
+    }
+
     /// Handle an inbound message through the busy/pending state machine.
     ///
     /// If `sender_id` is provided and the message starts with `/approve` or


### PR DESCRIPTION
重构 cli/chat.rs 的 Gateway 构建，使 chat Gateway 的配置与 daemon Gateway 对齐，确保消息经过完整的出入站 Pipeline。

主要变更：
- 配置 ProcessorRegistry（入站 RawLogProcessor + ContentNormalizer，出站 DslParser）
- 配置 SlashDispatcher（Help、Stop、Status、Clear、NewSession 核心 handlers）
- 配置 SessionMessageHandler（FallbackClient + UnifiedFallbackClient，接入 LLM）
- REPL 循环改用 TerminalPlugin::parse_inbound() 替代自定义 read_user_input()
- E2 Code Review 修复：消除 block_on panic、拆分超长函数、修复无断言测试和硬编码路径

Source: issue #45
Type: feat
