### PR TITLE
refactor: align daemon hot-reload with design doc

### DIFF
--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -158,7 +158,7 @@ impl ConfigManager {
     /// Used by the daemon to roll back agent state when `reload_agents()`
     /// fails. Call `snapshot_agents()` before reloading, then pass the
     /// snapshot here on failure.
-    pub fn restore_agents(
+    pub(crate) fn restore_agents(
         &self,
         agents: HashMap<String, ResolvedAgentConfig>,
         permissions: HashMap<String, crate::agent::config::AgentPermissions>,
@@ -171,7 +171,7 @@ impl ConfigManager {
     }
 
     /// Snapshot the current agents and permissions for later rollback.
-    pub fn snapshot_agents(
+    pub(crate) fn snapshot_agents(
         &self,
     ) -> (
         HashMap<String, ResolvedAgentConfig>,

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -153,6 +153,35 @@ impl ConfigManager {
         Ok(())
     }
 
+    /// Restore agents and permissions from a snapshot.
+    ///
+    /// Used by the daemon to roll back agent state when `reload_agents()`
+    /// fails. Call `snapshot_agents()` before reloading, then pass the
+    /// snapshot here on failure.
+    pub fn restore_agents(
+        &self,
+        agents: HashMap<String, ResolvedAgentConfig>,
+        permissions: HashMap<String, crate::agent::config::AgentPermissions>,
+    ) {
+        *self.agents.write().expect("RwLock for agents was poisoned") = agents;
+        *self
+            .agent_permissions
+            .write()
+            .expect("RwLock for agent_permissions was poisoned") = permissions;
+    }
+
+    /// Snapshot the current agents and permissions for later rollback.
+    pub fn snapshot_agents(
+        &self,
+    ) -> (
+        HashMap<String, ResolvedAgentConfig>,
+        HashMap<String, crate::agent::config::AgentPermissions>,
+    ) {
+        let agents = self.agents();
+        let permissions = self.agent_permissions();
+        (agents, permissions)
+    }
+
     /// Get all resolved agent configurations.
     pub fn agents(&self) -> HashMap<String, ResolvedAgentConfig> {
         self.agents

--- a/src/config/events.rs
+++ b/src/config/events.rs
@@ -1,0 +1,71 @@
+//! Configuration change event types and broadcast channel.
+//!
+//! Provides `ConfigChangeEvent` describing config section changes and
+//! `ConfigChangeBroadcaster` for creating/subscribing to broadcast channels.
+
+use super::ConfigSection;
+use tokio::sync::broadcast;
+
+/// Default capacity for the config change broadcast channel.
+const DEFAULT_CHANNEL_CAPACITY: usize = 64;
+
+/// A config change event describing which section changed and the outcome.
+#[derive(Debug, Clone)]
+pub enum ConfigChangeEvent {
+    /// Config section was successfully reloaded.
+    Reloaded { section: ConfigSection },
+    /// Config section reload failed (parse or validation error).
+    Failed {
+        section: ConfigSection,
+        error: String,
+    },
+}
+
+/// Broadcast sender for config change events.
+///
+/// Cheaply cloneable; multiple receivers can subscribe independently.
+#[derive(Debug, Clone)]
+pub struct ConfigChangeBroadcaster {
+    tx: broadcast::Sender<ConfigChangeEvent>,
+}
+
+impl ConfigChangeBroadcaster {
+    /// Create a new broadcaster with default channel capacity.
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(DEFAULT_CHANNEL_CAPACITY);
+        Self { tx }
+    }
+
+    /// Create a new broadcaster with a custom channel capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Subscribe to config change events.
+    ///
+    /// Returns a receiver that will receive all future events published
+    /// after this subscription was created. Missed events (published
+    /// before subscription) are not replayed.
+    pub fn subscribe(&self) -> broadcast::Receiver<ConfigChangeEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Publish a config change event to all active subscribers.
+    ///
+    /// If there are no active subscribers the event is silently dropped.
+    pub fn send(&self, event: ConfigChangeEvent) {
+        // Ignore SendError: no active subscribers is not an error.
+        let _ = self.tx.send(event);
+    }
+}
+
+impl Default for ConfigChangeBroadcaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[path = "events_tests.rs"]
+mod tests;

--- a/src/config/events_tests.rs
+++ b/src/config/events_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for config change event types and broadcast channel.
 
 use super::*;
+use tokio::sync::broadcast::error::TryRecvError;
 
 #[test]
 fn test_broadcaster_new_has_zero_receivers() {
@@ -77,4 +78,103 @@ fn test_default_capacity() {
     b.send(ConfigChangeEvent::Reloaded {
         section: ConfigSection::Models,
     });
+}
+
+#[test]
+fn test_broadcaster_with_custom_capacity() {
+    let b = ConfigChangeBroadcaster::with_capacity(2);
+    let mut rx = b.subscribe();
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Models,
+    });
+    let event = rx.try_recv().unwrap();
+    match event {
+        ConfigChangeEvent::Reloaded { section } => {
+            assert_eq!(section, ConfigSection::Models);
+        }
+        _ => panic!("unexpected variant"),
+    }
+}
+
+#[test]
+fn test_subscribe_after_send_misses_old_events() {
+    let b = ConfigChangeBroadcaster::new();
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Models,
+    });
+    // Subscribe AFTER the send — old event must not be replayed
+    let mut rx = b.subscribe();
+    match rx.try_recv() {
+        Err(TryRecvError::Empty) => {} // expected
+        other => panic!("expected Empty, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_subscriber_dropped_then_send_does_not_panic() {
+    let b = ConfigChangeBroadcaster::new();
+    {
+        let _rx = b.subscribe();
+    } // _rx dropped here
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Gateway,
+    });
+    // No panic
+}
+
+#[test]
+fn test_failed_event_clone() {
+    let event = ConfigChangeEvent::Failed {
+        section: ConfigSection::Channels,
+        error: "timeout".into(),
+    };
+    let cloned = event.clone();
+    match cloned {
+        ConfigChangeEvent::Failed { section, error } => {
+            assert_eq!(section, ConfigSection::Channels);
+            assert_eq!(error, "timeout");
+        }
+        _ => panic!("unexpected variant"),
+    }
+}
+
+#[test]
+fn test_multiple_events_fifo_order() {
+    let b = ConfigChangeBroadcaster::new();
+    let mut rx = b.subscribe();
+
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Models,
+    });
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Channels,
+    });
+    b.send(ConfigChangeEvent::Failed {
+        section: ConfigSection::Gateway,
+        error: "bad".into(),
+    });
+
+    // Events must arrive in FIFO order
+    let e1 = rx.try_recv().unwrap();
+    assert!(matches!(
+        e1,
+        ConfigChangeEvent::Reloaded {
+            section: ConfigSection::Models
+        }
+    ));
+    let e2 = rx.try_recv().unwrap();
+    assert!(matches!(
+        e2,
+        ConfigChangeEvent::Reloaded {
+            section: ConfigSection::Channels
+        }
+    ));
+    let e3 = rx.try_recv().unwrap();
+    assert!(matches!(
+        e3,
+        ConfigChangeEvent::Failed {
+            section: ConfigSection::Gateway,
+            ..
+        }
+    ));
 }

