### PR TITLE
fix: CLI 代码与 Design Doc 对齐

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -45,7 +45,7 @@ enum ExitReason {
 /// 2. Create a session for the given `agent_id`.
 /// 3. Loop: read user input → route through gateway → print response.
 pub async fn run_chat(agent_id: &str) -> anyhow::Result<()> {
-    let sender_id = crate::im::terminal::current_uid();
+    let sender_id = crate::platform::current_uid();
     let (gateway, session_manager) = build_gateway(agent_id).await;
     let session_id = create_session(&session_manager, agent_id, &sender_id).await?;
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -397,37 +397,8 @@ impl Daemon {
         })
     }
     /// Run the daemon — blocks until shutdown signal is received.
-    #[cfg(unix)]
     pub async fn run(&self) -> anyhow::Result<()> {
-        use tokio::signal::unix::{signal, SignalKind};
-        let mut sigint = signal(SignalKind::interrupt())?;
-        let mut sigterm = signal(SignalKind::terminate())?;
-        tokio::select! {
-            _ = sigint.recv() => {
-                info!("Received Ctrl+C, initiating shutdown...");
-            }
-            _ = sigterm.recv() => {
-                info!("Received SIGTERM, initiating graceful shutdown...");
-            }
-        }
-        self.shutdown.initiate_shutdown().await;
-        // Flush all active session checkpoints before shutdown
-        match self.gateway.flush_all_sessions().await {
-            Ok(n) => tracing::info!(count = n, "flushed session checkpoints"),
-            Err(e) => tracing::warn!(error = %e, "failed to flush sessions"),
-        }
-        // Clear all pending approval requests (denied with callbacks triggered)
-        self.approval_flow.lock().await.clear();
-        let _ = self.sweeper_shutdown_tx.send(());
-        // Clean up admin socket file
-        let _ = tokio::fs::remove_file(&self.admin_socket_path).await;
-        Ok(())
-    }
-    /// Run the daemon on non-Unix platforms (falls back to Ctrl+C only).
-    #[cfg(not(unix))]
-    pub async fn run(&self) -> anyhow::Result<()> {
-        tokio::signal::ctrl_c().await?;
-        info!("Received Ctrl+C, initiating shutdown...");
+        crate::platform::process::wait_for_shutdown_signal().await?;
         self.shutdown.initiate_shutdown().await;
         // Flush all active session checkpoints before shutdown
         match self.gateway.flush_all_sessions().await {

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -832,7 +832,7 @@ impl TerminalAdapter {
     fn make_message(&self, content: String) -> NormalizedMessage {
         NormalizedMessage {
             platform: "terminal".to_string(),
-            sender_id: current_uid(),
+            sender_id: crate::platform::current_uid(),
             peer_id: "cli".to_string(),
             content,
             timestamp: current_timestamp(),
@@ -847,23 +847,6 @@ fn get_terminal_width() -> usize {
     terminal_size::terminal_size()
         .map(|(w, _)| w.0 as usize)
         .unwrap_or(120)
-}
-
-/// Return the current user's system UID as a string.
-///
-/// On Unix, uses `libc::getuid()`. On other platforms, falls back to a
-/// static identifier.
-pub(crate) fn current_uid() -> String {
-    #[cfg(unix)]
-    {
-        // SAFETY: libc::getuid() is always safe — it reads the calling
-        // process's real user ID without side effects.
-        unsafe { libc::getuid() }.to_string()
-    }
-    #[cfg(not(unix))]
-    {
-        "terminal-user".to_string()
-    }
 }
 
 /// Return the current Unix timestamp in seconds.

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -33,31 +33,6 @@ pub(crate) const ITALIC: &str = "\x1b[3m";
 pub(crate) const RESET: &str = "\x1b[0m";
 
 // ---------------------------------------------------------------------------
-// ANSI capability detection
-// ---------------------------------------------------------------------------
-
-/// Returns `true` if the current terminal supports ANSI escape sequences.
-///
-/// Checks the `TERM` environment variable for known ANSI-capable values
-/// (`xterm`, `screen`, `ansi`, `vt100`, `color`). On Windows, detects the
-/// Windows Terminal environment via `WT_SESSION`.
-fn supports_ansi() -> bool {
-    if std::env::var("WT_SESSION").is_ok() {
-        return true;
-    }
-    std::env::var("TERM")
-        .map(|term| {
-            let t = term.to_lowercase();
-            t.contains("xterm")
-                || t.contains("screen")
-                || t.contains("ansi")
-                || t.contains("vt100")
-                || t.contains("color")
-        })
-        .unwrap_or(false)
-}
-
-// ---------------------------------------------------------------------------
 // Plain-text fallback
 // ---------------------------------------------------------------------------
 
@@ -633,7 +608,7 @@ impl TerminalRenderer {
     /// Create a new renderer that auto-detects ANSI capability.
     pub fn new() -> Self {
         Self {
-            ansi: supports_ansi(),
+            ansi: crate::platform::terminal::supports_ansi(),
         }
     }
 

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -707,13 +707,27 @@ impl TerminalRenderer {
         }
     }
 
-    /// Skip DSL rendering for the terminal channel.
+    /// Render DSL instructions as plain-text hints for the terminal channel.
     ///
-    /// DSL instructions (e.g. buttons) are not supported on the terminal.
-    /// The instructions are still preserved in metadata for other renderers,
-    /// but the terminal does not output them as visible text.
-    fn render_dsl(&self, _dsl_result: &DslParseResult) -> String {
-        String::new()
+    /// Buttons and selectors are rendered as `[Button: label (action: X, value: Y)]`
+    /// since the terminal has no interactive elements.
+    fn render_dsl(&self, dsl_result: &DslParseResult) -> String {
+        let mut out = String::new();
+        for inst in &dsl_result.instructions {
+            match inst {
+                crate::processor_chain::DslInstruction::Button {
+                    label,
+                    action,
+                    value,
+                } => {
+                    out.push_str(&format!(
+                        "[Button: {} (action: {}, value: {})]\n",
+                        label, action, value
+                    ));
+                }
+            }
+        }
+        out
     }
 }
 

--- a/src/im/terminal_tests.rs
+++ b/src/im/terminal_tests.rs
@@ -896,8 +896,7 @@ mod tests {
     // DSL skip rendering tests (Step 1.7)
     // =========================================================================
 
-    /// Verify TerminalRenderer does not render DSL instructions as visible text.
-    /// Uses the public render() method which internally calls render_dsl().
+    /// Verify TerminalRenderer renders DSL Button instructions as plain-text hints.
     #[test]
     fn test_render_dsl_not_in_output() {
         let r = TerminalRenderer::with_ansi(false);
@@ -919,12 +918,12 @@ mod tests {
             .unwrap();
         assert!(text.contains("Hello"));
         assert!(
-            !text.contains("Click Me"),
-            "DSL button should not appear in output"
+            text.contains("[Button: Click Me (action: navigate, value: /home)]"),
+            "DSL button should appear as plain-text hint in output"
         );
     }
 
-    /// Verify DSL is not rendered even in ANSI mode.
+    /// Verify DSL Button renders as plain-text hint even in ANSI mode.
     #[test]
     fn test_render_dsl_not_in_output_ansi() {
         let r = TerminalRenderer::with_ansi(true);
@@ -946,8 +945,8 @@ mod tests {
             .unwrap();
         assert!(text.contains("Content"));
         assert!(
-            !text.contains("OK"),
-            "DSL button should not appear in output"
+            text.contains("[Button: OK (action: confirm, value: yes)]"),
+            "DSL button should appear as plain-text hint in output"
         );
     }
 
@@ -970,7 +969,7 @@ mod tests {
         assert!(text.contains("Hello world"));
     }
 
-    /// Verify DSL button text is NOT in the final output.
+    /// Verify DSL Button text appears in plugin-level render output.
     #[test]
     fn test_plugin_render_dsl_not_in_output() {
         let plugin = TerminalPlugin::with_ansi(false);
@@ -992,8 +991,8 @@ mod tests {
             .unwrap();
         assert!(text.contains("Some text"));
         assert!(
-            !text.contains("Click"),
-            "DSL button should not appear in output"
+            text.contains("[Button: Click (action: go, value: ok)]"),
+            "DSL button should appear as plain-text hint in output"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod im;
 pub mod im_adapter;
 pub mod llm;
 pub mod permission;
+pub mod platform;
 pub mod processor_chain;
 pub mod renderer;
 pub mod session;

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -25,31 +25,3 @@ pub fn config_dir() -> anyhow::Result<PathBuf> {
         Ok(PathBuf::from(appdata).join("closeclaw"))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_config_dir_returns_valid_path() {
-        let dir = config_dir().unwrap();
-        assert!(dir.is_absolute(), "config_dir must return an absolute path");
-
-        let path_str = dir.to_string_lossy();
-        assert!(
-            path_str.contains("closeclaw"),
-            "config_dir must contain 'closeclaw': {path_str}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_config_dir_unix_format() {
-        let dir = config_dir().unwrap();
-        let path_str = dir.to_string_lossy();
-        assert!(
-            path_str.ends_with("/.closeclaw"),
-            "Unix config_dir must end with /.closeclaw: {path_str}"
-        );
-    }
-}

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -1,0 +1,55 @@
+//! Configuration directory resolution.
+//!
+//! Returns the platform-appropriate root directory for CloseClaw configuration files.
+//! Linux/macOS: `~/.closeclaw`
+//! Windows: `%APPDATA%\closeclaw`
+
+use std::path::PathBuf;
+
+/// Returns the configuration directory path for the current platform.
+///
+/// # Errors
+///
+/// Returns an error if the home directory or APPDATA cannot be determined.
+pub fn config_dir() -> anyhow::Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        let home = std::env::var("HOME")
+            .map_err(|_| anyhow::anyhow!("HOME environment variable not set"))?;
+        Ok(PathBuf::from(home).join(".closeclaw"))
+    }
+    #[cfg(not(unix))]
+    {
+        let appdata = std::env::var("APPDATA")
+            .map_err(|_| anyhow::anyhow!("APPDATA environment variable not set"))?;
+        Ok(PathBuf::from(appdata).join("closeclaw"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_dir_returns_valid_path() {
+        let dir = config_dir().unwrap();
+        assert!(dir.is_absolute(), "config_dir must return an absolute path");
+
+        let path_str = dir.to_string_lossy();
+        assert!(
+            path_str.contains("closeclaw"),
+            "config_dir must contain 'closeclaw': {path_str}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_config_dir_unix_format() {
+        let dir = config_dir().unwrap();
+        let path_str = dir.to_string_lossy();
+        assert!(
+            path_str.ends_with("/.closeclaw"),
+            "Unix config_dir must end with /.closeclaw: {path_str}"
+        );
+    }
+}

--- a/src/platform/config_tests.rs
+++ b/src/platform/config_tests.rs
@@ -1,0 +1,46 @@
+use crate::platform::config::config_dir;
+
+#[test]
+fn test_config_dir_returns_valid_path() {
+    let dir = config_dir().unwrap();
+    assert!(dir.is_absolute(), "config_dir must return an absolute path");
+
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.contains("closeclaw"),
+        "config_dir must contain 'closeclaw': {path_str}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_config_dir_unix_format() {
+    let dir = config_dir().unwrap();
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.ends_with("/.closeclaw"),
+        "Unix config_dir must end with /.closeclaw: {path_str}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_config_dir_starts_with_home() {
+    let dir = config_dir().unwrap();
+    let home = std::env::var("HOME").unwrap();
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.starts_with(&home),
+        "config_dir must start with HOME ({home}): {path_str}"
+    );
+}
+
+#[test]
+fn test_config_dir_not_empty_component() {
+    let dir = config_dir().unwrap();
+    let components: Vec<_> = dir.components().collect();
+    assert!(
+        components.len() >= 2,
+        "config_dir must have at least 2 path components"
+    );
+}

--- a/src/platform/fs.rs
+++ b/src/platform/fs.rs
@@ -26,28 +26,3 @@ pub fn expand_home(path: &Path) -> PathBuf {
     }
     path.to_path_buf()
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_normalize_path_unix() {
-        let path = Path::new("/usr/local/bin");
-        let normalized = normalize_path(path);
-        assert_eq!(normalized, PathBuf::from("/usr/local/bin"));
-    }
-
-    #[test]
-    fn test_normalize_path_backslashes() {
-        let path = Path::new(r"C:\Users\test\file.txt");
-        let normalized = normalize_path(path);
-        assert_eq!(normalized, PathBuf::from("C:/Users/test/file.txt"));
-    }
-
-    #[test]
-    fn test_expand_home_no_tilde() {
-        let path = Path::new("/absolute/path");
-        assert_eq!(expand_home(path), PathBuf::from("/absolute/path"));
-    }
-}

--- a/src/platform/fs.rs
+++ b/src/platform/fs.rs
@@ -1,0 +1,53 @@
+//! File path normalization.
+//!
+//! Provides utilities to normalize path separators to `/` and expand
+//! environment-variable-based path prefixes (e.g. `~`).
+
+use std::path::{Path, PathBuf};
+
+/// Normalizes a path to use `/` as the separator.
+///
+/// This is useful for canonicalizing paths across platforms before
+/// comparing or storing them.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy().replace('\\', "/");
+    PathBuf::from(s)
+}
+
+/// Expands `~` at the start of a path to the user's home directory.
+///
+/// On Windows, also expands `%APPDATA%`.
+pub fn expand_home(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path_unix() {
+        let path = Path::new("/usr/local/bin");
+        let normalized = normalize_path(path);
+        assert_eq!(normalized, PathBuf::from("/usr/local/bin"));
+    }
+
+    #[test]
+    fn test_normalize_path_backslashes() {
+        let path = Path::new(r"C:\Users\test\file.txt");
+        let normalized = normalize_path(path);
+        assert_eq!(normalized, PathBuf::from("C:/Users/test/file.txt"));
+    }
+
+    #[test]
+    fn test_expand_home_no_tilde() {
+        let path = Path::new("/absolute/path");
+        assert_eq!(expand_home(path), PathBuf::from("/absolute/path"));
+    }
+}

--- a/src/platform/fs_tests.rs
+++ b/src/platform/fs_tests.rs
@@ -1,0 +1,44 @@
+use crate::platform::fs::normalize_path;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn test_normalize_path_unix() {
+    let path = Path::new("/usr/local/bin");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from("/usr/local/bin"));
+}
+
+#[test]
+fn test_normalize_path_backslashes() {
+    let path = Path::new(r"C:\Users\test\file.txt");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from("C:/Users/test/file.txt"));
+}
+
+#[test]
+fn test_normalize_path_mixed_separators() {
+    let path = Path::new(r"C:\Users/test\another/file");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from("C:/Users/test/another/file"));
+}
+
+#[test]
+fn test_normalize_path_already_normalized() {
+    let path = Path::new("/a/b/c");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from("/a/b/c"));
+}
+
+#[test]
+fn test_normalize_path_empty() {
+    let path = Path::new("");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from(""));
+}
+
+#[test]
+fn test_normalize_path_trailing_separator() {
+    let path = Path::new(r"C:\Users\test\");
+    let normalized = normalize_path(path);
+    assert_eq!(normalized, PathBuf::from("C:/Users/test/"));
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,0 +1,15 @@
+//! Platform abstraction layer.
+//!
+//! Provides unified interfaces for OS-specific operations including
+//! terminal capability detection, process management, configuration
+//! directory resolution, and file path normalization.
+
+pub mod config;
+pub mod fs;
+pub mod process;
+pub mod terminal;
+
+pub use config::config_dir;
+pub use fs::normalize_path;
+pub use process::{send_signal, write_pid_file};
+pub use terminal::{current_uid, supports_ansi};

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -13,3 +13,12 @@ pub use config::config_dir;
 pub use fs::normalize_path;
 pub use process::{send_signal, wait_for_shutdown_signal, write_pid_file};
 pub use terminal::{current_uid, supports_ansi};
+
+#[cfg(test)]
+mod config_tests;
+#[cfg(test)]
+mod fs_tests;
+#[cfg(test)]
+mod process_tests;
+#[cfg(test)]
+mod terminal_tests;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -11,5 +11,5 @@ pub mod terminal;
 
 pub use config::config_dir;
 pub use fs::normalize_path;
-pub use process::{send_signal, write_pid_file};
+pub use process::{send_signal, wait_for_shutdown_signal, write_pid_file};
 pub use terminal::{current_uid, supports_ansi};

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -4,6 +4,7 @@
 //! Unix uses SIGTERM/SIGINT; Windows uses process termination API.
 
 use std::path::{Path, PathBuf};
+use tracing::info;
 
 /// Returns the platform-specific PID file path.
 ///
@@ -52,6 +53,33 @@ pub fn send_signal(pid: u32) -> anyhow::Result<()> {
         if !status.success() {
             anyhow::bail!("Failed to terminate process {pid}");
         }
+    }
+    Ok(())
+}
+
+/// Blocks until a platform-appropriate shutdown signal is received.
+///
+/// On Unix, listens for both SIGINT (Ctrl+C) and SIGTERM.
+/// On non-Unix platforms, listens for Ctrl+C only.
+pub async fn wait_for_shutdown_signal() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigint = signal(SignalKind::interrupt())?;
+        let mut sigterm = signal(SignalKind::terminate())?;
+        tokio::select! {
+            _ = sigint.recv() => {
+                info!("Received Ctrl+C, initiating shutdown...");
+            }
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM, initiating graceful shutdown...");
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+        info!("Received Ctrl+C, initiating shutdown...");
     }
     Ok(())
 }

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -1,0 +1,86 @@
+//! Process lifecycle management.
+//!
+//! Provides PID file read/write and signal-based process termination.
+//! Unix uses SIGTERM/SIGINT; Windows uses process termination API.
+
+use std::path::{Path, PathBuf};
+
+/// Returns the platform-specific PID file path.
+///
+/// On Unix: `{config_dir}/daemon.pid`
+/// On Windows: `{config_dir}\daemon.pid`
+pub fn pid_file_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("daemon.pid")
+}
+
+/// Writes the given PID to the specified file, creating or overwriting it.
+pub fn write_pid_file(path: &Path, pid: u32) -> anyhow::Result<()> {
+    std::fs::write(path, pid.to_string())?;
+    Ok(())
+}
+
+/// Reads a PID from the specified file.
+///
+/// Returns `None` if the file does not exist or cannot be parsed.
+pub fn read_pid_file(path: &Path) -> Option<u32> {
+    let content = std::fs::read_to_string(path).ok()?;
+    content.trim().parse::<u32>().ok()
+}
+
+/// Sends a termination signal to the process identified by `pid`.
+///
+/// On Unix, sends SIGTERM. On Windows, terminates the process via API.
+pub fn send_signal(pid: u32) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        // SAFETY: kill with SIGTERM is a standard termination signal.
+        // The process ID is validated by the OS kernel.
+        let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+        if ret != 0 {
+            anyhow::bail!(
+                "Failed to send SIGTERM to process {pid}: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows: use taskkill to terminate the process
+        let status = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/F"])
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("Failed to terminate process {pid}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_pid_file_path() {
+        let dir = Path::new("/tmp/test");
+        let path = pid_file_path(dir);
+        assert_eq!(path, PathBuf::from("/tmp/test/daemon.pid"));
+    }
+
+    #[test]
+    fn test_write_and_read_pid_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = pid_file_path(tmp.path());
+
+        write_pid_file(&path, 12345).unwrap();
+        let pid = read_pid_file(&path);
+        assert_eq!(pid, Some(12345));
+    }
+
+    #[test]
+    fn test_read_pid_file_missing() {
+        let path = Path::new("/nonexistent/daemon.pid");
+        assert_eq!(read_pid_file(path), None);
+    }
+}

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -83,32 +83,3 @@ pub async fn wait_for_shutdown_signal() -> anyhow::Result<()> {
     }
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn test_pid_file_path() {
-        let dir = Path::new("/tmp/test");
-        let path = pid_file_path(dir);
-        assert_eq!(path, PathBuf::from("/tmp/test/daemon.pid"));
-    }
-
-    #[test]
-    fn test_write_and_read_pid_file() {
-        let tmp = TempDir::new().unwrap();
-        let path = pid_file_path(tmp.path());
-
-        write_pid_file(&path, 12345).unwrap();
-        let pid = read_pid_file(&path);
-        assert_eq!(pid, Some(12345));
-    }
-
-    #[test]
-    fn test_read_pid_file_missing() {
-        let path = Path::new("/nonexistent/daemon.pid");
-        assert_eq!(read_pid_file(path), None);
-    }
-}

--- a/src/platform/process_tests.rs
+++ b/src/platform/process_tests.rs
@@ -1,0 +1,47 @@
+use crate::platform::process::{pid_file_path, read_pid_file, write_pid_file};
+use tempfile::TempDir;
+
+#[test]
+fn test_write_and_read_pid_file() {
+    let tmp = TempDir::new().unwrap();
+    let path = pid_file_path(tmp.path());
+
+    write_pid_file(&path, 12345).unwrap();
+    let pid = read_pid_file(&path);
+    assert_eq!(pid, Some(12345));
+}
+
+#[test]
+fn test_read_pid_file_missing() {
+    let path = std::path::Path::new("/nonexistent/daemon.pid");
+    assert_eq!(read_pid_file(path), None);
+}
+
+#[test]
+fn test_write_pid_file_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    let path = pid_file_path(tmp.path());
+
+    write_pid_file(&path, 111).unwrap();
+    write_pid_file(&path, 222).unwrap();
+    let pid = read_pid_file(&path);
+    assert_eq!(pid, Some(222), "should read the latest written PID");
+}
+
+#[test]
+fn test_write_pid_file_invalid_content() {
+    let tmp = TempDir::new().unwrap();
+    let path = pid_file_path(tmp.path());
+
+    // Manually write non-numeric content.
+    std::fs::write(&path, "not_a_number").unwrap();
+    let pid = read_pid_file(&path);
+    assert_eq!(pid, None, "non-numeric PID file should return None");
+}
+
+#[test]
+fn test_pid_file_path_format() {
+    let dir = std::path::Path::new("/tmp/test");
+    let path = pid_file_path(dir);
+    assert_eq!(path, std::path::PathBuf::from("/tmp/test/daemon.pid"));
+}

--- a/src/platform/terminal.rs
+++ b/src/platform/terminal.rs
@@ -1,0 +1,53 @@
+//! Terminal capability detection and user identity.
+//!
+//! Provides functions to detect whether the current terminal supports
+//! ANSI escape sequences, and to retrieve the current user's UID.
+
+/// Returns `true` if the current terminal supports ANSI escape sequences.
+///
+/// On Unix, checks the `TERM` environment variable for known values.
+/// On Windows, detects terminal emulation environments (e.g. ConEmu, mintty).
+pub fn supports_ansi() -> bool {
+    cfg!(unix)
+        && std::env::var("TERM")
+            .map(|v| v != "dumb" && !v.is_empty())
+            .unwrap_or(false)
+}
+
+/// Returns the current user's UID as a string.
+///
+/// On Unix, returns the numeric UID via `libc::getuid()`.
+/// On Windows, returns the username via environment variable.
+pub fn current_uid() -> String {
+    #[cfg(unix)]
+    {
+        // SAFETY: getuid() is always safe and returns the real UID.
+        unsafe { libc::getuid().to_string() }
+    }
+    #[cfg(not(unix))]
+    {
+        std::env::var("USERNAME")
+            .or_else(|_| std::env::var("USER"))
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supports_ansi_returns_bool() {
+        // supports_ansi should not panic regardless of environment
+        let _ = supports_ansi();
+    }
+
+    #[test]
+    fn test_current_uid_non_empty() {
+        let uid = current_uid();
+        assert!(
+            !uid.is_empty(),
+            "current_uid() must return non-empty string"
+        );
+    }
+}

--- a/src/platform/terminal.rs
+++ b/src/platform/terminal.rs
@@ -41,23 +41,3 @@ pub fn current_uid() -> String {
             .unwrap_or_else(|_| "unknown".to_string())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_supports_ansi_returns_bool() {
-        // supports_ansi should not panic regardless of environment
-        let _ = supports_ansi();
-    }
-
-    #[test]
-    fn test_current_uid_non_empty() {
-        let uid = current_uid();
-        assert!(
-            !uid.is_empty(),
-            "current_uid() must return non-empty string"
-        );
-    }
-}

--- a/src/platform/terminal.rs
+++ b/src/platform/terminal.rs
@@ -5,13 +5,23 @@
 
 /// Returns `true` if the current terminal supports ANSI escape sequences.
 ///
-/// On Unix, checks the `TERM` environment variable for known values.
-/// On Windows, detects terminal emulation environments (e.g. ConEmu, mintty).
+/// On Windows, detects the Windows Terminal environment via `WT_SESSION`.
+/// On all platforms, checks the `TERM` environment variable for known
+/// ANSI-capable values (`xterm`, `screen`, `ansi`, `vt100`, `color`).
 pub fn supports_ansi() -> bool {
-    cfg!(unix)
-        && std::env::var("TERM")
-            .map(|v| v != "dumb" && !v.is_empty())
-            .unwrap_or(false)
+    if std::env::var("WT_SESSION").is_ok() {
+        return true;
+    }
+    std::env::var("TERM")
+        .map(|term| {
+            let t = term.to_lowercase();
+            t.contains("xterm")
+                || t.contains("screen")
+                || t.contains("ansi")
+                || t.contains("vt100")
+                || t.contains("color")
+        })
+        .unwrap_or(false)
 }
 
 /// Returns the current user's UID as a string.

--- a/src/platform/terminal_tests.rs
+++ b/src/platform/terminal_tests.rs
@@ -1,0 +1,37 @@
+use crate::platform::terminal::{current_uid, supports_ansi};
+
+#[test]
+fn test_current_uid_non_empty() {
+    let uid = current_uid();
+    assert!(
+        !uid.is_empty(),
+        "current_uid() must return a non-empty string"
+    );
+}
+
+#[test]
+fn test_current_uid_alphanumeric() {
+    let uid = current_uid();
+    // On Unix it should be numeric; on Windows it's a username string.
+    // Either way, no whitespace allowed.
+    assert!(
+        !uid.contains(char::is_whitespace),
+        "current_uid() must not contain whitespace: {uid}"
+    );
+}
+
+#[test]
+fn test_supports_ansi_returns_bool() {
+    // Must not panic regardless of environment.
+    let result = supports_ansi();
+    // Result is a bool; just verify it doesn't panic and is deterministic.
+    let result2 = supports_ansi();
+    assert_eq!(result, result2, "supports_ansi() must be deterministic");
+}
+
+#[test]
+fn test_supports_ansi_no_dumb_term() {
+    // Even without checking env, supports_ansi must not panic.
+    // On this Linux CI, TERM is typically set to "xterm" or similar.
+    let _ = supports_ansi();
+}


### PR DESCRIPTION
fix: CLI 代码与 Design Doc 对齐

修复代码与 design doc 之间的两处 must_fix 差异（F2b 扫描发现）：

1. **TerminalRenderer DSL 按钮纯文本渲染**：`render_dsl()` 对 Button 类型 DSL 指令生成纯文本提示
   `[Button: {label} (action: {action}, value: {value})]`，符合文档"终端无交互元素"要求

2. **platform 模块创建**：按 `docs/design/platform/README.md` 创建 `src/platform/` 模块
   - `terminal.rs`：终端 ANSI 检测 + `current_uid()` 从 `im::terminal` 迁入
   - `process.rs`：PID 文件管理和进程信号处理从 `daemon` 迁入
   - `config.rs`：配置目录路径解析
   - `fs.rs`：路径统一处理
   消除业务代码中的 `#[cfg]` 内联

Source: design doc 差异扫描
Type: fix
