### PR TITLE
fix: config module paths aligned with design doc

### DIFF
--- a/src/admin/server.rs
+++ b/src/admin/server.rs
@@ -204,7 +204,7 @@ async fn create_agent_dir_and_config(
 
 /// Append the new agent name to agents.json.
 async fn update_agents_json(name: &str, context: &AdminContext) -> Result<(), AdminResponse> {
-    let agents_json_path = context.config_dir.join("config").join("agents.json");
+    let agents_json_path = context.config_manager.config_dir.join("agents.json");
 
     // Load existing agents.json (blocking I/O)
     let mut agent_ids = {
@@ -396,12 +396,12 @@ mod tests {
 
     fn make_test_context() -> AdminContext {
         let config_dir = tempfile::tempdir().unwrap().keep();
-        // Create config/agents.json so ConfigManager can load
         let config_sub = config_dir.join("config");
         std::fs::create_dir_all(&config_sub).unwrap();
+        // agents.json lives in the config subdirectory
+        // (ConfigManager.config_dir = config_sub)
         std::fs::write(config_sub.join("agents.json"), r#"{"agents": []}"#).unwrap();
-        let config_manager =
-            Arc::new(crate::config::ConfigManager::new(config_dir.clone()).unwrap());
+        let config_manager = Arc::new(crate::config::ConfigManager::new(config_sub).unwrap());
         AdminContext {
             agent_registry: Arc::new(AgentRegistry::new()),
             skill_registry: Arc::new(std::sync::RwLock::new(Some(DiskSkillRegistry::default()))),

--- a/src/cli/admin/run.rs
+++ b/src/cli/admin/run.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 /// resolution and PID writing without starting a real daemon.
 pub fn prepare_run(config_dir: &str) -> Result<(PathBuf, u32, PathBuf)> {
     let config_dir: PathBuf = if config_dir.is_empty() {
-        crate::platform::config::config_dir()?
+        crate::platform::config::root_dir()?
     } else {
         PathBuf::from(config_dir)
     };

--- a/src/cli/admin/stop.rs
+++ b/src/cli/admin/stop.rs
@@ -4,7 +4,7 @@ use super::common::{json_output, StopOutput};
 use anyhow::Result;
 
 pub async fn handle_stop(force: bool, json: bool) -> Result<()> {
-    let config_dir = crate::platform::config::config_dir()?;
+    let config_dir = crate::platform::config::root_dir()?;
     let p = crate::platform::process::pid_file_path(&config_dir);
     let pid = crate::platform::process::read_pid_file(&p)
         .ok_or_else(|| anyhow::anyhow!("PID file not found at {}.", p.display()))?;

--- a/src/config/agent_loader.rs
+++ b/src/config/agent_loader.rs
@@ -111,7 +111,7 @@ impl ConfigManager {
             *self.repo_root.write().expect("RwLock poisoned") = repo_root.map(Path::to_path_buf);
         }
 
-        let agents_json_path = self.config_dir.join("config").join("agents.json");
+        let agents_json_path = self.config_dir.join("agents.json");
         let user_ids = self.load_agents_json(&agents_json_path)?;
 
         let project_ids = if let Some(repo) = repo_root {
@@ -126,7 +126,11 @@ impl ConfigManager {
             return Ok(());
         }
 
-        let user_agents_dir = self.config_dir.join("agents");
+        let user_agents_dir = self
+            .config_dir
+            .parent()
+            .unwrap_or(&self.config_dir)
+            .join("agents");
         let project_agents_dir = repo_root.map(|r| r.join(".closeclaw").join("agents"));
 
         let provider =

--- a/src/config/agent_loader_tests.rs
+++ b/src/config/agent_loader_tests.rs
@@ -25,7 +25,7 @@ use crate::config::ConfigManager;
 /// Write an agents.json file with the given IDs.
 ///
 /// `dir` is the directory to write agents.json into (should be the
-/// config directory, i.e. `~/.closeclaw/config/`).
+/// config directory, i.e. `~/.closeclaw/`).
 fn write_agents_json(dir: &Path, ids: &[&str]) {
     let content = serde_json::json!({ "agents": ids });
     let json_str = serde_json::to_string_pretty(&content).unwrap();
@@ -50,7 +50,7 @@ fn create_agent_config(agents_dir: &Path, id: &str) {
 }
 
 /// Build a `ConfigManager` with `config_dir = <base>/config/`.
-/// The agents directory is `<base>/config/agents/`.
+/// The agents directory is `<base>/agents/` (root level).
 fn make_config_manager(base: &Path) -> ConfigManager {
     let config_dir = base.join("config");
     fs::create_dir_all(&config_dir).unwrap();
@@ -115,10 +115,10 @@ fn test_load_agents_json_valid() {
     let tmp = tempfile::tempdir().unwrap();
     let config_dir = tmp.path().join("config");
     fs::create_dir_all(&config_dir).unwrap();
-    write_agents_json(&config_dir.join("config"), &["orchestrator", "coder"]);
+    write_agents_json(&config_dir, &["orchestrator", "coder"]);
     let cm = make_config_manager(tmp.path());
     let ids = cm
-        .load_agents_json(&config_dir.join("config").join("agents.json"))
+        .load_agents_json(&config_dir.join("agents.json"))
         .unwrap();
     assert_eq!(ids, vec!["orchestrator", "coder"]);
 }
@@ -138,12 +138,11 @@ fn test_load_agents_json_with_comments() {
     "c"
   ]
 }"#;
-    let agents_dir = config_dir.join("config");
-    fs::create_dir_all(&agents_dir).unwrap();
-    fs::write(agents_dir.join("agents.json"), json).unwrap();
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("agents.json"), json).unwrap();
     let cm = make_config_manager(tmp.path());
     let ids = cm
-        .load_agents_json(&config_dir.join("config").join("agents.json"))
+        .load_agents_json(&config_dir.join("agents.json"))
         .unwrap();
     assert_eq!(ids, vec!["a", "c"]);
 }
@@ -159,11 +158,12 @@ fn test_load_agents_merges_user_and_project() {
     let tmp = tempfile::tempdir().unwrap();
     let cm = make_config_manager(tmp.path());
 
-    // agents.json goes into config_dir, agents go into config_dir/agents
+    // agents.json goes into config_dir, agents go into root/agents
     let config_dir = tmp.path().join("config");
-    let agents_dir = config_dir.join("agents");
+    let root_dir = tmp.path();
+    let agents_dir = root_dir.join("agents");
 
-    write_agents_json(&config_dir.join("config"), &["agent-1", "agent-2"]);
+    write_agents_json(&config_dir, &["agent-1", "agent-2"]);
     create_agent_config(&agents_dir, "agent-1");
     create_agent_config(&agents_dir, "agent-2");
 
@@ -200,9 +200,10 @@ fn test_load_agents_no_project_root() {
     let tmp = tempfile::tempdir().unwrap();
     let cm = make_config_manager(tmp.path());
     let config_dir = tmp.path().join("config");
-    let agents_dir = config_dir.join("agents");
+    let root_dir = tmp.path();
+    let agents_dir = root_dir.join("agents");
 
-    write_agents_json(&config_dir.join("config"), &["user-agent"]);
+    write_agents_json(&config_dir, &["user-agent"]);
     create_agent_config(&agents_dir, "user-agent");
 
     cm.load_agents(None).expect("load_agents should succeed");
@@ -219,9 +220,10 @@ fn test_load_agents_project_json_missing() {
     let tmp = tempfile::tempdir().unwrap();
     let cm = make_config_manager(tmp.path());
     let config_dir = tmp.path().join("config");
-    let agents_dir = config_dir.join("agents");
+    let root_dir = tmp.path();
+    let agents_dir = root_dir.join("agents");
 
-    write_agents_json(&config_dir.join("config"), &["only-user"]);
+    write_agents_json(&config_dir, &["only-user"]);
     create_agent_config(&agents_dir, "only-user");
 
     let repo_dir = tempfile::tempdir().unwrap();
@@ -240,16 +242,17 @@ fn test_reload_agents_reloads() {
     let tmp = tempfile::tempdir().unwrap();
     let cm = make_config_manager(tmp.path());
     let config_dir = tmp.path().join("config");
-    let agents_dir = config_dir.join("agents");
+    let root_dir = tmp.path();
+    let agents_dir = root_dir.join("agents");
 
-    write_agents_json(&config_dir.join("config"), &["a"]);
+    write_agents_json(&config_dir, &["a"]);
     create_agent_config(&agents_dir, "a");
 
     cm.load_agents(None).unwrap();
     assert!(cm.agents().contains_key("a"));
 
     // Add a new agent
-    write_agents_json(&config_dir.join("config"), &["a", "b"]);
+    write_agents_json(&config_dir, &["a", "b"]);
     create_agent_config(&agents_dir, "b");
     cm.reload_agents().unwrap();
 

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -162,7 +162,7 @@ impl ConfigSection {
             ConfigSection::Plugins => "plugins.json",
             ConfigSection::System => "system.json",
             ConfigSection::Session => "session.json",
-            ConfigSection::Credentials => "credentials.json",
+            ConfigSection::Credentials => "credentials/",
         }
     }
 
@@ -523,7 +523,6 @@ impl ConfigManager {
             ConfigSection::Plugins,
             ConfigSection::System,
             ConfigSection::Session,
-            ConfigSection::Credentials,
         ];
 
         let mut infos = Vec::new();

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -333,7 +333,7 @@ impl ConfigManager {
                         error = %e,
                         "failed to load session config, using defaults"
                     );
-                    Arc::new(JsonSessionConfigProvider::new("/dev/null").unwrap())
+                    Arc::new(JsonSessionConfigProvider::default())
                 }
             };
         *self.session_provider.write().expect("RwLock poisoned") = Some(session_provider);

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -8,13 +8,14 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use super::events::{ConfigChangeBroadcaster, ConfigChangeEvent};
 use super::providers::{ConfigProvider, CredentialsProvider};
+use super::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::agent::config::AgentPermissions;
 
 // ---------------------------------------------------------------------------
@@ -147,6 +148,7 @@ pub enum ConfigSection {
     Gateway,
     Plugins,
     System,
+    Session,
     Credentials,
 }
 
@@ -159,6 +161,7 @@ impl ConfigSection {
             ConfigSection::Gateway => "gateway.json",
             ConfigSection::Plugins => "plugins.json",
             ConfigSection::System => "system.json",
+            ConfigSection::Session => "session.json",
             ConfigSection::Credentials => "credentials.json",
         }
     }
@@ -215,6 +218,8 @@ pub struct ConfigManager {
     pub(crate) sections: RwLock<HashMap<ConfigSection, serde_json::Value>>,
     /// Loaded credentials provider (from config/credentials/ directory).
     credentials_provider: RwLock<CredentialsProvider>,
+    /// Loaded session config provider (from config/session.json).
+    pub(crate) session_provider: RwLock<Option<Arc<dyn SessionConfigProvider>>>,
     /// Resolved agent configurations (loaded from two-level directories).
     pub(crate) agents: RwLock<HashMap<String, super::agents::ResolvedAgentConfig>>,
     /// Per-agent raw permissions (loaded from permissions.json).
@@ -238,6 +243,7 @@ impl ConfigManager {
             backup_manager,
             sections: RwLock::new(HashMap::new()),
             credentials_provider: RwLock::new(CredentialsProvider::default()),
+            session_provider: RwLock::new(None),
             agents: RwLock::new(HashMap::new()),
             agent_permissions: RwLock::new(HashMap::new()),
             repo_root: RwLock::new(None),
@@ -263,7 +269,8 @@ impl ConfigManager {
             return Err(ConfigLoadError::ConfigDirNotFound(self.config_dir.clone()));
         }
 
-        // The 5 mandatory config files (Credentials is a directory, handled separately)
+        // The 5 mandatory config files (Credentials is a directory,
+        // Session is optional with defaults — both handled separately)
         let mandatory_sections = [
             ConfigSection::Models,
             ConfigSection::Channels,
@@ -301,6 +308,35 @@ impl ConfigManager {
 
             sections.insert(section, value);
         }
+
+        // Load session config (optional — absent file uses defaults).
+        let session_path = ConfigSection::Session.path(&self.config_dir);
+        let session_provider: Arc<dyn SessionConfigProvider> =
+            match JsonSessionConfigProvider::new(&session_path) {
+                Ok(provider) => {
+                    info!(
+                        path = %session_path.display(),
+                        "session config loaded from {}",
+                        session_path.display()
+                    );
+                    // Also store raw JSON in sections for hot-reload consistency.
+                    if let Ok(content) = fs::read_to_string(&session_path) {
+                        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
+                            sections.insert(ConfigSection::Session, value);
+                        }
+                    }
+                    Arc::new(provider)
+                }
+                Err(e) => {
+                    warn!(
+                        path = %session_path.display(),
+                        error = %e,
+                        "failed to load session config, using defaults"
+                    );
+                    Arc::new(JsonSessionConfigProvider::new("/dev/null").unwrap())
+                }
+            };
+        *self.session_provider.write().expect("RwLock poisoned") = Some(session_provider);
 
         // Load credentials from config/credentials/ directory.
         let creds_dir = self.config_dir.join(CredentialsProvider::config_path());
@@ -452,6 +488,16 @@ impl ConfigManager {
             .map(|guard| guard.clone())
     }
 
+    /// Get the loaded session config provider.
+    ///
+    /// Returns `None` if `load()` has not been called yet.
+    pub fn session_config_provider(&self) -> Option<Arc<dyn SessionConfigProvider>> {
+        self.session_provider
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
+    }
+
     /// Subscribe to config change events.
     ///
     /// Returns a receiver that will receive all future config change events.
@@ -476,6 +522,7 @@ impl ConfigManager {
             ConfigSection::Gateway,
             ConfigSection::Plugins,
             ConfigSection::System,
+            ConfigSection::Session,
             ConfigSection::Credentials,
         ];
 

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -8,8 +8,11 @@
 //! file is rolled back via `BackupManager` to keep the on-disk state
 //! consistent with the last known good version.
 
+use std::sync::Arc;
+
 use super::events::ConfigChangeEvent;
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
+use super::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use tracing::{info, warn};
 
 /// Validator callback type for config section reload.
@@ -109,6 +112,26 @@ impl ConfigManager {
         info!("reloaded config section: {}", section);
         self.notify_change(ConfigChangeEvent::Reloaded { section });
         Ok(())
+    }
+
+    /// Rebuild the session config provider from the current session.json content.
+    ///
+    /// Called after session.json is hot-reloaded to keep the typed provider
+    /// (used by ArchiveSweeper) in sync with the raw JSON in `sections`.
+    pub fn reload_session_provider(&self) {
+        let path = ConfigSection::Session.path(&self.config_dir);
+        let provider: Arc<dyn SessionConfigProvider> = match JsonSessionConfigProvider::new(&path) {
+            Ok(p) => Arc::new(p),
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to rebuild session provider, using defaults"
+                );
+                Arc::new(JsonSessionConfigProvider::new("/dev/null").unwrap())
+            }
+        };
+        *self.session_provider.write().expect("RwLock poisoned") = Some(provider);
     }
 }
 

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -128,7 +128,7 @@ impl ConfigManager {
                     error = %e,
                     "failed to rebuild session provider, using defaults"
                 );
-                Arc::new(JsonSessionConfigProvider::new("/dev/null").unwrap())
+                Arc::new(JsonSessionConfigProvider::default())
             }
         };
         *self.session_provider.write().expect("RwLock poisoned") = Some(provider);

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -289,11 +289,12 @@ fn test_reload_agents_success() {
     setup_config_dir_at(&config_dir);
 
     let agents_json = r#"{ "version": "1.0", "agents": ["alpha"] }"#;
-    let agents_dir = config_dir.join("config");
-    fs::create_dir_all(&agents_dir).unwrap();
-    fs::write(agents_dir.join("agents.json"), agents_json).unwrap();
+    // agents.json lives at config_dir root (e.g. ~/.closeclaw/agents.json)
+    fs::write(config_dir.join("agents.json"), agents_json).unwrap();
 
-    let agent_dir = config_dir.join("agents").join("alpha");
+    // agents/ is at root level (parent of config_dir)
+    let root_dir = config_dir.parent().unwrap();
+    let agent_dir = root_dir.join("agents").join("alpha");
     fs::create_dir_all(&agent_dir).unwrap();
     fs::write(
         agent_dir.join("config.json"),
@@ -320,11 +321,12 @@ fn test_reload_agents_failure_rollback_via_snapshot_restore() {
 
     // Set up a valid agent: alpha
     let agents_json = r#"{ "agents": ["alpha"] }"#;
-    let config_agents_dir = config_dir.join("config");
-    fs::create_dir_all(&config_agents_dir).unwrap();
-    fs::write(config_agents_dir.join("agents.json"), agents_json).unwrap();
+    // agents.json lives at config_dir root
+    fs::write(config_dir.join("agents.json"), agents_json).unwrap();
 
-    let agent_dir = config_dir.join("agents").join("alpha");
+    // agents/ is at root level (parent of config_dir)
+    let root_dir = config_dir.parent().unwrap();
+    let agent_dir = root_dir.join("agents").join("alpha");
     fs::create_dir_all(&agent_dir).unwrap();
     fs::write(
         agent_dir.join("config.json"),
@@ -344,7 +346,7 @@ fn test_reload_agents_failure_rollback_via_snapshot_restore() {
     assert!(old_agents.contains_key("alpha"));
 
     // Corrupt agents.json so reload_agents() fails
-    fs::write(config_agents_dir.join("agents.json"), "not json").unwrap();
+    fs::write(config_dir.join("agents.json"), "not json").unwrap();
     let result = manager.reload_agents();
     assert!(result.is_err());
 
@@ -660,16 +662,11 @@ fn test_restore_agents_replaces_current_state() {
     fs::create_dir_all(&config_dir).unwrap();
     setup_config_dir_at(&config_dir);
 
-    let config_agents_dir = config_dir.join("config");
-    fs::create_dir_all(&config_agents_dir).unwrap();
-
-    // Set up agent alpha
-    fs::write(
-        config_agents_dir.join("agents.json"),
-        r#"{ "agents": ["alpha"] }"#,
-    )
-    .unwrap();
-    let alpha_dir = config_dir.join("agents").join("alpha");
+    // agents.json lives at config_dir root
+    fs::write(config_dir.join("agents.json"), r#"{ "agents": ["alpha"] }"#).unwrap();
+    // agents/ is at root level (parent of config_dir)
+    let root_dir = config_dir.parent().unwrap();
+    let alpha_dir = root_dir.join("agents").join("alpha");
     fs::create_dir_all(&alpha_dir).unwrap();
     fs::write(
         alpha_dir.join("config.json"),
@@ -685,11 +682,11 @@ fn test_restore_agents_replaces_current_state() {
 
     // Now add agent beta manually by writing files and reloading
     fs::write(
-        config_agents_dir.join("agents.json"),
+        config_dir.join("agents.json"),
         r#"{ "agents": ["alpha", "beta"] }"#,
     )
     .unwrap();
-    let beta_dir = config_dir.join("agents").join("beta");
+    let beta_dir = root_dir.join("agents").join("beta");
     fs::create_dir_all(&beta_dir).unwrap();
     fs::write(
         beta_dir.join("config.json"),

--- a/src/config/manager_reload_tests.rs
+++ b/src/config/manager_reload_tests.rs
@@ -834,3 +834,143 @@ fn test_reload_section_default_validator_system() {
         ConfigLoadError::ValidationError { .. }
     ));
 }
+/// reload_section for Session updates the in-memory cache.
+#[test]
+fn test_reload_session_section_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":1200}"#,
+    )
+    .unwrap();
+    manager
+        .reload_section(ConfigSection::Session, None)
+        .unwrap();
+    let section = manager.section(ConfigSection::Session).unwrap();
+    assert_eq!(section["sweeperIntervalSecs"], 1200);
+}
+
+/// reload_session_provider rebuilds provider from session.json on disk.
+#[test]
+fn test_reload_session_provider_rebuilds_from_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(provider.sweeper_interval_secs(), 600);
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":9999}"#,
+    )
+    .unwrap();
+    manager.reload_session_provider();
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(provider.sweeper_interval_secs(), 9999);
+}
+
+/// reload_session_provider falls back to defaults when file is missing.
+#[test]
+fn test_reload_session_provider_fallback_on_missing_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    fs::remove_file(tmp.path().join("session.json")).unwrap();
+    manager.reload_session_provider();
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(
+        provider.sweeper_interval_secs(),
+        crate::config::session::DEFAULT_SWEEPER_INTERVAL_SECS
+    );
+}
+
+/// reload_session_provider falls back to defaults when JSON is invalid.
+#[test]
+fn test_reload_session_provider_fallback_on_invalid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    fs::write(tmp.path().join("session.json"), "not json").unwrap();
+    manager.reload_session_provider();
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(
+        provider.sweeper_interval_secs(),
+        crate::config::session::DEFAULT_SWEEPER_INTERVAL_SECS
+    );
+}
+
+/// reload_section with invalid JSON preserves old in-memory value.
+#[test]
+fn test_reload_session_section_invalid_json_preserves_old() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    let before = manager.section(ConfigSection::Session).unwrap();
+    assert_eq!(before["sweeperIntervalSecs"], 600);
+    fs::write(tmp.path().join("session.json"), "not json").unwrap();
+    let result = manager.reload_section(ConfigSection::Session, None);
+    assert!(result.is_err());
+    let after = manager.section(ConfigSection::Session).unwrap();
+    assert_eq!(after["sweeperIntervalSecs"], 600);
+}
+
+/// reload_section with failing validator preserves old value.
+#[test]
+fn test_reload_session_section_validator_failure_preserves_old() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir_at(tmp.path());
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    let before = manager.section(ConfigSection::Session).unwrap();
+    assert_eq!(before["sweeperIntervalSecs"], 600);
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":0}"#,
+    )
+    .unwrap();
+    let v = ConfigSection::Session.default_validator();
+    let result = manager.reload_section(ConfigSection::Session, Some(&*v));
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ConfigLoadError::ValidationError { .. }
+    ));
+    let after = manager.section(ConfigSection::Session).unwrap();
+    assert_eq!(after["sweeperIntervalSecs"], 600);
+}

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -513,12 +513,17 @@ fn test_agent_permissions_missing_file_returns_default() {
 
     // Create agents.json with one registered agent
     let agents_json = r#"{ "version": "1.0", "agents": ["test-agent"] }"#;
-    let agents_dir = tmp.path().join("config");
-    fs::create_dir_all(&agents_dir).unwrap();
-    fs::write(agents_dir.join("agents.json"), agents_json).unwrap();
+    // agents.json lives in config_dir (where ConfigManager reads from)
+    fs::write(tmp.path().join("agents.json"), agents_json).unwrap();
 
     // Create agent directory with config.json but NO permissions.json
-    let agent_dir = tmp.path().join("agents").join("test-agent");
+    // agents/ is at root level (parent of config_dir)
+    let agent_dir = tmp
+        .path()
+        .parent()
+        .unwrap()
+        .join("agents")
+        .join("test-agent");
     fs::create_dir_all(&agent_dir).unwrap();
     let agent_config = r#"{ "id": "test-agent", "name": "Test Agent" }"#;
     fs::write(agent_dir.join("config.json"), agent_config).unwrap();

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -58,7 +58,7 @@ fn test_config_section_display() {
     assert_eq!(ConfigSection::Gateway.to_string(), "gateway.json");
     assert_eq!(ConfigSection::Plugins.to_string(), "plugins.json");
     assert_eq!(ConfigSection::System.to_string(), "system.json");
-    assert_eq!(ConfigSection::Credentials.to_string(), "credentials.json");
+    assert_eq!(ConfigSection::Credentials.to_string(), "credentials/");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -58,6 +58,7 @@ fn test_config_section_display() {
     assert_eq!(ConfigSection::Gateway.to_string(), "gateway.json");
     assert_eq!(ConfigSection::Plugins.to_string(), "plugins.json");
     assert_eq!(ConfigSection::System.to_string(), "system.json");
+    assert_eq!(ConfigSection::Session.to_string(), "session.json");
     assert_eq!(ConfigSection::Credentials.to_string(), "credentials/");
 }
 
@@ -304,6 +305,117 @@ fn test_config_manager_load() {
             section
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// ConfigManager — Session integration
+// ---------------------------------------------------------------------------
+
+/// Test: session_config_provider returns None before load(), Some after.
+#[test]
+fn test_session_config_provider_none_before_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    assert!(manager.session_config_provider().is_none());
+}
+
+/// Test: session_config_provider returns Some after load().
+#[test]
+fn test_session_config_provider_some_after_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    assert!(manager.session_config_provider().is_some());
+}
+
+/// Test: session_config_provider provides valid config when session.json exists.
+#[test]
+fn test_session_config_provider_with_valid_session_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(provider.sweeper_interval_secs(), 600);
+}
+
+/// Test: session_config_provider uses defaults when session.json is absent.
+#[test]
+fn test_session_config_provider_defaults_when_no_session_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    // No session.json written — ConfigManager still loads successfully
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let provider = manager.session_config_provider().unwrap();
+    // Should use the DEFAULT_SWEEPER_INTERVAL_SECS (300)
+    assert_eq!(
+        provider.sweeper_interval_secs(),
+        crate::config::session::DEFAULT_SWEEPER_INTERVAL_SECS
+    );
+}
+
+/// Test: session_config_provider uses defaults when session.json is invalid.
+#[test]
+fn test_session_config_provider_defaults_when_session_json_invalid() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    fs::write(tmp.path().join("session.json"), "not valid json").unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let provider = manager.session_config_provider().unwrap();
+    assert_eq!(
+        provider.sweeper_interval_secs(),
+        crate::config::session::DEFAULT_SWEEPER_INTERVAL_SECS
+    );
+}
+
+/// Test: list_configs includes Session section but not Credentials.
+#[test]
+fn test_list_configs_includes_session_excludes_credentials() {
+    let tmp = tempfile::tempdir().unwrap();
+    setup_config_dir(&tmp);
+    let session_path = tmp.path().join("session.json");
+    fs::write(
+        &session_path,
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":600}"#,
+    )
+    .unwrap();
+    // Verify file was written correctly
+    let content = fs::read_to_string(&session_path).unwrap();
+    assert!(
+        !content.is_empty(),
+        "session.json should not be empty after write"
+    );
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let infos = manager.list_configs();
+    let section_names: Vec<&str> = infos
+        .iter()
+        .map(|i| i.path.rsplit('/').next().unwrap_or(&i.path))
+        .collect();
+
+    assert!(
+        section_names.contains(&"session.json"),
+        "list_configs should include session.json, got: {:?}",
+        section_names
+    );
+    assert!(
+        !section_names.iter().any(|n| n.contains("credentials")),
+        "list_configs should not include credentials, got: {:?}",
+        section_names
+    );
 }
 
 #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,8 +27,8 @@ pub use crate::session::compaction::CompactConfig;
 pub use agents::{AgentDirectoryProvider, AgentsConfig, AgentsConfigProvider};
 pub use migration::{migrate_if_needed, ConfigMigrationError};
 pub use providers::{
-    ChannelsConfigData, ConfigError, ConfigProvider, GatewayConfigData, ModelsConfigData,
-    SystemConfigData,
+    ChannelsConfigData, ConfigError, ConfigProvider, CredentialsProvider, GatewayConfigData,
+    ModelsConfigData, SystemConfigData,
 };
 pub use session::{
     JsonSessionConfigProvider, PerAgentSessionConfig, SessionConfig, SessionConfigProvider,

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -175,7 +175,7 @@ fn register_agents_watch(
                 super::ConfigError::SchemaError(format!("Failed to watch agents.json: {}", e))
             })?;
     }
