### PR TITLE
feat: add dual-mode shutdown support with graceful/forceful escalation

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -436,12 +436,60 @@ impl Daemon {
     }
 
     /// Run the daemon — blocks until shutdown signal is received.
+    ///
+    /// First signal triggers graceful shutdown; subsequent signals escalate to forceful.
     pub async fn run(&self) -> anyhow::Result<()> {
-        crate::platform::process::wait_for_shutdown_signal().await?;
-        self.shutdown.initiate_shutdown().await;
+        use tokio::signal::unix::{signal, SignalKind};
+
+        // Set up signal listeners for SIGTERM and SIGINT
+        let mut sigint = signal(SignalKind::interrupt())
+            .map_err(|e| anyhow::anyhow!("failed to register SIGINT handler: {}", e))?;
+        let mut sigterm = signal(SignalKind::terminate())
+            .map_err(|e| anyhow::anyhow!("failed to register SIGTERM handler: {}", e))?;
+
+        // Wait for the first shutdown signal
+        tokio::select! {
+            _ = sigint.recv() => {
+                info!("Received Ctrl+C, initiating graceful shutdown...");
+            }
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM, initiating graceful shutdown...");
+            }
+        }
+
+        // Start graceful shutdown in a background task
+        let shutdown_handle = self.shutdown.clone();
+        let mut shutdown_task = tokio::spawn(async move {
+            shutdown_handle.initiate_shutdown().await;
+        });
+
+        // Monitor for escalation signals during graceful drain
+        loop {
+            tokio::select! {
+                result = &mut shutdown_task => {
+                    // Shutdown drain completed (graceful or forceful)
+                    if let Err(e) = result {
+                        tracing::error!(error = %e, "shutdown task panicked");
+                    }
+                    break;
+                }
+                _ = sigint.recv() => {
+                    if self.shutdown.escalate_to_forceful() {
+                        info!("Received repeated Ctrl+C, escalated to forceful shutdown");
+                    }
+                }
+                _ = sigterm.recv() => {
+                    if self.shutdown.escalate_to_forceful() {
+                        info!("Received repeated SIGTERM, escalated to forceful shutdown");
+                    }
+                }
+            }
+        }
+
         // Flush all active session checkpoints before shutdown
-        match self.gateway.flush_all_sessions().await {
-            Ok(n) => tracing::info!(count = n, "flushed session checkpoints"),
+        let mode = self.shutdown.mode();
+        match self.gateway.flush_all_sessions(mode).await {
+            Ok(n) => tracing::info!(count = n, mode = ?mode, "flushed session checkpoints"),
             Err(e) => tracing::warn!(error = %e, "failed to flush sessions"),
         }
         // Clear all pending approval requests (denied with callbacks triggered)

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -12,6 +12,16 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{info, warn};
 
+/// Shutdown mode — distinguishes graceful from forceful shutdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ShutdownMode {
+    /// Graceful: wait for in-flight operations to complete
+    #[default]
+    Graceful,
+    /// Forceful: immediately terminate operations
+    Forceful,
+}
+
 /// Shutdown state machine
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ShutdownState {
@@ -24,6 +34,8 @@ pub enum ShutdownState {
     Draining,
     /// Clean exit
     Stopped,
+    /// Forceful shutdown — skip drain, terminate immediately
+    ForcefulShuttingDown,
 }
 
 impl ShutdownState {
@@ -33,7 +45,25 @@ impl ShutdownState {
             1 => ShutdownState::ShuttingDown,
             2 => ShutdownState::Draining,
             3 => ShutdownState::Stopped,
+            4 => ShutdownState::ForcefulShuttingDown,
             _ => ShutdownState::Running,
+        }
+    }
+
+    /// Returns true if the state represents an active shutdown
+    /// (either graceful or forceful).
+    fn is_shutting_down_state(self) -> bool {
+        matches!(
+            self,
+            ShutdownState::ShuttingDown | ShutdownState::ForcefulShuttingDown
+        )
+    }
+
+    /// Returns the shutdown mode for an active shutdown state.
+    fn mode(self) -> ShutdownMode {
+        match self {
+            ShutdownState::ForcefulShuttingDown => ShutdownMode::Forceful,
+            _ => ShutdownMode::Graceful,
         }
     }
 }
