### PR TITLE
fix: config validation gaps alignment with design doc

### DIFF
--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -52,82 +52,99 @@ impl AgentDirectoryProvider {
         self.permissions.clear();
 
         for id in &self.registry {
-            let user_config_path = self.user_agents_dir.join(id).join("config.json");
-            let project_config_path = self
-                .project_agents_dir
-                .as_ref()
-                .map(|d| d.join(id).join("config.json"));
-
-            // Try loading configs from both levels.
-            // Ok(Some(…)) = loaded, Ok(None) = file not found, Err(…) = parse/read error.
-            let (mut user_config, mut project_config) = {
-                let user_result = Self::load_agent_config(&user_config_path);
-                let project_result = project_config_path
-                    .as_ref()
-                    .map(|p| Self::load_agent_config(p))
-                    .unwrap_or(Ok(None));
-                match (user_result, project_result) {
-                    (Ok(uc), Ok(pc)) => (uc, pc),
-                    (Ok(uc), Err(e)) => {
-                        warn!("Agent '{}' project config parse error: {}", id, e);
-                        (uc, None)
-                    }
-                    (Err(e), Ok(pc)) => {
-                        warn!("Agent '{}' user config parse error: {}", id, e);
-                        (None, pc)
-                    }
-                    (Err(e1), Err(e2)) => {
-                        warn!(
-                            "Agent '{}' config parse errors: user: {}; project: {}",
-                            id, e1, e2
-                        );
-                        continue;
-                    }
-                }
+            let entry = self.load_agent_entry(id)?;
+            let Some((resolved, perms)) = entry else {
+                continue;
             };
-
-            // Backfill `id` from the directory name when missing, and
-            // warn on mismatch. The project layer is processed first so
-            // its injected id wins when both levels have an empty id
-            // (project fields override user fields in the merge below).
-            Self::inject_dirname_id(&mut project_config, id);
-            Self::inject_dirname_id(&mut user_config, id);
-
-            let path_label = id.as_str();
-            let resolved = match (project_config, user_config) {
-                (Some(proj), Some(usr)) => ResolvedAgentConfig::merge(proj, usr, path_label)?,
-                (Some(proj), None) => {
-                    ResolvedAgentConfig::from_single(proj, ConfigSource::Project, path_label)?
-                }
-                (None, Some(usr)) => {
-                    ResolvedAgentConfig::from_single(usr, ConfigSource::User, path_label)?
-                }
-                (None, None) => {
-                    warn!("Agent '{}' in registry but no config.json found", id);
-                    continue;
-                }
-            };
-
-            // Load permissions (same priority: project > user)
-            let user_perm_path = self.user_agents_dir.join(id).join("permissions.json");
-            let project_perm_path = self
-                .project_agents_dir
-                .as_ref()
-                .map(|d| d.join(id).join("permissions.json"));
-
-            let perms = project_perm_path
-                .as_ref()
-                .and_then(|p| Self::load_permissions(p))
-                .or_else(|| Self::load_permissions(&user_perm_path));
-
             if let Some(p) = perms {
                 self.permissions.insert(id.clone(), p);
             }
-
             self.entries.insert(id.clone(), resolved);
         }
 
         Ok(())
+    }
+
+    /// Load and merge configs for a single agent, returning `None` to
+    /// signal "skip this agent" (missing config or parse errors on
+    /// both levels).
+    fn load_agent_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<(ResolvedAgentConfig, Option<AgentPermissions>)>, ConfigError> {
+        let user_config_path = self.user_agents_dir.join(id).join("config.json");
+        let project_config_path = self
+            .project_agents_dir
+            .as_ref()
+            .map(|d| d.join(id).join("config.json"));
+
+        let (mut user_config, mut project_config) = Self::load_configs_from_both_levels(
+            id,
+            &user_config_path,
+            project_config_path.as_deref(),
+        )?;
+
+        Self::inject_dirname_id(&mut project_config, id);
+        Self::inject_dirname_id(&mut user_config, id);
+
+        let resolved = match (project_config, user_config) {
+            (Some(proj), Some(usr)) => ResolvedAgentConfig::merge(proj, usr, id)?,
+            (Some(proj), None) => {
+                ResolvedAgentConfig::from_single(proj, ConfigSource::Project, id)?
+            }
+            (None, Some(usr)) => ResolvedAgentConfig::from_single(usr, ConfigSource::User, id)?,
+            (None, None) => {
+                warn!("Agent '{}' in registry but no config.json found", id);
+                return Ok(None);
+            }
+        };
+
+        let perms = self.load_permissions_for_agent(id);
+        Ok(Some((resolved, perms)))
+    }
+
+    /// Load agent config.json from both user and project levels,
+    /// handling parse errors per-level with warnings.
+    fn load_configs_from_both_levels(
+        id: &str,
+        user_config_path: &std::path::Path,
+        project_config_path: Option<&std::path::Path>,
+    ) -> Result<(Option<AgentConfig>, Option<AgentConfig>), ConfigError> {
+        let user_result = Self::load_agent_config(user_config_path);
+        let project_result = project_config_path
+            .map(Self::load_agent_config)
+            .unwrap_or(Ok(None));
+        match (user_result, project_result) {
+            (Ok(uc), Ok(pc)) => Ok((uc, pc)),
+            (Ok(uc), Err(e)) => {
+                warn!("Agent '{}' project config parse error: {}", id, e);
+                Ok((uc, None))
+            }
+            (Err(e), Ok(pc)) => {
+                warn!("Agent '{}' user config parse error: {}", id, e);
+                Ok((None, pc))
+            }
+            (Err(e1), Err(e2)) => {
+                warn!(
+                    "Agent '{}' config parse errors: user: {}; project: {}",
+                    id, e1, e2
+                );
+                Ok((None, None))
+            }
+        }
+    }
+
+    /// Load permissions for a single agent (project > user priority).
+    fn load_permissions_for_agent(&self, id: &str) -> Option<AgentPermissions> {
+        let user_perm_path = self.user_agents_dir.join(id).join("permissions.json");
+        let project_perm_path = self
+            .project_agents_dir
+            .as_ref()
+            .map(|d| d.join(id).join("permissions.json"));
+        project_perm_path
+            .as_ref()
+            .and_then(|p| Self::load_permissions(p))
+            .or_else(|| Self::load_permissions(&user_perm_path))
     }
 
     fn load_agent_config(path: &std::path::Path) -> Result<Option<AgentConfig>, String> {

--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -66,8 +66,7 @@ impl AgentDirectoryProvider {
     }
 
     /// Load and merge configs for a single agent, returning `None` to
-    /// signal "skip this agent" (missing config or parse errors on
-    /// both levels).
+    /// signal "skip this agent" (no config.json found at either level).
     fn load_agent_entry(
         &self,
         id: &str,
@@ -82,7 +81,7 @@ impl AgentDirectoryProvider {
             id,
             &user_config_path,
             project_config_path.as_deref(),
-        )?;
+        );
 
         Self::inject_dirname_id(&mut project_config, id);
         Self::inject_dirname_id(&mut user_config, id);
@@ -109,27 +108,27 @@ impl AgentDirectoryProvider {
         id: &str,
         user_config_path: &std::path::Path,
         project_config_path: Option<&std::path::Path>,
-    ) -> Result<(Option<AgentConfig>, Option<AgentConfig>), ConfigError> {
+    ) -> (Option<AgentConfig>, Option<AgentConfig>) {
         let user_result = Self::load_agent_config(user_config_path);
         let project_result = project_config_path
             .map(Self::load_agent_config)
             .unwrap_or(Ok(None));
         match (user_result, project_result) {
-            (Ok(uc), Ok(pc)) => Ok((uc, pc)),
+            (Ok(uc), Ok(pc)) => (uc, pc),
             (Ok(uc), Err(e)) => {
                 warn!("Agent '{}' project config parse error: {}", id, e);
-                Ok((uc, None))
+                (uc, None)
             }
             (Err(e), Ok(pc)) => {
                 warn!("Agent '{}' user config parse error: {}", id, e);
-                Ok((None, pc))
+                (None, pc)
             }
             (Err(e1), Err(e2)) => {
                 warn!(
                     "Agent '{}' config parse errors: user: {}; project: {}",
                     id, e1, e2
                 );
-                Ok((None, None))
+                (None, None)
             }
         }
     }

--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -58,11 +58,33 @@ impl AgentDirectoryProvider {
                 .as_ref()
                 .map(|d| d.join(id).join("config.json"));
 
-            // Try loading configs from both levels
-            let mut user_config = Self::load_agent_config(&user_config_path);
-            let mut project_config = project_config_path
-                .as_ref()
-                .and_then(|p| Self::load_agent_config(p));
+            // Try loading configs from both levels.
+            // Ok(Some(…)) = loaded, Ok(None) = file not found, Err(…) = parse/read error.
+            let (mut user_config, mut project_config) = {
+                let user_result = Self::load_agent_config(&user_config_path);
+                let project_result = project_config_path
+                    .as_ref()
+                    .map(|p| Self::load_agent_config(p))
+                    .unwrap_or(Ok(None));
+                match (user_result, project_result) {
+                    (Ok(uc), Ok(pc)) => (uc, pc),
+                    (Ok(uc), Err(e)) => {
+                        warn!("Agent '{}' project config parse error: {}", id, e);
+                        (uc, None)
+                    }
+                    (Err(e), Ok(pc)) => {
+                        warn!("Agent '{}' user config parse error: {}", id, e);
+                        (None, pc)
+                    }
+                    (Err(e1), Err(e2)) => {
+                        warn!(
+                            "Agent '{}' config parse errors: user: {}; project: {}",
+                            id, e1, e2
+                        );
+                        continue;
+                    }
+                }
+            };
 
             // Backfill `id` from the directory name when missing, and
             // warn on mismatch. The project layer is processed first so
@@ -108,12 +130,15 @@ impl AgentDirectoryProvider {
         Ok(())
     }
 
-    fn load_agent_config(path: &std::path::Path) -> Option<AgentConfig> {
+    fn load_agent_config(path: &std::path::Path) -> Result<Option<AgentConfig>, String> {
         if !path.exists() {
-            return None;
+            return Ok(None);
         }
-        let content = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&content).ok()
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read '{}': {}", path.display(), e))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("failed to parse '{}': {}", path.display(), e))
+            .map(Some)
     }
 
     /// Backfill the agent's `id` from the directory name when missing,

--- a/src/config/agents/directory_tests.rs
+++ b/src/config/agents/directory_tests.rs
@@ -470,37 +470,6 @@ fn test_both_configs_parse_error_skips_agent() {
     );
 }
 
-/// load_agent_config returns Err with file path and error detail for invalid JSON.
-/// Test through the public reload() API — agent with bad JSON gets skipped.
-#[test]
-fn test_load_agent_config_error_skips_agent_and_loads_others() {
-    let user = TempDir::new().unwrap();
-
-    // Agent with invalid JSON
-    let bad_dir = user.path().join("bad-parse");
-    std::fs::create_dir_all(&bad_dir).unwrap();
-    std::fs::write(bad_dir.join("config.json"), "{{bad").unwrap();
-
-    // Agent with valid JSON
-    write_config(user.path(), "good-parse", "Good Agent");
-
-    let provider = AgentDirectoryProvider::new(
-        vec!["bad-parse".to_string(), "good-parse".to_string()],
-        user.path().to_path_buf(),
-        None,
-    )
-    .unwrap();
-
-    assert!(
-        provider.get("bad-parse").is_none(),
-        "agent with invalid config should be skipped"
-    );
-    assert!(
-        provider.get("good-parse").is_some(),
-        "valid agent should still be loaded"
-    );
-}
-
 /// Agent directory exists but config.json is a directory (not a file) →
 /// read_to_string fails → agent is skipped.
 #[test]

--- a/src/config/agents/directory_tests.rs
+++ b/src/config/agents/directory_tests.rs
@@ -383,3 +383,142 @@ fn test_directory_provider_id_mismatch_warn() {
         output
     );
 }
+
+// =====================================================================
+// Step 1.4 — Tests for `load_agent_config` parse error path
+// =====================================================================
+
+/// Agent with invalid JSON in user config.json → warn and skip.
+#[test]
+fn test_user_config_parse_error_skips_agent() {
+    let user = TempDir::new().unwrap();
+    let agent_dir = user.path().join("bad-user");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("config.json"), "not valid json {{").unwrap();
+
+    // Also create a valid agent to ensure loading continues.
+    write_config(user.path(), "good-user", "Good Agent");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["bad-user".to_string(), "good-user".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        provider.get("bad-user").is_none(),
+        "agent with invalid config.json should be skipped"
+    );
+    assert!(
+        provider.get("good-user").is_some(),
+        "valid agent should still be loaded"
+    );
+}
+
+/// Agent with invalid JSON in project config.json → warn and skip project
+/// config, but still load user config.
+#[test]
+fn test_project_config_parse_error_falls_back_to_user() {
+    let user = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    write_config(user.path(), "mixed", "User Name");
+
+    let project_dir = project.path().join("mixed");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(project_dir.join("config.json"), "totally broken json").unwrap();
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["mixed".to_string()],
+        user.path().to_path_buf(),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let entry = provider
+        .get("mixed")
+        .expect("agent should load from user config");
+    assert_eq!(entry.name, "User Name");
+    assert_eq!(entry.source, ConfigSource::User);
+}
+
+/// Both user and project config.json have invalid JSON → agent skipped entirely.
+#[test]
+fn test_both_configs_parse_error_skips_agent() {
+    let user = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let user_dir = user.path().join("both-bad");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("config.json"), "bad user json").unwrap();
+
+    let project_dir = project.path().join("both-bad");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(project_dir.join("config.json"), "bad project json").unwrap();
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["both-bad".to_string()],
+        user.path().to_path_buf(),
+        Some(project.path().to_path_buf()),
+    )
+    .unwrap();
+
+    assert!(
+        provider.get("both-bad").is_none(),
+        "agent with both configs broken should be skipped"
+    );
+}
+
+/// load_agent_config returns Err with file path and error detail for invalid JSON.
+/// Test through the public reload() API — agent with bad JSON gets skipped.
+#[test]
+fn test_load_agent_config_error_skips_agent_and_loads_others() {
+    let user = TempDir::new().unwrap();
+
+    // Agent with invalid JSON
+    let bad_dir = user.path().join("bad-parse");
+    std::fs::create_dir_all(&bad_dir).unwrap();
+    std::fs::write(bad_dir.join("config.json"), "{{bad").unwrap();
+
+    // Agent with valid JSON
+    write_config(user.path(), "good-parse", "Good Agent");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["bad-parse".to_string(), "good-parse".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        provider.get("bad-parse").is_none(),
+        "agent with invalid config should be skipped"
+    );
+    assert!(
+        provider.get("good-parse").is_some(),
+        "valid agent should still be loaded"
+    );
+}
+
+/// Agent directory exists but config.json is a directory (not a file) →
+/// read_to_string fails → agent is skipped.
+#[test]
+fn test_config_json_is_directory_skips_agent() {
+    let user = TempDir::new().unwrap();
+    let agent_dir = user.path().join("dir-agent");
+    // Create config.json as a directory instead of a file
+    std::fs::create_dir_all(agent_dir.join("config.json")).unwrap();
+
+    write_config(user.path(), "normal", "Normal Agent");
+
+    let provider = AgentDirectoryProvider::new(
+        vec!["dir-agent".to_string(), "normal".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    assert!(provider.get("dir-agent").is_none());
+    assert!(provider.get("normal").is_some());
+}

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -22,7 +22,7 @@ use super::events::{ConfigChangeBroadcaster, ConfigChangeEvent};
 /// downstream components (e.g. `SessionManager`) can swap to the
 /// latest config without holding a lock on `ConfigManager`.
 pub type ConfigSnapshot = Arc<HashMap<ConfigSection, serde_json::Value>>;
-use super::providers::{ConfigProvider, CredentialsProvider};
+use super::providers::{ConfigProvider, CredentialsProvider, ModelsConfigData};
 use super::session::{JsonSessionConfigProvider, SessionConfigProvider};
 use crate::agent::config::AgentPermissions;
 
@@ -376,6 +376,26 @@ impl ConfigManager {
         // Store as JSON value in sections (may be empty/default if dir is absent)
         if let Ok(json) = serde_json::to_value(&creds_provider) {
             sections.insert(ConfigSection::Credentials, json);
+        }
+
+        // Cross-validate credentials against models.json references.
+        if let Some(models_value) = sections.get(&ConfigSection::Models) {
+            match serde_json::from_value::<ModelsConfigData>(models_value.clone()) {
+                Ok(models_config) => {
+                    if let Err(e) = creds_provider.validate_model_references(&models_config) {
+                        warn!(
+                            error = %e,
+                            "credentials-models cross-validation warning"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "failed to parse models.json for credentials cross-validation"
+                    );
+                }
+            }
         }
 
         drop(sections);

--- a/src/config/providers/credentials.rs
+++ b/src/config/providers/credentials.rs
@@ -133,7 +133,9 @@ impl CredentialsProvider {
                 return Err(ConfigError::ValueError {
                     field: format!("credentials.{}", provider_id),
                     message: format!(
-                        "provider '{}' is referenced in models.json but has no credentials",
+                        "provider '{}' is referenced in models.json but has no credentials \
+                         (create a credentials file in config/credentials/ or check the \
+                         provider ID in models.json)",
                         provider_id
                     ),
                 });

--- a/src/config/providers/credentials.rs
+++ b/src/config/providers/credentials.rs
@@ -7,8 +7,9 @@ use std::fs;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
-use crate::config::providers::ConfigError;
+use crate::config::providers::{ConfigError, ModelsConfigData};
 use crate::config::ConfigProvider;
 
 // ---------------------------------------------------------------------------
@@ -115,6 +116,41 @@ impl CredentialsProvider {
             AnyProviderCredentials::Feishu(f) => Some(f),
             AnyProviderCredentials::ApiKey(_) => None,
         })
+    }
+
+    /// Cross-validate that every provider referenced in models.json has
+    /// corresponding credentials defined.
+    ///
+    /// Returns `Err` if any model provider is missing credentials.
+    /// Extra credentials (providers defined in credentials but not in models)
+    /// emit a warning but do not fail validation.
+    pub fn validate_model_references(
+        &self,
+        models_provider: &ModelsConfigData,
+    ) -> Result<(), ConfigError> {
+        for provider_id in models_provider.providers.keys() {
+            if !self.providers.contains_key(provider_id) {
+                return Err(ConfigError::ValueError {
+                    field: format!("credentials.{}", provider_id),
+                    message: format!(
+                        "provider '{}' is referenced in models.json but has no credentials",
+                        provider_id
+                    ),
+                });
+            }
+        }
+
+        for cred_id in self.providers.keys() {
+            if !models_provider.providers.contains_key(cred_id) {
+                warn!(
+                    provider = %cred_id,
+                    "credentials defined for provider '{}' but not referenced in models.json",
+                    cred_id
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -379,5 +415,103 @@ mod tests {
     fn test_version() {
         let provider = default_provider();
         assert_eq!(provider.version(), "1.0.0");
+    }
+
+    // -----------------------------------------------------------------
+    // validate_model_references tests
+    // -----------------------------------------------------------------
+
+    fn models_from_json(json: &str) -> super::ModelsConfigData {
+        super::ModelsConfigData::from_json_str(json).unwrap()
+    }
+
+    #[test]
+    fn test_validate_model_references_complete_match() {
+        let creds_json = r#"{"providers":{
+            "openai": {"provider":"openai","apiKey":"sk-test"},
+            "anthropic": {"provider":"anthropic","apiKey":"sk-ant"}
+        }}"#;
+        let creds = CredentialsProvider::from_json_str(creds_json).unwrap();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": { "models": [{"id":"gpt-4"}] },
+                "anthropic": { "models": [{"id":"claude-3"}] }
+            }
+        }"#,
+        );
+        assert!(creds.validate_model_references(&models).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_references_missing_credential() {
+        let creds_json = r#"{"providers":{
+            "openai": {"provider":"openai","apiKey":"sk-test"}
+        }}"#;
+        let creds = CredentialsProvider::from_json_str(creds_json).unwrap();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": { "models": [{"id":"gpt-4"}] },
+                "anthropic": { "models": [{"id":"claude-3"}] }
+            }
+        }"#,
+        );
+        let result = creds.validate_model_references(&models);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValueError { ref field, .. } if field.contains("anthropic")),
+            "error should reference the missing provider: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_model_references_extra_credentials_only_warn() {
+        let creds_json = r#"{"providers":{
+            "openai": {"provider":"openai","apiKey":"sk-test"},
+            "backup": {"provider":"backup","apiKey":"sk-backup"}
+        }}"#;
+        let creds = CredentialsProvider::from_json_str(creds_json).unwrap();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": { "models": [{"id":"gpt-4"}] }
+            }
+        }"#,
+        );
+        assert!(creds.validate_model_references(&models).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_references_empty_models() {
+        let creds_json = r#"{"providers":{
+            "openai": {"provider":"openai","apiKey":"sk-test"}
+        }}"#;
+        let creds = CredentialsProvider::from_json_str(creds_json).unwrap();
+        let models = models_from_json(r#"{"providers": {}}"#);
+        assert!(creds.validate_model_references(&models).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_references_empty_credentials_with_models() {
+        let creds = CredentialsProvider::default();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": { "models": [{"id":"gpt-4"}] }
+            }
+        }"#,
+        );
+        let result = creds.validate_model_references(&models);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_model_references_empty_both() {
+        let creds = CredentialsProvider::default();
+        let models = models_from_json(r#"{"providers": {}}"#);
+        assert!(creds.validate_model_references(&models).is_ok());
     }
 }