--- a/src/config/events_tests.rs
+++ b/src/config/events_tests.rs
@@ -1,0 +1,80 @@
+//! Tests for config change event types and broadcast channel.
+
+use super::*;
+
+#[test]
+fn test_broadcaster_new_has_zero_receivers() {
+    let b = ConfigChangeBroadcaster::new();
+    let _rx = b.subscribe();
+    // After subscribing, the sender still works
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Models,
+    });
+}
+
+#[test]
+fn test_subscribe_receives_events() {
+    let b = ConfigChangeBroadcaster::new();
+    let mut rx = b.subscribe();
+
+    let event = ConfigChangeEvent::Failed {
+        section: ConfigSection::Channels,
+        error: "bad json".into(),
+    };
+    b.send(event.clone());
+
+    let received = rx.try_recv().unwrap();
+    match received {
+        ConfigChangeEvent::Failed { section, error } => {
+            assert_eq!(section, ConfigSection::Channels);
+            assert_eq!(error, "bad json");
+        }
+        other => panic!("unexpected event: {:?}", other),
+    }
+}
+
+#[test]
+fn test_multiple_subscribers_receive_events() {
+    let b = ConfigChangeBroadcaster::new();
+    let mut rx1 = b.subscribe();
+    let mut rx2 = b.subscribe();
+
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Gateway,
+    });
+
+    assert!(rx1.try_recv().is_ok());
+    assert!(rx2.try_recv().is_ok());
+}
+
+#[test]
+fn test_send_without_subscribers_does_not_panic() {
+    let b = ConfigChangeBroadcaster::new();
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::System,
+    });
+    // No panic, no error
+}
+
+#[test]
+fn test_reloaded_event_clone() {
+    let event = ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Plugins,
+    };
+    let cloned = event.clone();
+    match cloned {
+        ConfigChangeEvent::Reloaded { section } => {
+            assert_eq!(section, ConfigSection::Plugins);
+        }
+        _ => panic!("unexpected variant"),
+    }
+}
+
+#[test]
+fn test_default_capacity() {
+    let b = ConfigChangeBroadcaster::default();
+    let _rx = b.subscribe();
+    b.send(ConfigChangeEvent::Reloaded {
+        section: ConfigSection::Models,
+    });
+}

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -209,7 +209,7 @@ pub struct ConfigManager {
     /// Base directory containing all config files.
     pub(crate) config_dir: PathBuf,
     /// Thread-safe backup manager.
-    backup_manager: SafeBackupManager,
+    pub(crate) backup_manager: SafeBackupManager,
     /// In-memory cache of all loaded config sections.
     pub(crate) sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
     /// Loaded credentials provider (from config/credentials/ directory).

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -210,7 +210,7 @@ pub struct ConfigManager {
     /// Base directory containing all config files.
     pub(crate) config_dir: PathBuf,
     /// Thread-safe backup manager.
-    pub(crate) backup_manager: SafeBackupManager,
+    backup_manager: SafeBackupManager,
     /// In-memory cache of all loaded config sections.
     pub(crate) sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
     /// Loaded credentials provider (from config/credentials/ directory).

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use tracing::{error, warn};
 use uuid::Uuid;
 
+use super::events::{ConfigChangeBroadcaster, ConfigChangeEvent};
 use super::providers::{ConfigProvider, CredentialsProvider};
 use crate::agent::config::AgentPermissions;
 
@@ -220,6 +221,8 @@ pub struct ConfigManager {
     pub(crate) agent_permissions: RwLock<HashMap<String, AgentPermissions>>,
     /// Optional project root for loading project-level agents.json.
     pub(crate) repo_root: RwLock<Option<PathBuf>>,
+    /// Broadcast channel for config change events.
+    event_broadcaster: ConfigChangeBroadcaster,
 }
 
 impl ConfigManager {
@@ -238,6 +241,7 @@ impl ConfigManager {
             agents: RwLock::new(HashMap::new()),
             agent_permissions: RwLock::new(HashMap::new()),
             repo_root: RwLock::new(None),
+            event_broadcaster: ConfigChangeBroadcaster::new(),
         })
     }
 
@@ -438,6 +442,19 @@ impl ConfigManager {
             .read()
             .ok()
             .map(|guard| guard.clone())
+    }
+
+    /// Subscribe to config change events.
+    ///
+    /// Returns a receiver that will receive all future config change events.
+    /// Existing events published before subscription are not replayed.
+    pub fn subscribe_config_changes(&self) -> tokio::sync::broadcast::Receiver<ConfigChangeEvent> {
+        self.event_broadcaster.subscribe()
+    }
+
+    /// Publish a config change event to all active subscribers.
+    pub(crate) fn notify_change(&self, event: ConfigChangeEvent) {
+        self.event_broadcaster.send(event);
     }
 
     /// List metadata about all configuration files.

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -3,6 +3,7 @@
 //! Provides `reload_section()` for updating a single config section's
 //! in-memory cache with backup, validation, and rollback support.
 
+use super::events::ConfigChangeEvent;
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
 use tracing::{info, warn};
 
@@ -49,6 +50,10 @@ impl ConfigManager {
                     "rollback also failed after parse error"
                 );
             }