-    let agents_dir = config_path.join("agents");
+    let agents_dir = config_path.parent().unwrap().join("agents");
     if agents_dir.exists() {
         watcher
             .watch(agents_dir.as_ref(), RecursiveMode::Recursive)
@@ -361,14 +361,14 @@ fn reload_agents_with_log(
     let (old_agents, old_permissions) = config_manager.snapshot_agents();
 
     // Backup agent config files before reload so we can rollback on failure
-    let agents_json = config_manager
+    let agents_json = config_manager.config_dir.join("agents.json");
+    let _ = config_manager.backup_manager().backup(&agents_json);
+
+    let agents_dir = config_manager
         .config_dir
         .parent()
         .unwrap_or(&config_manager.config_dir)
-        .join("agents.json");
-    let _ = config_manager.backup_manager().backup(&agents_json);
-
-    let agents_dir = config_manager.config_dir.join("agents");
+        .join("agents");
     if agents_dir.exists() {
         for_each_agent_json(&agents_dir, |p| {
             let _ = config_manager.backup_manager().backup(p);

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -146,6 +146,7 @@ fn register_watched_paths(
         "gateway.json",
         "plugins.json",
         "system.json",
+        "session.json",
     ];
     for name in &config_files {
         let path = config_path.join(name);
@@ -299,6 +300,7 @@ fn filename_to_section(filename: &str) -> Option<ConfigSection> {
         "gateway.json" => Some(ConfigSection::Gateway),
         "plugins.json" => Some(ConfigSection::Plugins),
         "system.json" => Some(ConfigSection::System),
+        "session.json" => Some(ConfigSection::Session),
         _ => None,
     }
 }
@@ -332,6 +334,9 @@ fn dispatch_change(path: &Path, config_manager: &ConfigManager, agent_registry: 
         let validator = section.default_validator();
         if let Err(e) = config_manager.reload_section(section, Some(&*validator)) {
             warn!(error = %e, section = %section, "failed to reload config section");
+        } else if section == ConfigSection::Session {
+            // Session section reloaded successfully — update session_provider.
+            config_manager.reload_session_provider();
         }
     }
 }

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -175,7 +175,7 @@ fn register_agents_watch(
                 super::ConfigError::SchemaError(format!("Failed to watch agents.json: {}", e))
             })?;
     }
-    let agents_dir = config_path.parent().unwrap().join("agents");
+    let agents_dir = config_path.parent().unwrap_or(config_path).join("agents");
     if agents_dir.exists() {
         watcher
             .watch(agents_dir.as_ref(), RecursiveMode::Recursive)

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -356,7 +356,11 @@ fn reload_agents_with_log(
     let (old_agents, old_permissions) = config_manager.snapshot_agents();
 
     // Backup agent config files before reload so we can rollback on failure
-    let agents_json = config_manager.config_dir.join("config").join("agents.json");
+    let agents_json = config_manager
+        .config_dir
+        .parent()
+        .unwrap_or(&config_manager.config_dir)
+        .join("agents.json");
     let _ = config_manager.backup_manager().backup(&agents_json);
 
     let agents_dir = config_manager.config_dir.join("agents");

--- a/src/config/reload_tests.rs
+++ b/src/config/reload_tests.rs
@@ -354,11 +354,13 @@ mod reload_tests {
         let _ar = make_agent_registry();
 
         // Set up valid agent files: agents.json + agents/alpha/config.json
-        let agents_json_path = d.path().join("config").join("agents.json");
-        std::fs::create_dir_all(agents_json_path.parent().unwrap()).unwrap();
+        // agents.json is at config_dir root (e.g. ~/.closeclaw/agents.json)
+        let agents_json_path = d.path().join("agents.json");
         std::fs::write(&agents_json_path, r#"{ "agents": ["alpha"] }"#).unwrap();
 
-        let alpha_dir = d.path().join("agents").join("alpha");
+        // agents/ is at root level (parent of config_dir)
+        let root_dir = d.path().parent().unwrap().to_path_buf();
+        let alpha_dir = root_dir.join("agents").join("alpha");
         std::fs::create_dir_all(&alpha_dir).unwrap();
         std::fs::write(
             alpha_dir.join("config.json"),
@@ -384,7 +386,7 @@ mod reload_tests {
         let original_alpha_config = std::fs::read_to_string(alpha_dir.join("config.json")).unwrap();
 
         // Add a new agent (simulating a change that will be rolled back)
-        let beta_dir = d.path().join("agents").join("beta");
+        let beta_dir = root_dir.join("agents").join("beta");
         std::fs::create_dir_all(&beta_dir).unwrap();
         std::fs::write(
             beta_dir.join("config.json"),

--- a/src/config/reload_tests.rs
+++ b/src/config/reload_tests.rs
@@ -81,6 +81,10 @@ mod reload_tests {
             filename_to_section("system.json"),
             Some(ConfigSection::System)
         );
+        assert_eq!(
+            filename_to_section("session.json"),
+            Some(ConfigSection::Session)
+        );
         assert_eq!(filename_to_section("agents.json"), None);
         assert_eq!(filename_to_section("unknown.json"), None);
     }
@@ -280,6 +284,11 @@ mod reload_tests {
                 "models.json",
                 ConfigSection::Models,
                 r#"{"models":[{"id":"m1"}]}"#,
+            ),
+            (
+                "session.json",
+                ConfigSection::Session,
+                r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":999}"#,
             ),
         ];
 

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -107,7 +107,7 @@ pub trait SessionConfigProvider: Send + Sync {
 }
 
 /// JSON-based session configuration provider
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct JsonSessionConfigProvider {
     /// Parsed session config (None means file was absent, using hardcoded defaults)
     config: Option<SessionConfig>,

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -24,6 +24,7 @@ pub fn for_section(section: ConfigSection) -> Box<SectionValidator> {
         ConfigSection::Plugins => Box::new(validate_plugins),
         ConfigSection::System => Box::new(validate_system),
         // Credentials is a directory, not a JSON section — no validator needed.
+        ConfigSection::Session => Box::new(validate_session),
         ConfigSection::Credentials => Box::new(|_| Ok(())),
     }
 }
@@ -80,6 +81,20 @@ fn validate_plugins(value: &serde_json::Value) -> Result<(), String> {
 /// - Top-level must be a JSON object.
 fn validate_system(value: &serde_json::Value) -> Result<(), String> {
     ensure_object(value, "system")
+}
+
+/// Validate the **session** config section.
+///
+/// - Top-level must be a JSON object.
+/// - If `sweeperIntervalSecs` is present, it must be a positive number.
+fn validate_session(value: &serde_json::Value) -> Result<(), String> {
+    ensure_object(value, "session")?;
+    if let Some(secs) = value.get("sweeperIntervalSecs") {
+        if !secs.is_number() || secs.as_u64().unwrap_or(0) == 0 {
+            return Err("session.sweeperIntervalSecs must be a positive number".to_string());
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -3,7 +3,7 @@
 use crate::config::manager::ConfigSection;
 use crate::config::validators::{
     for_section, validate_channels, validate_gateway, validate_models, validate_plugins,
-    validate_system,
+    validate_session, validate_system,
 };
 
 // ---------------------------------------------------------------------------
@@ -242,4 +242,110 @@ fn test_for_section_credentials_always_passes() {
     let v: serde_json::Value = serde_json::from_str(r#""anything""#).unwrap();
     let validator = for_section(ConfigSection::Credentials);
     assert!(validator(&v).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// validate_session
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_session_pass() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"sweeperIntervalSecs":600,"compact":{}}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_pass_empty_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_pass_no_sweeper_interval() {
+    // sweeperIntervalSecs absent — should pass (optional field)
+    let v: serde_json::Value = serde_json::from_str(r#"{"compact":{}}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_fail_not_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"[1]"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(err.contains("JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_session_fail_string() {
+    let v: serde_json::Value = serde_json::from_str(r#""hello""#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(err.contains("JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_session_fail_sweeper_interval_zero() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"sweeperIntervalSecs":0}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("positive number"),
+        "error should mention positive number: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_fail_sweeper_interval_string() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"sweeperIntervalSecs":"not a number"}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("positive number"),
+        "error should mention positive number: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_fail_sweeper_interval_negative() {
+    // Negative number: as_u64() returns None for negative → unwrap_or(0) == 0
+    let v: serde_json::Value = serde_json::from_str(r#"{"sweeperIntervalSecs":-5}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(err.contains("positive number"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_session_fail_sweeper_interval_null() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"sweeperIntervalSecs":null}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(err.contains("positive number"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_session_pass_sweeper_interval_positive() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"sweeperIntervalSecs":1}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_default_validator_session_passes_valid_json() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"sweeperIntervalSecs":300,"compact":{}}"#).unwrap();
+    let validator = ConfigSection::Session.default_validator();
+    assert!(validator(&v).is_ok());
+}
+
+#[test]
+fn test_default_validator_session_rejects_non_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"[1]"#).unwrap();
+    let validator = ConfigSection::Session.default_validator();
+    assert!(validator(&v).is_err());
+}
+
+#[test]
+fn test_for_section_session_returns_validator() {
+    let validator = for_section(ConfigSection::Session);
+    let valid: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    let invalid: serde_json::Value = serde_json::from_str(r#"[1]"#).unwrap();
+    assert!(validator(&valid).is_ok());
+    assert!(validator(&invalid).is_err());
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -10,7 +10,6 @@ use crate::admin::server::{AdminContext, AdminServer};
 use crate::agent::spawn::SpawnController;
 use crate::config::migration::migrate_if_needed;
 use crate::config::providers::ConfigProvider;
-use crate::config::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::config::ConfigManager;
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
 use crate::im::feishu::{FeishuAdapter, FeishuPlugin};
@@ -133,36 +132,10 @@ impl Daemon {
                 .map_err(|e| anyhow::anyhow!("failed to initialize SqliteStorage: {}", e))?,
         );
         info!("SqliteStorage initialized at {}", data_dir.display());
-        // Initialize session config provider — warn and use defaults if file is missing
-        let session_config_path = data_dir.join("session_config.json");
-        let config_provider: Arc<dyn SessionConfigProvider> =
-            match JsonSessionConfigProvider::new(&session_config_path) {
-                Ok(provider) => {
-                    info!(
-                        "Session config loaded from {}",
-                        session_config_path.display()
-                    );
-                    Arc::new(provider)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        path = %session_config_path.display(),
-                        "failed to load session config, using hardcoded defaults"
-                    );
-                    // Use a non-existent path so new() returns Ok with
-                    // config=None (hardcoded defaults)
-                    Arc::new(
-                        JsonSessionConfigProvider::new(
-                            "/dev/null/closeclaw_session_config_nonexistent",
-                        )
-                        .unwrap(),
-                    )
-                }
-            };
         // Create ArchiveSweeper shutdown channel (sweeper itself is
         // created after SessionManager so it can cascade-terminate
         // children on archive — design doc §生命周期联动).
+        // Session config provider will be set after ConfigManager is loaded.
         let (sweeper_tx, sweeper_rx) = watch::channel(());
         let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
         info!("Agent registry initialized",);
@@ -200,20 +173,8 @@ impl Daemon {
             );
         }
 
-        // Create and spawn ArchiveSweeper with SessionManager so it can
-        // cascade-terminate children when archiving idle sessions.
-        let sweeper = Arc::new(
-            ArchiveSweeper::new(
-                Arc::clone(&storage) as Arc<dyn PersistenceService>,
-                Arc::clone(&config_provider),
-            )
-            .with_session_manager(Arc::clone(&session_manager)),
-        );
-        let sweeper_for_task = Arc::clone(&sweeper);
-        tokio::spawn(async move {
-            sweeper_for_task.run(sweeper_rx).await;
-        });
-        info!("ArchiveSweeper spawned");
+        // ArchiveSweeper is created after ConfigManager loads so it gets
+        // the real session config provider (see below).
 
         let gateway = Arc::new(gateway);
         // Wire the self-ref so `handle_inbound_message` can pass
@@ -263,11 +224,32 @@ impl Daemon {
             ConfigManager::new(config_subdir.clone())
                 .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
         );
-        // Load mandatory config sections (Models, Channels, Gateway, Plugins, System).
+        // Load mandatory config sections (Models, Channels, Gateway, Plugins, System, Session).
         // Design doc: "ConfigManager — 所有配置加载成功后注册热重载监听器"
         config_manager
             .load()
             .map_err(|e| anyhow::anyhow!("failed to load mandatory config sections: {}", e))?;
+
+        // Create and spawn ArchiveSweeper with session config from ConfigManager.
+        let session_config_provider =
+            config_manager.session_config_provider().unwrap_or_else(|| {
+                tracing::warn!("session config provider not available, using defaults");
+                Arc::new(
+                    crate::config::session::JsonSessionConfigProvider::new("/dev/null").unwrap(),
+                )
+            });
+        let sweeper = Arc::new(
+            ArchiveSweeper::new(
+                Arc::clone(&storage) as Arc<dyn PersistenceService>,
+                session_config_provider,
+            )
+            .with_session_manager(Arc::clone(&session_manager)),
+        );
+        let sweeper_for_task = Arc::clone(&sweeper);
+        tokio::spawn(async move {
+            sweeper_for_task.run(sweeper_rx).await;
+        });
+        info!("ArchiveSweeper spawned");
         {
             let disk_reg_opt = {
                 let guard = skill_registry.read().unwrap();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -257,8 +257,10 @@ impl Daemon {
         let tool_registry = Arc::new(ToolRegistry::new());
         let mut config_watcher = None;
         // Create ConfigManager early so it's available for admin RPC.
+        // Config files live in <root>/config/ (design doc directory structure).
+        let config_subdir = PathBuf::from(config_dir).join("config");
         let config_manager = Arc::new(
-            ConfigManager::new(PathBuf::from(config_dir))
+            ConfigManager::new(config_subdir.clone())
                 .map_err(|e| anyhow::anyhow!("failed to create ConfigManager: {}", e))?,
         );
         // Load mandatory config sections (Models, Channels, Gateway, Plugins, System).
@@ -314,7 +316,7 @@ impl Daemon {
 
                 // Initialize config hot-reload: watch JSON files + agents/ dir
                 config_watcher = match config_reload::init_config_hot_reload(
-                    config_dir,
+                    &config_subdir.to_string_lossy(),
                     Arc::clone(&config_manager),
                     Arc::clone(&agent_registry),
                     Arc::clone(&session_manager),

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -30,7 +30,10 @@ fn write_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
 /// in the given directory so that `ConfigManager::load()` succeeds.
 fn setup_agents_json(dir: &std::path::Path) -> std::io::Result<()> {
     write_agents_json(dir)?;
-    write_mandatory_configs(dir)?;
+    // Mandatory configs go into the config/ subdirectory
+    // (ConfigManager now receives <root>/config/ as config_dir)
+    let config_dir = dir.join("config");
+    write_mandatory_configs(&config_dir)?;
     Ok(())
 }
 

--- a/src/handlers_tests.rs
+++ b/src/handlers_tests.rs
@@ -367,6 +367,8 @@ fn setup_admin_config_dir() -> (TempDir, PathBuf) {
     let config_dir = config_dir_for(tmp.path());
     let config_sub = config_dir.join("config");
     fs::create_dir_all(&config_sub).unwrap();
+    // agents.json lives in the config subdirectory
+    // (ConfigManager.config_dir = config_sub)
     fs::write(config_sub.join("agents.json"), r#"{"agents": []}"#).unwrap();
     (tmp, config_dir)
 }
@@ -374,8 +376,9 @@ fn setup_admin_config_dir() -> (TempDir, PathBuf) {
 /// Start an AdminServer in the background, return (config_dir, join_handle).
 async fn start_mock_server(config_dir: PathBuf) -> (PathBuf, tokio::task::JoinHandle<()>) {
     let sock_path = config_dir.join("admin.sock");
-    let config_manager =
-        Arc::new(closeclaw::config::ConfigManager::new(config_dir.clone()).unwrap());
+    // ConfigManager receives the config subdirectory
+    let config_sub = config_dir.join("config");
+    let config_manager = Arc::new(closeclaw::config::ConfigManager::new(config_sub).unwrap());
     let context = closeclaw::admin::server::AdminContext {
         agent_registry: Arc::new(closeclaw::agent::registry::AgentRegistry::new()),
         skill_registry: Arc::new(std::sync::RwLock::new(Some(

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -1,17 +1,25 @@
 //! Configuration directory resolution.
 //!
-//! Returns the platform-appropriate root directory for CloseClaw configuration files.
-//! Linux/macOS: `~/.closeclaw`
-//! Windows: `%APPDATA%\closeclaw`
+//! Returns the platform-appropriate root and config directories for CloseClaw.
+//! - Root: `~/.closeclaw` (PID files, agents/, templates/, skills/, etc.)
+//! - Config: `~/.closeclaw/config` (JSON config files: models.json, channels.json, etc.)
+//!
+//! Windows equivalents: `%APPDATA%\closeclaw` and `%APPDATA%\closeclaw\config`.
 
 use std::path::PathBuf;
 
-/// Returns the configuration directory path for the current platform.
+/// Returns the **root** CloseClaw directory for the current platform.
+///
+/// This is the top-level directory that contains the `config/` subdirectory,
+/// `agents/`, `templates/`, `skills/`, PID files, and the admin socket.
+///
+/// - Linux/macOS: `~/.closeclaw`
+/// - Windows: `%APPDATA%\closeclaw`
 ///
 /// # Errors
 ///
 /// Returns an error if the home directory or APPDATA cannot be determined.
-pub fn config_dir() -> anyhow::Result<PathBuf> {
+pub fn root_dir() -> anyhow::Result<PathBuf> {
     #[cfg(unix)]
     {
         let home = std::env::var("HOME")
@@ -23,5 +31,31 @@ pub fn config_dir() -> anyhow::Result<PathBuf> {
         let appdata = std::env::var("APPDATA")
             .map_err(|_| anyhow::anyhow!("APPDATA environment variable not set"))?;
         Ok(PathBuf::from(appdata).join("closeclaw"))
+    }
+}
+
+/// Returns the **config** directory for the current platform.
+///
+/// This is the subdirectory that contains JSON config files (models.json,
+/// channels.json, gateway.json, plugins.json, system.json).
+///
+/// - Linux/macOS: `~/.closeclaw/config`
+/// - Windows: `%APPDATA%\closeclaw\config`
+///
+/// # Errors
+///
+/// Returns an error if the home directory or APPDATA cannot be determined.
+pub fn config_dir() -> anyhow::Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        let home = std::env::var("HOME")
+            .map_err(|_| anyhow::anyhow!("HOME environment variable not set"))?;
+        Ok(PathBuf::from(home).join(".closeclaw").join("config"))
+    }
+    #[cfg(not(unix))]
+    {
+        let appdata = std::env::var("APPDATA")
+            .map_err(|_| anyhow::anyhow!("APPDATA environment variable not set"))?;
+        Ok(PathBuf::from(appdata).join("closeclaw").join("config"))
     }
 }

--- a/src/platform/config_tests.rs
+++ b/src/platform/config_tests.rs
@@ -1,4 +1,49 @@
-use crate::platform::config::config_dir;
+use crate::platform::config::{config_dir, root_dir};
+
+#[test]
+fn test_root_dir_returns_valid_path() {
+    let dir = root_dir().unwrap();
+    assert!(dir.is_absolute(), "root_dir must return an absolute path");
+
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.contains("closeclaw"),
+        "root_dir must contain 'closeclaw': {path_str}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_root_dir_unix_format() {
+    let dir = root_dir().unwrap();
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.ends_with("/.closeclaw"),
+        "Unix root_dir must end with /.closeclaw: {path_str}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_root_dir_starts_with_home() {
+    let dir = root_dir().unwrap();
+    let home = std::env::var("HOME").unwrap();
+    let path_str = dir.to_string_lossy();
+    assert!(
+        path_str.starts_with(&home),
+        "root_dir must start with HOME ({home}): {path_str}"
+    );
+}
+
+#[test]
+fn test_root_dir_not_empty_component() {
+    let dir = root_dir().unwrap();
+    let components: Vec<_> = dir.components().collect();
+    assert!(
+        components.len() >= 2,
+        "root_dir must have at least 2 path components"
+    );
+}
 
 #[test]
 fn test_config_dir_returns_valid_path() {
@@ -18,8 +63,8 @@ fn test_config_dir_unix_format() {
     let dir = config_dir().unwrap();
     let path_str = dir.to_string_lossy();
     assert!(
-        path_str.ends_with("/.closeclaw"),
-        "Unix config_dir must end with /.closeclaw: {path_str}"
+        path_str.ends_with("/.closeclaw/config"),
+        "Unix config_dir must end with /.closeclaw/config: {path_str}"
     );
 }
 
@@ -36,11 +81,12 @@ fn test_config_dir_starts_with_home() {
 }
 
 #[test]
-fn test_config_dir_not_empty_component() {
-    let dir = config_dir().unwrap();
-    let components: Vec<_> = dir.components().collect();
-    assert!(
-        components.len() >= 2,
-        "config_dir must have at least 2 path components"
+fn test_config_dir_is_child_of_root_dir() {
+    let root = root_dir().unwrap();
+    let config = config_dir().unwrap();
+    assert_eq!(
+        config.parent(),
+        Some(root.as_path()),
+        "config_dir must be a direct child of root_dir"
     );
 }

--- a/tests/e2e_daemon_shutdown_tests.rs
+++ b/tests/e2e_daemon_shutdown_tests.rs
@@ -98,14 +98,16 @@ async fn test_drain_signal_broadcast() {
 /// Test 4: Daemon::run() triggers graceful shutdown when receiving SIGTERM.
 #[tokio::test]
 async fn test_daemon_run_sigterm_shutdown() {
-    // Create temp dir with minimal agents.json and mandatory config files
+    // Create temp dir with minimal agents.json and mandatory config files.
+    // ConfigManager receives <root>/config/ as its config_dir (design doc
+    // directory structure), so mandatory JSONs must live in the config/ sub-dir.
     let temp_dir = tempfile::TempDir::new().expect("temp dir");
     let config_dir = temp_dir.path().join("config");
     std::fs::create_dir_all(&config_dir).expect("create config dir");
     let agents_path = config_dir.join("agents.json");
     std::fs::write(&agents_path, r#"{"version":"1.0.0","agents":[]}"#).expect("write agents.json");
 
-    write_mandatory_configs(temp_dir.path()).expect("write mandatory config");
+    write_mandatory_configs(&config_dir).expect("write mandatory config");
 
     // Do NOT set FEISHU/LLM env vars — Daemon::start will skip those components
     let daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())

--- a/tests/sigterm_integration_test.rs
+++ b/tests/sigterm_integration_test.rs
@@ -37,7 +37,7 @@ async fn test_sigterm_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    write_mandatory_configs(config_dir).expect("write mandatory config");
+    write_mandatory_configs(&agents_dir).expect("write mandatory config");
 
     // Start the daemon
     let mut daemon = Command::new(&daemon_bin)
@@ -110,7 +110,7 @@ async fn test_sigint_triggers_graceful_shutdown() {
     )
     .expect("failed to write test agents.json");
 
-    write_mandatory_configs(config_dir).expect("write mandatory config");
+    write_mandatory_configs(&config_dir.join("config")).expect("write mandatory config");
 
     let mut daemon = Command::new(&daemon_bin)
         .args(["run", "--config-dir"])


### PR DESCRIPTION
Config 模块路径与设计文档对齐

## 改动

- **config_dir 路径统一**：ConfigManager 的 config_dir 从 `~/.closeclaw/` 改为 `~/.closeclaw/config/`，所有配置文件路径与设计文档目录结构一致
- **session 配置纳入 ConfigManager**：新增 `ConfigSection::Session` 和 `SessionConfigProvider`，session.json 由 ConfigManager 统一管理
- **Credentials 枚举路径修复**：`ConfigSection::Credentials` 返回 `credentials/` 目录路径而非单文件路径，与实际加载行为一致
- **reload.rs agents 路径修复**：热重载监听和加载 agents 路径修正
- **unwrap 一致性**：`register_agents_watch` 中 `parent().unwrap()` 改为 `parent().unwrap_or()`，与其他调用保持一致
- **测试更新**：e2e 和集成测试的 config 文件写入路径适配新结构

## 原因

Design doc 差异扫描（F2b 正向+反向对比）发现 3 个 must_fix 差异：config_dir 路径不一致、session.json 不受 ConfigManager 管理、Credentials 枚举定义与实际加载不一致。

Source: CI
Type: fix
