### PR TITLE
feat: add DmScope::PerChannelSender and switch CLI chat session_key

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -68,7 +68,7 @@ pub(crate) async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
         name: "closeclaw-chat".to_string(),
         rate_limit_per_minute: 0,
         max_message_size: 16_384,
-        dm_scope: DmScope::PerChannelPeer,
+        dm_scope: DmScope::PerChannelSender,
         ..Default::default()
     };
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -52,6 +52,13 @@ pub enum DmScope {
     PerChannelPeer,
     /// One session per account + channel + peer pair
     PerAccountChannelPeer,
+    /// One session per channel + sender (excludes `to` field).
+    ///
+    /// Used when agent-level isolation is provided by a per-agent
+    /// [`SessionManager`] — the session key is `{channel}:{from}`, so
+    /// different agents sharing the same channel naturally stay isolated
+    /// without embedding `agent_id` in the key.
+    PerChannelSender,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -78,6 +85,9 @@ impl DmScope {
             DmScope::PerAccountChannelPeer => {
                 let acc = account_id.unwrap_or("default");
                 format!("{}:{}:{}:{}", acc, channel, message.from, message.to)
+            }
+            DmScope::PerChannelSender => {
+                format!("{}:{}", channel, message.from)
             }
         }
     }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -211,6 +211,20 @@ fn test_dm_scope_per_account_channel_peer_without_account() {
 }
 
 #[test]
+fn test_dm_scope_per_channel_sender_session_key() {
+    let key = DmScope::PerChannelSender.compute_session_key("ch_x", &msg("a", "b"), None);
+    assert_eq!(key, "ch_x:a");
+}
+
+#[test]
+fn test_dm_scope_per_channel_sender_serde_roundtrip() {
+    let json = serde_json::to_string(&DmScope::PerChannelSender).unwrap();
+    assert_eq!(json, "\"per-channel-sender\"");
+    let parsed: DmScope = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed, DmScope::PerChannelSender);
+}
+
+#[test]
 fn test_dm_scope_default_is_per_channel_peer() {
     assert_eq!(DmScope::default(), DmScope::PerChannelPeer);
 }
@@ -227,6 +241,7 @@ fn test_gateway_config_dm_scope_values() {
             "\"per-account-channel-peer\"",
             DmScope::PerAccountChannelPeer,
         ),
+        ("\"per-channel-sender\"", DmScope::PerChannelSender),
     ];
     for (json_val, expected) in cases {
         let json = format!("{{\"name\":\"g\",\"dm_scope\":{}}}", json_val);


### PR DESCRIPTION
Add DmScope::PerChannelSender variant for CLI chat session key computation.

Design doc requires that agent-level isolation is provided by per-agent
SessionManager, so session_key should not include agent_id. Currently
CLI chat uses DmScope::PerChannelPeer which produces key = {channel}:{from}:{to}
(including agent_id as `to`). This PR adds PerChannelSender (key = {channel}:{from})
and switches CLI chat to use it.

Changes:
- Add DmScope::PerChannelSender variant with key = {channel}:{from}
- CLI chat build_gateway() uses PerChannelSender instead of PerChannelPeer
- Unit tests for session_key computation and serde round-trip

Source: design doc
Type: feat
