### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -75,5 +75,12 @@
     "commit_time": "2026-06-22T10:58:53+08:00",
     "confirmed_time": "2026-06-22T11:08:19.648114+08:00",
     "comment": ""
+  },
+  {
+    "path": "docs/design/daemon/README.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-22T18:44:05.434607+08:00",
+    "comment": "blocked: dependency declarations place SystemPromptBuilder at Layer 3 but layer table says Layer 4"
   }
 ]


### PR DESCRIPTION
操作 docs/design/daemon/README.md，标记为 blocked。

原因：设计文档内部矛盾 — 依赖声明将 SystemPromptBuilder 的依赖定为 [AgentRegistry, SkillsRegistry]（均为 Layer 2），拓扑排序自然推导结果为 Layer 3，但层归属表标注为 Layer 4。