### PR TITLE
fix: migrate stop command to platform module for cross-platform support

### DIFF
--- a/src/cli/admin/stop.rs
+++ b/src/cli/admin/stop.rs
@@ -1,51 +1,27 @@
 //! Stop handler function for CLI admin.
 
-use super::common::{json_error, json_output, pid_file_path, StopOutput};
+use super::common::{json_output, StopOutput};
 use anyhow::Result;
 
 pub async fn handle_stop(force: bool, json: bool) -> Result<()> {
-    let p = pid_file_path();
-    let pid: u32 = if p.exists() {
-        std::fs::read_to_string(&p)?
-            .trim()
-            .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid PID"))?
-    } else {
-        anyhow::bail!("PID file not found at {}.", p.display())
-    };
+    let config_dir = crate::platform::config::config_dir()?;
+    let p = crate::platform::process::pid_file_path(&config_dir);
+    let pid = crate::platform::process::read_pid_file(&p)
+        .ok_or_else(|| anyhow::anyhow!("PID file not found at {}.", p.display()))?;
     if pid == std::process::id() {
         anyhow::bail!("Refusing to kill self.");
     }
+    crate::platform::process::send_signal(pid, force)?;
+    let _ = std::fs::remove_file(&p);
     let sig = if force { "KILL" } else { "TERM" };
-    match std::process::Command::new("kill")
-        .arg(format!("-{}", sig))
-        .arg(pid.to_string())
-        .output()
-    {
-        Ok(o) if o.status.success() => {
-            let _ = std::fs::remove_file(&p);
-            if json {
-                json_output(&StopOutput {
-                    pid,
-                    signal: sig.to_string(),
-                    stopped: true,
-                });
-                return Ok(());
-            }
-            println!("Daemon (PID {}) stopped ({}).", pid, sig);
-        }
-        Ok(o) => {
-            if json {
-                return Err(json_error(&format!("kill returned {}", o.status)));
-            }
-            anyhow::bail!("kill returned {}", o.status);
-        }
-        Err(e) => {
-            if json {
-                return Err(json_error(&format!("Failed to kill: {}", e)));
-            }
-            anyhow::bail!("Failed to kill: {}", e);
-        }
+    if json {
+        json_output(&StopOutput {
+            pid,
+            signal: sig.to_string(),
+            stopped: true,
+        });
+        return Ok(());
     }
+    println!("Daemon (PID {}) stopped ({}).", pid, sig);
     Ok(())
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -11,7 +11,9 @@ pub mod terminal;
 
 pub use config::config_dir;
 pub use fs::normalize_path;
-pub use process::{send_signal, wait_for_shutdown_signal, write_pid_file};
+pub use process::{
+    pid_file_path, read_pid_file, send_signal, wait_for_shutdown_signal, write_pid_file,
+};
 pub use terminal::{current_uid, supports_ansi};
 
 #[cfg(test)]

--- a/src/platform/process.rs
+++ b/src/platform/process.rs
@@ -30,25 +30,31 @@ pub fn read_pid_file(path: &Path) -> Option<u32> {
 
 /// Sends a termination signal to the process identified by `pid`.
 ///
-/// On Unix, sends SIGTERM. On Windows, terminates the process via API.
-pub fn send_signal(pid: u32) -> anyhow::Result<()> {
+/// On Unix, sends SIGTERM by default or SIGKILL when `force` is true.
+/// On Windows, uses `taskkill` without `/F` by default or with `/F`
+/// when `force` is true.
+pub fn send_signal(pid: u32, force: bool) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
-        // SAFETY: kill with SIGTERM is a standard termination signal.
+        let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
+        // SAFETY: kill with a valid signal is a standard POSIX operation.
         // The process ID is validated by the OS kernel.
-        let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+        let ret = unsafe { libc::kill(pid as i32, signal) };
         if ret != 0 {
             anyhow::bail!(
-                "Failed to send SIGTERM to process {pid}: {}",
+                "Failed to send signal to process {pid}: {}",
                 std::io::Error::last_os_error()
             );
         }
     }
     #[cfg(not(unix))]
     {
-        // Windows: use taskkill to terminate the process
+        let mut args = vec!["/PID".to_string(), pid.to_string()];
+        if force {
+            args.push("/F".to_string());
+        }
         let status = std::process::Command::new("taskkill")
-            .args(["/PID", &pid.to_string(), "/F"])
+            .args(&args)
             .status()?;
         if !status.success() {
             anyhow::bail!("Failed to terminate process {pid}");

--- a/src/platform/process_tests.rs
+++ b/src/platform/process_tests.rs
@@ -1,4 +1,6 @@
-use crate::platform::process::{pid_file_path, read_pid_file, write_pid_file};
+use crate::platform::process::{pid_file_path, read_pid_file, send_signal, write_pid_file};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 use tempfile::TempDir;
 
 #[test]
@@ -44,4 +46,67 @@ fn test_pid_file_path_format() {
     let dir = std::path::Path::new("/tmp/test");
     let path = pid_file_path(dir);
     assert_eq!(path, std::path::PathBuf::from("/tmp/test/daemon.pid"));
+}
+
+// ── send_signal tests ──────────────────────────────────────────────
+
+/// Helper: spawn a long-running child process and return it.
+fn spawn_sleep_child() -> std::process::Child {
+    std::process::Command::new("sleep")
+        .arg("60")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("failed to spawn sleep child")
+}
+
+#[cfg(unix)]
+#[test]
+fn test_send_signal_sigterm() {
+    let mut child = spawn_sleep_child();
+    let pid = child.id();
+
+    // Send SIGTERM (force=false). Should succeed and terminate the child.
+    send_signal(pid, false).expect("send_signal(pid, SIGTERM) failed");
+    let status = child.wait().unwrap();
+    // Default SIGTERM handler kills with signal 15.
+    assert_eq!(
+        status.signal(),
+        Some(15),
+        "child should be killed by SIGTERM: {status}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_send_signal_sigkill() {
+    let mut child = spawn_sleep_child();
+    let pid = child.id();
+
+    // Send SIGKILL (force=true). Should succeed and terminate the child.
+    send_signal(pid, true).expect("send_signal(pid, SIGKILL) failed");
+    let status = child.wait().unwrap();
+    // SIGKILL cannot be caught; process must exit with signal 9.
+    assert_eq!(
+        status.signal(),
+        Some(9),
+        "child should be killed by SIGKILL: {status}"
+    );
+}
+
+#[test]
+fn test_send_signal_invalid_pid() {
+    // PID 999999999 is almost certainly not running.
+    let err = send_signal(999999999, false);
+    assert!(err.is_err(), "send_signal to invalid PID should fail");
+}
+
+#[test]
+fn test_send_signal_invalid_pid_force() {
+    let err = send_signal(999999999, true);
+    assert!(
+        err.is_err(),
+        "send_signal(force) to invalid PID should fail"
+    );
 }


### PR DESCRIPTION
Migrate `closeclaw stop` from direct Unix `kill` calls to platform module abstractions for cross-platform support.

- Extend `platform::process::send_signal` with `force: bool` parameter (SIGKILL on Unix, `taskkill /F` on Windows)
- Export `read_pid_file` from platform module
- Rewrite `stop.rs` to use `platform::process::read_pid_file` + `send_signal` instead of `Command::new("kill")`
- Add unit tests covering `force` parameter logic

Source: design doc
Type: fix
