### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -54,5 +54,12 @@
     "commit_time": "2026-06-21T02:42:50+08:00",
     "confirmed_time": "2026-06-21T13:23:04.290757+08:00",
     "comment": ""
+  },
+  {
+    "path": "docs/design/cli/renderer.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-21T23:56:35.870722+08:00",
+    "comment": "blocked: 文档内部矛盾 - (1) 概述/数据流章节描述 TerminalRenderer 输出到 stdout 且流式输出，但代码实际为批量渲染器，I/O 由 TerminalPlugin.send 负责，流式由 DefaultStreamingRenderer 负责。(2) 数据流章节与模块关系章节对 Gateway-TerminalRenderer 调用链描述矛盾。另发现 ToolUse 参数摘要格式 must_fix：代码输出原始 JSON，文档要求 arg1=val1 arg2=val2 格式。"
   }
 ]


### PR DESCRIPTION
## Design Doc Tracker 更新

- **Doc 路径**: `docs/design/cli/renderer.md`
- **操作类型**: `blocked`
- **原因**: 文档内部矛盾 - TerminalRenderer 架构描述不一致（概述/数据流说输出到 stdout 且流式，实际是 batch renderer；数据流与模块关系章节对调用链描述矛盾）。另发现 ToolUse 参数摘要格式 must_fix。