### PR TITLE
fix: use sort_by_key in dreaming.rs to fix clippy lint

### DIFF
--- a/src/memory/dreaming.rs
+++ b/src/memory/dreaming.rs
@@ -246,7 +246,7 @@ impl DreamingPipeline {
 
         let top_words: Vec<String> = {
             let mut pairs: Vec<_> = word_freq.into_iter().collect();
-            pairs.sort_by(|a, b| b.1.cmp(&a.1));
+            pairs.sort_by_key(|a| std::cmp::Reverse(a.1));
             pairs.into_iter().take(10).map(|(w, _)| w).collect()
         };
 


### PR DESCRIPTION
Fix clippy lint error in dreaming.rs

CI run #27945906727 failed due to clippy lint `unnecessary_sort_by` in `src/memory/dreaming.rs:249`. The `sort_by(|a, b| b.1.cmp(&a.1))` was replaced with `sort_by_key(|a| std::cmp::Reverse(a.1))` which is semantically equivalent (descending sort) and satisfies the clippy lint requirement.

Source: CI
Type: fix
