### PR TITLE
feat: add Gateway::process_inbound_chain for CLI inbound processor chain

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -385,6 +385,22 @@ async fn repl_loop(gateway: &Arc<Gateway>, session_id: &str, sender_id: &str) ->
         };
 
         let content = message.content;
+        let message_id = format!(
+            "cli-{}-{}",
+            sender_id,
+            chrono::Utc::now().timestamp_millis()
+        );
+
+        // Run the inbound processor chain (ContentNormalizer, RawLog, etc.).
+        let processed = gateway
+            .process_inbound_chain("terminal", sender_id, "cli", &content, &message_id)
+            .await;
+
+        if processed.suppress {
+            continue;
+        }
+
+        let content = processed.content;
         let trimmed = content.trim();
 
         if trimmed.eq_ignore_ascii_case("quit") || trimmed.eq_ignore_ascii_case("exit") {

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -204,3 +204,104 @@ fn test_stop_detection() {
     assert!(!is_stop_command("stop"));
     assert!(!is_stop_command("/stopextra"));
 }
+
+// ── Inbound Processor Chain integration tests ─────────────────────────────
+
+use crate::processor_chain::content_normalizer::ContentNormalizer;
+use crate::processor_chain::context::ProcessedMessage;
+use crate::processor_chain::{MessageContext, ProcessError, ProcessorRegistry};
+use async_trait::async_trait;
+
+/// A mock processor that suppresses messages (for testing suppress behavior).
+struct SuppressProcessor;
+
+#[async_trait]
+impl crate::processor_chain::MessageProcessor for SuppressProcessor {
+    fn name(&self) -> &str {
+        "suppress-processor"
+    }
+
+    fn phase(&self) -> crate::processor_chain::ProcessPhase {
+        crate::processor_chain::ProcessPhase::Inbound
+    }
+
+    fn priority(&self) -> u8 {
+        0
+    }
+
+    async fn process(
+        &self,
+        _ctx: &MessageContext,
+    ) -> Result<Option<ProcessedMessage>, ProcessError> {
+        Ok(Some(ProcessedMessage {
+            content: String::new(),
+            metadata: serde_json::Map::new(),
+            suppress: true,
+            content_blocks: vec![],
+        }))
+    }
+}
+
+/// Build a Gateway with the given ProcessorRegistry (shared across chat tests).
+fn make_gw_with_registry(registry: ProcessorRegistry) -> crate::gateway::Gateway {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        ..Default::default()
+    };
+    crate::gateway::Gateway::with_processor_registry(
+        config,
+        Arc::new(crate::gateway::SessionManager::new(
+            &crate::gateway::GatewayConfig {
+                name: "test".to_string(),
+                ..Default::default()
+            },
+            None,
+            None,
+            crate::session::bootstrap::BootstrapMode::Full,
+            crate::session::persistence::ReasoningLevel::default(),
+        )),
+        Arc::new(registry),
+    )
+}
+
+#[tokio::test]
+async fn test_process_inbound_chain_cleans_control_characters() {
+    let mut registry = ProcessorRegistry::new();
+    registry.register(Arc::new(ContentNormalizer::new()));
+    let gateway = make_gw_with_registry(registry);
+
+    let input = "hello\x1b[31mworld\x1b[0m";
+    let processed = gateway
+        .process_inbound_chain("terminal", "u1", "cli", input, "msg-1")
+        .await;
+
+    assert_eq!(processed.content, "helloworld");
+    assert!(!processed.suppress);
+}
+
+#[tokio::test]
+async fn test_process_inbound_chain_suppress_message() {
+    let mut registry = ProcessorRegistry::new();
+    registry.register(Arc::new(SuppressProcessor));
+    let gateway = make_gw_with_registry(registry);
+
+    let processed = gateway
+        .process_inbound_chain("terminal", "u1", "cli", "hello", "msg-1")
+        .await;
+
+    assert!(processed.suppress, "expected suppress flag to be set");
+}
+
+#[tokio::test]
+async fn test_process_inbound_chain_quit_exit_not_affected() {
+    let mut registry = ProcessorRegistry::new();
+    registry.register(Arc::new(ContentNormalizer::new()));
+    let gateway = make_gw_with_registry(registry);
+
+    for cmd in &["quit", "exit", "/stop"] {
+        let processed = gateway
+            .process_inbound_chain("terminal", "u1", "cli", cmd, "msg-1")
+            .await;
+        assert_eq!(processed.content.trim(), *cmd);
+    }
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -30,6 +30,7 @@ use crate::session::checkpoint_manager::CheckpointManager;
 use crate::session::persistence::PersistenceService;
 use crate::slash::SlashDispatcher;
 
+use crate::processor_chain::context::{ProcessedMessage, RawMessage};
 pub use crate::processor_chain::ProcessorRegistry;
 pub use session_handler::{HandleResult, SessionMessageHandler};
 pub use session_manager::SessionManager;
@@ -431,6 +432,55 @@ impl Gateway {
     pub async fn get_agent_sessions(&self, agent_id: &str) -> Vec<Session> {
         self.session_manager.get_agent_sessions(agent_id).await
     }
+
+    /// Process an inbound message through the processor chain.
+    ///
+    /// Builds a [`RawMessage`] from the provided fields and runs it through
+    /// the inbound processor chain (if a [`ProcessorRegistry`] is configured).
+    ///
+    /// - When no registry exists, returns a bypass [`ProcessedMessage`]
+    ///   wrapping the original content.
+    /// - On processor failure, logs a warning and falls back to the
+    ///   original content.
+    pub(crate) async fn process_inbound_chain(
+        &self,
+        platform: &str,
+        sender_id: &str,
+        peer_id: &str,
+        content: &str,
+        message_id: &str,
+    ) -> ProcessedMessage {
+        let Some(registry) = &self.processor_registry else {
+            return ProcessedMessage {
+                content: content.to_string(),
+                metadata: serde_json::Map::new(),
+                suppress: false,
+                content_blocks: vec![],
+            };
+        };
+
+        let raw = RawMessage {
+            platform: platform.to_string(),
+            sender_id: sender_id.to_string(),
+            peer_id: peer_id.to_string(),
+            content: content.to_string(),
+            timestamp: chrono::Utc::now(),
+            message_id: message_id.to_string(),
+        };
+
+        match registry.process_inbound(raw).await {
+            Ok(processed) => processed,
+            Err(e) => {
+                tracing::warn!(?e, "processor chain failed, falling back to raw content");
+                ProcessedMessage {
+                    content: content.to_string(),
+                    metadata: serde_json::Map::new(),
+                    suppress: false,
+                    content_blocks: vec![],
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -474,5 +524,7 @@ mod session_handler_tests;
 mod tests;
 #[cfg(test)]
 mod tests_dmscope;
+#[cfg(test)]
+mod tests_processor_chain;
 #[cfg(test)]
 mod tests_thread;

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -4,7 +4,7 @@
 //! under the 500-line limit.
 
 use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
-use crate::im::IMAdapter;
+use crate::im::IMPlugin;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -12,6 +12,8 @@ use std::sync::Arc;
 use crate::processor_chain::error::ProcessError;
 use crate::processor_chain::loader::{ProcessorChainConfig, ProcessorChainLoader, ProcessorConfig};
 use crate::processor_chain::{MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -85,33 +87,36 @@ fn make_gw(config: GatewayConfig) -> (crate::gateway::Gateway, Arc<SessionManage
 struct MockAdapter;
 
 #[async_trait]
-impl IMAdapter for MockAdapter {
-    fn name(&self) -> &str {
+impl IMPlugin for MockAdapter {
+    fn platform(&self) -> &str {
         "mock"
     }
 
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Message, crate::im::AdapterError> {
-        Ok(Message {
-            id: "1".into(),
-            from: "a".into(),
-            to: "b".into(),
-            content: "hi".into(),
-            channel: "mock".into(),
-            timestamp: 0,
-            metadata: HashMap::new(),
-        })
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<crate::im::NormalizedMessage>, crate::im::AdapterError> {
+        Ok(None)
     }
 
-    async fn send_message(
+    fn render(
         &self,
-        _message: &Message,
-        _root_id: Option<&str>,
+        _content_blocks: &[crate::llm::types::ContentBlock],
+        _dsl_result: Option<&crate::processor_chain::DslParseResult>,
+    ) -> crate::renderer::RenderedOutput {
+        crate::renderer::RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({"content": {"text": ""}}),
+        }
+    }
+
+    async fn send(
+        &self,
+        _output: &crate::renderer::RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
     ) -> Result<(), crate::im::AdapterError> {
         Ok(())
-    }
-
-    async fn validate_signature(&self, _signature: &str, _payload: &[u8]) -> bool {
-        true
     }
 }
 
@@ -119,9 +124,8 @@ impl IMAdapter for MockAdapter {
 #[tokio::test]
 async fn test_processor_chain_bypass_no_registry() {
     let (gw, sm) = make_gw(make_config());
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
-    let mut msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
+    gw.register_plugin(Arc::new(MockAdapter)).await;
+    let msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
     let result = gw.route_message("mock", msg, None).await;
     assert!(result.is_ok(), "expected ok, got {result:?}");
 }
@@ -148,15 +152,13 @@ async fn test_processor_chain_bypass_empty_registry() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
-    let mut msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
+    gw.register_plugin(Arc::new(MockAdapter)).await;
+    let msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
     let content_before = msg.content.clone();
     gw.route_message("mock", msg, None).await.unwrap();
     let (gw2, sm2) = make_gw(make_config());
-    gw2.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
-    let mut msg2 = msg_with_session(&sm2, "mock", "agent-1", "plain text").await;
+    gw2.register_plugin(Arc::new(MockAdapter)).await;
+    let msg2 = msg_with_session(&sm2, "mock", "agent-1", "plain text").await;
     assert_eq!(msg2.content, content_before);
 }
 
@@ -187,9 +189,8 @@ async fn test_processor_chain_applies_processors() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
-    let mut msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
+    gw.register_plugin(Arc::new(MockAdapter)).await;
+    let msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
     let result = gw.route_message("mock", msg, None).await;
     assert!(result.is_ok(), "expected ok, got {result:?}");
 }
@@ -198,7 +199,6 @@ async fn test_processor_chain_applies_processors() {
 #[tokio::test]
 async fn test_processor_chain_execution_order_by_priority() {
     use crate::processor_chain::ProcessorRegistry;
-    use crate::session::persistence::ReasoningLevel;
 
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
@@ -223,8 +223,7 @@ async fn test_processor_chain_execution_order_by_priority() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
+    gw.register_plugin(Arc::new(MockAdapter)).await;
 
     let raw_feishu = r#"{"msg_type":"text","text":{"text":"hello"}}"#;
     let mut msg = Message {
@@ -235,6 +234,7 @@ async fn test_processor_chain_execution_order_by_priority() {
         channel: "mock".into(),
         timestamp: 0,
         metadata: HashMap::new(),
+        thread_id: None,
     };
     let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
     msg.metadata.insert("session_id".into(), sid);
@@ -297,8 +297,7 @@ async fn test_processor_chain_metadata_merge() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_adapter("mock".into(), Arc::new(MockAdapter))
-        .await;
+    gw.register_plugin(Arc::new(MockAdapter)).await;
 
     let mut msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
     msg.content = r#"{"msg_type":"text","text":{"text":"hello"}}"#.into();
@@ -321,6 +320,7 @@ fn make_message(to: &str, content: &str) -> Message {
         channel: "mock".to_string(),
         timestamp: chrono::Utc::now().timestamp(),
         metadata: HashMap::new(),
+        thread_id: None,
     }
 }
 
@@ -329,4 +329,272 @@ async fn msg_with_session(sm: &SessionManager, channel: &str, to: &str, content:
     let sid = sm.find_or_create(channel, &msg, None).await.unwrap();
     msg.metadata.insert("session_id".into(), sid);
     msg
+}
+
+/// Build a Gateway with the given ProcessorRegistry (shared across E2E tests).
+fn make_gw_with_registry(
+    registry: crate::processor_chain::ProcessorRegistry,
+) -> crate::gateway::Gateway {
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    crate::gateway::Gateway::with_processor_registry(config, sm, Arc::new(registry))
+}
+
+/// A processor that always suppresses the message (for E2E suppress tests).
+struct SuppressTestProcessor;
+
+#[async_trait]
+impl MessageProcessor for SuppressTestProcessor {
+    fn name(&self) -> &str {
+        "suppress"
+    }
+
+    fn phase(&self) -> ProcessPhase {
+        ProcessPhase::Inbound
+    }
+
+    fn priority(&self) -> u8 {
+        10
+    }
+
+    async fn process(
+        &self,
+        ctx: &MessageContext,
+    ) -> Result<Option<ProcessedMessage>, ProcessError> {
+        Ok(Some(ProcessedMessage {
+            content: ctx.content.clone(),
+            metadata: ctx.metadata.clone(),
+            suppress: true,
+            content_blocks: vec![],
+        }))
+    }
+}
+
+// ── process_inbound_chain tests ──────────────────────────────────────────────
+
+/// When no ProcessorRegistry is configured, `process_inbound_chain` returns
+/// the original content unchanged (bypass).
+#[tokio::test]
+async fn test_process_inbound_chain_no_registry() {
+    let (gw, _sm) = make_gw(make_config());
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "cli", "hello world", "msg-1")
+        .await;
+    assert_eq!(result.content, "hello world");
+    assert!(!result.suppress);
+    assert!(result.metadata.is_empty());
+}
+
+/// ContentNormalizer registered in the chain strips ANSI control characters
+/// from stdin input.
+#[tokio::test]
+async fn test_process_inbound_chain_with_normalizer() {
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(
+        crate::processor_chain::content_normalizer::ContentNormalizer::new(),
+    ));
+    let gw = crate::gateway::Gateway::with_processor_registry(
+        config,
+        Arc::clone(&sm),
+        Arc::new(registry),
+    );
+
+    // Input with ANSI escape sequences and invisible control characters.
+    let raw_input = "\x1b[31mhello\x1b[0m\x01world";
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-1")
+        .await;
+    // ANSI stripped, control char stripped, plain text remains.
+    assert_eq!(result.content, "helloworld");
+    assert!(!result.suppress);
+}
+
+/// SessionRouter in the chain computes and attaches `session_key` to metadata.
+#[tokio::test]
+async fn test_process_inbound_chain_with_session_router() {
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(crate::processor_chain::SessionRouter::new(
+        DmScope::default(),
+    )));
+    let gw = crate::gateway::Gateway::with_processor_registry(
+        config,
+        Arc::clone(&sm),
+        Arc::new(registry),
+    );
+
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-1")
+        .await;
+    assert_eq!(result.content, "hi");
+    // SessionRouter injects session_key = "terminal:user1:peer1" (PerChannelPeer)
+    let key = result.metadata.get("session_key").and_then(|v| v.as_str());
+    assert_eq!(key, Some("terminal:user1:peer1"));
+}
+
+/// When a processor returns an error, `process_inbound_chain` falls back to
+/// the original content and logs a warning.
+#[tokio::test]
+async fn test_process_inbound_chain_processor_error() {
+    /// A processor that always returns an error.
+    struct FailProcessor;
+
+    #[async_trait]
+    impl MessageProcessor for FailProcessor {
+        fn name(&self) -> &str {
+            "fail"
+        }
+
+        fn phase(&self) -> ProcessPhase {
+            ProcessPhase::Inbound
+        }
+
+        fn priority(&self) -> u8 {
+            0
+        }
+
+        async fn process(
+            &self,
+            _ctx: &MessageContext,
+        ) -> Result<Option<ProcessedMessage>, ProcessError> {
+            Err(ProcessError::processor_failed("fail", "deliberate"))
+        }
+    }
+
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(FailProcessor));
+    let gw = crate::gateway::Gateway::with_processor_registry(
+        config,
+        Arc::clone(&sm),
+        Arc::new(registry),
+    );
+
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "cli", "original", "msg-1")
+        .await;
+    // Fallback to original content.
+    assert_eq!(result.content, "original");
+    assert!(!result.suppress);
+    assert!(result.metadata.is_empty());
+}
+
+// ── End-to-end integration tests ─────────────────────────────────────────────
+
+/// Full inbound pipeline: SessionRouter + ContentNormalizer both present.
+/// Verifies that ANSI control characters are stripped AND session_key is
+/// injected into metadata after the chain completes.
+#[tokio::test]
+async fn test_e2e_inbound_full_stack_strips_ansi_and_injects_session_key() {
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(crate::processor_chain::SessionRouter::new(
+        DmScope::default(),
+    )));
+    registry.register(Arc::new(
+        crate::processor_chain::content_normalizer::ContentNormalizer::new(),
+    ));
+    let gw = make_gw_with_registry(registry);
+
+    let raw_input = "\x1b[32mhello\x1b[0m\x01world\x1b[1;34m!";
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "peer1", raw_input, "msg-e2e-1")
+        .await;
+
+    assert_eq!(result.content, "helloworld!");
+    assert!(!result.suppress);
+
+    let expected_key = DmScope::default().compute_session_key(
+        "terminal",
+        &Message {
+            id: String::new(),
+            from: "user1".to_string(),
+            to: "peer1".to_string(),
+            content: String::new(),
+            channel: "terminal".to_string(),
+            timestamp: 0,
+            metadata: HashMap::new(),
+            thread_id: None,
+        },
+        None,
+    );
+    let key = result.metadata.get("session_key").and_then(|v| v.as_str());
+    assert_eq!(key, Some(expected_key.as_str()));
+}
+
+/// After processing through the inbound chain, the cleaned content is
+/// accepted by `handle_inbound_message` without error (returns None
+/// when no session handler is installed — expected in unit test context).
+#[tokio::test]
+async fn test_e2e_processed_content_feeds_into_handle_inbound() {
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(crate::processor_chain::SessionRouter::new(
+        DmScope::default(),
+    )));
+    registry.register(Arc::new(
+        crate::processor_chain::content_normalizer::ContentNormalizer::new(),
+    ));
+    let gw = make_gw_with_registry(registry);
+
+    let raw_input = "\x1b[33mwhat is the weather\x1b[0m";
+    let processed = gw
+        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-e2e-2")
+        .await;
+
+    assert_eq!(processed.content, "what is the weather");
+    assert!(!processed.suppress);
+
+    let handle_result = gw
+        .handle_inbound_message("sess-1", processed.content, Some("user1"), "terminal")
+        .await;
+    assert!(
+        handle_result.is_none(),
+        "expected None when no session handler installed"
+    );
+}
+
+/// Verify that a suppress=true processor in the chain causes the final
+/// processed message to have suppress set, and the cleaned content
+/// is still available for inspection.
+#[tokio::test]
+async fn test_e2e_suppress_flag_propagates_through_chain() {
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(SuppressTestProcessor));
+    registry.register(Arc::new(
+        crate::processor_chain::content_normalizer::ContentNormalizer::new(),
+    ));
+    let gw = make_gw_with_registry(registry);
+
+    let result = gw
+        .process_inbound_chain("terminal", "user1", "cli", "hello", "msg-e2e-4")
+        .await;
+    assert!(result.suppress, "suppress flag should propagate");
+    assert_eq!(result.content, "hello");
 }


### PR DESCRIPTION
## Summary

Aligns CLI Chat inbound flow with the design doc (`docs/design/cli/chat.md`) by invoking the registered inbound processor chain before gateway message handling.

Previously, `repl_loop` called `plugin.parse_inbound()` → `handle_inbound_message()` directly, bypassing the `ProcessorRegistry` (ContentNormalizer, RawLogProcessor, SessionRouter) that was already registered in `build_gateway()`.

## Changes

- **`Gateway::process_inbound_chain`** (new `pub(crate)` method): Runs inbound processors with fallback on error. When no registry is configured, returns a bypass `ProcessedMessage` with the original content.
- **`repl_loop` integration**: Inserts chain processing between `parse_inbound` and `handle_inbound_message`. Checks `suppress` flag (returns early if true). Moves quit/exit/stop check to after chain processing for safety.
- **Unit tests**: Coverage for no-registry bypass, ContentNormalizer stripping ANSI, SessionRouter injecting session_key, processor error fallback, and suppress flag propagation.
- **E2E integration tests**: Full stack ANSI stripping + session key injection; suppress flag propagation through chain.

## Design Doc Alignment

| # | Gap | Resolution |
|---|-----|------------|
| 1 | ProcessorChain not called from CLI | ✅ Fixed: `process_inbound_chain` invoked in `repl_loop` |
| 2 | SessionRouter skipped | ⏭️ Downgraded: `find_or_create` already computes identical `session_key` |
| 3 | RawLogProcessor conditional | ✅ Preserved: only registers when `raw_log_dir` is set |

Source: CI
Type: feat