@@ -96,6 +126,25 @@ impl ShutdownCoordinator {
             .is_ok()
     }
 
+    /// Atomically escalate from ShuttingDown → ForcefulShuttingDown.
+    /// Returns true if the escalation succeeded, false if already in a
+    /// non-ShuttingDown state.
+    pub fn escalate_to_forceful(&self) -> bool {
+        self.state
+            .compare_exchange(
+                ShutdownState::ShuttingDown as u8,
+                ShutdownState::ForcefulShuttingDown as u8,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+    }
+
+    /// Returns the current shutdown mode.
+    pub fn mode(&self) -> ShutdownMode {
+        ShutdownState::from_u8(self.state.load(Ordering::SeqCst)).mode()
+    }
+
     /// Transition to Draining state
     pub fn start_drain(&self) {
         self.state
@@ -145,7 +194,27 @@ impl ShutdownHandle {
 
     /// Returns true if shutdown has been initiated (not Running)
     pub fn is_shutting_down(&self) -> bool {
-        self.coordinator.state() != ShutdownState::Running
+        self.coordinator.state().is_shutting_down_state()
+    }
+
+    /// Returns true if the current shutdown is forceful.
+    pub fn is_forceful(&self) -> bool {
+        self.coordinator.state() == ShutdownState::ForcefulShuttingDown
+    }
+
+    /// Returns the current shutdown mode.
+    pub fn mode(&self) -> ShutdownMode {
+        self.coordinator.mode()
+    }
+
+    /// Escalate a graceful shutdown to forceful.
+    /// Returns true if escalation succeeded, false if not in ShuttingDown state.
+    pub fn escalate_to_forceful(&self) -> bool {
+        let ok = self.coordinator.escalate_to_forceful();
+        if ok {
+            info!("Upgraded to forceful shutdown");
+        }
+        ok
     }
 
     /// Initiate graceful shutdown — called when SIGTERM/SIGINT is received.
@@ -154,10 +223,14 @@ impl ShutdownHandle {
     /// 2. Wait up to DRAIN_TIMEOUT_SECS for in-flight work to complete
     /// 3. Transition to Draining → Stopped
     ///
+    /// If already shutting down, escalates to forceful.
     /// If timeout is exceeded, force-exit.
     pub async fn initiate_shutdown(&self) {
         if !self.coordinator.try_start_shutdown() {
-            info!("Shutdown already in progress");
+            // Already shutting down — escalate to forceful on repeated signal
+            if self.escalate_to_forceful() {
+                self.wait_for_drain().await;
+            }
             return;
         }
 
@@ -171,10 +244,19 @@ impl ShutdownHandle {
     }
 
     /// Wait for busy_count to reach 0 or timeout, then finalize shutdown.
+    /// In forceful mode, skip the timeout and finalize immediately.
     async fn wait_for_drain(&self) {
         let started_at = std::time::Instant::now();
 
         loop {
+            // If upgraded to forceful mid-drain, finalize immediately
+            if self.is_forceful() {
+                info!("Forceful mode — skipping drain wait");
+                self.coordinator.start_drain();
+                self.coordinator.mark_stopped();
+                return;
+            }
+
             let count = self.busy_count.load(Ordering::SeqCst);
             if count == 0 {
                 info!("All in-flight operations complete, shutting down immediately");
@@ -250,6 +332,10 @@ mod tests {
         assert_eq!(ShutdownState::from_u8(1), ShutdownState::ShuttingDown);
         assert_eq!(ShutdownState::from_u8(2), ShutdownState::Draining);
         assert_eq!(ShutdownState::from_u8(3), ShutdownState::Stopped);
+        assert_eq!(
+            ShutdownState::from_u8(4),
+            ShutdownState::ForcefulShuttingDown
+        );
         // Invalid values default to Running
         assert_eq!(ShutdownState::from_u8(99), ShutdownState::Running);
     }
@@ -288,11 +374,84 @@ mod tests {
     }
 
     #[test]
+    fn test_coordinator_escalate_to_forceful_success() {
+        let coordinator = ShutdownCoordinator::new();
+        coordinator.try_start_shutdown();
+        assert!(coordinator.escalate_to_forceful());
+        assert_eq!(coordinator.state(), ShutdownState::ForcefulShuttingDown);
+    }
+
+    #[test]
+    fn test_coordinator_escalate_to_forceful_fails_when_running() {
+        let coordinator = ShutdownCoordinator::new();
+        assert!(!coordinator.escalate_to_forceful());
+        assert_eq!(coordinator.state(), ShutdownState::Running);
+    }
+
+    #[test]
+    fn test_coordinator_escalate_to_forceful_fails_when_stopped() {
+        let coordinator = ShutdownCoordinator::new();
+        coordinator.try_start_shutdown();
+        coordinator.start_drain();
+        coordinator.mark_stopped();
+        assert!(!coordinator.escalate_to_forceful());
+        assert_eq!(coordinator.state(), ShutdownState::Stopped);
+    }
+
+    #[test]
+    fn test_coordinator_escalate_to_forceful_fails_when_already_forceful() {
+        let coordinator = ShutdownCoordinator::new();
+        coordinator.try_start_shutdown();
+        assert!(coordinator.escalate_to_forceful());
+        // Second escalate should fail (already forceful, not ShuttingDown)
+        assert!(!coordinator.escalate_to_forceful());
+        assert_eq!(coordinator.state(), ShutdownState::ForcefulShuttingDown);
+    }
+
+    #[test]
+    fn test_coordinator_mode() {
+        let coordinator = ShutdownCoordinator::new();
+        assert_eq!(coordinator.mode(), ShutdownMode::Graceful);
+
+        coordinator.try_start_shutdown();
+        assert_eq!(coordinator.mode(), ShutdownMode::Graceful);
+
+        coordinator.escalate_to_forceful();
+        assert_eq!(coordinator.mode(), ShutdownMode::Forceful);
+    }
+
+    #[test]
     fn test_shutdown_handle_initial_state() {
         let handle = ShutdownHandle::new();
         assert_eq!(handle.state(), ShutdownState::Running);
         assert!(!handle.is_shutting_down());
         assert!(!handle.is_stopped());
+        assert!(!handle.is_forceful());
+        assert_eq!(handle.mode(), ShutdownMode::Graceful);
+    }
+
+    #[test]
+    fn test_shutdown_handle_escalate_success() {
+        let handle = ShutdownHandle::new();
+        handle.coordinator.try_start_shutdown();
+        assert!(handle.escalate_to_forceful());
+        assert!(handle.is_forceful());
+        assert_eq!(handle.mode(), ShutdownMode::Forceful);
+    }
+
+    #[test]
+    fn test_shutdown_handle_escalate_fails_when_running() {
+        let handle = ShutdownHandle::new();
+        assert!(!handle.escalate_to_forceful());
+        assert!(!handle.is_forceful());
+    }
+
+    #[test]
+    fn test_shutdown_handle_is_shutting_down_in_forceful() {
+        let handle = ShutdownHandle::new();
+        handle.coordinator.try_start_shutdown();
+        handle.escalate_to_forceful();
+        assert!(handle.is_shutting_down());
     }
 
     #[test]
@@ -306,18 +465,21 @@ mod tests {
     #[tokio::test]
     async fn test_initiate_shutdown_first_caller_wins() {
         let handle = ShutdownHandle::new();
+        // Register a busy operation so drain doesn't complete immediately
+        handle.busy_count.fetch_add(1, Ordering::SeqCst);
 
         // First initiate succeeds
         let handle2 = handle.clone();
-        let (tx, _rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
             handle2.initiate_shutdown().await;
-            let _ = tx.send(());
         });
 
         // Give it a moment to start
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(handle.is_shutting_down());
+
+        // Release the busy count so drain can complete
+        handle.decrement_busy();
     }
 
     #[test]
@@ -326,6 +488,16 @@ mod tests {
         assert_eq!(format!("{:?}", ShutdownState::ShuttingDown), "ShuttingDown");
         assert_eq!(format!("{:?}", ShutdownState::Draining), "Draining");
         assert_eq!(format!("{:?}", ShutdownState::Stopped), "Stopped");
+        assert_eq!(
+            format!("{:?}", ShutdownState::ForcefulShuttingDown),
+            "ForcefulShuttingDown"
+        );
+    }
+
+    #[test]
+    fn test_shutdown_mode_debug() {
+        assert_eq!(format!("{:?}", ShutdownMode::Graceful), "Graceful");
+        assert_eq!(format!("{:?}", ShutdownMode::Forceful), "Forceful");
     }
 
     #[test]

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -55,7 +55,9 @@ impl ShutdownState {
     fn is_shutting_down_state(self) -> bool {
         matches!(
             self,
-            ShutdownState::ShuttingDown | ShutdownState::ForcefulShuttingDown
+            ShutdownState::ShuttingDown
+                | ShutdownState::Draining
+                | ShutdownState::ForcefulShuttingDown
         )
     }
 
@@ -210,11 +212,7 @@ impl ShutdownHandle {
     /// Escalate a graceful shutdown to forceful.
     /// Returns true if escalation succeeded, false if not in ShuttingDown state.
     pub fn escalate_to_forceful(&self) -> bool {
-        let ok = self.coordinator.escalate_to_forceful();
-        if ok {
-            info!("Upgraded to forceful shutdown");
-        }
-        ok
+        self.coordinator.escalate_to_forceful()
     }
 
     /// Initiate graceful shutdown — called when SIGTERM/SIGINT is received.
@@ -576,6 +574,17 @@ mod tests {
         // Second escalation is a no-op (already forceful)
         assert!(!handle.escalate_to_forceful());
         assert!(handle.is_forceful());
+    }
+
+    #[test]
+    fn test_is_shutting_down_true_when_draining() {
+        let handle = ShutdownHandle::new();
+        handle.coordinator.try_start_shutdown();
+        handle.coordinator.start_drain();
+
+        // Draining is still "shutting down" — components should reject new work
+        assert!(handle.is_shutting_down());
+        assert!(!handle.is_forceful());
     }
 
     #[test]

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -511,4 +511,82 @@ mod tests {
         // In test mode, drain_poll_interval should return 100ms (not 2s)
         assert_eq!(drain_poll_interval(), std::time::Duration::from_millis(100));
     }
+
+    #[test]
+    fn test_busy_count_unchanged_in_forceful_mode() {
+        let handle = ShutdownHandle::new();
+
+        // Start a graceful shutdown with pending work
+        handle.coordinator.try_start_shutdown();
+        handle.increment_busy();
+        assert_eq!(handle.busy_count(), 1);
+
+        // Escalate to forceful
+        assert!(handle.escalate_to_forceful());
+        assert!(handle.is_forceful());
+
+        // busy_count is still 1 — forceful mode doesn't clear it;
+        // the drain path simply skips waiting for it to reach 0
+        assert_eq!(handle.busy_count(), 1);
+
+        // Decrement still works normally
+        handle.decrement_busy();
+        assert_eq!(handle.busy_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_drain_triggers_on_escalation() {
+        let handle = ShutdownHandle::new();
+        let mut rx = handle.subscribe_drain();
+        handle.increment_busy();
+
+        // Spawn initiate_shutdown — it will block on drain because busy_count > 0
+        let h = handle.clone();
+        tokio::spawn(async move {
+            h.initiate_shutdown().await;
+        });
+        // Let it enter the drain loop
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(handle.is_shutting_down());
+
+        // Escalate — drain_done_tx fires during initiate_shutdown,
+        // so the subscriber should receive the signal
+        handle.escalate_to_forceful();
+        // Release busy count so drain can finalize
+        handle.decrement_busy();
+
+        // Wait for shutdown to finish
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // The subscriber received at least one drain signal
+        // (sent in initiate_shutdown before the drain loop)
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn test_handle_escalate_idempotent() {
+        let handle = ShutdownHandle::new();
+        handle.coordinator.try_start_shutdown();
+
+        // First escalation succeeds
+        assert!(handle.escalate_to_forceful());
+        assert!(handle.is_forceful());
+        assert_eq!(handle.mode(), ShutdownMode::Forceful);
+
+        // Second escalation is a no-op (already forceful)
+        assert!(!handle.escalate_to_forceful());
+        assert!(handle.is_forceful());
+    }
+
+    #[test]
+    fn test_is_shutting_down_false_when_stopped() {
+        let handle = ShutdownHandle::new();
+        handle.coordinator.try_start_shutdown();
+        handle.coordinator.start_drain();
+        handle.coordinator.mark_stopped();
+
+        // Stopped is not "shutting down" — the shutdown is complete
+        assert!(!handle.is_shutting_down());
+        assert!(!handle.is_forceful());
+    }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -339,8 +339,9 @@ impl Gateway {
     /// Flush all active sessions to persistence (proxied to SessionManager).
     pub async fn flush_all_sessions(
         &self,
+        mode: crate::daemon::shutdown::ShutdownMode,
     ) -> Result<usize, crate::session::persistence::PersistenceError> {
-        self.session_manager.flush_all().await
+        self.session_manager.flush_all(mode).await
     }
 
     /// Register an IM plugin.

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -5,6 +5,7 @@
 
 use crate::config::manager::{ConfigManager, ConfigSnapshot};
 use crate::config::ConfigSection;
+use crate::daemon::shutdown::ShutdownMode;
 use crate::gateway::{DmScope, GatewayConfig, Message, Session};
 use crate::im::processor::ProcessError;
 use crate::im::IMAdapter;
@@ -315,7 +316,7 @@ impl SessionManager {
 
     /// Flush all active sessions to persistence.
     /// Returns the number of sessions successfully saved.
-    pub async fn flush_all(&self) -> Result<usize, PersistenceError> {
+    pub async fn flush_all(&self, _mode: ShutdownMode) -> Result<usize, PersistenceError> {
         let storage = self.storage.read().await;
         let Some(storage) = storage.as_ref() else {
             return Ok(0);

--- a/src/gateway/session_manager/bug904_tests.rs
+++ b/src/gateway/session_manager/bug904_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::daemon::shutdown::ShutdownMode;
 use crate::gateway::GatewayConfig;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::{AgentRole, PersistenceError, SessionCheckpoint};
@@ -186,7 +187,7 @@ async fn test_flush_all_preserves_existing_thread_id() {
         );
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 

--- a/src/gateway/session_manager/flush_tests.rs
+++ b/src/gateway/session_manager/flush_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::daemon::shutdown::ShutdownMode;
 use crate::gateway::{GatewayConfig, Message};
 use crate::llm::session::ConversationSession;
 use crate::session::bootstrap::BootstrapMode;
@@ -137,7 +138,7 @@ async fn test_flush_all_no_storage() {
         BootstrapMode::Full,
         ReasoningLevel::default(),
     );
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -152,7 +153,7 @@ async fn test_flush_all_empty_sessions() {
         BootstrapMode::Full,
         ReasoningLevel::default(),
     );
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -176,7 +177,7 @@ async fn test_flush_all_saves_checkpoints() {
         }
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 3);
 
@@ -213,7 +214,7 @@ async fn test_flush_all_partial_failure() {
         }
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 
@@ -284,7 +285,7 @@ async fn test_flush_all_with_pending_messages() {
         conv_sessions.insert(session_id.to_string(), conv_session);
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 
@@ -331,7 +332,7 @@ async fn test_flush_all_without_pending_messages() {
         conv_sessions.insert(session_id.to_string(), conv_session);
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 
@@ -361,7 +362,7 @@ async fn test_flush_all_no_conversation_session() {
         sessions.insert(session_id.to_string(), make_test_session(session_id));
     }
 
-    let result = mgr.flush_all().await;
+    let result = mgr.flush_all(ShutdownMode::Graceful).await;
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 


### PR DESCRIPTION
feat: add dual-mode shutdown support with graceful/forceful escalation

Extend ShutdownCoordinator with a ForcefulShuttingDown state and
ShutdownMode enum. Add escalate_to_forceful() for CAS upgrade from
graceful to forceful. Refactor Daemon::run() to listen for repeated
SIGTERM/SIGINT and escalate accordingly. Update flush_all_sessions()
to accept ShutdownMode for downstream forceful behavior.

Source: design doc
Type: feat