--- a/src/config/providers/plugins.rs
+++ b/src/config/providers/plugins.rs
@@ -118,7 +118,7 @@ impl ConfigProvider for PluginsConfigData {
     where
         Self: Sized,
     {
-        "config/plugins.json"
+        "plugins.json"
     }
 
     fn is_default(&self) -> bool {
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_config_path() {
-        assert_eq!(PluginsConfigData::config_path(), "config/plugins.json");
+        assert_eq!(PluginsConfigData::config_path(), "plugins.json");
     }
 
     #[test]


### PR DESCRIPTION
Fix three must-fix validation gaps between code and design doc (`docs/design/config/README.md`):

1. **Credentials cross-validation missing**: Added `validate_model_references()` method to `CredentialsProvider` that checks model providers have corresponding credentials defined. Models referencing undefined credentials now return an error; extra credentials only warn.
2. **Agent config.json parse error silently skipped**: Changed `load_agent_config()` to return `Result<AgentConfig, String>` with detailed error info instead of `Option<AgentConfig>`, while preserving skip behavior with proper warning logging.
3. **PluginsConfigData::config_path() inconsistent return value**: Fixed to return `"plugins.json"` (without `config/` prefix) matching `ConfigSection::Plugins::filename()` and other providers.

Additional improvements:
- Extracted `reload()` sub-methods to meet 50-line function limit
- Cleaned up code quality issues from E2 review (doc comment fix, redundant Result removal, duplicate test removal, error message improvements)

Source: design doc
Type: fix