+            self.notify_change(ConfigChangeEvent::Failed {
+                section,
+                error: e.to_string(),
+            });
             ConfigLoadError::ParseError {
                 path: path.clone(),
                 error: e.to_string(),
@@ -65,6 +70,10 @@ impl ConfigManager {
                         "rollback also failed after validation error"
                     );
                 }
+                self.notify_change(ConfigChangeEvent::Failed {
+                    section,
+                    error: msg.clone(),
+                });
                 return Err(ConfigLoadError::ValidationError { path, message: msg });
             }
         }
@@ -76,6 +85,7 @@ impl ConfigManager {
             .expect("RwLock for config sections was poisoned");
         sections.insert(section, value);
         info!("reloaded config section: {}", section);
+        self.notify_change(ConfigChangeEvent::Reloaded { section });
         Ok(())
     }
 }

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -1,23 +1,75 @@
 //! Hot-reload extension for ConfigManager.
 //!
 //! Provides `reload_section()` for updating a single config section's
-//! in-memory cache from validated file content without backup or disk write.
+//! in-memory cache with backup, validation, and rollback support.
 
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
-use tracing::info;
+use tracing::{info, warn};
+
+/// Validator callback type for config section reload.
+///
+/// Receives the parsed JSON value and returns `Ok(())` if valid,
+/// or `Err(message)` to reject the reload.
+pub type SectionValidator = dyn Fn(&serde_json::Value) -> Result<(), String>;
 
 impl ConfigManager {
-    /// Hot-reload a single section from file content (no backup/write).
+    /// Hot-reload a single section from file content.
+    ///
+    /// Flow: backup current file → parse JSON → validate →
+    ///   success: update in-memory cache
+    ///   failure: rollback file, keep old in-memory value, log error
+    ///
+    /// The `validator` callback performs additional business validation
+    /// on the parsed JSON value. Return `Ok(())` to accept, or
+    /// `Err(message)` to reject.
     pub fn reload_section(
         &self,
         section: ConfigSection,
         content: &str,
+        validator: Option<&SectionValidator>,
     ) -> Result<(), ConfigLoadError> {
-        let value: serde_json::Value =
-            serde_json::from_str(content).map_err(|e| ConfigLoadError::ParseError {
-                path: section.path(&self.config_dir),
+        let path = section.path(&self.config_dir);
+
+        // Step 1: backup current file before overwriting
+        if path.exists() {
+            if let Err(e) = self.backup_manager.backup(&path) {
+                warn!(
+                    error = %e, section = %section,
+                    "failed to backup config before reload"
+                );
+            }
+        }
+
+        // Step 2: parse new content
+        let value: serde_json::Value = serde_json::from_str(content).map_err(|e| {
+            // Parse failed → rollback file
+            if let Err(rb) = self.backup_manager.rollback(&path) {
+                warn!(
+                    error = %rb, section = %section,
+                    "rollback also failed after parse error"
+                );
+            }
+            ConfigLoadError::ParseError {
+                path: path.clone(),
                 error: e.to_string(),
-            })?;
+            }
+        })?;
+
+        // Step 3: validate
+        if let Some(validate_fn) = validator {
+            if let Err(msg) = validate_fn(&value) {
+                // Validation failed → rollback file
+                if let Err(rb) = self.backup_manager.rollback(&path) {
+                    warn!(
+                        error = %rb, section = %section,
+                        "rollback also failed after validation error"
+                    );
+                }
+                return Err(ConfigLoadError::ValidationError { path, message: msg });
+            }
+        }
+
+        // Step 4: success — update in-memory cache
         let mut sections = self
             .sections
             .write()

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -5,6 +5,7 @@
 
 use super::events::ConfigChangeEvent;
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
+use std::path::Path;
 use tracing::{info, warn};
 
 /// Validator callback type for config section reload.
@@ -14,9 +15,9 @@ use tracing::{info, warn};
 pub type SectionValidator = dyn Fn(&serde_json::Value) -> Result<(), String>;
 
 impl ConfigManager {
-    /// Hot-reload a single section from file content.
+    /// Hot-reload a single section by reading from a file path.
     ///
-    /// Flow: backup current file → parse JSON → validate →
+    /// Flow: read file → backup current file → parse JSON → validate →
     ///   success: update in-memory cache
     ///   failure: rollback file, keep old in-memory value, log error
     ///
@@ -26,10 +27,16 @@ impl ConfigManager {
     pub fn reload_section(
         &self,
         section: ConfigSection,
-        content: &str,
+        file_path: &Path,
         validator: Option<&SectionValidator>,
     ) -> Result<(), ConfigLoadError> {
         let path = section.path(&self.config_dir);
+
+        // Step 0: read file content
+        let content = std::fs::read_to_string(file_path).map_err(|e| ConfigLoadError::IoError {
+            path: file_path.to_path_buf(),
+            error: e.to_string(),
+        })?;
 
         // Step 1: backup current file before overwriting
         if path.exists() {
@@ -42,7 +49,7 @@ impl ConfigManager {
         }
 
         // Step 2: parse new content
-        let value: serde_json::Value = serde_json::from_str(content).map_err(|e| {
+        let value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
             // Parse failed → rollback file
             if let Err(rb) = self.backup_manager.rollback(&path) {
                 warn!(

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -1,12 +1,16 @@
 //! Hot-reload extension for ConfigManager.
 //!
 //! Provides `reload_section()` for updating a single config section's
-//! in-memory cache with backup, validation, and rollback support.
+//! in-memory cache with validation support.
+//!
+//! Note: `reload_section` reads from the canonical section file path
+//! (`section.path(&self.config_dir)`). It does NOT backup/rollback the
+//! file because the file is modified externally (by an editor or tool).
+//! Backup/rollback is the responsibility of `ConfigManager::update()`.
 
 use super::events::ConfigChangeEvent;
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
-use std::path::Path;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Validator callback type for config section reload.
 ///
@@ -15,11 +19,15 @@ use tracing::{info, warn};
 pub type SectionValidator = dyn Fn(&serde_json::Value) -> Result<(), String>;
 
 impl ConfigManager {
-    /// Hot-reload a single section by reading from a file path.
+    /// Hot-reload a single section by reading its canonical file.
     ///
-    /// Flow: read file → backup current file → parse JSON → validate →
-    ///   success: update in-memory cache
-    ///   failure: rollback file, keep old in-memory value, log error
+    /// Flow: read canonical file → parse JSON → validate →
+    ///   success: update in-memory cache, emit Reloaded event
+    ///   failure: keep old in-memory value, emit Failed event
+    ///
+    /// This method does NOT backup or rollback the file. The file is
+    /// modified externally (editor, CLI, etc.), so ConfigManager has no
+    /// authority to revert it. Backup/rollback belongs to `update()`.
     ///
     /// The `validator` callback performs additional business validation
     /// on the parsed JSON value. Return `Ok(())` to accept, or
@@ -27,36 +35,18 @@ impl ConfigManager {
     pub fn reload_section(
         &self,
         section: ConfigSection,
-        file_path: &Path,
         validator: Option<&SectionValidator>,
     ) -> Result<(), ConfigLoadError> {
         let path = section.path(&self.config_dir);
 
-        // Step 0: read file content
-        let content = std::fs::read_to_string(file_path).map_err(|e| ConfigLoadError::IoError {
-            path: file_path.to_path_buf(),
+        // Step 1: read the canonical config file
+        let content = std::fs::read_to_string(&path).map_err(|e| ConfigLoadError::IoError {
+            path: path.clone(),
             error: e.to_string(),
         })?;
 
-        // Step 1: backup current file before overwriting
-        if path.exists() {
-            if let Err(e) = self.backup_manager.backup(&path) {
-                warn!(
-                    error = %e, section = %section,
-                    "failed to backup config before reload"
-                );
-            }
-        }
-
         // Step 2: parse new content
         let value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-            // Parse failed → rollback file
-            if let Err(rb) = self.backup_manager.rollback(&path) {
-                warn!(
-                    error = %rb, section = %section,
-                    "rollback also failed after parse error"
-                );
-            }
             self.notify_change(ConfigChangeEvent::Failed {
                 section,
                 error: e.to_string(),
@@ -70,13 +60,6 @@ impl ConfigManager {
         // Step 3: validate
         if let Some(validate_fn) = validator {
             if let Err(msg) = validate_fn(&value) {
-                // Validation failed → rollback file
-                if let Err(rb) = self.backup_manager.rollback(&path) {
-                    warn!(
-                        error = %rb, section = %section,
-                        "rollback also failed after validation error"
-                    );
-                }
                 self.notify_change(ConfigChangeEvent::Failed {
                     section,
                     error: msg.clone(),

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -40,10 +40,19 @@ impl ConfigManager {
         let path = section.path(&self.config_dir);
 
         // Step 1: read the canonical config file
-        let content = std::fs::read_to_string(&path).map_err(|e| ConfigLoadError::IoError {
-            path: path.clone(),
-            error: e.to_string(),
-        })?;
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                self.notify_change(ConfigChangeEvent::Failed {
+                    section,
+                    error: e.to_string(),
+                });
+                return Err(ConfigLoadError::IoError {
+                    path,
+                    error: e.to_string(),
+                });
+            }
+        };
 
         // Step 2: parse new content
         let value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -23,9 +23,11 @@ fn test_reload_section_success() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let new_json = r#"{"version": "9.9", "updated": true}"#;
+    let new_content = r#"{"version": "9.9", "updated": true}"#;
+    let new_file = tmp.path().join("new_system.json");
+    fs::write(&new_file, new_content).unwrap();
     manager
-        .reload_section(ConfigSection::System, new_json, None)
+        .reload_section(ConfigSection::System, &new_file, None)
         .unwrap();
 
     let after = manager.section(ConfigSection::System).unwrap();
@@ -44,7 +46,9 @@ fn test_reload_section_invalid_json() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let result = manager.reload_section(ConfigSection::System, "not json", None);
+    let bad_file = tmp.path().join("bad.json");
+    fs::write(&bad_file, "not json").unwrap();
+    let result = manager.reload_section(ConfigSection::System, &bad_file, None);
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -230,9 +230,9 @@ fn test_reload_section_parse_failure_emits_failed_event() {
     }
 }
 
-/// Test: no event is emitted if the file does not exist (early IoError return).
+/// Test: file not found emits a Failed event (IoError path).
 #[test]
-fn test_reload_section_file_not_found_no_event() {
+fn test_reload_section_file_not_found_emits_failed_event() {
     let tmp = tempfile::tempdir().unwrap();
     // Don't create any config files
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
@@ -242,8 +242,15 @@ fn test_reload_section_file_not_found_no_event() {
     let result = manager.reload_section(ConfigSection::System, None);
     assert!(result.is_err());
 
-    // IoError path returns before any event is emitted
-    assert!(rx.try_recv().is_err());
+    // IoError path should emit a Failed event
+    let event = rx.try_recv().expect("should receive a Failed event");
+    match event {
+        ConfigChangeEvent::Failed { section, error } => {
+            assert_eq!(section, ConfigSection::System);
+            assert!(error.contains("No such file") || error.contains("os error"));
+        }
+        other => panic!("expected Failed, got {:?}", other),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for ConfigManager hot-reload methods (reload_section / reload_agents).
 
+use crate::config::events::ConfigChangeEvent;
 use crate::config::manager::*;
+use crate::config::manager_reload::SectionValidator;
 use std::fs;
 
 /// Helper: set up a valid config directory with all mandatory JSON files.
@@ -11,6 +13,10 @@ fn setup_config_dir_at(dir: &std::path::Path) {
     fs::write(dir.join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
     fs::write(dir.join("system.json"), r#"{"version": "1.0"}"#).unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// reload_section — basic (no validator)
+// ---------------------------------------------------------------------------
 
 /// Test: reload_section with valid JSON updates the in-memory cache.
 #[test]
@@ -35,7 +41,8 @@ fn test_reload_section_success() {
     assert_eq!(after["updated"], true);
 }
 
-/// Test: reload_section with invalid JSON returns an error and leaves the cache unchanged.
+/// Test: reload_section with invalid JSON returns an error and leaves the
+/// cache unchanged.
 #[test]
 fn test_reload_section_invalid_json() {
     let tmp = tempfile::tempdir().unwrap();
@@ -59,11 +66,208 @@ fn test_reload_section_invalid_json() {
     assert_eq!(after["version"], "1.0");
 }
 
+// ---------------------------------------------------------------------------
+// reload_section — validator callback
+// ---------------------------------------------------------------------------
+
+/// Test: reload_section with passing validator updates in-memory cache.
+#[test]
+fn test_reload_section_validator_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let new_file = tmp.path().join("new_system.json");
+    fs::write(&new_file, r#"{"version": "2.0"}"#).unwrap();
+
+    let validator: &SectionValidator = &|v: &serde_json::Value| {
+        if v.get("version").is_some() {
+            Ok(())
+        } else {
+            Err("version required".into())
+        }
+    };
+
+    manager
+        .reload_section(ConfigSection::System, &new_file, Some(validator))
+        .unwrap();
+
+    let after = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(after["version"], "2.0");
+}
+
+/// Test: reload_section with failing validator rejects the reload, keeps old
+/// value in memory, and rolls back the file.
+#[test]
+fn test_reload_section_validator_failure_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let before = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(before["version"], "1.0");
+
+    let system_path = tmp.path().join("system.json");
+    let original_content = fs::read_to_string(&system_path).unwrap();
+
+    let new_file = tmp.path().join("new_system.json");
+    fs::write(&new_file, r#"{"version": "2.0", "bad_field": true}"#).unwrap();
+
+    let validator: &SectionValidator = &|v: &serde_json::Value| {
+        if v.get("bad_field").is_some() {
+            Err("bad_field is not allowed".into())
+        } else {
+            Ok(())
+        }
+    };
+
+    let result = manager.reload_section(ConfigSection::System, &new_file, Some(validator));
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigLoadError::ValidationError { .. }
+    ));
+
+    // In-memory cache must still be the old value
+    let after = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(after["version"], "1.0");
+    assert!(after.get("bad_field").is_none());
+
+    // File must be rolled back to original content
+    let file_after = fs::read_to_string(&system_path).unwrap();
+    assert_eq!(file_after, original_content);
+}
+
+/// Test: reload_section parse failure rolls back the file and keeps old value.
+#[test]
+fn test_reload_section_parse_failure_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let system_path = tmp.path().join("system.json");
+    let original_content = fs::read_to_string(&system_path).unwrap();
+
+    let bad_file = tmp.path().join("bad.json");
+    fs::write(&bad_file, "not json").unwrap();
+
+    let result = manager.reload_section(ConfigSection::System, &bad_file, None);
+    assert!(result.is_err());
+
+    // In-memory unchanged
+    let after = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(after["version"], "1.0");
+
+    // File rolled back to original
+    let file_after = fs::read_to_string(&system_path).unwrap();
+    assert_eq!(file_after, original_content);
+}
+
+// ---------------------------------------------------------------------------
+// reload_section — event emission
+// ---------------------------------------------------------------------------
+
+/// Test: successful reload emits a Reloaded event via the broadcast channel.
+#[test]
+fn test_reload_section_success_emits_reloaded_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_changes();
+
+    let new_file = tmp.path().join("new_models.json");
+    fs::write(&new_file, r#"{"version": "3.0"}"#).unwrap();
+    manager
+        .reload_section(ConfigSection::Models, &new_file, None)
+        .unwrap();
+
+    let event = rx.try_recv().expect("should receive a Reloaded event");
+    match event {
+        ConfigChangeEvent::Reloaded { section } => {
+            assert_eq!(section, ConfigSection::Models);
+        }
+        other => panic!("expected Reloaded, got {:?}", other),
+    }
+}
+
+/// Test: validation failure emits a Failed event with the error message.
+#[test]
+fn test_reload_section_validation_failure_emits_failed_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_changes();
+
+    let new_file = tmp.path().join("new_models.json");
+    fs::write(&new_file, r#"{"version": "3.0"}"#).unwrap();
+
+    let validator: &SectionValidator = &|_: &serde_json::Value| Err("reject all".into());
+    let _ = manager.reload_section(ConfigSection::Models, &new_file, Some(validator));
+
+    let event = rx.try_recv().expect("should receive a Failed event");
+    match event {
+        ConfigChangeEvent::Failed { section, error } => {
+            assert_eq!(section, ConfigSection::Models);
+            assert_eq!(error, "reject all");
+        }
+        other => panic!("expected Failed, got {:?}", other),
+    }
+}
+
+/// Test: parse failure emits a Failed event.
+#[test]
+fn test_reload_section_parse_failure_emits_failed_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_changes();
+
+    let bad_file = tmp.path().join("bad.json");
+    fs::write(&bad_file, "not json").unwrap();
+    let _ = manager.reload_section(ConfigSection::Gateway, &bad_file, None);
+
+    let event = rx.try_recv().expect("should receive a Failed event");
+    match event {
+        ConfigChangeEvent::Failed { section, error } => {
+            assert_eq!(section, ConfigSection::Gateway);
+            assert!(error.contains("expected"), "error: {}", error);
+        }
+        other => panic!("expected Failed, got {:?}", other),
+    }
+}
+
+/// Test: no event is emitted if the file does not exist (early IoError return).
+#[test]
+fn test_reload_section_file_not_found_no_event() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_changes();
+
+    let missing = tmp.path().join("does_not_exist.json");
+    let result = manager.reload_section(ConfigSection::System, &missing, None);
+    assert!(result.is_err());
+
+    // IoError path returns before any event is emitted
+    assert!(rx.try_recv().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// reload_agents (existing)
+// ---------------------------------------------------------------------------
+
 /// Test: reload_agents succeeds when agents/ directory has valid agent configs.
-///
-/// Note: `load_agents` resolves the user agents directory as
-/// `config_dir.join("agents")`, so the agent directory must
-/// be inside the config directory.
 #[test]
 fn test_reload_agents_success() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -29,12 +29,13 @@ fn test_reload_section_success() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let new_content = r#"{"version": "9.9", "updated": true}"#;
-    let new_file = tmp.path().join("new_system.json");
-    fs::write(&new_file, new_content).unwrap();
-    manager
-        .reload_section(ConfigSection::System, &new_file, None)
-        .unwrap();
+    // Overwrite the canonical file with new content
+    fs::write(
+        tmp.path().join("system.json"),
+        r#"{"version": "9.9", "updated": true}"#,
+    )
+    .unwrap();
+    manager.reload_section(ConfigSection::System, None).unwrap();
 
     let after = manager.section(ConfigSection::System).unwrap();
     assert_eq!(after["version"], "9.9");
@@ -53,9 +54,9 @@ fn test_reload_section_invalid_json() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let bad_file = tmp.path().join("bad.json");
-    fs::write(&bad_file, "not json").unwrap();
-    let result = manager.reload_section(ConfigSection::System, &bad_file, None);
+    // Corrupt the canonical file
+    fs::write(tmp.path().join("system.json"), "not json").unwrap();
+    let result = manager.reload_section(ConfigSection::System, None);
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -78,8 +79,7 @@ fn test_reload_section_validator_success() {
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
     manager.load().unwrap();
 
-    let new_file = tmp.path().join("new_system.json");
-    fs::write(&new_file, r#"{"version": "2.0"}"#).unwrap();
+    fs::write(tmp.path().join("system.json"), r#"{"version": "2.0"}"#).unwrap();
 
     let validator: &SectionValidator = &|v: &serde_json::Value| {
         if v.get("version").is_some() {
@@ -90,7 +90,7 @@ fn test_reload_section_validator_success() {
     };
 
     manager
-        .reload_section(ConfigSection::System, &new_file, Some(validator))
+        .reload_section(ConfigSection::System, Some(validator))
         .unwrap();
 
     let after = manager.section(ConfigSection::System).unwrap();
@@ -98,9 +98,9 @@ fn test_reload_section_validator_success() {
 }
 
 /// Test: reload_section with failing validator rejects the reload, keeps old
-/// value in memory, and rolls back the file.
+/// value in memory.
 #[test]
-fn test_reload_section_validator_failure_rollback() {
+fn test_reload_section_validator_failure_keeps_old_value() {
     let tmp = tempfile::tempdir().unwrap();
     setup_config_dir_at(tmp.path());
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
@@ -109,11 +109,12 @@ fn test_reload_section_validator_failure_rollback() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let system_path = tmp.path().join("system.json");
-    let original_content = fs::read_to_string(&system_path).unwrap();
-
-    let new_file = tmp.path().join("new_system.json");
-    fs::write(&new_file, r#"{"version": "2.0", "bad_field": true}"#).unwrap();
+    // Write content that will fail validation
+    fs::write(
+        tmp.path().join("system.json"),
+        r#"{"version": "2.0", "bad_field": true}"#,
+    )
+    .unwrap();
 
     let validator: &SectionValidator = &|v: &serde_json::Value| {
         if v.get("bad_field").is_some() {
@@ -123,7 +124,7 @@ fn test_reload_section_validator_failure_rollback() {
         }
     };
 
-    let result = manager.reload_section(ConfigSection::System, &new_file, Some(validator));
+    let result = manager.reload_section(ConfigSection::System, Some(validator));
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -134,36 +135,25 @@ fn test_reload_section_validator_failure_rollback() {
     let after = manager.section(ConfigSection::System).unwrap();
     assert_eq!(after["version"], "1.0");
     assert!(after.get("bad_field").is_none());
-
-    // File must be rolled back to original content
-    let file_after = fs::read_to_string(&system_path).unwrap();
-    assert_eq!(file_after, original_content);
 }
 
-/// Test: reload_section parse failure rolls back the file and keeps old value.
+/// Test: reload_section parse failure keeps old value.
 #[test]
-fn test_reload_section_parse_failure_rollback() {
+fn test_reload_section_parse_failure_keeps_old_value() {
     let tmp = tempfile::tempdir().unwrap();
     setup_config_dir_at(tmp.path());
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
     manager.load().unwrap();
 
-    let system_path = tmp.path().join("system.json");
-    let original_content = fs::read_to_string(&system_path).unwrap();
+    // Corrupt the canonical file
+    fs::write(tmp.path().join("system.json"), "not json").unwrap();
 
-    let bad_file = tmp.path().join("bad.json");
-    fs::write(&bad_file, "not json").unwrap();
-
-    let result = manager.reload_section(ConfigSection::System, &bad_file, None);
+    let result = manager.reload_section(ConfigSection::System, None);
     assert!(result.is_err());
 
     // In-memory unchanged
     let after = manager.section(ConfigSection::System).unwrap();
     assert_eq!(after["version"], "1.0");
-
-    // File rolled back to original
-    let file_after = fs::read_to_string(&system_path).unwrap();
-    assert_eq!(file_after, original_content);
 }
 
 // ---------------------------------------------------------------------------
@@ -180,11 +170,8 @@ fn test_reload_section_success_emits_reloaded_event() {
 
     let mut rx = manager.subscribe_config_changes();
 
-    let new_file = tmp.path().join("new_models.json");
-    fs::write(&new_file, r#"{"version": "3.0"}"#).unwrap();
-    manager
-        .reload_section(ConfigSection::Models, &new_file, None)
-        .unwrap();
+    fs::write(tmp.path().join("models.json"), r#"{"version": "3.0"}"#).unwrap();
+    manager.reload_section(ConfigSection::Models, None).unwrap();
 
     let event = rx.try_recv().expect("should receive a Reloaded event");
     match event {
@@ -205,11 +192,10 @@ fn test_reload_section_validation_failure_emits_failed_event() {
 
     let mut rx = manager.subscribe_config_changes();
 
-    let new_file = tmp.path().join("new_models.json");
-    fs::write(&new_file, r#"{"version": "3.0"}"#).unwrap();
+    fs::write(tmp.path().join("models.json"), r#"{"version": "3.0"}"#).unwrap();
 
     let validator: &SectionValidator = &|_: &serde_json::Value| Err("reject all".into());
-    let _ = manager.reload_section(ConfigSection::Models, &new_file, Some(validator));
+    let _ = manager.reload_section(ConfigSection::Models, Some(validator));
 
     let event = rx.try_recv().expect("should receive a Failed event");
     match event {
@@ -231,9 +217,8 @@ fn test_reload_section_parse_failure_emits_failed_event() {
 
     let mut rx = manager.subscribe_config_changes();
 
-    let bad_file = tmp.path().join("bad.json");
-    fs::write(&bad_file, "not json").unwrap();
-    let _ = manager.reload_section(ConfigSection::Gateway, &bad_file, None);
+    fs::write(tmp.path().join("gateway.json"), "not json").unwrap();
+    let _ = manager.reload_section(ConfigSection::Gateway, None);
 
     let event = rx.try_recv().expect("should receive a Failed event");
     match event {
@@ -249,14 +234,12 @@ fn test_reload_section_parse_failure_emits_failed_event() {
 #[test]
 fn test_reload_section_file_not_found_no_event() {
     let tmp = tempfile::tempdir().unwrap();
-    setup_config_dir_at(tmp.path());
+    // Don't create any config files
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
-    manager.load().unwrap();
 
     let mut rx = manager.subscribe_config_changes();
 
-    let missing = tmp.path().join("does_not_exist.json");
-    let result = manager.reload_section(ConfigSection::System, &missing, None);
+    let result = manager.reload_section(ConfigSection::System, None);
     assert!(result.is_err());
 
     // IoError path returns before any event is emitted

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -278,3 +278,109 @@ fn test_reload_agents_success() {
     assert!(agents.contains_key("alpha"));
     assert_eq!(agents["alpha"].id, "alpha");
 }
+
+/// Test: when reload_agents() fails, snapshot_agents + restore_agents
+/// preserves the original in-memory state.
+#[test]
+fn test_reload_agents_failure_rollback_via_snapshot_restore() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    setup_config_dir_at(&config_dir);
+
+    // Set up a valid agent: alpha
+    let agents_json = r#"{ "agents": ["alpha"] }"#;
+    let config_agents_dir = config_dir.join("config");
+    fs::create_dir_all(&config_agents_dir).unwrap();
+    fs::write(config_agents_dir.join("agents.json"), agents_json).unwrap();
+
+    let agent_dir = config_dir.join("agents").join("alpha");
+    fs::create_dir_all(&agent_dir).unwrap();
+    fs::write(
+        agent_dir.join("config.json"),
+        r#"{ "id": "alpha", "name": "Alpha" }"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(config_dir.clone()).unwrap();
+    manager.load_agents(None).unwrap();
+
+    // Verify alpha is loaded
+    assert!(manager.agents().contains_key("alpha"));
+
+    // Take a snapshot
+    let (old_agents, old_permissions) = manager.snapshot_agents();
+    assert_eq!(old_agents.len(), 1);
+    assert!(old_agents.contains_key("alpha"));
+
+    // Corrupt agents.json so reload_agents() fails
+    fs::write(config_agents_dir.join("agents.json"), "not json").unwrap();
+    let result = manager.reload_agents();
+    assert!(result.is_err());
+
+    // Restore from snapshot
+    manager.restore_agents(old_agents, old_permissions);
+
+    // Verify alpha is still present (rollback succeeded)
+    let agents = manager.agents();
+    assert!(agents.contains_key("alpha"));
+    assert_eq!(agents["alpha"].id, "alpha");
+}
+
+/// Test: restore_agents correctly replaces current state with snapshot.
+#[test]
+fn test_restore_agents_replaces_current_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    setup_config_dir_at(&config_dir);
+
+    let config_agents_dir = config_dir.join("config");
+    fs::create_dir_all(&config_agents_dir).unwrap();
+
+    // Set up agent alpha
+    fs::write(
+        config_agents_dir.join("agents.json"),
+        r#"{ "agents": ["alpha"] }"#,
+    )
+    .unwrap();
+    let alpha_dir = config_dir.join("agents").join("alpha");
+    fs::create_dir_all(&alpha_dir).unwrap();
+    fs::write(
+        alpha_dir.join("config.json"),
+        r#"{ "id": "alpha", "name": "Alpha" }"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(config_dir.clone()).unwrap();
+    manager.load_agents(None).unwrap();
+
+    // Snapshot the initial state (alpha only)
+    let snapshot = manager.snapshot_agents();
+
+    // Now add agent beta manually by writing files and reloading
+    fs::write(
+        config_agents_dir.join("agents.json"),
+        r#"{ "agents": ["alpha", "beta"] }"#,
+    )
+    .unwrap();
+    let beta_dir = config_dir.join("agents").join("beta");
+    fs::create_dir_all(&beta_dir).unwrap();
+    fs::write(
+        beta_dir.join("config.json"),
+        r#"{ "id": "beta", "name": "Beta" }"#,
+    )
+    .unwrap();
+    manager.reload_agents().unwrap();
+    assert!(manager.agents().contains_key("beta"));
+
+    // Restore the snapshot (should remove beta)
+    manager.restore_agents(snapshot.0, snapshot.1);
+
+    let agents = manager.agents();
+    assert!(agents.contains_key("alpha"));
+    assert!(
+        !agents.contains_key("beta"),
+        "beta should not exist after restore"
+    );
+}

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -25,7 +25,7 @@ fn test_reload_section_success() {
 
     let new_json = r#"{"version": "9.9", "updated": true}"#;
     manager
-        .reload_section(ConfigSection::System, new_json)
+        .reload_section(ConfigSection::System, new_json, None)
         .unwrap();
 
     let after = manager.section(ConfigSection::System).unwrap();
@@ -44,7 +44,7 @@ fn test_reload_section_invalid_json() {
     let before = manager.section(ConfigSection::System).unwrap();
     assert_eq!(before["version"], "1.0");
 
-    let result = manager.reload_section(ConfigSection::System, "not json");
+    let result = manager.reload_section(ConfigSection::System, "not json", None);
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -160,10 +160,18 @@ fn test_config_manager_load_corrupted_backup_also_corrupted() {
 
     // Corrupt the backup itself: find backup path and overwrite with bad JSON
     let models_path = tmp.path().join("models.json");
-    let backup_path = manager
-        .backup_manager
-        .find_latest_backup(&models_path)
-        .unwrap();
+    let backup_dir = tmp.path().join(".backups");
+    let backup_path = fs::read_dir(&backup_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.starts_with("models."))
+                .unwrap_or(false)
+        })
+        .expect("should find a models backup");
     fs::write(&backup_path, "also not valid json {{").unwrap();
 
     // Corrupt models.json

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ pub mod agent_loader;
 mod agent_loader_tests;
 pub mod agents;
 pub mod backup;
+pub mod events;
 pub mod manager;
 pub mod manager_reload;
 pub mod migration;
@@ -15,6 +16,7 @@ pub mod reload;
 pub mod session;
 
 // Public re-exports from manager
+pub use events::{ConfigChangeBroadcaster, ConfigChangeEvent};
 pub use manager::{
     ConfigInfo, ConfigLoadError, ConfigManager, ConfigSection, ConfigValidationError,
     ConfigWriteError, SafeBackupManager,

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -125,26 +125,16 @@ async fn handle_changed_path(
     }
 
     if let Some(section) = filename_to_section(filename) {
-        match tokio::fs::read_to_string(path).await {
-            Ok(content) => {
-                info!(
-                    path = %path.display(),
-                    section = %section,
-                    "config file changed, reloading section"
-                );
-                if let Err(e) = cm.reload_section(section, &content, None) {
-                    tracing::warn!(
-                        error = %e, section = %section,
-                        "failed to reload config section"
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e, path = %path.display(),
-                    "failed to read changed config file"
-                );
-            }
+        info!(
+            path = %path.display(),
+            section = %section,
+            "config file changed, reloading section"
+        );
+        if let Err(e) = cm.reload_section(section, path, None) {
+            tracing::warn!(
+                error = %e, section = %section,
+                "failed to reload config section"
+            );
         }
     }
 }

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -132,7 +132,7 @@ async fn handle_changed_path(
                     section = %section,
                     "config file changed, reloading section"
                 );
-                if let Err(e) = cm.reload_section(section, &content) {
+                if let Err(e) = cm.reload_section(section, &content, None) {
                     tracing::warn!(
                         error = %e, section = %section,
                         "failed to reload config section"

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -83,6 +83,10 @@ fn setup_watcher(
 }
 
 /// Reload all agent configs and sync the AgentRegistry.
+///
+/// Takes a snapshot before reloading; if `reload_agents()` fails,
+/// restores the previous in-memory state so the daemon keeps running
+/// with the last-known-good agent configuration.
 async fn reload_agents_with_log(
     path: &std::path::Path,
     cm: &ConfigManager,
@@ -92,8 +96,13 @@ async fn reload_agents_with_log(
         path = %path.display(),
         "agent config change detected, reloading agents"
     );
+
+    // Snapshot before reload so we can roll back on failure
+    let (old_agents, old_permissions) = cm.snapshot_agents();
+
     if let Err(e) = cm.reload_agents() {
-        tracing::warn!(error = %e, "failed to reload agent configs");
+        tracing::warn!(error = %e, "failed to reload agent configs, rolling back");
+        cm.restore_agents(old_agents, old_permissions);
         return;
     }
     // Sync the new configs into AgentRegistry (design-doc hot-reload path).
@@ -130,7 +139,7 @@ async fn handle_changed_path(
             section = %section,
             "config file changed, reloading section"
         );
-        if let Err(e) = cm.reload_section(section, path, None) {
+        if let Err(e) = cm.reload_section(section, None) {
             tracing::warn!(
                 error = %e, section = %section,
                 "failed to reload config section"


### PR DESCRIPTION
Refactor daemon hot-reload to align with design doc `docs/design/config/hot-reload.md`.

- Enhance `reload_section()`: parse → validate → update memory / fail-keep-old-value + emit ConfigChangeEvent
- Add ConfigChangeEvent type and tokio broadcast channel for config change notifications
- Unify daemon config reload through ConfigManager, remove direct JSON parsing in daemon
- Agent reload: add memory snapshot + rollback protection on failure
- Visibility cleanup: snapshot_agents/restore_agents pub → pub(crate)
- IoError path now emits ConfigChangeEvent::Failed for event consistency
- Comprehensive UT covering all reload paths, event channel, and agent rollback

Source: issue #42
Type: refactor
