### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -40,5 +40,12 @@
     "commit_time": "2026-06-20T12:30:40+08:00",
     "confirmed_time": "2026-06-20T12:35:31.599807+08:00",
     "comment": ""
+  },
+  {
+    "path": "docs/design/cli/chat.md",
+    "commit": "6bc3fc05d9beee6bee24ddb047437676c05309c2",
+    "commit_time": "2026-06-21T02:42:50+08:00",
+    "confirmed_time": "2026-06-21T13:23:04.290757+08:00",
+    "comment": ""
   }
 ]


### PR DESCRIPTION
## Design Doc Tracker Update

- **操作类型**: finished
- **文档路径**: docs/design/cli/chat.md
- **说明**: 将 CLI chat 设计文档标记为 finished 状态。

> 仅包含 records.json 元数据变更，无代码改动。