### PR TITLE
refactor: hot-reload config push mechanism alignment with design doc

### DIFF
--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -270,6 +270,16 @@ impl ConfigManager {
         &self.backup_manager
     }
 
+    /// Get a reference to the config directory.
+    pub(crate) fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+
+    /// Rollback a file to its most recent backup.
+    pub(crate) fn rollback_file(&self, path: &Path) -> Result<(), io::Error> {
+        self.backup_manager.rollback(path).map(|_| ())
+    }
+
     /// Load all configuration sections from disk into memory.
     ///
     /// Returns `Ok(())` if all mandatory config files are loaded successfully.

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -10,10 +10,18 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use thiserror::Error;
+use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use super::events::{ConfigChangeBroadcaster, ConfigChangeEvent};
+
+/// Snapshot of all config sections at a point in time.
+///
+/// Broadcast via `ConfigManager` on every successful reload so that
+/// downstream components (e.g. `SessionManager`) can swap to the
+/// latest config without holding a lock on `ConfigManager`.
+pub type ConfigSnapshot = Arc<HashMap<ConfigSection, serde_json::Value>>;
 use super::providers::{ConfigProvider, CredentialsProvider};
 use super::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::agent::config::AgentPermissions;
@@ -228,6 +236,8 @@ pub struct ConfigManager {
     pub(crate) repo_root: RwLock<Option<PathBuf>>,
     /// Broadcast channel for config change events.
     event_broadcaster: ConfigChangeBroadcaster,
+    /// Broadcast channel for config snapshots after each successful reload.
+    snapshot_tx: broadcast::Sender<ConfigSnapshot>,
 }
 
 impl ConfigManager {
@@ -248,6 +258,7 @@ impl ConfigManager {
             agent_permissions: RwLock::new(HashMap::new()),
             repo_root: RwLock::new(None),
             event_broadcaster: ConfigChangeBroadcaster::new(),
+            snapshot_tx: broadcast::channel(16).0,
         })
     }
 
@@ -476,6 +487,38 @@ impl ConfigManager {
             .expect("RwLock for config sections was poisoned")
             .get(&section)
             .cloned()
+    }
+
+    /// Subscribe to config snapshot broadcasts.
+    ///
+    /// Returns a receiver that yields a new `ConfigSnapshot` each time
+    /// a config section is successfully reloaded. Only the most recent
+    /// snapshot is retained; lagging subscribers receive the latest one.
+    pub fn subscribe_config_snapshots(&self) -> broadcast::Receiver<ConfigSnapshot> {
+        self.snapshot_tx.subscribe()
+    }
+
+    /// Update the in-memory cache for a single section and broadcast
+    /// the resulting snapshot to all snapshot subscribers.
+    ///
+    /// This is the single write-path for section updates that should
+    /// trigger snapshot delivery. Callers that need to update the cache
+    /// (e.g. `ConfigReloadManager::reload_section`) must go through
+    /// this method instead of directly inserting into `sections`.
+    pub(crate) fn update_section_cache(&self, section: ConfigSection, value: serde_json::Value) {
+        let snapshot = {
+            let mut sections = self
+                .sections
+                .write()
+                .expect("RwLock for config sections was poisoned");
+            sections.insert(section, value);
+            ConfigSnapshot::new(sections.clone())
+        };
+        // Broadcast snapshot (ignore send errors — no active subscribers).
+        let _ = self.snapshot_tx.send(snapshot);
+        // Broadcast change event.
+        self.notify_change(ConfigChangeEvent::Reloaded { section });
+        info!(section = %section, "reloaded config section");
     }
 
     /// Get the loaded credentials provider.

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -492,6 +492,13 @@ impl ConfigManager {
     ///
     /// Returns `None` if the section has not been loaded.
     pub fn section(&self, section: ConfigSection) -> Option<serde_json::Value> {
+        self.get_section_value(section)
+    }
+
+    /// Get a single section value from the in-memory cache.
+    ///
+    /// Returns `None` if the section has not been loaded.
+    pub(crate) fn get_section_value(&self, section: ConfigSection) -> Option<serde_json::Value> {
         self.sections
             .read()
             .expect("RwLock for config sections was poisoned")

--- a/src/config/manager_reload.rs
+++ b/src/config/manager_reload.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use super::events::ConfigChangeEvent;
 use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
 use super::session::{JsonSessionConfigProvider, SessionConfigProvider};
-use tracing::{info, warn};
+use tracing::warn;
 
 /// Validator callback type for config section reload.
 ///
@@ -103,14 +103,8 @@ impl ConfigManager {
             }
         }
 
-        // Step 5: success — update in-memory cache
-        let mut sections = self
-            .sections
-            .write()
-            .expect("RwLock for config sections was poisoned");
-        sections.insert(section, value);
-        info!("reloaded config section: {}", section);
-        self.notify_change(ConfigChangeEvent::Reloaded { section });
+        // Step 5: success — update in-memory cache and broadcast snapshot
+        self.update_section_cache(section, value);
         Ok(())
     }
 

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -729,3 +729,32 @@ fn test_snapshot_contains_updated_section() {
         "snapshot should contain the updated version"
     );
 }
+
+/// When reload_section fails validation, no snapshot is broadcast.
+/// The snapshot broadcast channel should remain empty.
+#[test]
+fn test_snapshot_broadcast_on_reload_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_snapshots();
+
+    // Write invalid JSON for Models section (non-array "models" field)
+    fs::write(
+        tmp.path().join("models.json"),
+        r#"{"models":"not an array"}"#,
+    )
+    .unwrap();
+
+    let v = ConfigSection::Models.default_validator();
+    let result = manager.reload_section(ConfigSection::Models, Some(&*v));
+    assert!(result.is_err());
+
+    // No snapshot should have been broadcast on validation failure
+    assert!(
+        rx.try_recv().is_err(),
+        "snapshot broadcast channel should be empty after validation failure"
+    );
+}

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -672,3 +672,60 @@ fn test_agent_permissions_missing_file_returns_default() {
         );
     }
 }
