### PR TITLE
feat: implement Selector DSL

### DIFF
--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -182,14 +182,22 @@ fn parse_dsl_line(line: &str) -> Option<DslInstruction> {
     None
 }
 
-/// Parse a `::button[...]` line into a [`DslInstruction::Button`].
-fn parse_button(trimmed: &str) -> Option<DslInstruction> {
+/// Extract the bracket content from a DSL line.
+///
+/// Given `::tag[...]`, returns the trimmed inner content between `[` and `]`.
+/// Returns `None` if brackets are empty or missing.
+fn extract_bracket_content(trimmed: &str) -> Option<&str> {
     let start = trimmed.find('[')? + 1;
     let end = trimmed.len() - 1;
     if start >= end {
         return None;
     }
-    let inner = &trimmed[start..end];
+    Some(&trimmed[start..end])
+}
+
+/// Parse a `::button[...]` line into a [`DslInstruction::Button`].
+fn parse_button(trimmed: &str) -> Option<DslInstruction> {
+    let inner = extract_bracket_content(trimmed)?;
 
     let mut label: Option<String> = None;
     let mut action: Option<String> = None;
@@ -222,12 +230,7 @@ fn parse_button(trimmed: &str) -> Option<DslInstruction> {
 
 /// Parse a `::selector[...]` line into a [`DslInstruction::Selector`].
 fn parse_selector(trimmed: &str) -> Option<DslInstruction> {
-    let start = trimmed.find('[')? + 1;
-    let end = trimmed.len() - 1;
-    if start >= end {
-        return None;
-    }
-    let inner = &trimmed[start..end];
+    let inner = extract_bracket_content(trimmed)?;
 
     let mut label: Option<String> = None;
     let mut action: Option<String> = None;

--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -30,6 +30,12 @@ pub enum DslInstruction {
         action: String,
         value: String,
     },
+    /// A selector with a label, multiple option choices, and an action identifier.
+    Selector {
+        label: String,
+        options: Vec<String>,
+        action: String,
+    },
 }
 
 /// Result of parsing a markdown string for DSL instructions.
@@ -162,11 +168,22 @@ impl DslParser {
 /// Returns `None` if the line is not a DSL line.
 fn parse_dsl_line(line: &str) -> Option<DslInstruction> {
     let trimmed = line.trim();
-    if !trimmed.starts_with("::button[") || !trimmed.ends_with(']') {
+    if !trimmed.ends_with(']') {
         return None;
     }
 
-    // Extract content between `[` and `]`
+    if trimmed.starts_with("::button[") {
+        return parse_button(trimmed);
+    }
+    if trimmed.starts_with("::selector[") {
+        return parse_selector(trimmed);
+    }
+
+    None
+}
+
+/// Parse a `::button[...]` line into a [`DslInstruction::Button`].
+fn parse_button(trimmed: &str) -> Option<DslInstruction> {
     let start = trimmed.find('[')? + 1;
     let end = trimmed.len() - 1;
     if start >= end {
@@ -174,7 +191,6 @@ fn parse_dsl_line(line: &str) -> Option<DslInstruction> {
     }
     let inner = &trimmed[start..end];
 
-    // Parse parameters: key:value separated by ';'
     let mut label: Option<String> = None;
     let mut action: Option<String> = None;
     let mut value: Option<String> = None;
@@ -201,6 +217,49 @@ fn parse_dsl_line(line: &str) -> Option<DslInstruction> {
         label,
         action,
         value,
+    })
+}
+
+/// Parse a `::selector[...]` line into a [`DslInstruction::Selector`].
+fn parse_selector(trimmed: &str) -> Option<DslInstruction> {
+    let start = trimmed.find('[')? + 1;
+    let end = trimmed.len() - 1;
+    if start >= end {
+        return None;
+    }
+    let inner = &trimmed[start..end];
+
+    let mut label: Option<String> = None;
+    let mut action: Option<String> = None;
+    let mut options: Vec<String> = Vec::new();
+
+    for param in inner.split(';') {
+        let param = param.trim();
+        if let Some((key, val)) = param.split_once(':') {
+            let key = key.trim();
+            let val = val.trim();
+            match key {
+                "label" => label = Some(val.to_string()),
+                "action" => action = Some(val.to_string()),
+                "options" => {
+                    options = val
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let label = label?;
+    let action = action?;
+
+    Some(DslInstruction::Selector {
+        label,
+        options,
+        action,
     })
 }
 

--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -356,9 +356,11 @@ mod tests {
         assert_eq!(result.instructions.len(), 2);
         match &result.instructions[0] {
             DslInstruction::Button { label, .. } => assert_eq!(label, "Yes"),
+            _ => panic!("Expected Button instruction"),
         }
         match &result.instructions[1] {
             DslInstruction::Button { label, .. } => assert_eq!(label, "No"),
+            _ => panic!("Expected Button instruction"),
         }
         assert!(result.clean_content.is_empty());
     }
@@ -420,6 +422,7 @@ mod tests {
                 assert_eq!(action, "say hello");
                 assert_eq!(value, "greeting");
             }
+            _ => panic!("Expected Button instruction"),
         }
     }
 
@@ -538,6 +541,7 @@ mod tests {
                 assert_eq!(action, "go");
                 assert_eq!(value, "ok");
             }
+            _ => panic!("Expected Button instruction"),
         }
         assert_eq!(result.clean_content, "");
     }
@@ -552,5 +556,138 @@ mod tests {
         let result_convenience = DslParseResult::from_content_blocks(&blocks);
         let result_manual = DslParser::default().parse_content_blocks(&blocks);
         assert_eq!(result_convenience, result_manual);
+    }
+
+    // -----------------------------------------------------------------------
+    // Selector DSL tests (Step 1.3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_single_selector() {
+        let parser = DslParser;
+        let input = "::selector[label:Pick color;options:Red,Green,Blue;action:select_color]";
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 1);
+        assert_eq!(
+            result.instructions[0],
+            DslInstruction::Selector {
+                label: "Pick color".to_string(),
+                options: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+                action: "select_color".to_string(),
+            }
+        );
+        assert!(result.clean_content.is_empty());
+    }
+
+    #[test]
+    fn test_selector_empty_options() {
+        let parser = DslParser;
+        let input = "::selector[label:Choose;options:;action:pick]";
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 1);
+        match &result.instructions[0] {
+            DslInstruction::Selector {
+                label,
+                options,
+                action,
+            } => {
+                assert_eq!(label, "Choose");
+                assert!(options.is_empty());
+                assert_eq!(action, "pick");
+            }
+            _ => panic!("Expected Selector instruction"),
+        }
+    }
+
+    #[test]
+    fn test_selector_with_spaces() {
+        let parser = DslParser;
+        let input = "::selector[label: Pick one ;options: A , B , C ;action: choose ]";
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 1);
+        match &result.instructions[0] {
+            DslInstruction::Selector {
+                label,
+                options,
+                action,
+            } => {
+                assert_eq!(label, "Pick one");
+                assert_eq!(
+                    options,
+                    &vec!["A".to_string(), "B".to_string(), "C".to_string()]
+                );
+                assert_eq!(action, "choose");
+            }
+            _ => panic!("Expected Selector instruction"),
+        }
+    }
+
+    #[test]
+    fn test_selector_mixed_with_text() {
+        let parser = DslParser;
+        let input = "Hello\n::selector[label:Pick;options:X,Y;action:go]\nWorld";
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 1);
+        assert_eq!(result.clean_content, "Hello\nWorld");
+    }
+
+    #[test]
+    fn test_selector_and_button_mixed() {
+        let parser = DslParser;
+        let input = concat!(
+            "::button[label:Yes;action:confirm;value:1]\n",
+            "::selector[label:Pick;options:A,B;action:choose]",
+        );
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 2);
+        assert!(matches!(
+            &result.instructions[0],
+            DslInstruction::Button { .. }
+        ));
+        assert!(matches!(
+            &result.instructions[1],
+            DslInstruction::Selector { .. }
+        ));
+        assert!(result.clean_content.is_empty());
+    }
+
+    #[test]
+    fn test_selector_missing_label() {
+        let parser = DslParser;
+        let input = "::selector[options:A,B;action:go]";
+        let result = parser.parse(input);
+
+        assert!(result.instructions.is_empty());
+        assert_eq!(result.clean_content, input);
+    }
+
+    #[test]
+    fn test_selector_missing_action() {
+        let parser = DslParser;
+        let input = "::selector[label:Pick;options:A,B]";
+        let result = parser.parse(input);
+
+        assert!(result.instructions.is_empty());
+        assert_eq!(result.clean_content, input);
+    }
+
+    #[test]
+    fn test_selector_single_option() {
+        let parser = DslParser;
+        let input = "::selector[label:Only one;options:Only;action:single]";
+        let result = parser.parse(input);
+
+        assert_eq!(result.instructions.len(), 1);
+        match &result.instructions[0] {
+            DslInstruction::Selector { options, .. } => {
+                assert_eq!(options, &vec!["Only".to_string()]);
+            }
+            _ => panic!("Expected Selector instruction"),
+        }
     }
 }

