### PR TITLE
feat: enhance config validation with business rules

### DIFF
--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -327,6 +327,20 @@ impl ConfigManager {
                 }
             };
 
+            // Business validation: reuse the same validators used by hot-reload.
+            let validate = super::validators::for_section(section);
+            if let Err(msg) = validate(&value) {
+                warn!(
+                    section = %section,
+                    error = %msg,
+                    "config business validation failed, attempting rollback"
+                );
+                match self.try_rollback_and_retry(&path, section, &mut sections) {
+                    Ok(()) => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+
             sections.insert(section, value);
         }
 

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -902,10 +902,9 @@ fn test_load_business_validation_success_all_sections() {
     }
 }
 
-/// Test: load() with negative idleMinutes in session.json uses defaults.
-/// Session is loaded separately from mandatory sections.
+/// Test: load() with invalid session.json (negative idleMinutes) falls back to defaults.
 #[test]
-fn test_load_session_business_validation_failure_uses_defaults() {
+fn test_load_invalid_session_fallback_to_defaults() {
     let tmp = tempfile::tempdir().unwrap();
     write_mandatory_configs(tmp.path()).unwrap();
     // Session with negative idleMinutes in defaults — validation fails

--- a/src/config/manager_tests.rs
+++ b/src/config/manager_tests.rs
@@ -758,3 +758,236 @@ fn test_snapshot_broadcast_on_reload_failure() {
         "snapshot broadcast channel should be empty after validation failure"
     );
 }
+
+// =========================================================================
+// Step 1.8 — load() business validation integration tests
+// =========================================================================
+
+/// Helper: write a backup file for the given section.
+/// Backup naming follows BackupManager convention: `{stem}.{timestamp}.{ext}`
+fn write_backup(dir: &std::path::Path, section: ConfigSection, content: &str) {
+    let backup_dir = dir.join(".backups");
+    fs::create_dir_all(&backup_dir).unwrap();
+    let filename = section.filename();
+    let stem = filename.split('.').next().unwrap_or(filename);
+    let ext = filename.split('.').last().unwrap_or("json");
+    let ts = chrono::Local::now().format("%Y%m%d_%H%M%S_%f");
+    let backup_name = format!("{}.{}.{}", stem, ts, ext);
+    fs::write(backup_dir.join(backup_name), content).unwrap();
+}
+
+/// Test: load() triggers rollback when models.json has business validation
+/// failure (empty provider ID). Verifies file is restored from backup.
+#[test]
+fn test_load_business_validation_failure_models_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    // Create a backup of the valid config, then corrupt the file
+    let valid = fs::read_to_string(tmp.path().join("models.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Models, &valid);
+    fs::write(
+        tmp.path().join("models.json"),
+        r#"{"providers":{"":{"models":[]}}}"#,
+    )
+    .unwrap();
+
+    // load() should succeed because rollback restores the valid backup
+    manager.load().unwrap();
+    // In-memory cache should be updated to the backup value
+    let section = manager.section(ConfigSection::Models).unwrap();
+    assert_eq!(section["version"], "1.0");
+}
+
+/// Test: load() triggers rollback when channels.json has business validation
+/// failure (unknown channel type).
+#[test]
+fn test_load_business_validation_failure_channels_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let valid = fs::read_to_string(tmp.path().join("channels.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Channels, &valid);
+    fs::write(
+        tmp.path().join("channels.json"),
+        r#"{"channels":{"unknown-type":{"enabled":true}}}"#,
+    )
+    .unwrap();
+
+    manager.load().unwrap();
+    let section = manager.section(ConfigSection::Channels).unwrap();
+    assert_eq!(section["version"], "1.0");
+}
+
+/// Test: load() triggers rollback when gateway.json has business validation
+/// failure (invalid port).
+#[test]
+fn test_load_business_validation_failure_gateway_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let valid = fs::read_to_string(tmp.path().join("gateway.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Gateway, &valid);
+    fs::write(tmp.path().join("gateway.json"), r#"{"port":99999}"#).unwrap();
+
+    manager.load().unwrap();
+    let section = manager.section(ConfigSection::Gateway).unwrap();
+    assert_eq!(section["version"], "1.0");
+}
+
+/// Test: load() triggers rollback when plugins.json has business validation
+/// failure (empty plugin name).
+#[test]
+fn test_load_business_validation_failure_plugins_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let valid = fs::read_to_string(tmp.path().join("plugins.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Plugins, &valid);
+    fs::write(
+        tmp.path().join("plugins.json"),
+        r#"{"entries":{"":{"enabled":true}}}"#,
+    )
+    .unwrap();
+
+    manager.load().unwrap();
+    let section = manager.section(ConfigSection::Plugins).unwrap();
+    assert_eq!(section["version"], "1.0");
+}
+
+/// Test: load() triggers rollback when system.json has business validation
+/// failure (empty version string).
+#[test]
+fn test_load_business_validation_failure_system_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let valid = fs::read_to_string(tmp.path().join("system.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::System, &valid);
+    fs::write(tmp.path().join("system.json"), r#"{"version":""}"#).unwrap();
+
+    manager.load().unwrap();
+    let section = manager.section(ConfigSection::System).unwrap();
+    assert_eq!(section["version"], "1.0");
+}
+
+/// Test: load() succeeds normally when all mandatory sections have valid
+/// business values.
+#[test]
+fn test_load_business_validation_success_all_sections() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    for section in &[
+        ConfigSection::Models,
+        ConfigSection::Channels,
+        ConfigSection::Gateway,
+        ConfigSection::Plugins,
+        ConfigSection::System,
+    ] {
+        let value = manager.section(*section).unwrap();
+        assert_eq!(value["version"], "1.0", "section {:?} mismatch", section);
+    }
+}
+
+/// Test: load() with negative idleMinutes in session.json uses defaults.
+/// Session is loaded separately from mandatory sections.
+#[test]
+fn test_load_session_business_validation_failure_uses_defaults() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    // Session with negative idleMinutes in defaults — validation fails
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{"mainAgent":{"idleMinutes":-1}},"agents":{}}"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let session = manager.session_config_provider().unwrap();
+    assert_eq!(
+        session.sweeper_interval_secs(),
+        crate::config::session::DEFAULT_SWEEPER_INTERVAL_SECS
+    );
+}
+
+/// Test: load() with valid session.json loads successfully.
+#[test]
+fn test_load_session_business_validation_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    fs::write(
+        tmp.path().join("session.json"),
+        r#"{"defaults":{},"agents":{},"sweeperIntervalSecs":900}"#,
+    )
+    .unwrap();
+
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    let session = manager.session_config_provider().unwrap();
+    assert_eq!(session.sweeper_interval_secs(), 900);
+}
+
+/// Test: load() with multiple invalid sections triggers rollback for each.
+#[test]
+fn test_load_multiple_business_validation_failures_rollback() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+
+    // Create backups for both sections before corruption
+    let valid_models = fs::read_to_string(tmp.path().join("models.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Models, &valid_models);
+    let valid_gw = fs::read_to_string(tmp.path().join("gateway.json")).unwrap();
+    write_backup(tmp.path(), ConfigSection::Gateway, &valid_gw);
+
+    // Corrupt two mandatory sections simultaneously
+    fs::write(
+        tmp.path().join("models.json"),
+        r#"{"providers":{"":{"models":[]}}}"#,
+    )
+    .unwrap();
+    fs::write(tmp.path().join("gateway.json"), r#"{"port":99999}"#).unwrap();
+
+    // load() should succeed: both sections rollback independently
+    manager.load().unwrap();
+    assert_eq!(
+        manager.section(ConfigSection::Models).unwrap()["version"],
+        "1.0"
+    );
+    assert_eq!(
+        manager.section(ConfigSection::Gateway).unwrap()["version"],
+        "1.0"
+    );
+}
+
+/// Test: load() with empty models array (no providers key) passes validation.
+#[test]
+fn test_load_models_empty_providers_passes() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_mandatory_configs(tmp.path()).unwrap();
+    fs::write(tmp.path().join("models.json"), r#"{"providers":{}}"#).unwrap();
+
+    let manager = ConfigManager::new(tmp.path().to_path_buf()).unwrap();
+    manager.load().unwrap();
+    assert_eq!(
+        manager.section(ConfigSection::Models).unwrap()["providers"],
+        serde_json::json!({})
+    );
+}

--- a/src/config/providers/channels.rs
+++ b/src/config/providers/channels.rs
@@ -47,7 +47,8 @@ pub struct ChannelsConfigData {
 }
 
 /// Allowed channel types in the system.
-const ALLOWED_CHANNEL_TYPES: &[&str] = &[
+/// Known channel types accepted by the system.
+pub const ALLOWED_CHANNEL_TYPES: &[&str] = &[
     "feishu",
     "discord",
     "telegram",

--- a/src/config/providers/channels.rs
+++ b/src/config/providers/channels.rs
@@ -48,7 +48,7 @@ pub struct ChannelsConfigData {
 
 /// Allowed channel types in the system.
 /// Known channel types accepted by the system.
-pub const ALLOWED_CHANNEL_TYPES: &[&str] = &[
+pub(crate) const ALLOWED_CHANNEL_TYPES: &[&str] = &[
     "feishu",
     "discord",
     "telegram",

--- a/src/config/reload_tests.rs
+++ b/src/config/reload_tests.rs
@@ -13,7 +13,7 @@ mod reload_tests {
     fn make_config_manager(dir: &std::path::Path) -> Arc<ConfigManager> {
         let sections = [
             ("models.json", r#"{"models":[]}"#),
-            ("channels.json", r#"{"channels":[]}"#),
+            ("channels.json", r#"{"channels":{}}"#),
             ("gateway.json", r#"{"port":8080}"#),
             ("plugins.json", r#"{"plugins":[]}"#),
             ("system.json", r#"{"version":"1"}"#),
@@ -242,7 +242,7 @@ mod reload_tests {
         std::fs::write(d.path().join("models.json"), r#"{"models":[{"id":"m1"}]}"#).unwrap();
         std::fs::write(
             d.path().join("channels.json"),
-            r#"{"channels":[{"id":"ch1"}]}"#,
+            r#"{"channels":{"type":{}}}"#,
         )
         .unwrap();
         std::fs::write(d.path().join("gateway.json"), r#"{"port":9999}"#).unwrap();
@@ -276,7 +276,7 @@ mod reload_tests {
             (
                 "channels.json",
                 ConfigSection::Channels,
-                r#"{"channels":[{"id":"ch1"}]}"#,
+                r#"{"channels":{"type":{}}}"#,
             ),
             ("gateway.json", ConfigSection::Gateway, r#"{"port":9090}"#),
             (

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -275,11 +275,74 @@ fn validate_gateway(value: &serde_json::Value) -> Result<(), String> {
 /// Validate the **plugins** config section.
 ///
 /// - Top-level must be a JSON object.
-/// - If a `plugins` key is present, it must be an array.
+/// - Each plugin name in `entries` must be non-empty.
+/// - Each plugin name in `allow` must be non-empty.
+/// - For installed plugins (`installs`), the `installPath` must point to
+///   an existing file or directory if present.
 fn validate_plugins(value: &serde_json::Value) -> Result<(), String> {
     ensure_object(value, "plugins")?;
-    if let Some(arr) = value.get("plugins") {
-        ensure_array(arr, "plugins.plugins")?;
+
+    // Validate entries: each plugin name must be non-empty
+    if let Some(entries) = value.get("entries") {
+        if let Some(obj) = entries.as_object() {
+            for (name, _) in obj {
+                if name.is_empty() {
+                    return Err("plugins.entries plugin name cannot be empty".to_string());
+                }
+            }
+        }
+    }
+
+    // Validate allow: each plugin name must be non-empty
+    if let Some(allow) = value.get("allow") {
+        if let Some(arr) = allow.as_array() {
+            for (i, entry) in arr.iter().enumerate() {
+                match entry {
+                    serde_json::Value::String(s) if s.is_empty() => {
+                        return Err(format!("plugins.allow[{}] plugin name cannot be empty", i));
+                    }
+                    serde_json::Value::String(_) => {}
+                    _ => {
+                        return Err(format!("plugins.allow[{}] must be a string", i));
+                    }
+                }
+            }
+        }
+    }
+
+    // Validate installs: installPath must exist if present
+    if let Some(installs) = value.get("installs") {
+        if let Some(obj) = installs.as_object() {
+            for (name, info) in obj {
+                if name.is_empty() {
+                    return Err("plugins.installs plugin name cannot be empty".to_string());
+                }
+                validate_plugin_install(name, info)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a single plugin install entry.
+fn validate_plugin_install(name: &str, info: &serde_json::Value) -> Result<(), String> {
+    if !info.is_object() {
+        return Err(format!("plugins.installs.{} must be a JSON object", name));
+    }
+    // If installPath is present, verify the path exists
+    if let Some(path_val) = info.get("installPath") {
+        if let Some(path_str) = path_val.as_str() {
+            if !path_str.is_empty() {
+                let path = std::path::Path::new(path_str);
+                if !path.exists() {
+                    return Err(format!(
+                        "plugins.installs.{}.installPath '{}' does not exist",
+                        name, path_str
+                    ));
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -1,9 +1,9 @@
-//! Default validators for hot-reloaded config sections.
+//! Validators for hot-reloaded config sections.
 //!
-//! Each validator performs lightweight structural checks on the parsed JSON
-//! value — verifying the top-level type and presence of expected fields.
-//! Deep business validation (e.g., model name existence) is intentionally
-//! out of scope; those checks belong in the callers.
+//! Each validator performs structural checks and lightweight business
+//! validation (field presence, range, format) on the parsed JSON value.
+//! Deep cross-section validation (e.g., credentials reference resolution)
+//! belongs in the startup path via Provider `validate()` methods.
 
 use super::manager::ConfigSection;
 use super::manager_reload::SectionValidator;

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -37,10 +37,83 @@ pub fn for_section(section: ConfigSection) -> Box<SectionValidator> {
 ///
 /// - Top-level must be a JSON object.
 /// - If a `models` key is present, it must be an array.
+/// - Each provider ID (map key) must be non-empty.
+/// - Each model ID must be non-empty.
+/// - `baseUrl`, if present, must start with `http://` or `https://` (or be
+///   empty/absent).
 fn validate_models(value: &serde_json::Value) -> Result<(), String> {
     ensure_object(value, "models")?;
     if let Some(arr) = value.get("models") {
         ensure_array(arr, "models.models")?;
+    }
+    // Business validation: iterate providers and models
+    if let Some(providers) = value.get("providers") {
+        if let Some(obj) = providers.as_object() {
+            for (provider_id, provider_val) in obj {
+                if provider_id.is_empty() {
+                    return Err("models provider ID cannot be empty".to_string());
+                }
+                validate_provider(provider_id, provider_val)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a single provider entry within the models section.
+fn validate_provider(provider_id: &str, provider: &serde_json::Value) -> Result<(), String> {
+    if !provider.is_object() {
+        return Err(format!(
+            "models.providers.{} must be a JSON object",
+            provider_id
+        ));
+    }
+    // Validate base_url format if present
+    if let Some(base_url) = provider.get("baseUrl") {
+        if let Some(url) = base_url.as_str() {
+            if !url.is_empty() && !url.starts_with("http://") && !url.starts_with("https://") {
+                return Err(format!(
+                    "models.providers.{}.baseUrl must start with \
+                     http:// or https://",
+                    provider_id
+                ));
+            }
+        }
+    }
+    // Validate each model entry
+    if let Some(models) = provider.get("models") {
+        if let Some(arr) = models.as_array() {
+            for model in arr {
+                validate_model(provider_id, model)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a single model entry within a provider.
+fn validate_model(provider_id: &str, model: &serde_json::Value) -> Result<(), String> {
+    if !model.is_object() {
+        return Err(format!(
+            "models.providers.{}.models[] must be objects",
+            provider_id
+        ));
+    }
+    // Model ID is required and must be non-empty
+    match model.get("id") {
+        Some(serde_json::Value::String(id)) if id.is_empty() => {
+            return Err(format!(
+                "models.providers.{}.models[].id cannot be empty",
+                provider_id
+            ));
+        }
+        None => {
+            return Err(format!(
+                "models.providers.{}.models[].id is required",
+                provider_id
+            ));
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -350,8 +350,35 @@ fn validate_plugin_install(name: &str, info: &serde_json::Value) -> Result<(), S
 /// Validate the **system** config section.
 ///
 /// - Top-level must be a JSON object.
+/// - `version`, if present, must be a non-empty string.
+/// - `cron`, if present, must be a JSON object.
 fn validate_system(value: &serde_json::Value) -> Result<(), String> {
-    ensure_object(value, "system")
+    ensure_object(value, "system")?;
+
+    // version field: if present, must be a non-empty string
+    if let Some(version) = value.get("version") {
+        match version {
+            serde_json::Value::String(s) if s.is_empty() => {
+                return Err("system.version cannot be an empty string".to_string());
+            }
+            serde_json::Value::String(_) => {}
+            _ => {
+                return Err("system.version must be a string".to_string());
+            }
+        }
+    }
+
+    // cron field: if present, must be a JSON object
+    if let Some(cron) = value.get("cron") {
+        if !cron.is_object() {
+            return Err(format!(
+                "system.cron must be a JSON object, got {}",
+                type_name(cron)
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Validate the **session** config section.

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -174,19 +174,11 @@ fn validate_binding_entry(index: usize, entry: &serde_json::Value) -> Result<(),
             index
         ));
     }
-    // agentId is required and must be non-empty
-    match entry.get("agentId") {
-        Some(serde_json::Value::String(s)) if s.is_empty() => {
-            return Err(format!(
-                "channels.bindings[{}].agentId cannot be empty",
-                index
-            ));
-        }
-        None => {
-            return Err(format!("channels.bindings[{}].agentId is required", index));
-        }
-        _ => {}
-    }
+    require_non_empty(
+        entry,
+        "agentId",
+        &format!("channels.bindings[{}].agentId", index),
+    )?;
     // match sub-object
     let match_obj = match entry.get("match") {
         Some(m) if m.is_object() => m,
@@ -200,38 +192,16 @@ fn validate_binding_entry(index: usize, entry: &serde_json::Value) -> Result<(),
             return Err(format!("channels.bindings[{}].match is required", index));
         }
     };
-    // match.channel required, non-empty
-    match match_obj.get("channel") {
-        Some(serde_json::Value::String(s)) if s.is_empty() => {
-            return Err(format!(
-                "channels.bindings[{}].match.channel cannot be empty",
-                index
-            ));
-        }
-        None => {
-            return Err(format!(
-                "channels.bindings[{}].match.channel is required",
-                index
-            ));
-        }
-        _ => {}
-    }
-    // match.accountId required, non-empty
-    match match_obj.get("accountId") {
-        Some(serde_json::Value::String(s)) if s.is_empty() => {
-            return Err(format!(
-                "channels.bindings[{}].match.accountId cannot be empty",
-                index
-            ));
-        }
-        None => {
-            return Err(format!(
-                "channels.bindings[{}].match.accountId is required",
-                index
-            ));
-        }
-        _ => {}
-    }
+    require_non_empty(
+        match_obj,
+        "channel",
+        &format!("channels.bindings[{}].match.channel", index),
+    )?;
+    require_non_empty(
+        match_obj,
+        "accountId",
+        &format!("channels.bindings[{}].match.accountId", index),
+    )?;
     Ok(())
 }
 
@@ -245,7 +215,10 @@ fn validate_gateway(value: &serde_json::Value) -> Result<(), String> {
     if let Some(port) = value.get("port") {
         match port.as_u64() {
             Some(p) if p == 0 || p > 65535 => {
-                return Err(format!("gateway.port must be in range 1-65535, got {}", p));
+                return Err(format!(
+                    "gateway.port must be in range 1-65535, got {} (port 0 is reserved by the OS)",
+                    p
+                ));
             }
             Some(_) => {}
             None => {
@@ -417,6 +390,21 @@ fn validate_non_negative_field(value: &serde_json::Value, field: &str) -> Result
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/// Ensure a field in a JSON object is a non-empty string.
+///
+/// Returns `Err` if the field is absent or is an empty string.
+/// `path` should be the full dotted path (e.g., `channels.bindings[0].match.channel`).
+fn require_non_empty(obj: &serde_json::Value, field: &str, path: &str) -> Result<(), String> {
+    match obj.get(field) {
+        Some(serde_json::Value::String(s)) if s.is_empty() => {
+            Err(format!("{} cannot be empty", path))
+        }
+        Some(serde_json::Value::String(_)) => Ok(()),
+        None => Err(format!("{} is required", path)),
+        _ => Err(format!("{} must be a string", path)),
+    }
+}
 
 /// Ensure `value` is a JSON object; returns `Err` with a descriptive
 /// message if not.

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -358,11 +358,30 @@ fn validate_system(value: &serde_json::Value) -> Result<(), String> {
 ///
 /// - Top-level must be a JSON object.
 /// - If `sweeperIntervalSecs` is present, it must be a positive number.
+/// - If `idleMinutes` is present, it must be non-negative.
+/// - If `purgeAfterMinutes` is present, it must be non-negative.
 fn validate_session(value: &serde_json::Value) -> Result<(), String> {
     ensure_object(value, "session")?;
     if let Some(secs) = value.get("sweeperIntervalSecs") {
         if !secs.is_number() || secs.as_u64().unwrap_or(0) == 0 {
             return Err("session.sweeperIntervalSecs must be a positive number".to_string());
+        }
+    }
+    validate_non_negative_field(value, "idleMinutes")?;
+    validate_non_negative_field(value, "purgeAfterMinutes")?;
+    Ok(())
+}
+
+/// Validate that a numeric field, if present, is non-negative.
+fn validate_non_negative_field(value: &serde_json::Value, field: &str) -> Result<(), String> {
+    if let Some(v) = value.get(field) {
+        if !v.is_number() {
+            return Err(format!("session.{} must be a number", field));
+        }
+        if let Some(n) = v.as_f64() {
+            if n < 0.0 {
+                return Err(format!("session.{} must be non-negative", field));
+            }
         }
     }
     Ok(())

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -238,8 +238,38 @@ fn validate_binding_entry(index: usize, entry: &serde_json::Value) -> Result<(),
 /// Validate the **gateway** config section.
 ///
 /// - Top-level must be a JSON object.
+/// - `port`, if present, must be a number in 1..=65535.
+/// - `timeout`, if present, must be a non-negative number.
 fn validate_gateway(value: &serde_json::Value) -> Result<(), String> {
-    ensure_object(value, "gateway")
+    ensure_object(value, "gateway")?;
+    if let Some(port) = value.get("port") {
+        match port.as_u64() {
+            Some(p) if p == 0 || p > 65535 => {
+                return Err(format!("gateway.port must be in range 1-65535, got {}", p));
+            }
+            Some(_) => {}
+            None => {
+                return Err("gateway.port must be a non-negative integer".to_string());
+            }
+        }
+    }
+    if let Some(timeout) = value.get("timeout") {
+        if !timeout.is_number() {
+            return Err("gateway.timeout must be a number".to_string());
+        }
+        // Negative values: as_f64() returns Some for valid floats,
+        // but negative numbers should be rejected.
+        match timeout.as_f64() {
+            Some(t) if t < 0.0 => {
+                return Err("gateway.timeout must be non-negative".to_string());
+            }
+            Some(_) => {}
+            None => {
+                return Err("gateway.timeout must be a number".to_string());
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Validate the **plugins** config section.

--- a/src/config/validators.rs
+++ b/src/config/validators.rs
@@ -7,6 +7,7 @@
 
 use super::manager::ConfigSection;
 use super::manager_reload::SectionValidator;
+use super::providers::channels::ALLOWED_CHANNEL_TYPES;
 
 // ---------------------------------------------------------------------------
 // Public helpers
@@ -121,11 +122,115 @@ fn validate_model(provider_id: &str, model: &serde_json::Value) -> Result<(), St
 /// Validate the **channels** config section.
 ///
 /// - Top-level must be a JSON object.
-/// - If a `channels` key is present, it must be an array.
+/// - `channels` key, if present, must be a JSON object whose keys are
+///   known channel types (non-empty, in the allowed list).
+/// - `bindings` key, if present, must be a JSON array.  Each entry must
+///   have non-empty `agentId`, `match.channel`, and `match.accountId`.
 fn validate_channels(value: &serde_json::Value) -> Result<(), String> {
     ensure_object(value, "channels")?;
-    if let Some(arr) = value.get("channels") {
-        ensure_array(arr, "channels.channels")?;
+
+    // Validate channel type keys
+    if let Some(channels) = value.get("channels") {
+        if !channels.is_object() {
+            return Err(format!(
+                "channels.channels must be a JSON object, got {}",
+                type_name(channels)
+            ));
+        }
+        if let Some(obj) = channels.as_object() {
+            for (channel_type, _) in obj {
+                if channel_type.is_empty() {
+                    return Err("channels type cannot be empty".to_string());
+                }
+                if !ALLOWED_CHANNEL_TYPES.contains(&channel_type.as_str()) {
+                    return Err(format!(
+                        "unknown channel type '{}'. Allowed: {}",
+                        channel_type,
+                        ALLOWED_CHANNEL_TYPES.join(", ")
+                    ));
+                }
+            }
+        }
+    }
+
+    // Validate bindings
+    if let Some(bindings) = value.get("bindings") {
+        ensure_array(bindings, "channels.bindings")?;
+        if let Some(arr) = bindings.as_array() {
+            for (i, entry) in arr.iter().enumerate() {
+                validate_binding_entry(i, entry)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a single binding entry within the channels section.
+fn validate_binding_entry(index: usize, entry: &serde_json::Value) -> Result<(), String> {
+    if !entry.is_object() {
+        return Err(format!(
+            "channels.bindings[{}] must be a JSON object",
+            index
+        ));
+    }
+    // agentId is required and must be non-empty
+    match entry.get("agentId") {
+        Some(serde_json::Value::String(s)) if s.is_empty() => {
+            return Err(format!(
+                "channels.bindings[{}].agentId cannot be empty",
+                index
+            ));
+        }
+        None => {
+            return Err(format!("channels.bindings[{}].agentId is required", index));
+        }
+        _ => {}
+    }
+    // match sub-object
+    let match_obj = match entry.get("match") {
+        Some(m) if m.is_object() => m,
+        Some(_) => {
+            return Err(format!(
+                "channels.bindings[{}].match must be a JSON object",
+                index
+            ));
+        }
+        None => {
+            return Err(format!("channels.bindings[{}].match is required", index));
+        }
+    };
+    // match.channel required, non-empty
+    match match_obj.get("channel") {
+        Some(serde_json::Value::String(s)) if s.is_empty() => {
+            return Err(format!(
+                "channels.bindings[{}].match.channel cannot be empty",
+                index
+            ));
+        }
+        None => {
+            return Err(format!(
+                "channels.bindings[{}].match.channel is required",
+                index
+            ));
+        }
+        _ => {}
+    }
+    // match.accountId required, non-empty
+    match match_obj.get("accountId") {
+        Some(serde_json::Value::String(s)) if s.is_empty() => {
+            return Err(format!(
+                "channels.bindings[{}].match.accountId cannot be empty",
+                index
+            ));
+        }
+        None => {
+            return Err(format!(
+                "channels.bindings[{}].match.accountId is required",
+                index
+            ));
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -744,6 +744,41 @@ fn test_for_section_credentials_always_passes() {
 }
 
 // ---------------------------------------------------------------------------
+// Boundary / edge-case tests (Step 1.8)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_models_pass_empty_providers_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"providers":{}}"#).unwrap();
+    assert!(validate_models(&v).is_ok());
+}
+
+#[test]
+fn test_validate_models_pass_providers_with_empty_models_array() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"models":[]}}}"#).unwrap();
+    assert!(validate_models(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_pass_empty_entries_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"entries":{}}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_pass_empty_allow_array() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"allow":[]}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_pass_empty_installs_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"installs":{}}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+// ---------------------------------------------------------------------------
 // validate_session
 // ---------------------------------------------------------------------------
 

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -740,6 +740,119 @@ fn test_validate_session_pass_sweeper_interval_positive() {
     assert!(validate_session(&v).is_ok());
 }
 
+// ---------------------------------------------------------------------------
+// validate_session — idleMinutes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_session_pass_idle_minutes_zero() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"idleMinutes":0}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_pass_idle_minutes_positive() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"idleMinutes":30}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_fail_idle_minutes_negative() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"idleMinutes":-1}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("idleMinutes must be non-negative"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_fail_idle_minutes_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"idleMinutes":"abc"}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("idleMinutes must be a number"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_pass_idle_minutes_absent() {
+    let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// validate_session — purgeAfterMinutes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_session_pass_purge_after_minutes_zero() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"purgeAfterMinutes":0}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_pass_purge_after_minutes_positive() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"purgeAfterMinutes":1440}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_fail_purge_after_minutes_negative() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"purgeAfterMinutes":-1}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("purgeAfterMinutes must be non-negative"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_fail_purge_after_minutes_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"purgeAfterMinutes":"abc"}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("purgeAfterMinutes must be a number"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_session_pass_purge_after_minutes_absent() {
+    let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// validate_session — combined fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_session_pass_all_session_fields() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"sweeperIntervalSecs":600,"idleMinutes":30,"purgeAfterMinutes":1440,"compact":{}}"#,
+    )
+    .unwrap();
+    assert!(validate_session(&v).is_ok());
+}
+
+#[test]
+fn test_validate_session_fail_multiple_invalid() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"idleMinutes":30,"purgeAfterMinutes":-1}"#).unwrap();
+    let err = validate_session(&v).unwrap_err();
+    assert!(
+        err.contains("purgeAfterMinutes must be non-negative"),
+        "error: {}",
+        err
+    );
+}
+
 #[test]
 fn test_default_validator_session_passes_valid_json() {
     let v: serde_json::Value =

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -144,7 +144,10 @@ fn test_validate_models_fail_provider_not_object() {
 
 #[test]
 fn test_validate_channels_pass() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"channels":[{"id":"ch1"}]}"#).unwrap();
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"channels":{"feishu":{"enabled":true}},"bindings":[{"agentId":"a1","match":{"channel":"feishu","accountId":"acc1"}}]}"#,
+    )
+    .unwrap();
     assert!(validate_channels(&v).is_ok());
 }
 
@@ -165,7 +168,141 @@ fn test_validate_channels_fail_not_object() {
 fn test_validate_channels_fail_channels_not_array() {
     let v: serde_json::Value = serde_json::from_str(r#"{"channels":"bad"}"#).unwrap();
     let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_unknown_type() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"channels":{"unknown-channel":{"enabled":true}}}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("unknown channel type"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_empty_type_key() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"channels":{"":{"enabled":true}}}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("cannot be empty"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_bindings_not_array() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"bindings":"not-array"}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
     assert!(err.contains("array"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_not_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"bindings":["bad"]}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("must be a JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_missing_agent_id() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"bindings":[{"match":{"channel":"feishu","accountId":"a"}}]}"#)
+            .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("agentId is required"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_empty_agent_id() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"bindings":[{"agentId":"","match":{"channel":"feishu","accountId":"a"}}]}"#,
+    )
+    .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("agentId cannot be empty"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_missing_match() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"bindings":[{"agentId":"a1"}]}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("match is required"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_match_not_object() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"bindings":[{"agentId":"a1","match":"bad"}]}"#).unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(
+        err.contains("match must be a JSON object"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_channels_fail_binding_missing_channel() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"bindings":[{"agentId":"a1","match":{"accountId":"a"}}]}"#)
+            .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(err.contains("match.channel is required"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_channels_fail_binding_empty_channel() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"bindings":[{"agentId":"a1","match":{"channel":"","accountId":"a"}}]}"#,
+    )
+    .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(
+        err.contains("match.channel cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_channels_fail_binding_missing_account_id() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"bindings":[{"agentId":"a1","match":{"channel":"feishu"}}]}"#)
+            .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(
+        err.contains("match.accountId is required"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_channels_fail_binding_empty_account_id() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"bindings":[{"agentId":"a1","match":{"channel":"feishu","accountId":""}}]}"#,
+    )
+    .unwrap();
+    let err = validate_channels(&v).unwrap_err();
+    assert!(
+        err.contains("match.accountId cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_channels_pass_multiple_valid() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"channels":{"feishu":{"enabled":true},"telegram":{"enabled":false}},"bindings":[{"agentId":"a1","match":{"channel":"feishu","accountId":"acc1"}},{"agentId":"a2","match":{"channel":"telegram","accountId":"bot1"}}]}"#,
+    )
+    .unwrap();
+    assert!(validate_channels(&v).is_ok());
+}
+
+#[test]
+fn test_validate_channels_pass_no_bindings() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"channels":{"feishu":{"enabled":true}}}"#).unwrap();
+    assert!(validate_channels(&v).is_ok());
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +401,8 @@ fn test_default_validator_models_rejects_non_object() {
 
 #[test]
 fn test_default_validator_channels_passes_valid_json() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"channels":[{"id":"ch1"}]}"#).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"channels":{"feishu":{"enabled":true}}}"#).unwrap();
     let validator = ConfigSection::Channels.default_validator();
     assert!(validator(&v).is_ok());
 }

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -568,6 +568,91 @@ fn test_validate_system_fail_not_object() {
 }
 
 // ---------------------------------------------------------------------------
+// validate_system — version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_system_pass_version_non_empty() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"version":"1.0"}"#).unwrap();
+    assert!(validate_system(&v).is_ok());
+}
+
+#[test]
+fn test_validate_system_pass_version_absent() {
+    let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(validate_system(&v).is_ok());
+}
+
+#[test]
+fn test_validate_system_fail_version_empty_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"version":""}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(
+        err.contains("version cannot be an empty string"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_system_fail_version_not_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"version":123}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(err.contains("version must be a string"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_system_fail_version_null() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"version":null}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(err.contains("version must be a string"), "error: {}", err);
+}
+
+// ---------------------------------------------------------------------------
+// validate_system — cron
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_validate_system_pass_cron_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"cron":{"enabled":true}}"#).unwrap();
+    assert!(validate_system(&v).is_ok());
+}
+
+#[test]
+fn test_validate_system_pass_cron_absent() {
+    let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(validate_system(&v).is_ok());
+}
+
+#[test]
+fn test_validate_system_fail_cron_not_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"cron":"bad"}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(err.contains("cron must be a JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_system_fail_cron_array() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"cron":[1,2]}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(err.contains("cron must be a JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_system_fail_cron_bool() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"cron":true}"#).unwrap();
+    let err = validate_system(&v).unwrap_err();
+    assert!(err.contains("cron must be a JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_system_pass_version_and_cron() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"version":"2.0","cron":{"enabled":false}}"#).unwrap();
+    assert!(validate_system(&v).is_ok());
+}
+
+// ---------------------------------------------------------------------------
 // ConfigSection::default_validator / for_section
 // ---------------------------------------------------------------------------
 

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -426,12 +426,6 @@ fn test_validate_gateway_pass_all_valid_fields() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_validate_plugins_pass() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"plugins":[{"id":"p1"}]}"#).unwrap();
-    assert!(validate_plugins(&v).is_ok());
-}
-
-#[test]
 fn test_validate_plugins_pass_empty_object() {
     let v: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
     assert!(validate_plugins(&v).is_ok());
@@ -445,10 +439,109 @@ fn test_validate_plugins_fail_not_object() {
 }
 
 #[test]
-fn test_validate_plugins_fail_plugins_not_array() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"plugins":42}"#).unwrap();
+fn test_validate_plugins_pass_with_entries() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"entries":{"minimax":{"enabled":true},"lark":{"enabled":false}}}"#,
+    )
+    .unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_fail_empty_entry_name() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"entries":{"":{"enabled":true}}}"#).unwrap();
     let err = validate_plugins(&v).unwrap_err();
-    assert!(err.contains("array"), "error: {}", err);
+    assert!(
+        err.contains("plugin name cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_plugins_pass_with_allow() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"allow":["minimax","openclaw-lark"]}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_fail_empty_allow_name() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"allow":["minimax",""]}"#).unwrap();
+    let err = validate_plugins(&v).unwrap_err();
+    assert!(
+        err.contains("plugins.allow[1] plugin name cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_plugins_fail_allow_not_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"allow":[123]}"#).unwrap();
+    let err = validate_plugins(&v).unwrap_err();
+    assert!(err.contains("must be a string"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_plugins_pass_with_installs() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"installs":{"openclaw-lark":{"source":"archive"}}}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_fail_empty_install_name() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"installs":{"":{"source":"archive"}}}"#).unwrap();
+    let err = validate_plugins(&v).unwrap_err();
+    assert!(
+        err.contains("plugin name cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_plugins_fail_install_not_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"installs":{"p":"not-object"}}"#).unwrap();
+    let err = validate_plugins(&v).unwrap_err();
+    assert!(err.contains("must be a JSON object"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_plugins_fail_install_path_not_exists() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"installs":{"p":{"installPath":"/nonexistent/path/to/plugin"}}}"#)
+            .unwrap();
+    let err = validate_plugins(&v).unwrap_err();
+    assert!(err.contains("does not exist"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_plugins_pass_install_path_empty_string() {
+    // Empty installPath should be ignored
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"installs":{"p":{"installPath":""}}}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_pass_install_path_absent() {
+    // No installPath field at all
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"installs":{"p":{"source":"archive"}}}"#).unwrap();
+    assert!(validate_plugins(&v).is_ok());
+}
+
+#[test]
+fn test_validate_plugins_pass_all_fields() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"version":"1.0.0","enabled":true,"allow":["minimax"],"entries":{"minimax":{"enabled":true}},"installs":{"minimax":{"source":"archive"}}}"#,
+    )
+    .unwrap();
+    assert!(validate_plugins(&v).is_ok());
 }
 
 // ---------------------------------------------------------------------------
@@ -509,7 +602,8 @@ fn test_default_validator_gateway_passes_valid_json() {
 
 #[test]
 fn test_default_validator_plugins_passes_valid_json() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"plugins":[{"id":"p1"}]}"#).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"entries":{"p":{"enabled":true}}}"#).unwrap();
     let validator = ConfigSection::Plugins.default_validator();
     assert!(validator(&v).is_ok());
 }

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -328,6 +328,99 @@ fn test_validate_gateway_fail_not_object() {
     assert!(err.contains("JSON object"), "error: {}", err);
 }
 
+#[test]
+fn test_validate_gateway_fail_zero_port() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"port":0}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("range 1-65535"),
+        "error should mention port range: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_fail_port_too_high() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"port":99999}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("range 1-65535"),
+        "error should mention port range: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_fail_port_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"port":"abc"}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("non-negative integer"),
+        "error should mention non-negative integer: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_fail_negative_port() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"port":-1}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("non-negative integer"),
+        "error should mention non-negative integer: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_pass_valid_port_boundaries() {
+    let v1: serde_json::Value = serde_json::from_str(r#"{"port":1}"#).unwrap();
+    assert!(validate_gateway(&v1).is_ok());
+    let v2: serde_json::Value = serde_json::from_str(r#"{"port":65535}"#).unwrap();
+    assert!(validate_gateway(&v2).is_ok());
+}
+
+#[test]
+fn test_validate_gateway_fail_negative_timeout() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"timeout":-1000}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("non-negative"),
+        "error should mention non-negative: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_fail_timeout_string() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"timeout":"not-a-number"}"#).unwrap();
+    let err = validate_gateway(&v).unwrap_err();
+    assert!(
+        err.contains("must be a number"),
+        "error should mention must be a number: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_gateway_pass_valid_timeout() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"timeout":30000}"#).unwrap();
+    assert!(validate_gateway(&v).is_ok());
+}
+
+#[test]
+fn test_validate_gateway_pass_zero_timeout() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"timeout":0}"#).unwrap();
+    assert!(validate_gateway(&v).is_ok());
+}
+
+#[test]
+fn test_validate_gateway_pass_all_valid_fields() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"port":8080,"timeout":30000,"name":"gw"}"#).unwrap();
+    assert!(validate_gateway(&v).is_ok());
+}
+
 // ---------------------------------------------------------------------------
 // validate_plugins
 // ---------------------------------------------------------------------------

--- a/src/config/validators_tests.rs
+++ b/src/config/validators_tests.rs
@@ -24,7 +24,8 @@ fn test_validate_models_pass_empty_object() {
 
 #[test]
 fn test_validate_models_pass_with_array() {
-    let v: serde_json::Value = serde_json::from_str(r#"{"models":[{"id":"m1"}]}"#).unwrap();
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"models":[{"id":"m1"}]}}}"#).unwrap();
     assert!(validate_models(&v).is_ok());
 }
 
@@ -47,6 +48,94 @@ fn test_validate_models_fail_models_not_array() {
     let v: serde_json::Value = serde_json::from_str(r#"{"models":"not array"}"#).unwrap();
     let err = validate_models(&v).unwrap_err();
     assert!(err.contains("array"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_models_fail_empty_provider_id() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"providers":{"":{"models":[]}}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(
+        err.contains("provider ID cannot be empty"),
+        "error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_validate_models_fail_empty_model_id() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"models":[{"id":""}]}}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(err.contains("id cannot be empty"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_models_fail_missing_model_id() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"models":[{"name":"no-id"}]}}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(err.contains("id is required"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_models_fail_invalid_base_url() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"baseUrl":"ftp://bad","models":[]}}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(err.contains("baseUrl must start with"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_models_pass_valid_base_url() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"{"providers":{"p":{"baseUrl":"https://api.example.com","models":[]}}}"#,
+    )
+    .unwrap();
+    assert!(validate_models(&v).is_ok());
+}
+
+#[test]
+fn test_validate_models_pass_empty_base_url() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"baseUrl":"","models":[]}}}"#).unwrap();
+    assert!(validate_models(&v).is_ok());
+}
+
+#[test]
+fn test_validate_models_pass_multiple_providers() {
+    let v: serde_json::Value = serde_json::from_str(
+        r#"
+        {
+            "providers": {
+                "openai": {
+                    "baseUrl": "https://api.openai.com",
+                    "models": [{"id": "gpt-4"}]
+                },
+                "anthropic": {
+                    "baseUrl": "https://api.anthropic.com",
+                    "models": [{"id": "claude-3"}]
+                }
+            }
+        }
+        "#,
+    )
+    .unwrap();
+    assert!(validate_models(&v).is_ok());
+}
+
+#[test]
+fn test_validate_models_fail_model_not_object() {
+    let v: serde_json::Value =
+        serde_json::from_str(r#"{"providers":{"p":{"models":["bad"]}}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(err.contains("must be objects"), "error: {}", err);
+}
+
+#[test]
+fn test_validate_models_fail_provider_not_object() {
+    let v: serde_json::Value = serde_json::from_str(r#"{"providers":{"p":"not-object"}}"#).unwrap();
+    let err = validate_models(&v).unwrap_err();
+    assert!(err.contains("must be a JSON object"), "error: {}", err);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
feat: enhance config validation with business rules for hot-reload and startup paths

Add comprehensive business validation to the config loading pipeline, aligning
code behavior with the design doc's validation rules table.

Hot-reload path (validators.rs):
- models: validate provider ID non-empty, model ID non-empty, base_url format
- channels: validate type in known types list
- gateway: validate port range (1-65535), timeout non-negative
- plugins: validate name non-empty
- session: validate idleMinutes/purgeAfterMinutes non-negative
- system: validate version non-empty

Startup path (ConfigManager::load()):
- Call section validators (from validators.rs) after serde deserialization
- Validation failure triggers rollback-and-retry flow

Also includes E2 review fixes, unit tests, and reload_tests schema updates.

Source: CI
Type: feat