+
+// =========================================================================
+// Step 1.5 — snapshot broadcast tests
+// =========================================================================
+
+/// After a successful reload_section, the snapshot broadcast channel delivers
+/// the updated snapshot to a subscriber.
+#[test]
+fn test_snapshot_broadcast_after_reload() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path();
+    write_mandatory_configs(config_dir).unwrap();
+    let manager = ConfigManager::new(config_dir.to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_snapshots();
+
+    // Trigger a reload that calls update_section_cache internally
+    fs::write(config_dir.join("system.json"), r#"{"version":"9.0"}"#).unwrap();
+    manager.reload_section(ConfigSection::System, None).unwrap();
+
+    // The snapshot receiver should have the new snapshot
+    let snapshot = rx
+        .try_recv()
+        .expect("should receive a snapshot after reload");
+    assert!(
+        snapshot.contains_key(&ConfigSection::System),
+        "snapshot should contain System section"
+    );
+}
+
+/// The snapshot broadcast after reload_section contains the exact value
+/// that was reloaded.
+#[test]
+fn test_snapshot_contains_updated_section() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path();
+    write_mandatory_configs(config_dir).unwrap();
+    let manager = ConfigManager::new(config_dir.to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let mut rx = manager.subscribe_config_snapshots();
+
+    fs::write(config_dir.join("system.json"), r#"{"version":"42.0"}"#).unwrap();
+    manager.reload_section(ConfigSection::System, None).unwrap();
+
+    let snapshot = rx
+        .try_recv()
+        .expect("should receive a snapshot after reload");
+    let system_val = snapshot
+        .get(&ConfigSection::System)
+        .expect("System section missing from snapshot");
+    assert_eq!(
+        system_val["version"], "42.0",
+        "snapshot should contain the updated version"
+    );
+}

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -14,7 +14,8 @@ use notify::{
 };
 use tracing::{debug, info, warn};
 
-use super::manager::{ConfigManager, ConfigSection};
+use super::events::ConfigChangeEvent;
+use super::manager::{ConfigLoadError, ConfigManager, ConfigSection};
 use crate::agent::registry::AgentRegistry;
 
 /// Default debounce duration for file change events.
@@ -39,8 +40,8 @@ impl WatcherHandle {
 /// Daemon-level config hot-reload manager.
 ///
 /// Watches a set of config JSON files and the `agents/` directory.
-/// On change, dispatches to `ConfigManager::reload_section()` or
-/// `ConfigManager::reload_agents()` with debounce protection.
+/// On change, dispatches to `ConfigReloadManager::reload_section()` or
+/// `ConfigReloadManager::reload_agents_with_log()` with debounce protection.
 pub struct ConfigReloadManager {
     /// Shared config manager — provides load/reload/backup logic.
     config_manager: Arc<ConfigManager>,
@@ -86,6 +87,102 @@ impl ConfigReloadManager {
         Self::new(config_manager, agent_registry, DEFAULT_DEBOUNCE)
     }
 
+    /// Clone shared references for spawning a background thread.
+    ///
+    /// Clones the `Arc` references (cheap) so the background thread
+    /// can call `ConfigReloadManager` methods directly.
+    fn clone_for_thread(&self) -> ConfigReloadManager {
+        ConfigReloadManager {
+            config_manager: Arc::clone(&self.config_manager),
+            agent_registry: Arc::clone(&self.agent_registry),
+            debounce_duration: self.debounce_duration,
+            #[cfg(test)]
+            test_completion_tx: None,
+        }
+    }
+
+    /// Reload a single config section: read file → parse → validate → update cache.
+    ///
+    /// On success, updates the in-memory cache and broadcasts a snapshot.
+    /// On failure, rolls back the file and emits a Failed event.
+    /// Corresponds to the design doc data flow: ConfigReloadManager drives
+    /// the reload orchestration (read → parse → validate → update).
+    pub fn reload_section(&self, section: ConfigSection) -> Result<(), ConfigLoadError> {
+        let path = section.path(self.config_manager.config_dir());
+
+        // Step 1: read file content
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                self.config_manager
+                    .notify_change(ConfigChangeEvent::Failed {
+                        section,
+                        error: e.to_string(),
+                    });
+                return Err(ConfigLoadError::IoError {
+                    path,
+                    error: e.to_string(),
+                });
+            }
+        };
+
+        // Step 2: backup old in-memory value before replacing
+        let old_value = self
+            .config_manager
+            .sections
+            .read()
+            .expect("RwLock for config sections was poisoned")
+            .get(&section)
+            .cloned();
+        if let Some(ref old) = old_value {
+            let old_json = serde_json::to_string(old).unwrap_or_default();
+            if let Err(e) = self
+                .config_manager
+                .backup_manager()
+                .backup_with_content(&path, old_json.as_bytes())
+            {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to backup config content before reload"
+                );
+            }
+        }
+
+        // Step 3: parse JSON
+        let value: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = self.config_manager.rollback_file(&path);
+                self.config_manager
+                    .notify_change(ConfigChangeEvent::Failed {
+                        section,
+                        error: e.to_string(),
+                    });
+                return Err(ConfigLoadError::ParseError {
+                    path,
+                    error: e.to_string(),
+                });
+            }
+        };
+
+        // Step 4: validate with section's default validator
+        let validator = section.default_validator();
+        if let Err(msg) = validator(&value) {
+            let _ = self.config_manager.rollback_file(&path);
+            self.config_manager
+                .notify_change(ConfigChangeEvent::Failed {
+                    section,
+                    error: msg.clone(),
+                });
+            return Err(ConfigLoadError::ValidationError { path, message: msg });
+        }
+
+        // Step 5: success — update cache and broadcast snapshot
+        self.config_manager.update_section_cache(section, value);
+        Ok(())
+    }
+
     /// Start watching config files under `config_dir`.
     ///
     /// Watches the following files (if they exist):