--- a/src/renderer/feishu.rs
+++ b/src/renderer/feishu.rs
@@ -319,7 +319,9 @@ impl FeishuRenderer {
         let mut seen = false;
 
         for inst in instructions {
-            let DslInstruction::Button { label, .. } = inst;
+            let DslInstruction::Button { label, .. } = inst else {
+                continue;
+            };
             let bt = if has_primary && !seen {
                 seen = true;
                 "primary"

--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -718,6 +718,9 @@ impl TerminalRenderer {
                         label, action, value
                     ));
                 }
+                crate::processor_chain::DslInstruction::Selector { .. } => {
+                    // Step 1.2 will implement full Selector rendering
+                }
             }
         }
         out

--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -718,8 +718,23 @@ impl TerminalRenderer {
                         label, action, value
                     ));
                 }
-                crate::processor_chain::DslInstruction::Selector { .. } => {
-                    // Step 1.2 will implement full Selector rendering
+                crate::processor_chain::DslInstruction::Selector {
+                    label,
+                    options,
+                    action,
+                } => {
+                    let options_str = options.join(", ");
+                    if self.ansi {
+                        out.push_str(&format!(
+                            "{}[Selector: {} (options: {}; action: {})]{}\n",
+                            DIM, label, options_str, action, RESET
+                        ));
+                    } else {
+                        out.push_str(&format!(
+                            "[Selector: {} (options: {}; action: {})]\n",
+                            label, options_str, action
+                        ));
+                    }
                 }
             }
         }

