### PR TITLE
feat: modify build_gateway to accept agent_id parameter

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -46,7 +46,7 @@ enum ExitReason {
 /// 3. Loop: read user input → route through gateway → print response.
 pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
     let sender_id = crate::im::terminal::current_uid();
-    let (gateway, session_manager) = build_gateway().await;
+    let (gateway, session_manager) = build_gateway(agent_id).await;
     let session_id = create_session(&session_manager, agent_id, &sender_id).await?;
 
     println!("CloseClaw Chat — agent: {}", agent_id);
@@ -63,9 +63,9 @@ pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
 
 /// Build a [`Gateway`] with [`ProcessorRegistry`], [`SlashDispatcher`],
 /// and [`SessionMessageHandler`] configured.
-pub(crate) async fn build_gateway() -> (Arc<Gateway>, Arc<SessionManager>) {
+pub(crate) async fn build_gateway(agent_id: &str) -> (Arc<Gateway>, Arc<SessionManager>) {
     let gateway_config = GatewayConfig {
-        name: "closeclaw-chat".to_string(),
+        name: format!("closeclaw-chat-{}", agent_id),
         rate_limit_per_minute: 0,
         max_message_size: 16_384,
         dm_scope: DmScope::PerChannelSender,

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -70,7 +70,7 @@ async fn test_build_processor_registry_with_raw_log() {
 
 #[tokio::test]
 async fn test_build_gateway_has_processor_registry() {
-    let (gateway, _session_manager) = build_gateway().await;
+    let (gateway, _session_manager) = build_gateway("test-agent").await;
 
     let (inbound, outbound) = gateway.processor_registry_len();
     assert!(inbound > 0, "expected inbound processors in gateway");
@@ -79,7 +79,7 @@ async fn test_build_gateway_has_processor_registry() {
 
 #[tokio::test]
 async fn test_build_gateway_has_slash_dispatcher() {
-    let (gateway, _session_manager) = build_gateway().await;
+    let (gateway, _session_manager) = build_gateway("test-agent").await;
 
     assert!(
         gateway.has_slash_dispatcher().await,
@@ -142,7 +142,7 @@ async fn test_build_gateway_slash_help_dispatchable() {
 
 #[tokio::test]
 async fn test_build_gateway_has_session_handler() {
-    let (gateway, _session_manager) = build_gateway().await;
+    let (gateway, _session_manager) = build_gateway("test-agent").await;
 
     // In test environments without LLM providers, session handler
     // should not be installed.

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -305,3 +305,59 @@ async fn test_process_inbound_chain_quit_exit_not_affected() {
         assert_eq!(processed.content.trim(), *cmd);
     }
 }
+
+// ── build_gateway agent_id parameterization tests ─────────────────────────
+
+#[tokio::test]
+async fn test_build_gateway_config_name_contains_agent_id() {
+    let (gateway, _sm) = build_gateway("my-agent").await;
+    assert_eq!(gateway.config_name(), "closeclaw-chat-my-agent");
+}
+
+#[tokio::test]
+async fn test_build_gateway_different_agent_ids_produce_different_names() {
+    let (gw_a, _) = build_gateway("agent-alpha").await;
+    let (gw_b, _) = build_gateway("agent-beta").await;
+    assert_ne!(gw_a.config_name(), gw_b.config_name());
+}
+
+#[tokio::test]
+async fn test_build_gateway_agent_id_appears_in_name() {
+    let agent_id = "my-special-agent-123";
+    let (gateway, _sm) = build_gateway(agent_id).await;
+    let name = gateway.config_name();
+    assert!(
+        name.contains(agent_id),
+        "config name '{}' should contain agent_id '{}'",
+        name,
+        agent_id
+    );
+}
+
+#[tokio::test]
+async fn test_build_gateway_empty_agent_id() {
+    let (gateway, _sm) = build_gateway("").await;
+    assert_eq!(gateway.config_name(), "closeclaw-chat-");
+}
+
+#[tokio::test]
+async fn test_build_gateway_agent_id_with_special_characters() {
+    let agent_id = "agent/with:special@chars";
+    let (gateway, _sm) = build_gateway(agent_id).await;
+    assert_eq!(
+        gateway.config_name(),
+        format!("closeclaw-chat-{}", agent_id)
+    );
+}
+
+#[tokio::test]
+async fn test_build_gateway_agent_id_with_unicode() {
+    let agent_id = "agent-\u{4e2d}\u{6587}"; // agent-中文
+    let (gateway, _sm) = build_gateway(agent_id).await;
+    assert!(
+        gateway.config_name().contains(agent_id),
+        "config name '{}' should contain unicode agent_id '{}'",
+        gateway.config_name(),
+        agent_id
+    );
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -257,6 +257,11 @@ impl Gateway {
         self.session_handler.is_some()
     }
 
+    #[cfg(test)]
+    pub(crate) fn config_name(&self) -> &str {
+        &self.config.name
+    }
+
     /// Handle an inbound message through the busy/pending state machine.
     ///
     /// If `sender_id` is provided and the message starts with `/approve` or


### PR DESCRIPTION
feat: modify build_gateway to accept agent_id parameter

显式化 per-agent SessionManager 架构：build_gateway() 现在接收 agent_id 参数，
将 agent_id 融入 GatewayConfig.name，使每个 agent 的 Gateway 实例可追溯、可区分，
对齐 design doc `docs/design/cli/chat.md` §"Session 与 Agent 指定"。

变更内容：
- build_gateway() 签名增加 agent_id: &str 参数
- GatewayConfig.name 从固定 "closeclaw-chat" 改为 "closeclaw-chat-{agent_id}"
- run_chat() 中传递 agent_id 给 build_gateway()
- 新增 UT 覆盖 agent_id 参数化（含空值、特殊字符、Unicode 边界情况）

Source: user
Type: feat