@@ -104,15 +201,61 @@ impl ConfigReloadManager {
         let completion_tx = self.test_completion_tx.take();
         #[cfg(not(test))]
         let completion_tx: Option<std::sync::mpsc::Sender<()>> = None;
-        spawn_reload_loop(
-            rx,
-            &self.config_manager,
-            &self.agent_registry,
-            self.debounce_duration,
-            completion_tx,
-        );
+        let manager_clone = self.clone_for_thread();
+        spawn_reload_loop(rx, manager_clone, self.debounce_duration, completion_tx);
         info!(config_dir = config_dir, "config hot-reload watcher started");
         Ok(WatcherHandle { watcher })
+    }
+
+    /// Reload agent configs and sync the `AgentRegistry`.
+    ///
+    /// Snapshots before reload; on failure, restores the previous in-memory
+    /// state so the daemon keeps running with the last-known-good config.
+    /// Additionally, agent config files (agents.json, agents/*.json) are
+    /// backed up before reload and rolled back on failure to keep the
+    /// on-disk state consistent.
+    fn reload_agents_with_log(&self, path: &Path) {
+        info!(
+            path = %path.display(),
+            "agent config change detected, reloading agents"
+        );
+
+        let (old_agents, old_permissions) = self.config_manager.snapshot_agents();
+
+        // Backup agent config files before reload so we can rollback on failure
+        let agents_json = self.config_manager.config_dir().join("agents.json");
+        let _ = self.config_manager.backup_manager().backup(&agents_json);
+
+        let agents_dir = self
+            .config_manager
+            .config_dir()
+            .parent()
+            .unwrap_or(self.config_manager.config_dir())
+            .join("agents");
+        if agents_dir.exists() {
+            for_each_agent_json(&agents_dir, |p| {
+                let _ = self.config_manager.backup_manager().backup(p);
+            });
+        }
+
+        if let Err(e) = self.config_manager.reload_agents() {
+            warn!(error = %e, "failed to reload agent configs, rolling back");
+            self.config_manager
+                .restore_agents(old_agents, old_permissions);
+
+            // Rollback disk files to last known good state
+            let _ = self.config_manager.backup_manager().rollback(&agents_json);
+            if agents_dir.exists() {
+                for_each_agent_json(&agents_dir, |p| {
+                    let _ = self.config_manager.backup_manager().rollback(p);
+                });
+            }
+            return;
+        }
+
+        // Sync new configs into AgentRegistry
+        let configs: Vec<_> = self.config_manager.agents().into_values().collect();
+        self.agent_registry.reload(configs);
     }
 }
 
@@ -187,17 +330,17 @@ fn register_agents_watch(
 }
 
 /// Spawn the debounce + dispatch loop on a background thread.
+///
+/// The `ConfigReloadManager` is cloned (Arc refs are shared) so the
+/// background thread can call its methods directly.
 fn spawn_reload_loop(
     rx: std::sync::mpsc::Receiver<notify::Result<Event>>,
-    config_manager: &Arc<ConfigManager>,
-    agent_registry: &Arc<AgentRegistry>,
+    manager: ConfigReloadManager,
     debounce: Duration,
     completion_tx: Option<std::sync::mpsc::Sender<()>>,
 ) {
-    let cm = Arc::clone(config_manager);
-    let ar = Arc::clone(agent_registry);
     std::thread::spawn(move || {
-        run_reload_loop(rx, cm, ar, debounce, completion_tx);
+        run_reload_loop(rx, manager, debounce, completion_tx);
     });
 }
 