--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -703,6 +703,15 @@ impl TerminalRenderer {
         }
     }
 
+    /// Wrap `text` with DIM/RESET when ANSI is enabled, otherwise return plain text.
+    fn dim_or_plain(&self, text: &str) -> String {
+        if self.ansi {
+            format!("{}{}{}", DIM, text, RESET)
+        } else {
+            text.to_string()
+        }
+    }
+
     /// Render DSL instructions as plain-text hints for the terminal channel.
     fn render_dsl(&self, dsl_result: &DslParseResult) -> String {
         let mut out = String::new();
@@ -713,10 +722,10 @@ impl TerminalRenderer {
                     action,
                     value,
                 } => {
-                    out.push_str(&format!(
-                        "[Button: {} (action: {}, value: {})]\n",
-                        label, action, value
-                    ));
+                    let line =
+                        format!("[Button: {} (action: {}, value: {})]", label, action, value);
+                    out.push_str(&self.dim_or_plain(&line));
+                    out.push('\n');
                 }
                 crate::processor_chain::DslInstruction::Selector {
                     label,
@@ -724,17 +733,12 @@ impl TerminalRenderer {
                     action,
                 } => {
                     let options_str = options.join(", ");
-                    if self.ansi {
-                        out.push_str(&format!(
-                            "{}[Selector: {} (options: {}; action: {})]{}\n",
-                            DIM, label, options_str, action, RESET
-                        ));
-                    } else {
-                        out.push_str(&format!(
-                            "[Selector: {} (options: {}; action: {})]\n",
-                            label, options_str, action
-                        ));
-                    }
+                    let line = format!(
+                        "[Selector: {} (options: {}; action: {})]",
+                        label, options_str, action
+                    );
+                    out.push_str(&self.dim_or_plain(&line));
+                    out.push('\n');
                 }
             }
         }

