### PR TITLE
refactor: call ConfigManager.load() at daemon startup

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,5 @@
+//! Cross-module shared types and utilities.
+//!
+//! Test helpers live in [`test_helpers`].
+
+pub mod test_helpers;

--- a/src/common/test_helpers.rs
+++ b/src/common/test_helpers.rs
@@ -1,0 +1,24 @@
+//! Shared test helpers for daemon and integration tests.
+
+use std::io;
+
+/// Write the 5 mandatory config files (models.json, channels.json,
+/// gateway.json, plugins.json, system.json) into `dir`.
+///
+/// Reused across daemon unit tests, E2E tests, and integration tests
+/// to avoid duplicating the same for-loop in every test helper.
+pub fn write_mandatory_configs(dir: &std::path::Path) -> io::Result<()> {
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(
+            dir.join(name),
+            serde_json::json!({"version": "1.0"}).to_string(),
+        )?;
+    }
+    Ok(())
+}

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -1,5 +1,6 @@
 //! Tests for ConfigManager hot-reload methods (reload_section / reload_agents).
 
+use crate::common::test_helpers::write_mandatory_configs;
 use crate::config::events::ConfigChangeEvent;
 use crate::config::manager::*;
 use crate::config::manager_reload::SectionValidator;
@@ -7,11 +8,7 @@ use std::fs;
 
 /// Helper: set up a valid config directory with all mandatory JSON files.
 fn setup_config_dir_at(dir: &std::path::Path) {
-    fs::write(dir.join("models.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("system.json"), r#"{"version": "1.0"}"#).unwrap();
+    write_mandatory_configs(dir).unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -435,15 +435,15 @@ fn test_load_populates_all_five_sections_with_values() {
 
     // After load: all 5 mandatory sections should be populated
     let models = manager.section(ConfigSection::Models).unwrap();
-    assert_eq!(models["version"], "1.0");
+    assert_eq!(models, serde_json::json!({"version": "1.0"}));
     let channels = manager.section(ConfigSection::Channels).unwrap();
-    assert_eq!(channels["version"], "1.0");
+    assert_eq!(channels, serde_json::json!({"version": "1.0"}));
     let gateway = manager.section(ConfigSection::Gateway).unwrap();
-    assert_eq!(gateway["version"], "1.0");
+    assert_eq!(gateway, serde_json::json!({"version": "1.0"}));
     let plugins = manager.section(ConfigSection::Plugins).unwrap();
-    assert_eq!(plugins["version"], "1.0");
+    assert_eq!(plugins, serde_json::json!({"version": "1.0"}));
     let system = manager.section(ConfigSection::System).unwrap();
-    assert_eq!(system["version"], "1.0");
+    assert_eq!(system, serde_json::json!({"version": "1.0"}));
 }
 
 /// Test: load() fails when one mandatory file is missing, returning

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for ConfigManager
 
 use super::*;
+use crate::common::test_helpers::write_mandatory_configs;
 use std::fs;
 
 // ---------------------------------------------------------------------------
@@ -274,11 +275,7 @@ fn setup_config_dir(tmp: &tempfile::TempDir) {
 }
 
 fn setup_config_dir_at(dir: &std::path::Path) {
-    fs::write(dir.join("models.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("channels.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("gateway.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("plugins.json"), r#"{"version": "1.0"}"#).unwrap();
-    fs::write(dir.join("system.json"), r#"{"version": "1.0"}"#).unwrap();
+    write_mandatory_configs(dir).unwrap();
 }
 
 #[test]

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -413,6 +413,76 @@ fn test_config_manager_update_backup_failure() {
 }
 
 // =====================================================================
+// Step 1.2 — ConfigManager.load() section-population tests
+// =====================================================================
+
+/// Test: load() populates memory cache with exact JSON values for all
+/// 5 mandatory sections.
+#[test]
+fn test_load_populates_all_five_sections_with_values() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+
+    // Before load: all sections should be None
+    assert!(manager.section(ConfigSection::Models).is_none());
+    assert!(manager.section(ConfigSection::Channels).is_none());
+    assert!(manager.section(ConfigSection::Gateway).is_none());
+    assert!(manager.section(ConfigSection::Plugins).is_none());
+    assert!(manager.section(ConfigSection::System).is_none());
+
+    manager.load().unwrap();
+
+    // After load: all 5 mandatory sections should be populated
+    let models = manager.section(ConfigSection::Models).unwrap();
+    assert_eq!(models["version"], "1.0");
+    let channels = manager.section(ConfigSection::Channels).unwrap();
+    assert_eq!(channels["version"], "1.0");
+    let gateway = manager.section(ConfigSection::Gateway).unwrap();
+    assert_eq!(gateway["version"], "1.0");
+    let plugins = manager.section(ConfigSection::Plugins).unwrap();
+    assert_eq!(plugins["version"], "1.0");
+    let system = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(system["version"], "1.0");
+}
+
+/// Test: load() fails when one mandatory file is missing, returning
+/// ConfigFileNotFound for the first missing section.
+#[test]
+fn test_load_fails_on_missing_mandatory_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Create only models.json, missing the other 4
+    fs::write(tmp.path().join("models.json"), r#"{"version": "1.0"}"#).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    let result = manager.load();
+    assert!(result.is_err(), "load() should fail when files are missing");
+    assert!(
+        matches!(result.unwrap_err(), ConfigLoadError::ConfigFileNotFound(_)),
+        "error should be ConfigFileNotFound"
+    );
+}
+
+/// Test: load() fails with ConfigDirNotFound when the config directory
+/// does not exist at the time of the call.
+#[test]
+fn test_load_fails_on_missing_config_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("vanishing_dir");
+    let manager = ConfigManager::new(target.clone()).unwrap();
+    // Remove the directory after construction to simulate it disappearing
+    fs::remove_dir_all(&target).ok();
+    let result = manager.load();
+    assert!(
+        result.is_err(),
+        "load() should fail when config dir is gone"
+    );
+    assert!(
+        matches!(result.unwrap_err(), ConfigLoadError::ConfigDirNotFound(_)),
+        "error should be ConfigDirNotFound"
+    );
+}
+
+// =====================================================================
 // Step 1.5 — agent_permissions default baseline tests
 // =====================================================================
 

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -220,11 +220,19 @@ fn test_config_manager_load_normal_unaffected() {
     manager.load().unwrap();
 
     // All mandatory sections should be loaded successfully
-    assert!(manager.section(ConfigSection::Models).is_some());
-    assert!(manager.section(ConfigSection::Channels).is_some());
-    assert!(manager.section(ConfigSection::Gateway).is_some());
-    assert!(manager.section(ConfigSection::Plugins).is_some());
-    assert!(manager.section(ConfigSection::System).is_some());
+    for section in &[
+        ConfigSection::Models,
+        ConfigSection::Channels,
+        ConfigSection::Gateway,
+        ConfigSection::Plugins,
+        ConfigSection::System,
+    ] {
+        assert!(
+            manager.section(*section).is_some(),
+            "section {:?} missing",
+            section
+        );
+    }
 }
 
 /// Test: credentials directory does not exist → load still succeeds.
@@ -286,11 +294,19 @@ fn test_config_manager_load() {
     setup_config_dir(&tmp);
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
     manager.load().unwrap();
-    assert!(manager.section(ConfigSection::Models).is_some());
-    assert!(manager.section(ConfigSection::Channels).is_some());
-    assert!(manager.section(ConfigSection::Gateway).is_some());
-    assert!(manager.section(ConfigSection::Plugins).is_some());
-    assert!(manager.section(ConfigSection::System).is_some());
+    for section in &[
+        ConfigSection::Models,
+        ConfigSection::Channels,
+        ConfigSection::Gateway,
+        ConfigSection::Plugins,
+        ConfigSection::System,
+    ] {
+        assert!(
+            manager.section(*section).is_some(),
+            "section {:?} missing",
+            section
+        );
+    }
 }
 
 #[test]
@@ -424,26 +440,32 @@ fn test_load_populates_all_five_sections_with_values() {
     setup_config_dir_at(tmp.path());
     let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
 
+    let mandatory_sections = [
+        ConfigSection::Models,
+        ConfigSection::Channels,
+        ConfigSection::Gateway,
+        ConfigSection::Plugins,
+        ConfigSection::System,
+    ];
+
     // Before load: all sections should be None
-    assert!(manager.section(ConfigSection::Models).is_none());
-    assert!(manager.section(ConfigSection::Channels).is_none());
-    assert!(manager.section(ConfigSection::Gateway).is_none());
-    assert!(manager.section(ConfigSection::Plugins).is_none());
-    assert!(manager.section(ConfigSection::System).is_none());
+    for section in &mandatory_sections {
+        assert!(
+            manager.section(*section).is_none(),
+            "section {:?} should be None before load",
+            section
+        );
+    }
 
     manager.load().unwrap();
 
-    // After load: all 5 mandatory sections should be populated
-    let models = manager.section(ConfigSection::Models).unwrap();
-    assert_eq!(models, serde_json::json!({"version": "1.0"}));
-    let channels = manager.section(ConfigSection::Channels).unwrap();
-    assert_eq!(channels, serde_json::json!({"version": "1.0"}));
-    let gateway = manager.section(ConfigSection::Gateway).unwrap();
-    assert_eq!(gateway, serde_json::json!({"version": "1.0"}));
-    let plugins = manager.section(ConfigSection::Plugins).unwrap();
-    assert_eq!(plugins, serde_json::json!({"version": "1.0"}));
-    let system = manager.section(ConfigSection::System).unwrap();
-    assert_eq!(system, serde_json::json!({"version": "1.0"}));
+    // After load: all 5 mandatory sections should be populated with
+    // the exact JSON value written by setup_config_dir_at.
+    let expected = serde_json::json!({"version": "1.0"});
+    for section in &mandatory_sections {
+        let value = manager.section(*section).unwrap();
+        assert_eq!(value, expected, "section {:?} mismatch", section);
+    }
 }
 
 /// Test: load() fails when one mandatory file is missing, returning

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -261,6 +261,11 @@ impl Daemon {
             ConfigManager::new(PathBuf::from(config_dir))
                 .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
         );
+        // Load mandatory config sections (Models, Channels, Gateway, Plugins, System).
+        // Design doc: "ConfigManager — 所有配置加载成功后注册热重载监听器"
+        config_manager
+            .load()
+            .map_err(|e| anyhow::anyhow!("failed to load mandatory config sections: {}", e))?;
         {
             let disk_reg_opt = {
                 let guard = skill_registry.read().unwrap();

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -4,10 +4,9 @@ use crate::common::test_helpers::write_mandatory_configs;
 use crate::daemon::Daemon;
 use crate::session::persistence::PersistenceService;
 
-/// Create a minimal agents.json and all 5 mandatory config files
-/// (models.json, channels.json, gateway.json, plugins.json, system.json)
-/// in the given directory so that `ConfigManager::load()` succeeds.
-fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
+/// Create only `config/agents.json` (without mandatory config files)
+/// in the given directory.
+fn write_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     let agents_content = serde_json::json!({
         "version": "1.0",
         "agents": [
@@ -23,6 +22,14 @@ fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     let config_dir = dir.join("config");
     std::fs::create_dir_all(&config_dir)?;
     std::fs::write(config_dir.join("agents.json"), agents_content.to_string())?;
+    Ok(())
+}
+
+/// Create a minimal agents.json and all 5 mandatory config files
+/// (models.json, channels.json, gateway.json, plugins.json, system.json)
+/// in the given directory so that `ConfigManager::load()` succeeds.
+fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
+    write_agents_json(dir)?;
     write_mandatory_configs(dir)?;
     Ok(())
 }
@@ -39,19 +46,7 @@ fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
 async fn test_daemon_start_fails_without_mandatory_config() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     // Create only agents.json — mandatory sections (models.json etc.) are absent
-    let agents_content = serde_json::json!({
-        "version": "1.0",
-        "agents": [{
-            "name": "guide",
-            "model": "minimax/MiniMax-M2",
-            "persona": "test persona",
-            "max_iterations": 10,
-            "timeout_minutes": 5
-        }]
-    });
-    let config_dir = temp_dir.path().join("config");
-    std::fs::create_dir_all(&config_dir).unwrap();
-    std::fs::write(config_dir.join("agents.json"), agents_content.to_string()).unwrap();
+    write_agents_json(temp_dir.path()).unwrap();
 
     let result = Daemon::start(temp_dir.path().to_str().unwrap()).await;
     assert!(

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -22,16 +22,22 @@ fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     let config_dir = dir.join("config");
     std::fs::create_dir_all(&config_dir)?;
     std::fs::write(config_dir.join("agents.json"), agents_content.to_string())?;
+    write_mandatory_configs(dir)?;
+    Ok(())
+}
 
-    // Create mandatory config files required by ConfigManager::load()
-    let mandatory = [
+/// Write the 5 mandatory config files (models.json, channels.json,
+/// gateway.json, plugins.json, system.json) into `dir`.
+/// Reused across daemon unit tests and integration tests to avoid
+/// duplicating the same for-loop in every test helper.
+fn write_mandatory_configs(dir: &std::path::Path) -> std::io::Result<()> {
+    for name in &[
         "models.json",
         "channels.json",
         "gateway.json",
         "plugins.json",
         "system.json",
-    ];
-    for name in &mandatory {
+    ] {
         std::fs::write(
             dir.join(name),
             serde_json::json!({"version": "1.0"}).to_string(),
@@ -76,8 +82,8 @@ async fn test_daemon_start_fails_without_mandatory_config() {
         _ => unreachable!(),
     };
     assert!(
-        err_msg.contains("mandatory config sections"),
-        "error should mention mandatory config sections: {err_msg}"
+        err_msg.contains("config"),
+        "error should mention config: {err_msg}"
     );
 }
 
@@ -95,8 +101,8 @@ async fn test_daemon_start_fails_with_empty_config_dir() {
         _ => unreachable!(),
     };
     assert!(
-        err_msg.contains("mandatory config sections"),
-        "error should mention mandatory config sections: {err_msg}"
+        err_msg.contains("config"),
+        "error should mention config: {err_msg}"
     );
 }
 

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1,5 +1,6 @@
 //! Daemon unit tests.
 
+use crate::common::test_helpers::write_mandatory_configs;
 use crate::daemon::Daemon;
 use crate::session::persistence::PersistenceService;
 
@@ -23,26 +24,6 @@ fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     std::fs::create_dir_all(&config_dir)?;
     std::fs::write(config_dir.join("agents.json"), agents_content.to_string())?;
     write_mandatory_configs(dir)?;
-    Ok(())
-}
-
-/// Write the 5 mandatory config files (models.json, channels.json,
-/// gateway.json, plugins.json, system.json) into `dir`.
-/// Reused across daemon unit tests and integration tests to avoid
-/// duplicating the same for-loop in every test helper.
-fn write_mandatory_configs(dir: &std::path::Path) -> std::io::Result<()> {
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(
-            dir.join(name),
-            serde_json::json!({"version": "1.0"}).to_string(),
-        )?;
-    }
     Ok(())
 }
 
@@ -82,8 +63,8 @@ async fn test_daemon_start_fails_without_mandatory_config() {
         _ => unreachable!(),
     };
     assert!(
-        err_msg.contains("config"),
-        "error should mention config: {err_msg}"
+        err_msg.contains("mandatory"),
+        "error should mention mandatory: {err_msg}"
     );
 }
 
@@ -101,8 +82,8 @@ async fn test_daemon_start_fails_with_empty_config_dir() {
         _ => unreachable!(),
     };
     assert!(
-        err_msg.contains("config"),
-        "error should mention config: {err_msg}"
+        err_msg.contains("mandatory"),
+        "error should mention mandatory: {err_msg}"
     );
 }
 

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -3,7 +3,9 @@
 use crate::daemon::Daemon;
 use crate::session::persistence::PersistenceService;
 
-/// Create a minimal agents.json in the given directory.
+/// Create a minimal agents.json and all 5 mandatory config files
+/// (models.json, channels.json, gateway.json, plugins.json, system.json)
+/// in the given directory so that `ConfigManager::load()` succeeds.
 fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     let agents_content = serde_json::json!({
         "version": "1.0",
@@ -20,7 +22,100 @@ fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     let config_dir = dir.join("config");
     std::fs::create_dir_all(&config_dir)?;
     std::fs::write(config_dir.join("agents.json"), agents_content.to_string())?;
+
+    // Create mandatory config files required by ConfigManager::load()
+    let mandatory = [
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ];
+    for name in &mandatory {
+        std::fs::write(
+            dir.join(name),
+            serde_json::json!({"version": "1.0"}).to_string(),
+        )?;
+    }
     Ok(())
+}
+
+// =====================================================================
+// Step 1.2 — daemon startup integration: load() gating tests
+// =====================================================================
+
+/// Test: daemon fails to start when mandatory config files are missing.
+/// Step 1.1 added `config_manager.load()` before hot-reload registration;
+/// a missing mandatory file (e.g. models.json) must cause daemon startup to
+/// fail with an error mentioning "mandatory config sections".
+#[tokio::test]
+async fn test_daemon_start_fails_without_mandatory_config() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    // Create only agents.json — mandatory sections (models.json etc.) are absent
+    let agents_content = serde_json::json!({
+        "version": "1.0",
+        "agents": [{
+            "name": "guide",
+            "model": "minimax/MiniMax-M2",
+            "persona": "test persona",
+            "max_iterations": 10,
+            "timeout_minutes": 5
+        }]
+    });
+    let config_dir = temp_dir.path().join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("agents.json"), agents_content.to_string()).unwrap();
+
+    let result = Daemon::start(temp_dir.path().to_str().unwrap()).await;
+    assert!(
+        result.is_err(),
+        "daemon should fail when mandatory config files are missing"
+    );
+    let err_msg = match result {
+        Err(e) => e.to_string(),
+        _ => unreachable!(),
+    };
+    assert!(
+        err_msg.contains("mandatory config sections"),
+        "error should mention mandatory config sections: {err_msg}"
+    );
+}
+
+/// Test: daemon fails to start when config directory has no config files
+/// at all (empty directory).
+#[tokio::test]
+async fn test_daemon_start_fails_with_empty_config_dir() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    // Empty directory — no config files, no agents.json
+
+    let result = Daemon::start(temp_dir.path().to_str().unwrap()).await;
+    assert!(result.is_err(), "daemon should fail with empty config dir");
+    let err_msg = match result {
+        Err(e) => e.to_string(),
+        _ => unreachable!(),
+    };
+    assert!(
+        err_msg.contains("mandatory config sections"),
+        "error should mention mandatory config sections: {err_msg}"
+    );
+}
+
+/// Test: daemon starts successfully when all mandatory config files exist.
+/// This verifies the happy path: load() populates sections, then hot-reload
+/// is registered (gate passes).
+#[tokio::test]
+async fn test_daemon_start_succeeds_with_all_mandatory_configs() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    setup_agents_json(temp_dir.path()).expect("setup agents.json");
+
+    let result = Daemon::start(temp_dir.path().to_str().unwrap()).await;
+    assert!(
+        result.is_ok(),
+        "daemon should start with all mandatory configs: {:?}",
+        result.err()
+    );
+    drop(result);
+    drop(temp_dir);
 }
 
 #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod system_prompt;
 pub mod tasks;
 pub mod tools;
 
+pub mod common;
+
 use tracing::info;
 
 /// Initialize the CloseClaw library

--- a/tests/e2e_daemon_shutdown_tests.rs
+++ b/tests/e2e_daemon_shutdown_tests.rs
@@ -5,6 +5,25 @@
 use closeclaw::daemon::shutdown::ShutdownHandle;
 use std::time::Duration;
 
+/// Write the 5 mandatory config files (models.json, channels.json,
+/// gateway.json, plugins.json, system.json) into `dir`.
+/// Uses `serde_json::json!` for consistent formatting with daemon tests.
+fn write_mandatory_configs(dir: &std::path::Path) {
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(
+            dir.join(name),
+            serde_json::json!({"version": "1.0"}).to_string(),
+        )
+        .expect("write mandatory config");
+    }
+}
+
 /// Test 1: drain waits until busy_count reaches zero before exiting.
 #[tokio::test]
 async fn test_drain_waits_until_busy_count_zero() {
@@ -104,17 +123,7 @@ async fn test_daemon_run_sigterm_shutdown() {
     let agents_path = config_dir.join("agents.json");
     std::fs::write(&agents_path, r#"{"version":"1.0.0","agents":[]}"#).expect("write agents.json");
 
-    // Create mandatory config files required by ConfigManager::load()
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(temp_dir.path().join(name), r#"{"version":"1.0"}"#)
-            .expect("write mandatory config");
-    }
+    write_mandatory_configs(temp_dir.path());
 
     // Do NOT set FEISHU/LLM env vars — Daemon::start will skip those components
     let daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())

--- a/tests/e2e_daemon_shutdown_tests.rs
+++ b/tests/e2e_daemon_shutdown_tests.rs
@@ -97,12 +97,24 @@ async fn test_drain_signal_broadcast() {
 /// Test 4: Daemon::run() triggers graceful shutdown when receiving SIGTERM.
 #[tokio::test]
 async fn test_daemon_run_sigterm_shutdown() {
-    // Create temp dir with minimal agents.json
+    // Create temp dir with minimal agents.json and mandatory config files
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let config_dir = temp_dir.path().join("config");
     std::fs::create_dir_all(&config_dir).expect("create config dir");
     let agents_path = config_dir.join("agents.json");
     std::fs::write(&agents_path, r#"{"version":"1.0.0","agents":[]}"#).expect("write agents.json");
+
+    // Create mandatory config files required by ConfigManager::load()
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(temp_dir.path().join(name), r#"{"version":"1.0"}"#)
+            .expect("write mandatory config");
+    }
 
     // Do NOT set FEISHU/LLM env vars — Daemon::start will skip those components
     let daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())

--- a/tests/e2e_daemon_shutdown_tests.rs
+++ b/tests/e2e_daemon_shutdown_tests.rs
@@ -2,27 +2,9 @@
 //!
 //! Covers ShutdownHandle drain state machine scenarios.
 
+use closeclaw::common::test_helpers::write_mandatory_configs;
 use closeclaw::daemon::shutdown::ShutdownHandle;
 use std::time::Duration;
-
-/// Write the 5 mandatory config files (models.json, channels.json,
-/// gateway.json, plugins.json, system.json) into `dir`.
-/// Uses `serde_json::json!` for consistent formatting with daemon tests.
-fn write_mandatory_configs(dir: &std::path::Path) {
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(
-            dir.join(name),
-            serde_json::json!({"version": "1.0"}).to_string(),
-        )
-        .expect("write mandatory config");
-    }
-}
 
 /// Test 1: drain waits until busy_count reaches zero before exiting.
 #[tokio::test]
@@ -123,7 +105,7 @@ async fn test_daemon_run_sigterm_shutdown() {
     let agents_path = config_dir.join("agents.json");
     std::fs::write(&agents_path, r#"{"version":"1.0.0","agents":[]}"#).expect("write agents.json");
 
-    write_mandatory_configs(temp_dir.path());
+    write_mandatory_configs(temp_dir.path()).expect("write mandatory config");
 
     // Do NOT set FEISHU/LLM env vars — Daemon::start will skip those components
     let daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())

--- a/tests/sigterm_integration_test.rs
+++ b/tests/sigterm_integration_test.rs
@@ -36,6 +36,18 @@ async fn test_sigterm_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
+    // Create mandatory config files required by ConfigManager::load()
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(config_dir.join(name), r#"{"version":"1.0"}"#)
+            .expect("write mandatory config");
+    }
+
     // Start the daemon
     let mut daemon = Command::new(&daemon_bin)
         .args(["run", "--config-dir"])
@@ -106,6 +118,18 @@ async fn test_sigint_triggers_graceful_shutdown() {
         r#"{"version":"1.0.0","agents":[]}"#,
     )
     .expect("failed to write test agents.json");
+
+    // Create mandatory config files required by ConfigManager::load()
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(config_dir.join(name), r#"{"version":"1.0"}"#)
+            .expect("write mandatory config");
+    }
 
     let mut daemon = Command::new(&daemon_bin)
         .args(["run", "--config-dir"])

--- a/tests/sigterm_integration_test.rs
+++ b/tests/sigterm_integration_test.rs
@@ -8,6 +8,25 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
 
+/// Write the 5 mandatory config files (models.json, channels.json,
+/// gateway.json, plugins.json, system.json) into `dir`.
+/// Uses `serde_json::json!` for consistent formatting with daemon tests.
+fn write_mandatory_configs(dir: &std::path::Path) {
+    for name in &[
+        "models.json",
+        "channels.json",
+        "gateway.json",
+        "plugins.json",
+        "system.json",
+    ] {
+        std::fs::write(
+            dir.join(name),
+            serde_json::json!({"version": "1.0"}).to_string(),
+        )
+        .expect("write mandatory config");
+    }
+}
+
 /// Returns the path to the `closeclaw` daemon binary (not the test binary).
 fn closeclaw_binary() -> std::path::PathBuf {
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -36,17 +55,7 @@ async fn test_sigterm_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    // Create mandatory config files required by ConfigManager::load()
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(config_dir.join(name), r#"{"version":"1.0"}"#)
-            .expect("write mandatory config");
-    }
+    write_mandatory_configs(config_dir);
 
     // Start the daemon
     let mut daemon = Command::new(&daemon_bin)
@@ -119,17 +128,7 @@ async fn test_sigint_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    // Create mandatory config files required by ConfigManager::load()
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(config_dir.join(name), r#"{"version":"1.0"}"#)
-            .expect("write mandatory config");
-    }
+    write_mandatory_configs(config_dir);
 
     let mut daemon = Command::new(&daemon_bin)
         .args(["run", "--config-dir"])

--- a/tests/sigterm_integration_test.rs
+++ b/tests/sigterm_integration_test.rs
@@ -3,29 +3,11 @@
 //! Verifies that `closeclaw stop` (SIGTERM) triggers graceful shutdown
 //! instead of hard-killing the daemon.
 
+use closeclaw::common::test_helpers::write_mandatory_configs;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
-
-/// Write the 5 mandatory config files (models.json, channels.json,
-/// gateway.json, plugins.json, system.json) into `dir`.
-/// Uses `serde_json::json!` for consistent formatting with daemon tests.
-fn write_mandatory_configs(dir: &std::path::Path) {
-    for name in &[
-        "models.json",
-        "channels.json",
-        "gateway.json",
-        "plugins.json",
-        "system.json",
-    ] {
-        std::fs::write(
-            dir.join(name),
-            serde_json::json!({"version": "1.0"}).to_string(),
-        )
-        .expect("write mandatory config");
-    }
-}
 
 /// Returns the path to the `closeclaw` daemon binary (not the test binary).
 fn closeclaw_binary() -> std::path::PathBuf {
@@ -55,7 +37,7 @@ async fn test_sigterm_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    write_mandatory_configs(config_dir);
+    write_mandatory_configs(config_dir).expect("write mandatory config");
 
     // Start the daemon
     let mut daemon = Command::new(&daemon_bin)
@@ -128,7 +110,7 @@ async fn test_sigint_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    write_mandatory_configs(config_dir);
+    write_mandatory_configs(config_dir).expect("write mandatory config");
 
     let mut daemon = Command::new(&daemon_bin)
         .args(["run", "--config-dir"])


### PR DESCRIPTION
## Hot-Reload 架构对齐 Design Doc — 子任务 1：启动加载 + 门控

### 问题
F2b 深度对比发现 hot-reload 实现与 design doc 不一致，涉及多个 gap：
- **Gap #4**：`ConfigManager.load()` 未在 daemon 启动时调用，5 个强制 section（Models、Channels、Gateway、Plugins、System）未加载到内存缓存
- **Gap #6**：缺少"所有配置加载成功后注册热重载监听器"的显式门控

### 改动
1. 在 daemon 启动流程中，`load_agents()` 之前添加 `config_manager.load()` 调用
2. `load()` 失败视为致命错误，daemon 不启动（门控机制）
3. 保持现有 `load_agents()` 调用不变
4. 为改动编写单元测试，验证 5 个 section 正确加载及失败场景
5. 抽取共享测试工具函数 `write_mandatory_configs`，消除跨文件重复代码

### 改动范围
- `src/daemon/mod.rs`：启动流程添加 `load()` 调用
- `src/common/test_helpers.rs`：新增共享测试辅助函数
- `src/daemon/tests.rs`：单元测试
- `src/config/manager_tests.rs`：配置管理器测试
- `tests/e2e_daemon_shutdown_tests.rs`：E2E 测试
- `tests/sigterm_integration_test.rs`：集成测试

### 验证
- `cargo fmt && cargo clippy --all -- -D warnings && cargo test` 通过

Source: design-doc
Type: refactor
