### PR TITLE
fix: add backtick fence for unsupported code block languages

### DIFF
--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -1,7 +1,13 @@
-//! Terminal renderer — ANSI-formatted text output for CLI chat.
+//! Terminal renderer — batch text rendering for the CLI channel.
 //!
-//! Converts LLM [`ContentBlock`]s to ANSI-styled text suitable for stdout.
-//! Detects terminal ANSI capability and falls back to plain text.
+//! Converts LLM [`ContentBlock`]s into ANSI-styled or plain text. This is a
+//! **batch renderer**: `render()` returns a complete [`RenderedOutput`] and
+//! performs no I/O itself. Streaming output is handled by the Gateway layer
+//! (`send_outbound_streaming()` + `DefaultStreamingRenderer`), which drives
+//! incremental delivery via `LineBuffer` and `plugin.send()`.
+//!
+//! Detects terminal ANSI capability and falls back to plain text when
+//! unavailable.
 
 use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
 use crate::im_adapter::renderer::{RenderedOutput, Renderer};
@@ -602,8 +608,12 @@ fn render_markdown(content: &str, ansi: bool) -> String {
 /// Renderer for the terminal (CLI) channel.
 ///
 /// Converts LLM [`ContentBlock`]s into ANSI-formatted text suitable for
-/// stdout display. Detects terminal ANSI support and falls back to plain
-/// text when unavailable.
+/// stdout display. This is a **batch renderer**: `render()` returns a
+/// complete [`RenderedOutput`] without performing I/O. Streaming delivery
+/// is handled by the Gateway layer via [`DefaultStreamingRenderer`].
+///
+/// Detects terminal ANSI support and falls back to plain text when
+/// unavailable.
 #[derive(Debug, Clone)]
 pub struct TerminalRenderer {
     ansi: bool,

--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -290,12 +290,28 @@ fn find_char_end(chars: &[char], start: usize, ch: char) -> Option<usize> {
 // Code block rendering
 // ---------------------------------------------------------------------------
 
+/// Check if the language has syntax highlighting support.
+fn is_supported_language(language: &str) -> bool {
+    matches!(
+        language,
+        "rust" | "python" | "javascript" | "typescript" | "go" | "c" | "cpp" | "java"
+    )
+}
+
 /// Render a fenced code block with language annotation, line numbers,
 /// and optional syntax highlighting.
+///
+/// For unsupported languages (non-empty but not in the supported set),
+/// wraps the output with ``` fence markers.
 fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
     let lines: Vec<&str> = code.lines().collect();
     let line_width = format!("{}", lines.len()).len();
     let mut out = String::new();
+    let unsupported = !language.is_empty() && !is_supported_language(language);
+
+    if unsupported {
+        out.push_str("```\n");
+    }
 
     if ansi && !language.is_empty() {
         out.push_str(&format!("{} {} {}\n", DIM, language, RESET));
@@ -312,6 +328,10 @@ fn render_code_block(language: &str, code: &str, ansi: bool) -> String {
             out.push_str(&format!("  {} │ {}", num, line));
         }
         out.push('\n');
+    }
+
+    if unsupported {
+        out.push_str("```\n");
     }
 
     out

--- a/src/renderer/terminal_tests.rs
+++ b/src/renderer/terminal_tests.rs
@@ -691,4 +691,97 @@ mod tests {
             .unwrap();
         assert!(text.contains("Hello world"));
     }
+
+    // =========================================================================
+    // Code block fence tests (Step 1.1)
+    // =========================================================================
+
+    /// Unsupported language code block output contains ``` fence (ANSI mode).
+    #[test]
+    fn test_code_block_unsupported_lang_fence_ansi() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("```haskell\nlet x = 1\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        // fence should appear (stripped ANSI sequences won't have ```)
+        assert!(
+            text.contains("```"),
+            "unsupported language block should contain ``` fence"
+        );
+    }
+
+    /// Unsupported language code block output contains ``` fence (plain text mode).
+    #[test]
+    fn test_code_block_unsupported_lang_fence_plain() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("```ruby\nputs \"hi\"\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        // plain text: ``` should be present
+        assert!(
+            text.contains("```"),
+            "unsupported language block in plain text should contain ``` fence"
+        );
+    }
+
+    /// Supported language code block output does NOT contain extra ``` fence.
+    #[test]
+    fn test_code_block_supported_lang_no_fence() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("```rust\nfn main() {}\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        // supported lang should NOT have ``` fence markers
+        let trimmed_lines: Vec<&str> = text
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .collect();
+        // the first non-empty line should NOT be ```
+        assert_ne!(
+            trimmed_lines.first().copied(),
+            Some("```"),
+            "supported language block should not start with ``` fence"
+        );
+    }
+
+    /// Empty language code block output does NOT contain ``` fence.
+    #[test]
+    fn test_code_block_empty_lang_no_fence() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("```\nhello\n```".into())];
+        let output = r.render(&blocks, None);
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        // empty language should NOT have ``` fence (only line numbers)
+        let trimmed_lines: Vec<&str> = text
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .collect();
+        assert_ne!(
+            trimmed_lines.first().copied(),
+            Some("```"),
+            "empty language block should not start with ``` fence"
+        );
+    }
 }


### PR DESCRIPTION
## 概述

修复 TerminalRenderer 代码块渲染与设计文档的两个差异：

1. **代码块反引号边界**：不支持的语言的代码块输出添加 ``` 围栏标记，符合设计文档要求
2. **模块文档注释更新**：准确描述 TerminalRenderer 的职责（批量渲染，流式输出由 Gateway 层处理）

## 变更

- `src/renderer/terminal.rs`：render_code_block() 对不支持语言添加围栏；模块文档注释更新
- `src/renderer/terminal_tests.rs`：新增 4 个 UT 覆盖围栏逻辑所有分支

## 来源

Design Doc 差异扫描（docs/design/cli/renderer.md）

Source: user
Type: fix