@@ -231,8 +374,7 @@ fn collect_event_paths(event: Event, pending_paths: &mut HashSet<PathBuf>) {
 ///   all collected paths are dispatched in a single batch.
 fn run_reload_loop(
     rx: std::sync::mpsc::Receiver<notify::Result<Event>>,
-    config_manager: Arc<ConfigManager>,
-    agent_registry: Arc<AgentRegistry>,
+    manager: ConfigReloadManager,
     debounce: Duration,
     completion_tx: Option<std::sync::mpsc::Sender<()>>,
 ) {
@@ -248,12 +390,12 @@ fn run_reload_loop(
                 if pending_paths.is_empty() {
                     continue;
                 }
-                dispatch_pending_batch(&pending_paths, &config_manager, &agent_registry);
+                dispatch_pending_batch(&pending_paths, &manager);
                 pending_paths.clear();
                 signal_completion(&completion_tx);
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                dispatch_pending_batch(&pending_paths, &config_manager, &agent_registry);
+                dispatch_pending_batch(&pending_paths, &manager);
                 signal_completion(&completion_tx);
                 break;
             }
@@ -262,11 +404,7 @@ fn run_reload_loop(
 }
 
 /// Dispatch all paths in a batch and signal test completion.
-fn dispatch_pending_batch(
-    paths: &HashSet<PathBuf>,
-    config_manager: &Arc<ConfigManager>,
-    agent_registry: &Arc<AgentRegistry>,
-) {
+fn dispatch_pending_batch(paths: &HashSet<PathBuf>, manager: &ConfigReloadManager) {
     if paths.is_empty() {
         return;
     }
@@ -275,7 +413,7 @@ fn dispatch_pending_batch(
         "debounce window closed, dispatching batch"
     );
     for path in paths {
-        dispatch_change(path, config_manager, agent_registry);
+        dispatch_change(path, manager);
     }
 }
 
@@ -306,10 +444,13 @@ fn filename_to_section(filename: &str) -> Option<ConfigSection> {
 }
 
 /// Dispatch a single changed path to the appropriate reload method.
-fn dispatch_change(path: &Path, config_manager: &ConfigManager, agent_registry: &AgentRegistry) {
+///
+/// This delegates to `ConfigReloadManager` methods, which drive the
+/// reload orchestration per the design doc (ConfigReloadManager → ConfigManager → SessionManager).
+fn dispatch_change(path: &Path, manager: &ConfigReloadManager) {
     // Agent-related changes → full agent reload + registry sync
     if is_agents_path(path) {
-        reload_agents_with_log(path, config_manager, agent_registry);
+        manager.reload_agents_with_log(path);
         return;
     }
 
@@ -320,7 +461,7 @@ fn dispatch_change(path: &Path, config_manager: &ConfigManager, agent_registry: 
 
     // agents.json triggers the same agent reload path
     if filename == "agents.json" {
-        reload_agents_with_log(path, config_manager, agent_registry);
+        manager.reload_agents_with_log(path);
         return;
     }
 
@@ -331,67 +472,13 @@ fn dispatch_change(path: &Path, config_manager: &ConfigManager, agent_registry: 
             section = %section,
             "config file changed, reloading section"
         );
-        let validator = section.default_validator();
-        if let Err(e) = config_manager.reload_section(section, Some(&*validator)) {
+        if let Err(e) = manager.reload_section(section) {
             warn!(error = %e, section = %section, "failed to reload config section");
         } else if section == ConfigSection::Session {
             // Session section reloaded successfully — update session_provider.
-            config_manager.reload_session_provider();
+            manager.config_manager.reload_session_provider();
         }
     }
-}
-
-/// Reload agent configs and sync the `AgentRegistry`.
-///
-/// Snapshots before reload; on failure, restores the previous in-memory
-/// state so the daemon keeps running with the last-known-good config.
-/// Additionally, agent config files (agents.json, agents/*.json) are
-/// backed up before reload and rolled back on failure to keep the
-/// on-disk state consistent.
-fn reload_agents_with_log(
-    path: &Path,
-    config_manager: &ConfigManager,
-    agent_registry: &AgentRegistry,
-) {
-    info!(
-        path = %path.display(),
-        "agent config change detected, reloading agents"
-    );
-
-    let (old_agents, old_permissions) = config_manager.snapshot_agents();
-
-    // Backup agent config files before reload so we can rollback on failure
-    let agents_json = config_manager.config_dir.join("agents.json");
-    let _ = config_manager.backup_manager().backup(&agents_json);
-
-    let agents_dir = config_manager
-        .config_dir
-        .parent()
-        .unwrap_or(&config_manager.config_dir)
-        .join("agents");
-    if agents_dir.exists() {
-        for_each_agent_json(&agents_dir, |p| {
-            let _ = config_manager.backup_manager().backup(p);
-        });
-    }
-
-    if let Err(e) = config_manager.reload_agents() {
-        warn!(error = %e, "failed to reload agent configs, rolling back");
-        config_manager.restore_agents(old_agents, old_permissions);
-
-        // Rollback disk files to last known good state
-        let _ = config_manager.backup_manager().rollback(&agents_json);
-        if agents_dir.exists() {
-            for_each_agent_json(&agents_dir, |p| {
-                let _ = config_manager.backup_manager().rollback(p);
-            });
-        }
-        return;
-    }
-
-    // Sync new configs into AgentRegistry
-    let configs: Vec<_> = config_manager.agents().into_values().collect();
-    agent_registry.reload(configs);
 }
 
 /// Iterate over `.json` files in the agents directory and apply `f` to each.

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -127,13 +127,7 @@ impl ConfigReloadManager {
         };
 
         // Step 2: backup old in-memory value before replacing
-        let old_value = self
-            .config_manager
-            .sections
-            .read()
-            .expect("RwLock for config sections was poisoned")
-            .get(&section)
-            .cloned();
+        let old_value = self.config_manager.get_section_value(section);
         if let Some(ref old) = old_value {
             let old_json = serde_json::to_string(old).unwrap_or_default();
             if let Err(e) = self
@@ -181,6 +175,13 @@ impl ConfigReloadManager {
         // Step 5: success — update cache and broadcast snapshot
         self.config_manager.update_section_cache(section, value);
         Ok(())
+    }
+
+    /// Reload the session config provider from disk.
+    ///
+    /// Delegates to `ConfigManager::reload_session_provider()`.
+    pub(crate) fn reload_session_provider(&self) {
+        self.config_manager.reload_session_provider();
     }
 
     /// Start watching config files under `config_dir`.
@@ -476,7 +477,7 @@ fn dispatch_change(path: &Path, manager: &ConfigReloadManager) {
             warn!(error = %e, section = %section, "failed to reload config section");
         } else if section == ConfigSection::Session {
             // Session section reloaded successfully — update session_provider.
-            manager.config_manager.reload_session_provider();
+            manager.reload_session_provider();
         }
     }
 }

--- a/src/config/reload_tests.rs
+++ b/src/config/reload_tests.rs
@@ -101,11 +101,12 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
 
         std::fs::write(d.path().join("models.json"), r#"{"models":[{"id":"m1"}]}"#).unwrap();
 
         let path = d.path().join("models.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
 
         let val = cm.section(ConfigSection::Models).unwrap();
         assert!(val.get("models").is_some());
@@ -116,12 +117,13 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm, ar);
 
         std::fs::create_dir_all(d.path().join("agents")).unwrap();
         std::fs::write(d.path().join("agents.json"), r#"{"agents":{}}"#).unwrap();
 
         let path = d.path().join("agents.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
     }
 
     #[test]
@@ -129,9 +131,10 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm, ar);
 
         let path = d.path().join("unknown.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
     }
 
     #[test]
@@ -139,9 +142,10 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm, ar);
 
         let path = d.path().join("agents").join("test.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
     }
 
     #[test]
@@ -266,6 +270,7 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
 
         let cases = [
             (
@@ -295,7 +300,7 @@ mod reload_tests {
         for (filename, section, content) in cases {
             std::fs::write(d.path().join(filename), content).unwrap();
             let path = d.path().join(filename);
-            dispatch_change(&path, &cm, &ar);
+            dispatch_change(&path, &mgr);
             let val = cm.section(section).unwrap();
             assert!(val.is_object(), "section {:?} should be an object", section);
         }
@@ -307,13 +312,14 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm, ar);
 
         let agents_dir = d.path().join("agents");
         std::fs::create_dir_all(&agents_dir).unwrap();
         std::fs::write(agents_dir.join("test.json"), r#"{}"#).unwrap();
 
         let path = agents_dir.join("test.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
         // Should not panic; agent reload path was exercised
     }
 
@@ -486,18 +492,19 @@ mod reload_tests {
         let d = TempDir::new().unwrap();
         let cm = make_config_manager(d.path());
         let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
 
         // Load initial valid models.json
         std::fs::write(d.path().join("models.json"), r#"{"models":[{"id":"m1"}]}"#).unwrap();
         let path = d.path().join("models.json");
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
         let before = cm.section(ConfigSection::Models).unwrap();
         assert!(before.get("models").is_some());
 
         // Write a valid JSON file but with a non-array "models" field.
         // The default validator should reject this.
         std::fs::write(d.path().join("models.json"), r#"{"models":"not an array"}"#).unwrap();
-        dispatch_change(&path, &cm, &ar);
+        dispatch_change(&path, &mgr);
 
         // In-memory must still be the old value (validator rejected reload)
         let after = cm.section(ConfigSection::Models).unwrap();
@@ -507,5 +514,44 @@ mod reload_tests {
             models.is_array(),
             "models should still be the valid array, not replaced by the invalid value"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // ConfigReloadManager::reload_section tests
+    // ------------------------------------------------------------------
+
+    /// ConfigReloadManager::reload_section correctly reloads a config section.
+    #[test]
+    fn test_reload_section_via_manager() {
+        let d = TempDir::new().unwrap();
+        let cm = make_config_manager(d.path());
+        let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
+
+        std::fs::write(d.path().join("system.json"), r#"{"version":"2.0"}"#).unwrap();
+        let section = ConfigSection::System;
+        mgr.reload_section(section).unwrap();
+
+        let val = cm.section(section).unwrap();
+        assert_eq!(val["version"], "2.0");
+    }
+
+    /// ConfigReloadManager::reload_section handles validation failure.
+    #[test]
+    fn test_reload_section_validation_failure_via_manager() {
+        let d = TempDir::new().unwrap();
+        let cm = make_config_manager(d.path());
+        let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
+
+        // Write invalid JSON (non-object for Models which expects array)
+        std::fs::write(d.path().join("models.json"), r#"{"models":"not array"}"#).unwrap();
+        let section = ConfigSection::Models;
+        let result = mgr.reload_section(section);
+        assert!(result.is_err());
+
+        // In-memory should still be the old value
+        let val = cm.section(section).unwrap();
+        assert!(val.get("models").is_some());
     }
 }

--- a/src/config/reload_tests.rs
+++ b/src/config/reload_tests.rs
@@ -554,4 +554,74 @@ mod reload_tests {
         let val = cm.section(section).unwrap();
         assert!(val.get("models").is_some());
     }
+
+    // ------------------------------------------------------------------
+    // Step 1.8 — supplementary tests
+    // ------------------------------------------------------------------
+
+    /// ConfigReloadManager::reload_section uses default_validator;
+    /// a section that passes default validation is reloaded into the
+    /// in-memory cache and a snapshot is broadcast.
+    #[test]
+    fn test_reload_section_via_manager_with_validation() {
+        let d = TempDir::new().unwrap();
+        let cm = make_config_manager(d.path());
+        let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar);
+
+        // Write valid system.json that passes the default validator
+        std::fs::write(d.path().join("system.json"), r#"{"version":"8.8"}"#).unwrap();
+        let mut snapshot_rx = cm.subscribe_config_snapshots();
+
+        mgr.reload_section(ConfigSection::System).unwrap();
+
+        // In-memory should be updated
+        let val = cm.section(ConfigSection::System).unwrap();
+        assert_eq!(val["version"], "8.8");
+
+        // Snapshot should have been broadcast
+        let snapshot = snapshot_rx
+            .try_recv()
+            .expect("should receive a snapshot after successful reload");
+        assert_eq!(
+            snapshot.get(&ConfigSection::System).unwrap()["version"],
+            "8.8"
+        );
+    }
+
+    /// ConfigReloadManager::reload_agents_with_log succeeds when agent
+    /// files are valid; the AgentRegistry is synced with the new configs.
+    #[test]
+    fn test_reload_agents_with_log_direct() {
+        let d = TempDir::new().unwrap();
+        let cm = make_config_manager(d.path());
+        let ar = make_agent_registry();
+        let mgr = ConfigReloadManager::with_defaults(cm.clone(), ar.clone());
+
+        // Set up valid agent files: agents.json + agents/alpha/config.json
+        // agents.json is at config_dir root
+        let agents_json_path = d.path().join("agents.json");
+        std::fs::write(&agents_json_path, r#"{ "agents": ["alpha"] }"#).unwrap();
+
+        // agents/ is at root level (parent of config_dir)
+        let root_dir = d.path().parent().unwrap().to_path_buf();
+        let alpha_dir = root_dir.join("agents").join("alpha");
+        std::fs::create_dir_all(&alpha_dir).unwrap();
+        std::fs::write(
+            alpha_dir.join("config.json"),
+            r#"{ "id": "alpha", "name": "Alpha" }"#,
+        )
+        .unwrap();
+
+        // Trigger reload via reload_agents_with_log
+        let path = agents_json_path.clone();
+        mgr.reload_agents_with_log(&path);
+
+        // AgentRegistry should be synced with alpha
+        let agents: Vec<_> = ar.iter().map(|e| e.key().clone()).collect();
+        assert!(
+            agents.contains(&"alpha".to_string()),
+            "AgentRegistry should contain alpha after reload"
+        );
+    }
 }

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -9,7 +9,7 @@ use crate::config::manager::ConfigManager;
 use crate::config::reload::{ConfigReloadManager, WatcherHandle};
 use crate::gateway::SessionManager;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 /// RAII handle for the config hot-reload system.
 ///
@@ -34,48 +34,42 @@ fn spawn_config_change_subscriber(
     let mut snapshot_rx = config_manager.subscribe_config_snapshots();
     tokio::spawn(async move {
         loop {
-            tokio::select! {
-                event = event_rx.recv() => {
-                    match event {
-                        Ok(ConfigChangeEvent::Reloaded { section }) => {
-                            info!(
-                                section = %section,
-                                "config change event received, notifying sessions"
-                            );
-                            // Block until the matching snapshot arrives.
-                            let snapshot = match snapshot_rx.recv().await {
-                                Ok(s) => s,
-                                Err(e) => {
-                                    warn!(
-                                        section = %section,
-                                        error = %e,
-                                        "failed to receive config snapshot, skipping session notification"
-                                    );
-                                    continue;
-                                }
-                            };
-                            session_manager
-                                .notify_config_changed(section, snapshot)
-                                .await;
-                        }
-                        Ok(ConfigChangeEvent::Failed { section, error }) => {
+            let event = event_rx.recv().await;
+            match event {
+                Ok(ConfigChangeEvent::Reloaded { section }) => {
+                    info!(
+                        section = %section,
+                        "config change event received, notifying sessions"
+                    );
+                    // Block until the matching snapshot arrives.
+                    let snapshot = match snapshot_rx.recv().await {
+                        Ok(s) => s,
+                        Err(e) => {
                             warn!(
                                 section = %section,
-                                error = %error,
-                                "config change event failed, skipping session notification"
+                                error = %e,
+                                "failed to receive config snapshot, skipping session notification"
                             );
+                            continue;
                         }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!(missed = n, "config change subscriber lagged, missed events");
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            info!("config change broadcast channel closed, subscriber exiting");
-                            break;
-                        }
-                    }
+                    };
+                    session_manager
+                        .notify_config_changed(section, snapshot)
+                        .await;
                 }
-                _ = snapshot_rx.recv() => {
-                    debug!("snapshot received without paired event, ignoring");
+                Ok(ConfigChangeEvent::Failed { section, error }) => {
+                    warn!(
+                        section = %section,
+                        error = %error,
+                        "config change event failed, skipping session notification"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(missed = n, "config change subscriber lagged, missed events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    info!("config change broadcast channel closed, subscriber exiting");
+                    break;
                 }
             }
         }

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -5,11 +5,11 @@
 
 use crate::agent::registry::AgentRegistry;
 use crate::config::events::ConfigChangeEvent;
-use crate::config::manager::{ConfigManager, ConfigSnapshot};
+use crate::config::manager::ConfigManager;
 use crate::config::reload::{ConfigReloadManager, WatcherHandle};
 use crate::gateway::SessionManager;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// RAII handle for the config hot-reload system.
 ///
@@ -42,14 +42,18 @@ fn spawn_config_change_subscriber(
                                 section = %section,
                                 "config change event received, notifying sessions"
                             );
-                            // Retrieve the latest snapshot (non-blocking).
-                            let snapshot = snapshot_rx
-                                .try_recv()
-                                .unwrap_or_else(|_| {
-                                    // Fallback: build an empty snapshot so
-                                    // notify_config_changed still works.
-                                    ConfigSnapshot::default()
-                                });
+                            // Block until the matching snapshot arrives.
+                            let snapshot = match snapshot_rx.recv().await {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    warn!(
+                                        section = %section,
+                                        error = %e,
+                                        "failed to receive config snapshot, skipping session notification"
+                                    );
+                                    continue;
+                                }
+                            };
                             session_manager
                                 .notify_config_changed(section, snapshot)
                                 .await;
@@ -71,8 +75,7 @@ fn spawn_config_change_subscriber(
                     }
                 }
                 _ = snapshot_rx.recv() => {
-                    // Snapshot broadcast without a preceding event — ignore.
-                    // Snapshots are only forwarded when paired with a Reloaded event.
+                    debug!("snapshot received without paired event, ignoring");
                 }
             }
         }

--- a/src/daemon/config_reload.rs
+++ b/src/daemon/config_reload.rs
@@ -5,7 +5,7 @@
 
 use crate::agent::registry::AgentRegistry;
 use crate::config::events::ConfigChangeEvent;
-use crate::config::manager::ConfigManager;
+use crate::config::manager::{ConfigManager, ConfigSnapshot};
 use crate::config::reload::{ConfigReloadManager, WatcherHandle};
 use crate::gateway::SessionManager;
 use std::sync::Arc;
@@ -23,36 +23,56 @@ pub(crate) struct ConfigWatcherHandle {
 /// notifies the [`SessionManager`].
 ///
 /// When a [`ConfigChangeEvent::Reloaded`] arrives, the subscriber calls
-/// [`SessionManager::notify_config_changed`]. `Failed` events are logged
-/// but do not trigger a session notification.
+/// [`SessionManager::notify_config_changed`] with the section and the
+/// latest config snapshot. `Failed` events are logged but do not
+/// trigger a session notification.
 fn spawn_config_change_subscriber(
     config_manager: Arc<ConfigManager>,
     session_manager: Arc<SessionManager>,
 ) {
-    let mut rx = config_manager.subscribe_config_changes();
+    let mut event_rx = config_manager.subscribe_config_changes();
+    let mut snapshot_rx = config_manager.subscribe_config_snapshots();
     tokio::spawn(async move {
         loop {
-            match rx.recv().await {
-                Ok(ConfigChangeEvent::Reloaded { section }) => {
-                    info!(
-                        section = %section,
-                        "config change event received, notifying sessions"
-                    );
-                    session_manager.notify_config_changed(section).await;
+            tokio::select! {
+                event = event_rx.recv() => {
+                    match event {
+                        Ok(ConfigChangeEvent::Reloaded { section }) => {
+                            info!(
+                                section = %section,
+                                "config change event received, notifying sessions"
+                            );
+                            // Retrieve the latest snapshot (non-blocking).
+                            let snapshot = snapshot_rx
+                                .try_recv()
+                                .unwrap_or_else(|_| {
+                                    // Fallback: build an empty snapshot so
+                                    // notify_config_changed still works.
+                                    ConfigSnapshot::default()
+                                });
+                            session_manager
+                                .notify_config_changed(section, snapshot)
+                                .await;
+                        }
+                        Ok(ConfigChangeEvent::Failed { section, error }) => {
+                            warn!(
+                                section = %section,
+                                error = %error,
+                                "config change event failed, skipping session notification"
+                            );
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            warn!(missed = n, "config change subscriber lagged, missed events");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            info!("config change broadcast channel closed, subscriber exiting");
+                            break;
+                        }
+                    }
                 }
-                Ok(ConfigChangeEvent::Failed { section, error }) => {
-                    warn!(
-                        section = %section,
-                        error = %error,
-                        "config change event failed, skipping session notification"
-                    );
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(missed = n, "config change subscriber lagged, missed events");
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    info!("config change broadcast channel closed, subscriber exiting");
-                    break;
+                _ = snapshot_rx.recv() => {
+                    // Snapshot broadcast without a preceding event — ignore.
+                    // Snapshots are only forwarded when paired with a Reloaded event.
                 }
             }
         }

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -3,7 +3,8 @@
 //! Responsible for session lifecycle: lookup, creation, restoration.
 //! On daemon shutdown, `flush_all()` serializes all active sessions to the persistence backend.
 
-use crate::config::{ConfigManager, ConfigSection};
+use crate::config::manager::{ConfigManager, ConfigSnapshot};
+use crate::config::ConfigSection;
 use crate::gateway::{DmScope, GatewayConfig, Message, Session};
 use crate::im::processor::ProcessError;
 use crate::im::IMAdapter;
@@ -70,6 +71,9 @@ pub struct SessionManager {
     config_manager: RwLock<Option<Arc<ConfigManager>>>,
     /// Agent registry for looking up resolved agent configs (design-doc query layer).
     agent_registry: RwLock<Option<Arc<crate::agent::registry::AgentRegistry>>>,
+    /// Latest config snapshot; swapped atomically on each hot-reload.
+    /// The old snapshot is released when all Arc references are dropped.
+    config_snapshot: RwLock<Option<ConfigSnapshot>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -107,6 +111,7 @@ impl SessionManager {
             key_registry: RwLock::new(HashMap::new()),
             config_manager: RwLock::new(None),
             agent_registry: RwLock::new(None),
+            config_snapshot: RwLock::new(None),
         }
     }
 
@@ -140,6 +145,15 @@ impl SessionManager {
     /// Get the current priority prompt overrides, if set.
     pub async fn get_prompt_overrides(&self) -> Option<PromptOverrides> {
         self.prompt_overrides.read().await.clone()
+    }
+
+    /// Swap in a new config snapshot, releasing the old one.
+    ///
+    /// The old snapshot's `Arc` reference count decrements; once all
+    /// holders release it, the memory is reclaimed automatically.
+    pub async fn swap_config_snapshot(&self, snapshot: ConfigSnapshot) {
+        let mut guard = self.config_snapshot.write().await;
+        *guard = Some(snapshot);
     }
 
     /// Set the tool registry for building system prompt ToolsSection.
@@ -433,11 +447,17 @@ impl SessionManager {
     /// Sessions already observe the latest config values through the shared
     /// `Arc<ConfigManager>` reference, so this notification is the only
     /// explicit refresh needed to invalidate derived caches.
-    pub async fn notify_config_changed(&self, section: ConfigSection) {
+    ///
+    /// The `snapshot` parameter carries the latest config snapshot for
+    /// downstream reference-swap semantics (fully utilised in Step 1.3).
+    pub async fn notify_config_changed(&self, section: ConfigSection, snapshot: ConfigSnapshot) {
         tracing::info!(
             section = %section,
+            snapshot_sections = snapshot.len(),
             "session_manager: config change notification received"
         );
+        // Swap in the new config snapshot (old one auto-released).
+        self.swap_config_snapshot(snapshot).await;
         let session_ids: Vec<String> = {
             let sessions = self.sessions.read().await;
             sessions.keys().cloned().collect()

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -156,6 +156,11 @@ impl SessionManager {
         *guard = Some(snapshot);
     }
 
+    /// Get the current config snapshot, if one has been swapped in.
+    pub async fn get_config_snapshot(&self) -> Option<ConfigSnapshot> {
+        self.config_snapshot.read().await.clone()
+    }
+
     /// Set the tool registry for building system prompt ToolsSection.
     pub async fn set_tool_registry(&self, registry: Arc<ToolRegistry>) {
         *self.tool_registry.write().await = Some(registry);

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -151,13 +151,14 @@ impl SessionManager {
     ///
     /// The old snapshot's `Arc` reference count decrements; once all
     /// holders release it, the memory is reclaimed automatically.
-    pub async fn swap_config_snapshot(&self, snapshot: ConfigSnapshot) {
+    pub(crate) async fn swap_config_snapshot(&self, snapshot: ConfigSnapshot) {
         let mut guard = self.config_snapshot.write().await;
         *guard = Some(snapshot);
     }
 
     /// Get the current config snapshot, if one has been swapped in.
-    pub async fn get_config_snapshot(&self) -> Option<ConfigSnapshot> {
+    #[allow(dead_code)] // used in tests
+    pub(crate) async fn get_config_snapshot(&self) -> Option<ConfigSnapshot> {
         self.config_snapshot.read().await.clone()
     }
 

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::manager::ConfigSnapshot;
 use crate::gateway::{GatewayConfig, Message};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::SessionCheckpoint;
@@ -351,8 +352,10 @@ use super::test_helpers::MockPersistService;
 #[tokio::test]
 async fn test_notify_config_changed_no_sessions() {
     let mgr = make_test_mgr(None);
+    let snapshot: ConfigSnapshot = ConfigSnapshot::default();
     // No sessions created — should complete without error
-    mgr.notify_config_changed(ConfigSection::Models).await;
+    mgr.notify_config_changed(ConfigSection::Models, snapshot)
+        .await;
 }
 
 /// notify_config_changed iterates over all active sessions and rebuilds
@@ -372,7 +375,9 @@ async fn test_notify_config_changed_iterates_active_sessions() {
     assert_ne!(id1, id2);
 
     // notify_config_changed should visit both sessions
-    mgr.notify_config_changed(ConfigSection::Channels).await;
+    let snapshot: ConfigSnapshot = ConfigSnapshot::default();
+    mgr.notify_config_changed(ConfigSection::Channels, snapshot)
+        .await;
 
     // Both sessions should still exist and have conversation sessions
     assert!(mgr.has_session(&id1).await);
@@ -396,7 +401,8 @@ async fn test_notify_config_changed_multiple_sections() {
         ConfigSection::Plugins,
         ConfigSection::System,
     ] {
-        mgr.notify_config_changed(section).await;
+        mgr.notify_config_changed(section, ConfigSnapshot::default())
+            .await;
     }
 
     // Session should still be intact

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -543,3 +543,57 @@ async fn test_clear_pending_empty() {
     };
     assert_eq!(count, 0);
 }
+
+// =====================================================================
+// Step 1.5 — swap_config_snapshot tests
+// =====================================================================
+
+/// swap_config_snapshot replaces the stored snapshot and subsequent reads
+/// return the new value.
+#[tokio::test]
+async fn test_swap_config_snapshot() {
+    use std::collections::HashMap;
+
+    let mgr = make_test_mgr(None);
+
+    // Initially no snapshot is stored
+    assert!(
+        mgr.get_config_snapshot().await.is_none(),
+        "no snapshot should be stored initially"
+    );
+
+    // Create and swap in a snapshot
+    let mut map = HashMap::new();
+    map.insert(ConfigSection::System, serde_json::json!({"version": "5.0"}));
+    let snapshot: ConfigSnapshot = ConfigSnapshot::new(map);
+    mgr.swap_config_snapshot(snapshot.clone()).await;
+
+    // Verify the stored snapshot is the one we swapped in
+    let stored = mgr
+        .get_config_snapshot()
+        .await
+        .expect("snapshot should exist");
+    assert!(
+        std::sync::Arc::ptr_eq(&stored, &snapshot),
+        "stored snapshot should be the same Arc as the one we swapped in"
+    );
+
+    // Swap in a different snapshot
+    let mut map2 = HashMap::new();
+    map2.insert(ConfigSection::Models, serde_json::json!({"models": []}));
+    let snapshot2: ConfigSnapshot = ConfigSnapshot::new(map2);
+    mgr.swap_config_snapshot(snapshot2.clone()).await;
+
+    let stored2 = mgr
+        .get_config_snapshot()
+        .await
+        .expect("snapshot should exist");
+    assert!(
+        std::sync::Arc::ptr_eq(&stored2, &snapshot2),
+        "stored snapshot should now be the second one"
+    );
+    assert!(
+        !std::sync::Arc::ptr_eq(&stored2, &snapshot),
+        "new snapshot should differ from the old one"
+    );
+}


### PR DESCRIPTION
## Summary

Align hot-reload config push mechanism with the design doc (`docs/design/config/hot-reload.md`).

Two architecture requirements from the design doc were not met by the current implementation:

1. **Config snapshot broadcast with reference-swap pattern**: ConfigManager now broadcasts `ConfigSnapshot` (an `Arc<HashMap<ConfigSection, Value>>`) via a `broadcast::Sender` after each successful reload. SessionManager holds the snapshot and atomically swaps the reference on new snapshot arrival. Old snapshots are automatically released when all references drop.

2. **Reload orchestration moved to ConfigReloadManager**: The read→parse→validate→update→broadcast pipeline is now driven by `ConfigReloadManager::reload_section()`, matching the design doc's data flow diagram. ConfigManager retains only low-level operations (`update_section_cache`, `backup_manager`, `rollback_file`).

### Files changed

- `src/config/manager.rs` — Added `ConfigSnapshot` type, broadcast channel, `update_section_cache()`, `get_section_value()`, `config_dir()`, `rollback_file()`
- `src/config/reload.rs` — ConfigReloadManager gains `reload_section()`, `reload_session_provider()`; `dispatch_change` and `run_reload_loop` refactored as methods
- `src/config/manager_reload.rs` — Adapted to use new ConfigManager internals
- `src/daemon/config_reload.rs` — Subscriber now receives snapshots via `tokio::select!` and forwards to SessionManager
- `src/gateway/session_manager.rs` — Added `config_snapshot` field, `swap_config_snapshot()`, updated `notify_config_changed()`
- Tests: `manager_tests.rs`, `reload_tests.rs`, `session_manager/tests.rs`

Source: user
Type: refactor