--- a/src/renderer/terminal_tests.rs
+++ b/src/renderer/terminal_tests.rs
@@ -668,6 +668,10 @@ mod tests {
             .unwrap();
         assert!(text.contains("Content"));
         assert!(
+            text.contains(DIM),
+            "DSL button should have DIM style in ANSI mode"
+        );
+        assert!(
             text.contains("[Button: OK (action: confirm, value: yes)]"),
             "DSL button should appear as plain-text hint in output"
         );

--- a/src/renderer/terminal_tests.rs
+++ b/src/renderer/terminal_tests.rs
@@ -784,4 +784,120 @@ mod tests {
             "empty language block should not start with ``` fence"
         );
     }
+
+    // =========================================================================
+    // Selector DSL rendering tests (Step 1.3)
+    // =========================================================================
+
+    /// Verify TerminalRenderer renders DSL Selector instructions as plain-text hints.
+    #[test]
+    fn test_render_selector_dsl_plain() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("Pick an option".into())];
+        let dsl = DslParseResult {
+            clean_content: String::new(),
+            instructions: vec![DslInstruction::Selector {
+                label: "Color".to_string(),
+                options: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+                action: "select_color".to_string(),
+            }],
+        };
+        let output = r.render(&blocks, Some(&dsl));
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Pick an option"));
+        assert!(
+            text.contains("[Selector: Color (options: Red, Green, Blue; action: select_color)]"),
+            "DSL selector should appear as plain-text hint in output"
+        );
+    }
+
+    /// Verify DSL Selector renders with DIM style in ANSI mode.
+    #[test]
+    fn test_render_selector_dsl_ansi() {
+        let r = TerminalRenderer::with_ansi(true);
+        let blocks = vec![ContentBlock::Text("Content".into())];
+        let dsl = DslParseResult {
+            clean_content: String::new(),
+            instructions: vec![DslInstruction::Selector {
+                label: "Size".to_string(),
+                options: vec!["S".to_string(), "M".to_string(), "L".to_string()],
+                action: "pick_size".to_string(),
+            }],
+        };
+        let output = r.render(&blocks, Some(&dsl));
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("Content"));
+        assert!(text.contains(DIM));
+        assert!(
+            text.contains("[Selector: Size (options: S, M, L; action: pick_size)]"),
+            "DSL selector should appear as plain-text hint with DIM style"
+        );
+    }
+
+    /// Verify DSL Selector with empty options.
+    #[test]
+    fn test_render_selector_empty_options() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("Hello".into())];
+        let dsl = DslParseResult {
+            clean_content: String::new(),
+            instructions: vec![DslInstruction::Selector {
+                label: "Choose".to_string(),
+                options: vec![],
+                action: "pick".to_string(),
+            }],
+        };
+        let output = r.render(&blocks, Some(&dsl));
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(
+            text.contains("[Selector: Choose (options: ; action: pick)]"),
+            "Selector with empty options should render correctly"
+        );
+    }
+
+    /// Verify Button and Selector DSL instructions render together.
+    #[test]
+    fn test_render_button_and_selector_dsl() {
+        let r = TerminalRenderer::with_ansi(false);
+        let blocks = vec![ContentBlock::Text("Choose:".into())];
+        let dsl = DslParseResult {
+            clean_content: String::new(),
+            instructions: vec![
+                DslInstruction::Button {
+                    label: "OK".to_string(),
+                    action: "confirm".to_string(),
+                    value: "yes".to_string(),
+                },
+                DslInstruction::Selector {
+                    label: "Color".to_string(),
+                    options: vec!["R".to_string(), "G".to_string()],
+                    action: "select".to_string(),
+                },
+            ],
+        };
+        let output = r.render(&blocks, Some(&dsl));
+        let text = output
+            .payload
+            .get("content")
+            .and_then(|c| c.get("text"))
+            .and_then(|t| t.as_str())
+            .unwrap();
+        assert!(text.contains("[Button: OK (action: confirm, value: yes)]"));
+        assert!(text.contains("[Selector: Color (options: R, G; action: select)]"));
+    }
 }


### PR DESCRIPTION
Implement Selector DSL: add Selector variant to DslInstruction enum,
DslParser, and TerminalRenderer rendering. Includes shared helpers
(extract_bracket_content, dim_or_plain) for Button/Selector consistency,
unit tests, and ANSI style unification.

Source: user
Type: feat
