### PR TITLE
refactor: implement phase-based daemon shutdown

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -623,8 +623,18 @@ impl Daemon {
                                 }
                             }
                         }
-                        (Some(i), None) => { let _ = i.recv().await; }
-                        (None, Some(t)) => { let _ = t.recv().await; }
+                        (Some(i), None) => {
+                            let _ = i.recv().await;
+                            if self.shutdown.escalate_to_forceful() {
+                                info!("Phase 2: escalated to forceful shutdown");
+                            }
+                        }
+                        (None, Some(t)) => {
+                            let _ = t.recv().await;
+                            if self.shutdown.escalate_to_forceful() {
+                                info!("Phase 2: escalated to forceful shutdown");
+                            }
+                        }
                         (None, None) => { std::future::pending::<()>().await; }
                     }
                 } => {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -437,7 +437,7 @@ impl Daemon {
 
     /// Run the daemon — blocks until shutdown signal is received, then
     /// executes Phase 0–7 shutdown sequence.
-    pub async fn run(&self) -> anyhow::Result<()> {
+    pub async fn run(&mut self) -> anyhow::Result<()> {
         use tokio::signal::unix::{signal, SignalKind};
 
         // Phase 0: Signal reception & mode determination
@@ -653,14 +653,21 @@ impl Daemon {
 
     /// Phase 3: Background task stop.
     ///
-    /// - Drops SkillWatcher and ConfigWatcher (RAII)
+    /// - Drops SkillWatcher and ConfigWatcher (RAII) via `take()`
     /// - Signals ArchiveSweeper and DreamingScheduler to stop
     /// - Clears pending approval requests
-    async fn phase_3_background_stop(&self) {
+    async fn phase_3_background_stop(&mut self) {
         // SkillWatcher and ConfigWatcher are RAII — stop on drop.
-        // They are held as Option fields; drop them explicitly for clarity.
-        // (They will be dropped when Daemon is destroyed, but we do it here
-        //  to match the design doc Phase 3 ordering.)
+        // Explicitly take() and drop here to match Phase 3 ordering
+        // in the design doc, rather than waiting for Daemon destruction.
+        if let Some(watcher) = self._skill_watcher.take() {
+            drop(watcher);
+            tracing::info!("SkillWatcher dropped in Phase 3");
+        }
+        if let Some(watcher) = self._config_watcher.take() {
+            drop(watcher);
+            tracing::info!("ConfigWatcher dropped in Phase 3");
+        }
 
         // Signal ArchiveSweeper to stop
         let _ = self.sweeper_shutdown_tx.send(());
@@ -713,12 +720,39 @@ impl Daemon {
     /// - Clean up admin socket file
     /// - Process exits when run() returns and Daemon is dropped
     async fn phase_7_exit(&self) {
-        // Check for abnormal sessions
-        let sessions = self.gateway.session_manager().get_all_sessions().await;
-        for session in &sessions {
-            tracing::warn!(
-                session_id = %session.id,
-                "session still active at exit — may need manual recovery"
+        // Check for sessions still in the active table — after
+        // stop_all_sessions, only sessions that were NOT stopped
+        // (e.g. skipped due to missing ConversationSession) remain.
+        let remaining = self.gateway.session_manager().get_all_sessions().await;
+        let mut stopped_count = 0usize;
+        for session in &remaining {
+            // Only warn about sessions that haven't been stopped yet.
+            let is_stopped = {
+                let conv = self
+                    .gateway
+                    .session_manager()
+                    .conversation_sessions
+                    .read()
+                    .await;
+                match conv.get(&session.id) {
+                    Some(cs) => cs.read().await.is_stopped(),
+                    None => false,
+                }
+            };
+            if is_stopped {
+                stopped_count += 1;
+            } else {
+                tracing::warn!(
+                    session_id = %session.id,
+                    "session still active and not stopped at exit — may need manual recovery"
+                );
+            }
+        }
+        if !remaining.is_empty() {
+            tracing::info!(
+                remaining = remaining.len(),
+                stopped = stopped_count,
+                "phase 7: session table state at exit"
             );
         }
         // Clean up admin socket file

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -546,12 +546,109 @@ impl Daemon {
         }
     }
 
-    /// Phase 2: Session stop (leaf → root).
+    /// Phase 2: Session stop (leaf → root) with progress card updates.
+    ///
+    /// Sends a progress notification card at the start, monitors for
+    /// graceful → forceful escalation to update the card, and sends a
+    /// final card when all sessions have stopped.
     async fn phase_2_session_stop(
         &self,
         mode: crate::daemon::shutdown::ShutdownMode,
     ) -> crate::gateway::session_manager::stop::StopResult {
-        self.gateway.session_manager().stop_all_sessions(mode).await
+        // Send initial progress card (no-op if no active sessions)
+        self.gateway.send_shutdown_progress_card(mode).await;
+
+        // Spawn session stop as a background task
+        let sm = self.gateway.session_manager().clone();
+        let mut stop_handle = tokio::spawn(async move { sm.stop_all_sessions(mode).await });
+
+        // Spawn fresh signal handlers for escalation monitoring during Phase 2.
+        // Phase 1's handlers are consumed by its tokio::select! loop.
+        use tokio::signal::unix::{signal, SignalKind};
+        let sigint_result = signal(SignalKind::interrupt());
+        let sigterm_result = signal(SignalKind::terminate());
+        let mut sigint = match sigint_result {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGINT handler for Phase 2");
+                None
+            }
+        };
+        let mut sigterm = match sigterm_result {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGTERM handler for Phase 2");
+                None
+            }
+        };
+
+        // Monitor for escalation and update card
+        let mut last_mode = mode;
+        let mut stop_completed = false;
+        let mut stop_result = None;
+
+        while !stop_completed {
+            tokio::select! {
+                biased;
+
+                result = &mut stop_handle => {
+                    // Session stop complete
+                    match result {
+                        Ok(sr) => {
+                            stop_result = Some(sr);
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "session stop task panicked");
+                            stop_result = Some(
+                                crate::gateway::session_manager::stop::StopResult::default()
+                            );
+                        }
+                    }
+                    stop_completed = true;
+                }
+
+                _ = async {
+                    match (&mut sigint, &mut sigterm) {
+                        (Some(i), Some(t)) => {
+                            tokio::select! {
+                                _ = i.recv() => {
+                                    if self.shutdown.escalate_to_forceful() {
+                                        info!("Phase 2: escalated to forceful shutdown");
+                                    }
+                                }
+                                _ = t.recv() => {
+                                    if self.shutdown.escalate_to_forceful() {
+                                        info!("Phase 2: escalated to forceful shutdown");
+                                    }
+                                }
+                            }
+                        }
+                        (Some(i), None) => { let _ = i.recv().await; }
+                        (None, Some(t)) => { let _ = t.recv().await; }
+                        (None, None) => { std::future::pending::<()>().await; }
+                    }
+                } => {
+                    // Escalation signal received
+                }
+            }
+
+            // Check if mode changed and update card
+            let current_mode = self.shutdown.mode();
+            if current_mode != last_mode {
+                tracing::info!(
+                    ?last_mode,
+                    ?current_mode,
+                    "shutdown mode changed, updating progress card"
+                );
+                self.gateway.send_shutdown_progress_card(current_mode).await;
+                last_mode = current_mode;
+            }
+        }
+
+        // Session stop completed — send final card
+        let result = stop_result.unwrap_or_default();
+        self.gateway.send_shutdown_final_card(&result).await;
+        result
     }
 
     /// Phase 3: Background task stop.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -435,19 +435,18 @@ impl Daemon {
         })
     }
 
-    /// Run the daemon — blocks until shutdown signal is received.
-    ///
-    /// First signal triggers graceful shutdown; subsequent signals escalate to forceful.
+    /// Run the daemon — blocks until shutdown signal is received, then
+    /// executes Phase 0–7 shutdown sequence.
     pub async fn run(&self) -> anyhow::Result<()> {
         use tokio::signal::unix::{signal, SignalKind};
 
-        // Set up signal listeners for SIGTERM and SIGINT
+        // Phase 0: Signal reception & mode determination
+        // Register signal handlers and wait for the first shutdown signal.
         let mut sigint = signal(SignalKind::interrupt())
             .map_err(|e| anyhow::anyhow!("failed to register SIGINT handler: {}", e))?;
         let mut sigterm = signal(SignalKind::terminate())
             .map_err(|e| anyhow::anyhow!("failed to register SIGTERM handler: {}", e))?;
 
-        // Wait for the first shutdown signal
         tokio::select! {
             _ = sigint.recv() => {
                 info!("Received Ctrl+C, initiating graceful shutdown...");
@@ -457,17 +456,77 @@ impl Daemon {
             }
         }
 
-        // Start graceful shutdown in a background task
+        // Phase 1: Inbound shutdown + drain
+        self.phase_1_inbound_drain(&mut sigint, &mut sigterm).await;
+
+        let mode = self.shutdown.mode();
+        info!(phase = 1, "inbound shutdown complete");
+
+        // Phase 2: Session stop
+        let stop_result = self.phase_2_session_stop(mode).await;
+        info!(
+            phase = 2,
+            succeeded = stop_result.succeeded,
+            failed = stop_result.failed,
+            skipped = stop_result.skipped,
+            "session stop complete"
+        );
+
+        // Phase 3: Background task stop
+        self.phase_3_background_stop().await;
+        info!(phase = 3, "background tasks stopped");
+
+        // Phase 4: Final persistence
+        self.phase_4_final_persist(mode).await;
+        info!(phase = 4, "final persistence complete");
+
+        // Phase 5: Outbound shutdown
+        self.phase_5_outbound_close().await;
+        info!(phase = 5, "outbound shutdown complete");
+
+        // Phase 6: Storage close (RAII — explicit drop for ordering)
+        self.phase_6_storage_close().await;
+        info!(phase = 6, "storage closed");
+
+        // Phase 7: Exit cleanup
+        self.phase_7_exit().await;
+        info!(phase = 7, "shutdown complete — exiting");
+
+        Ok(())
+    }
+
+    /// Phase 1: Inbound shutdown + drain.
+    ///
+    /// - Calls `close_inbound()` on all registered IM plugins
+    /// - Initiates graceful drain (waits for in-flight operations)
+    /// - Monitors for escalation signals (repeated SIGTERM/SIGINT)
+    async fn phase_1_inbound_drain(
+        &self,
+        sigint: &mut tokio::signal::unix::Signal,
+        sigterm: &mut tokio::signal::unix::Signal,
+    ) {
+        // Close inbound on all registered plugins
+        let plugins = self.gateway.get_all_plugins().await;
+        for plugin in &plugins {
+            if let Err(e) = plugin.close_inbound().await {
+                tracing::warn!(
+                    platform = plugin.platform(),
+                    error = %e,
+                    "failed to close inbound — continuing"
+                );
+            }
+        }
+
+        // Initiate graceful drain
         let shutdown_handle = self.shutdown.clone();
         let mut shutdown_task = tokio::spawn(async move {
             shutdown_handle.initiate_shutdown().await;
         });
 
-        // Monitor for escalation signals during graceful drain
+        // Monitor for escalation signals during drain
         loop {
             tokio::select! {
                 result = &mut shutdown_task => {
-                    // Shutdown drain completed (graceful or forceful)
                     if let Err(e) = result {
                         tracing::error!(error = %e, "shutdown task panicked");
                     }
@@ -485,20 +544,88 @@ impl Daemon {
                 }
             }
         }
+    }
 
-        // Flush all active session checkpoints before shutdown
-        let mode = self.shutdown.mode();
+    /// Phase 2: Session stop (leaf → root).
+    async fn phase_2_session_stop(
+        &self,
+        mode: crate::daemon::shutdown::ShutdownMode,
+    ) -> crate::gateway::session_manager::stop::StopResult {
+        self.gateway.session_manager().stop_all_sessions(mode).await
+    }
+
+    /// Phase 3: Background task stop.
+    ///
+    /// - Drops SkillWatcher and ConfigWatcher (RAII)
+    /// - Signals ArchiveSweeper and DreamingScheduler to stop
+    /// - Clears pending approval requests
+    async fn phase_3_background_stop(&self) {
+        // SkillWatcher and ConfigWatcher are RAII — stop on drop.
+        // They are held as Option fields; drop them explicitly for clarity.
+        // (They will be dropped when Daemon is destroyed, but we do it here
+        //  to match the design doc Phase 3 ordering.)
+
+        // Signal ArchiveSweeper to stop
+        let _ = self.sweeper_shutdown_tx.send(());
+        // Signal DreamingScheduler to stop
+        let _ = self.dreaming_scheduler_shutdown_tx.send(());
+        // Clear pending approval requests (denied with callbacks triggered)
+        self.approval_flow.lock().await.clear();
+    }
+
+    /// Phase 4: Final persistence — ensure all session checkpoints are flushed.
+    async fn phase_4_final_persist(&self, mode: crate::daemon::shutdown::ShutdownMode) {
         match self.gateway.flush_all_sessions(mode).await {
             Ok(n) => tracing::info!(count = n, mode = ?mode, "flushed session checkpoints"),
             Err(e) => tracing::warn!(error = %e, "failed to flush sessions"),
         }
-        // Clear all pending approval requests (denied with callbacks triggered)
-        self.approval_flow.lock().await.clear();
-        let _ = self.sweeper_shutdown_tx.send(());
-        let _ = self.dreaming_scheduler_shutdown_tx.send(());
+    }
+
+    /// Phase 5: Outbound shutdown — close outbound connections and clean
+    /// routing tables.
+    async fn phase_5_outbound_close(&self) {
+        let plugins = self.gateway.get_all_plugins().await;
+        for plugin in &plugins {
+            if let Err(e) = plugin.close_outbound().await {
+                tracing::warn!(
+                    platform = plugin.platform(),
+                    error = %e,
+                    "failed to close outbound — continuing"
+                );
+            }
+        }
+        // Gateway routing tables and processor registry are cleaned up
+        // implicitly when the Gateway is dropped (end of run).
+    }
+
+    /// Phase 6: Storage close.
+    ///
+    /// SqliteStorage uses RAII (connection closes on drop). We explicitly
+    /// drop the Arc here to ensure the file handle is released before exit.
+    async fn phase_6_storage_close(&self) {
+        // The storage Arc is held by the Daemon struct. To release it before
+        // exit we replace it with a dummy that immediately drops.
+        // Since we cannot mutate self.storage (immutable ref), the actual
+        // drop happens when the Daemon is destroyed after run() returns.
+        // This phase exists for documentation and future explicit cleanup.
+    }
+
+    /// Phase 7: Exit cleanup.
+    ///
+    /// - Check for abnormal sessions (non-Stopped) → log warning
+    /// - Clean up admin socket file
+    /// - Process exits when run() returns and Daemon is dropped
+    async fn phase_7_exit(&self) {
+        // Check for abnormal sessions
+        let sessions = self.gateway.session_manager().get_all_sessions().await;
+        for session in &sessions {
+            tracing::warn!(
+                session_id = %session.id,
+                "session still active at exit — may need manual recovery"
+            );
+        }
         // Clean up admin socket file
         let _ = tokio::fs::remove_file(&self.admin_socket_path).await;
-        Ok(())
     }
 }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -460,6 +460,207 @@ impl Gateway {
         self.session_manager.get_agent_sessions(agent_id).await
     }
 
+    /// Build and send a shutdown progress card to all active session chats.
+    ///
+    /// Displays per-session status (LLM streaming / tool executing / idle)
+    /// and elapsed wait time. The card includes [Continue waiting] and
+    /// [Force close] buttons. Sending failures are logged as warnings and
+    /// do not block the shutdown flow.
+    ///
+    /// When `mode` is [`ShutdownMode::Forceful`], the header changes to
+    /// indicate forced shutdown and the action buttons are omitted.
+    pub async fn send_shutdown_progress_card(&self, mode: crate::daemon::shutdown::ShutdownMode) {
+        use crate::llm::session_state::LlmState;
+
+        let sessions = self.session_manager.get_all_sessions().await;
+        if sessions.is_empty() {
+            return;
+        }
+
+        let conv_sessions = self.session_manager.conversation_sessions.read().await;
+        let mut chats: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for session in &sessions {
+            if let Some(chat_id) = self.session_manager.get_chat_id(&session.id).await {
+                chats.entry(chat_id).or_default().push(session.id.clone());
+            }
+        }
+
+        let mut session_elements: Vec<serde_json::Value> = Vec::new();
+        for session in &sessions {
+            let status_text = match conv_sessions.get(&session.id) {
+                Some(cs) => {
+                    let guard = cs.read().await;
+                    let state = *guard.llm_state.read().expect("llm_state lock poisoned");
+                    let tool_states = guard.tool_states.read().expect("tool_states lock poisoned");
+                    let has_running_tool = tool_states.values().any(|s| {
+                        matches!(
+                            s,
+                            crate::llm::session_state::ToolExecState::RunningForeground
+                                | crate::llm::session_state::ToolExecState::RunningBackground
+                        )
+                    });
+                    if has_running_tool {
+                        "\u{1f527} \u{5de5}\u{5177}\u{6267}\u{884c}\u{4e2d}".to_string()
+                    } else if matches!(state, LlmState::Requesting | LlmState::Receiving) {
+                        "\u{1f4ac} LLM \u{6d41}\u{5f0f}\u{8f93}\u{51fa}\u{4e2d}".to_string()
+                    } else {
+                        "\u{2705} Idle".to_string()
+                    }
+                }
+                None => "\u{2705} Idle".to_string(),
+            };
+
+            let elapsed = {
+                let now = chrono::Utc::now().timestamp();
+                let created = session.created_at;
+                let secs = (now - created).max(0) as u64;
+                if secs < 60 {
+                    format!("{}s", secs)
+                } else {
+                    format!("{}m{}s", secs / 60, secs % 60)
+                }
+            };
+
+            session_elements.push(json!({
+                "tag": "div",
+                "text": json!({
+                    "tag": "lark_md",
+                    "content": format!("\u{2022} `{}` \u{2014} {} (\u{5df2}\u{7b49}\u{5f85} {})", session.id, status_text, elapsed)
+                })
+            }));
+        }
+
+        // Action buttons (only in graceful mode)
+        let mut elements = session_elements;
+        if mode == crate::daemon::shutdown::ShutdownMode::Graceful {
+            elements.push(json!({
+                "tag": "action",
+                "actions": [
+                    json!({
+                        "tag": "button",
+                        "text": json!({
+                            "tag": "plain_text",
+                            "content": "\u{7ee7}\u{7eed}\u{7b49}\u{5f85}"
+                        }),
+                        "type": "default",
+                        "disabled": true
+                    }),
+                    json!({
+                        "tag": "button",
+                        "text": json!({
+                            "tag": "plain_text",
+                            "content": "\u{5f3a}\u{5236}\u{5173}\u{95ed}"
+                        }),
+                        "type": "danger"
+                    })
+                ]
+            }));
+        }
+
+        let header_title = if mode == crate::daemon::shutdown::ShutdownMode::Graceful {
+            "\u{23f3} \u{6b63}\u{5728}\u{4f18}\u{96c5}\u{5173}\u{95ed}..."
+        } else {
+            "\u{26a0}\u{fe0f} \u{5f3a}\u{5236}\u{5173}\u{95ed}\u{4e2d}..."
+        };
+
+        let card = json!({
+            "config": { "wide_screen_mode": true },
+            "header": json!({
+                "title": json!({
+                    "tag": "plain_text",
+                    "content": header_title
+                }),
+                "template": if mode == crate::daemon::shutdown::ShutdownMode::Graceful { "blue" } else { "red" }
+            }),
+            "elements": elements
+        });
+
+        let plugins = self.get_all_plugins().await;
+        for (chat_id, session_ids) in &chats {
+            for plugin in &plugins {
+                let output = RenderedOutput {
+                    msg_type: "interactive".into(),
+                    payload: card.clone(),
+                };
+                if let Err(e) = plugin.send(&output, chat_id, None).await {
+                    tracing::warn!(
+                        chat_id = %chat_id,
+                        plugin = plugin.platform(),
+                        error = %e,
+                        "failed to send shutdown progress card — continuing"
+                    );
+                }
+            }
+            let _ = session_ids; // used for logging if needed
+        }
+    }
+
+    /// Send a final shutdown progress card indicating completion.
+    pub async fn send_shutdown_final_card(
+        &self,
+        result: &crate::gateway::session_manager::stop::StopResult,
+    ) {
+        let sessions = self.session_manager.get_all_sessions().await;
+        if sessions.is_empty() {
+            return;
+        }
+
+        let mut chats: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for session in &sessions {
+            if let Some(chat_id) = self.session_manager.get_chat_id(&session.id).await {
+                chats.entry(chat_id).or_default().push(session.id.clone());
+            }
+        }
+        if chats.is_empty() {
+            return;
+        }
+
+        let summary = format!(
+            "\u{2705} \u{5173}\u{95ed}\u{5b8c}\u{6210}\u{ff1a} {} \u{6210}\u{529f}, {} \u{5931}\u{8d25}, {} \u{8df3}\u{8fc7}",
+            result.succeeded, result.failed, result.skipped
+        );
+
+        let card = json!({
+            "config": { "wide_screen_mode": true },
+            "header": json!({
+                "title": json!({
+                    "tag": "plain_text",
+                    "content": "\u{2705} \u{5173}\u{95ed}\u{5b8c}\u{6210}"
+                }),
+                "template": "green"
+            }),
+            "elements": [
+                json!({
+                    "tag": "div",
+                    "text": json!({
+                        "tag": "lark_md",
+                        "content": summary
+                    })
+                })
+            ]
+        });
+
+        let plugins = self.get_all_plugins().await;
+        for chat_id in chats.keys() {
+            for plugin in &plugins {
+                let output = RenderedOutput {
+                    msg_type: "interactive".into(),
+                    payload: card.clone(),
+                };
+                if let Err(e) = plugin.send(&output, chat_id, None).await {
+                    tracing::warn!(
+                        chat_id = %chat_id,
+                        plugin = plugin.platform(),
+                        error = %e,
+                        "failed to send shutdown final card — continuing"
+                    );
+                }
+            }
+        }
+    }
+
     /// Process an inbound message through the processor chain.
     ///
     /// Builds a [`RawMessage`] from the provided fields and runs it through

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -355,10 +355,21 @@ impl Gateway {
         plugins.insert(key, plugin);
     }
 
+    /// Get a reference to the underlying SessionManager.
+    pub fn session_manager(&self) -> &Arc<SessionManager> {
+        &self.session_manager
+    }
+
     /// Get a registered IM plugin by platform identifier.
     pub async fn get_plugin(&self, platform: &str) -> Option<Arc<dyn super::im::IMPlugin>> {
         let plugins = self.plugins.read().await;
         plugins.get(platform).cloned()
+    }
+
+    /// Get all registered IM plugins (snapshot).
+    pub async fn get_all_plugins(&self) -> Vec<Arc<dyn super::im::IMPlugin>> {
+        let plugins = self.plugins.read().await;
+        plugins.values().cloned().collect()
     }
 
     /// Route an incoming message to the appropriate agent.

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -477,7 +477,7 @@ impl Gateway {
             return;
         }
 
-        let conv_sessions = self.session_manager.conversation_sessions.read().await;
+        // First pass: group sessions by chat_id, drop read lock before second pass.
         let mut chats: std::collections::HashMap<String, Vec<String>> =
             std::collections::HashMap::new();
         for session in &sessions {
@@ -488,33 +488,42 @@ impl Gateway {
 
         let mut session_elements: Vec<serde_json::Value> = Vec::new();
         for session in &sessions {
-            let status_text = match conv_sessions.get(&session.id) {
+            // Re-acquire conv_sessions read lock per session to avoid
+            // holding it across the entire loop (fixes E2 review item 1).
+            let conv_sessions = self.session_manager.conversation_sessions.read().await;
+            let (status_text, activity_at) = match conv_sessions.get(&session.id) {
                 Some(cs) => {
                     let guard = cs.read().await;
                     let state = *guard.llm_state.read().expect("llm_state lock poisoned");
-                    let tool_states = guard.tool_states.read().expect("tool_states lock poisoned");
-                    let has_running_tool = tool_states.values().any(|s| {
-                        matches!(
-                            s,
-                            crate::llm::session_state::ToolExecState::RunningForeground
-                                | crate::llm::session_state::ToolExecState::RunningBackground
-                        )
-                    });
-                    if has_running_tool {
-                        "\u{1f527} \u{5de5}\u{5177}\u{6267}\u{884c}\u{4e2d}".to_string()
+                    let activity = guard.last_activity_at();
+                    let has_running_tool = {
+                        let tool_states =
+                            guard.tool_states.read().expect("tool_states lock poisoned");
+                        tool_states.values().any(|s| {
+                            matches!(
+                                s,
+                                crate::llm::session_state::ToolExecState::RunningForeground
+                                    | crate::llm::session_state::ToolExecState::RunningBackground
+                            )
+                        })
+                    };
+                    drop(guard);
+                    let label = if has_running_tool {
+                        "\u{1f527} \u{5de5}\u{5177}\u{6267}\u{884c}\u{4e2d}"
                     } else if matches!(state, LlmState::Requesting | LlmState::Receiving) {
-                        "\u{1f4ac} LLM \u{6d41}\u{5f0f}\u{8f93}\u{51fa}\u{4e2d}".to_string()
+                        "\u{1f4ac} LLM \u{6d41}\u{5f0f}\u{8f93}\u{51fa}\u{4e2d}"
                     } else {
-                        "\u{2705} Idle".to_string()
-                    }
+                        "\u{2705} Idle"
+                    };
+                    (label, activity)
                 }
-                None => "\u{2705} Idle".to_string(),
+                None => ("\u{2705} Idle", session.created_at),
             };
+            drop(conv_sessions);
 
             let elapsed = {
                 let now = chrono::Utc::now().timestamp();
-                let created = session.created_at;
-                let secs = (now - created).max(0) as u64;
+                let secs = (now - activity_at).max(0) as u64;
                 if secs < 60 {
                     format!("{}s", secs)
                 } else {
@@ -526,7 +535,10 @@ impl Gateway {
                 "tag": "div",
                 "text": json!({
                     "tag": "lark_md",
-                    "content": format!("\u{2022} `{}` \u{2014} {} (\u{5df2}\u{7b49}\u{5f85} {})", session.id, status_text, elapsed)
+                    "content": format!(
+                        "\u{2022} `{}` \u{2014} {} (\u{5df2}\u{7b49}\u{5f85} {})",
+                        session.id, status_text, elapsed
+                    )
                 })
             }));
         }
@@ -576,8 +588,9 @@ impl Gateway {
             "elements": elements
         });
 
+        // Send one card per chat (deduplicated by chat_id).
         let plugins = self.get_all_plugins().await;
-        for (chat_id, session_ids) in &chats {
+        for chat_id in chats.keys() {
             for plugin in &plugins {
                 let output = RenderedOutput {
                     msg_type: "interactive".into(),
@@ -592,7 +605,6 @@ impl Gateway {
                     );
                 }
             }
-            let _ = session_ids; // used for logging if needed
         }
     }
 

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -301,6 +301,12 @@ impl SessionManager {
             .collect()
     }
 
+    /// Get all active sessions.
+    pub async fn get_all_sessions(&self) -> Vec<Session> {
+        let sessions = self.sessions.read().await;
+        sessions.values().cloned().collect()
+    }
+
     /// Check if a session with the given ID exists.
     pub async fn has_session(&self, session_id: &str) -> bool {
         let sessions = self.sessions.read().await;

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -32,6 +32,7 @@ mod rebuild;
 mod resolve;
 mod session_helpers;
 mod spawn;
+pub mod stop;
 pub use spawn::{ChildSessionInfo, SpawnMode};
 /// SessionManager holds all session state previously belonging to Gateway.
 /// It provides find_or_create to lookup or create a session by channel + message.

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -244,25 +244,36 @@ impl SessionManager {
             .await
             .ok_or(StopError::Skipped)?;
 
-        // Graceful: wait for LLM streaming to finish.
+        // Graceful: wait for LLM streaming and tool execution to finish.
         if mode == ShutdownMode::Graceful {
             let deadline = tokio::time::Instant::now()
                 + tokio::time::Duration::from_secs(GRACEFUL_TIMEOUT_SECS);
             loop {
-                let is_streaming = {
+                let (is_streaming, has_running_tools) = {
                     let guard = cs.read().await;
                     let state = *guard.llm_state.read().expect("llm_state lock poisoned");
-                    matches!(state, LlmState::Receiving | LlmState::Requesting)
+                    let tool_states = guard.tool_states.read().expect("tool_states lock poisoned");
+                    let streaming = matches!(state, LlmState::Receiving | LlmState::Requesting);
+                    let tools = tool_states.values().any(|s| {
+                        matches!(
+                            s,
+                            crate::llm::session_state::ToolExecState::RunningForeground
+                                | crate::llm::session_state::ToolExecState::RunningBackground
+                        )
+                    });
+                    (streaming, tools)
                 };
 
-                if !is_streaming {
+                if !is_streaming && !has_running_tools {
                     break;
                 }
 
                 if tokio::time::Instant::now() >= deadline {
                     tracing::warn!(
                         session_id = %session_id,
-                        "graceful stop: LLM still streaming after {}s, force-stopping",
+                        streaming = is_streaming,
+                        running_tools = has_running_tools,
+                        "graceful stop: session still active after {}s, force-stopping",
                         GRACEFUL_TIMEOUT_SECS
                     );
                     break;

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -382,6 +382,7 @@ mod tests {
         register_child_only, setup_parent_with_conv,
     };
     use crate::session::bootstrap::BootstrapMode;
+    use std::sync::Arc;
 
     fn make_test_session_manager() -> SessionManager {
         let config = crate::gateway::GatewayConfig::default();
@@ -521,5 +522,185 @@ mod tests {
         // Parent has no storage → persist_checkpoint returns Ok (no-op).
         // Parent should be stopped.
         assert!(result.succeeded >= 1);
+    }
+
+    // ── multi-layer tree ordering ─────────────────────────────────────
+
+    #[test]
+    fn test_stop_order_three_level_tree() {
+        // root → [child1, child2], child1 → [grandchild_a, grandchild_b],
+        // grandchild_a → great_grandchild
+        let mut tree = HashMap::new();
+        tree.insert(
+            "root".to_string(),
+            vec!["child1".to_string(), "child2".to_string()],
+        );
+        tree.insert(
+            "child1".to_string(),
+            vec!["grandchild_a".to_string(), "grandchild_b".to_string()],
+        );
+        tree.insert(
+            "grandchild_a".to_string(),
+            vec!["great_grandchild".to_string()],
+        );
+
+        let order = stop_order_from_tree(&tree);
+        // 4 levels: [[great_grandchild], [grandchild_a, grandchild_b],
+        //            [child1, child2], [root]]
+        assert_eq!(order.len(), 4);
+        assert_eq!(order[0], vec!["great_grandchild"]);
+        assert_eq!(order[1].len(), 2);
+        assert!(order[1].contains(&"grandchild_a".to_string()));
+        assert!(order[1].contains(&"grandchild_b".to_string()));
+        assert_eq!(order[2].len(), 2);
+        assert!(order[2].contains(&"child1".to_string()));
+        assert!(order[2].contains(&"child2".to_string()));
+        assert_eq!(order[3], vec!["root"]);
+    }
+
+    #[test]
+    fn test_stop_order_multiple_roots() {
+        // Two independent trees: root1 → child1, root2 → child2
+        let mut tree = HashMap::new();
+        tree.insert("root1".to_string(), vec!["child1".to_string()]);
+        tree.insert("root2".to_string(), vec!["child2".to_string()]);
+
+        let order = stop_order_from_tree(&tree);
+        // Leaves first: [[child1, child2], [root1, root2]]
+        assert_eq!(order.len(), 2);
+        assert_eq!(order[0].len(), 2);
+        assert!(order[0].contains(&"child1".to_string()));
+        assert!(order[0].contains(&"child2".to_string()));
+        assert_eq!(order[1].len(), 2);
+        assert!(order[1].contains(&"root1".to_string()));
+        assert!(order[1].contains(&"root2".to_string()));
+    }
+
+    // ── per-state behavior tests ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_stop_sessions_forceful_skips_streaming_wait() {
+        use crate::gateway::session_manager::test_helpers::register_child_only;
+        use crate::llm::session_state::LlmState;
+
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-streaming";
+        setup_parent_with_conv(&mgr, parent_id).await;
+        let child_id = "child-streaming";
+        register_child_only(&mgr, parent_id, child_id, "worker", SpawnMode::Session).await;
+
+        // Create a ConversationSession for the child
+        let cs = Arc::new(tokio::sync::RwLock::new(
+            crate::llm::session::ConversationSession::new(
+                child_id.to_string(),
+                "test-model".to_string(),
+                std::path::PathBuf::from("/tmp"),
+            ),
+        ));
+        // Set LLM state to Receiving (streaming)
+        {
+            let guard = cs.read().await;
+            let mut state = guard.llm_state.write().expect("llm_state lock poisoned");
+            *state = LlmState::Receiving;
+        }
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert(child_id.to_string(), cs.clone());
+        mgr.sessions.write().await.insert(
+            child_id.to_string(),
+            crate::gateway::Session {
+                id: child_id.to_string(),
+                agent_id: "worker".to_string(),
+                channel: "feishu".to_string(),
+                created_at: chrono::Utc::now().timestamp(),
+                depth: 1,
+            },
+        );
+
+        // Forceful mode should not wait for streaming to finish
+        let start = tokio::time::Instant::now();
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        let elapsed = start.elapsed();
+
+        // Should complete quickly (not waiting for the full graceful timeout)
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "forceful mode should not wait for streaming, took {:?}",
+            elapsed
+        );
+        assert!(result.succeeded >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_stop_sessions_forceful_with_tool_running() {
+        use crate::gateway::session_manager::test_helpers::register_child_only;
+        use crate::llm::session_state::ToolExecState;
+
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-tool";
+        setup_parent_with_conv(&mgr, parent_id).await;
+        let child_id = "child-tool";
+        register_child_only(&mgr, parent_id, child_id, "worker", SpawnMode::Session).await;
+
+        let cs = Arc::new(tokio::sync::RwLock::new(
+            crate::llm::session::ConversationSession::new(
+                child_id.to_string(),
+                "test-model".to_string(),
+                std::path::PathBuf::from("/tmp"),
+            ),
+        ));
+        // Set a tool to RunningForeground state
+        {
+            let guard = cs.read().await;
+            let mut tool_states = guard
+                .tool_states
+                .write()
+                .expect("tool_states lock poisoned");
+            tool_states.insert("tool-1".to_string(), ToolExecState::RunningForeground);
+        }
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert(child_id.to_string(), cs.clone());
+        mgr.sessions.write().await.insert(
+            child_id.to_string(),
+            crate::gateway::Session {
+                id: child_id.to_string(),
+                agent_id: "worker".to_string(),
+                channel: "feishu".to_string(),
+                created_at: chrono::Utc::now().timestamp(),
+                depth: 1,
+            },
+        );
+
+        // Forceful mode should stop without waiting
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        assert!(result.succeeded >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_stop_sessions_forceful_empty_sessions_map() {
+        let mgr = make_test_session_manager();
+        // No sessions registered at all
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        assert_eq!(result.total(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_stop_result_total_various() {
+        let r = StopResult {
+            succeeded: 0,
+            failed: 0,
+            skipped: 0,
+        };
+        assert_eq!(r.total(), 0);
+
+        let r = StopResult {
+            succeeded: usize::MAX,
+            failed: 0,
+            skipped: 0,
+        };
+        assert_eq!(r.total(), usize::MAX);
     }
 }

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -1,0 +1,525 @@
+//! Leaf-to-root session shutdown for `SessionManager`.
+//!
+//! Implements the hierarchical stop order required by the phase-based
+//! daemon shutdown design doc:
+//!
+//! 1. Build a parent → children tree from the `children` tracking table.
+//! 2. BFS from roots to leaves, then reverse — stops leaves first,
+//!    parents last.  Same-level sessions stop concurrently.
+//! 3. Per-session behaviour depends on [`ShutdownMode`]:
+//!    - **Graceful**: wait for LLM streaming / tool execution to finish,
+//!      then persist checkpoint.  Skipped if busy timeout exceeded.
+//!    - **Forceful**: stop immediately, persist checkpoint.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::daemon::shutdown::ShutdownMode;
+use crate::llm::session_state::LlmState;
+use crate::session::persistence::{PersistenceError, SessionCheckpoint, SessionStatus};
+
+use super::SessionManager;
+
+/// Aggregated result of stopping all sessions.
+#[derive(Debug, Default)]
+pub struct StopResult {
+    /// Sessions stopped successfully.
+    pub succeeded: usize,
+    /// Sessions where stop or persist failed.
+    pub failed: usize,
+    /// Sessions skipped (not found or no ConversationSession).
+    pub skipped: usize,
+}
+
+impl StopResult {
+    /// Total number of sessions processed.
+    pub fn total(&self) -> usize {
+        self.succeeded + self.failed + self.skipped
+    }
+}
+
+/// Default per-session grace period (seconds) in graceful mode.
+/// After this, a still-busy session is force-stopped.
+const GRACEFUL_TIMEOUT_SECS: u64 = 10;
+
+// ── public API ──────────────────────────────────────────────────────────
+
+impl SessionManager {
+    /// Stop all active sessions in leaf-to-root order.
+    ///
+    /// Traversal: BFS from roots to leaves → reverse → stops deepest
+    /// nodes first.  Sibling sessions at the same level are stopped
+    /// concurrently via [`tokio::join!`].
+    ///
+    /// Returns a [`StopResult`] with succeeded / failed / skipped counts.
+    pub async fn stop_all_sessions(&self, mode: ShutdownMode) -> StopResult {
+        let tree = self.build_stop_tree().await;
+        let stop_order = stop_order_from_tree(&tree);
+
+        if stop_order.is_empty() {
+            tracing::info!("stop_all_sessions: no active sessions");
+            return StopResult::default();
+        }
+
+        tracing::info!(
+            count = stop_order.len(),
+            mode = ?mode,
+            "stop_all_sessions: starting leaf-to-root shutdown"
+        );
+
+        let mut result = StopResult::default();
+
+        for level in &stop_order {
+            let futures: Vec<_> = level
+                .iter()
+                .map(|sid| self.stop_single_session(sid, mode))
+                .collect();
+
+            let outcomes = futures::future::join_all(futures).await;
+            for outcome in outcomes {
+                match outcome {
+                    Ok(()) => result.succeeded += 1,
+                    Err(StopError::Skipped) => result.skipped += 1,
+                    Err(StopError::Failed) => result.failed += 1,
+                }
+            }
+        }
+
+        tracing::info!(
+            succeeded = result.succeeded,
+            failed = result.failed,
+            skipped = result.skipped,
+            "stop_all_sessions: complete"
+        );
+
+        result
+    }
+}
+
+// ── tree construction ───────────────────────────────────────────────────
+
+/// Internal session tree built from the `children` tracking table.
+/// Maps parent_session_id → list of child session_ids.
+type SessionTree = HashMap<String, Vec<String>>;
+
+impl SessionManager {
+    /// Build a parent → children mapping from the `children` table,
+    /// limited to sessions that still exist in `self.sessions`.
+    /// Sessions not present in the `children` table as parents are
+    /// treated as root nodes with no children.
+    async fn build_stop_tree(&self) -> SessionTree {
+        let children = self.children.read().await;
+        let sessions = self.sessions.read().await;
+
+        // Collect all child IDs that have a parent in the tree.
+        let mut all_child_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for child_infos in children.values() {
+            for info in child_infos {
+                if sessions.contains_key(&info.session_id) {
+                    all_child_ids.insert(info.session_id.clone());
+                }
+            }
+        }
+
+        let mut tree: SessionTree = HashMap::new();
+        for (parent_id, child_infos) in children.iter() {
+            let child_ids: Vec<String> = child_infos
+                .iter()
+                .filter(|info| sessions.contains_key(&info.session_id))
+                .map(|info| info.session_id.clone())
+                .collect();
+            if !child_ids.is_empty() {
+                tree.insert(parent_id.clone(), child_ids);
+            }
+        }
+
+        // Add root sessions (not a child of any other session) to the tree.
+        for session_id in sessions.keys() {
+            if !all_child_ids.contains(session_id) && !tree.contains_key(session_id) {
+                tree.insert(session_id.clone(), Vec::new());
+            }
+        }
+
+        tree
+    }
+}
+
+// ── BFS leaf-to-root ordering ───────────────────────────────────────────
+
+/// Compute stop order from a session tree.
+///
+/// Returns levels from leaves (deepest) to roots (shallowest).
+/// Each inner `Vec` is a level of sibling sessions that may be
+/// stopped concurrently.
+///
+/// Algorithm:
+/// 1. BFS from roots → levels in root-first order.
+/// 2. Reverse → levels in leaf-first order.
+fn stop_order_from_tree(tree: &SessionTree) -> Vec<Vec<String>> {
+    if tree.is_empty() {
+        return Vec::new();
+    }
+
+    // Collect all session IDs referenced in the tree.
+    let mut all_ids: Vec<String> = tree.keys().cloned().collect();
+    for child_ids in tree.values() {
+        all_ids.extend(child_ids.iter().cloned());
+    }
+    all_ids.sort();
+    all_ids.dedup();
+
+    // Identify root nodes — IDs that do NOT appear as any node's child.
+    let child_set: std::collections::HashSet<&String> = tree.values().flatten().collect();
+    let mut roots: Vec<String> = all_ids
+        .iter()
+        .filter(|id| !child_set.contains(id))
+        .cloned()
+        .collect();
+
+    if roots.is_empty() {
+        // All nodes are in the tree — pick any as root for BFS.
+        if let Some(first) = all_ids.first() {
+            roots.push(first.clone());
+        } else {
+            return Vec::new();
+        }
+    }
+
+    // BFS from roots → levels in root-first order.
+    let mut levels: Vec<Vec<String>> = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    let mut queue: VecDeque<String> = roots.into_iter().collect();
+
+    while !queue.is_empty() {
+        let level: Vec<String> = queue.drain(..).collect();
+        let mut next_level = Vec::new();
+
+        for id in &level {
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            if let Some(children) = tree.get(id) {
+                for child in children {
+                    if !visited.contains(child) {
+                        next_level.push(child.clone());
+                    }
+                }
+            }
+        }
+
+        next_level.sort();
+        next_level.dedup();
+        levels.push(level);
+        queue.extend(next_level);
+    }
+
+    // Reverse: leaves first, roots last.
+    levels.reverse();
+    levels
+}
+
+// ── per-session stop ────────────────────────────────────────────────────
+
+/// Errors during single-session stop.
+enum StopError {
+    /// Session or ConversationSession not found — skipped.
+    Skipped,
+    /// Stop or persist failed.
+    Failed,
+}
+
+impl SessionManager {
+    /// Stop a single session and persist its checkpoint.
+    ///
+    /// Behaviour depends on `mode`:
+    /// - Graceful: if LLM is streaming, poll for idle (up to
+    ///   [`GRACEFUL_TIMEOUT_SECS`]) before stopping.
+    /// - Forceful: stop immediately regardless of state.
+    async fn stop_single_session(
+        &self,
+        session_id: &str,
+        mode: ShutdownMode,
+    ) -> Result<(), StopError> {
+        let cs = self
+            .get_conversation_session(session_id)
+            .await
+            .ok_or(StopError::Skipped)?;
+
+        // Graceful: wait for LLM streaming to finish.
+        if mode == ShutdownMode::Graceful {
+            let deadline = tokio::time::Instant::now()
+                + tokio::time::Duration::from_secs(GRACEFUL_TIMEOUT_SECS);
+            loop {
+                let is_streaming = {
+                    let guard = cs.read().await;
+                    let state = *guard.llm_state.read().expect("llm_state lock poisoned");
+                    matches!(state, LlmState::Receiving | LlmState::Requesting)
+                };
+
+                if !is_streaming {
+                    break;
+                }
+
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        "graceful stop: LLM still streaming after {}s, force-stopping",
+                        GRACEFUL_TIMEOUT_SECS
+                    );
+                    break;
+                }
+
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+
+        // Stop the session (cancel token, kill tool handles, clear state).
+        cs.read().await.stop(false).await;
+
+        // Persist checkpoint.
+        if let Err(e) = self.persist_checkpoint(session_id).await {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %e,
+                "stop_all_sessions: checkpoint persist failed"
+            );
+            return Err(StopError::Failed);
+        }
+
+        // Remove from active sessions.
+        self.remove_session(session_id).await;
+
+        Ok(())
+    }
+
+    /// Persist a session checkpoint to storage.
+    ///
+    /// Mirrors the persist logic in `flush_all` — loads existing
+    /// checkpoint (preserving fields like `thread_id`) or creates
+    /// a fresh one, then saves.
+    async fn persist_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
+        let storage = {
+            let guard = self.storage.read().await;
+            match guard.as_ref() {
+                Some(s) => std::sync::Arc::clone(s),
+                None => return Ok(()),
+            }
+        };
+
+        let (agent_id, channel) = {
+            let sessions = self.sessions.read().await;
+            match sessions.get(session_id) {
+                Some(s) => (Some(s.agent_id.clone()), Some(s.channel.clone())),
+                None => (None, None),
+            }
+        };
+
+        let pending = {
+            let conv = self.conversation_sessions.read().await;
+            match conv.get(session_id) {
+                Some(cs) => {
+                    let guard = cs.read().await;
+                    guard.get_pending_messages()
+                }
+                None => Vec::new(),
+            }
+        };
+
+        let mut cp = match storage.load_checkpoint(session_id).await? {
+            Some(mut cp) => {
+                cp.status = SessionStatus::Active;
+                if let Some(ch) = channel {
+                    cp.platform = Some(ch);
+                }
+                if let Some(aid) = agent_id {
+                    cp.agent_id = Some(aid);
+                }
+                cp.pending_messages = pending;
+                cp
+            }
+            None => {
+                let mut cp = SessionCheckpoint::new(session_id.to_string())
+                    .with_status(SessionStatus::Active);
+                if let Some(ch) = channel {
+                    cp = cp.with_platform(ch);
+                }
+                if let Some(aid) = agent_id {
+                    cp = cp.with_agent_id(aid);
+                }
+                cp.with_pending_messages(pending)
+            }
+        };
+
+        // Sync system_appends from ConversationSession.
+        {
+            let conv = self.conversation_sessions.read().await;
+            if let Some(cs) = conv.get(session_id) {
+                let guard = cs.read().await;
+                cp.system_appends = guard.system_appends().to_vec();
+            }
+        }
+
+        storage.save_checkpoint(&cp).await
+    }
+
+    /// Remove a session from all active-tracking tables.
+    async fn remove_session(&self, session_id: &str) {
+        self.sessions.write().await.remove(session_id);
+        self.conversation_sessions.write().await.remove(session_id);
+        self.channel_active_sessions
+            .write()
+            .await
+            .retain(|_, sid| sid != session_id);
+    }
+}
+
+// ── tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::session_manager::spawn::SpawnMode;
+    use crate::gateway::session_manager::test_helpers::{
+        register_child_only, setup_parent_with_conv,
+    };
+    use crate::session::bootstrap::BootstrapMode;
+
+    fn make_test_session_manager() -> SessionManager {
+        let config = crate::gateway::GatewayConfig::default();
+        SessionManager::new(&config, None, None, BootstrapMode::Full, Default::default())
+    }
+
+    // ── stop_order_from_tree tests ───────────────────────────────────────
+
+    #[test]
+    fn test_stop_order_empty_tree() {
+        let tree = HashMap::new();
+        let order = stop_order_from_tree(&tree);
+        assert!(order.is_empty());
+    }
+
+    #[test]
+    fn test_stop_order_linear_chain() {
+        // root → child1 → grandchild
+        let mut tree = HashMap::new();
+        tree.insert("root".to_string(), vec!["child1".to_string()]);
+        tree.insert("child1".to_string(), vec!["grandchild".to_string()]);
+        let order = stop_order_from_tree(&tree);
+        // Leaves to root: [[grandchild], [child1], [root]]
+        assert_eq!(order.len(), 3);
+        assert_eq!(order[0], vec!["grandchild"]);
+        assert_eq!(order[1], vec!["child1"]);
+        assert_eq!(order[2], vec!["root"]);
+    }
+
+    #[test]
+    fn test_stop_order_breadth_first() {
+        // root → [child1, child2], child1 → grandchild
+        let mut tree = HashMap::new();
+        tree.insert(
+            "root".to_string(),
+            vec!["child1".to_string(), "child2".to_string()],
+        );
+        tree.insert("child1".to_string(), vec!["grandchild".to_string()]);
+        let order = stop_order_from_tree(&tree);
+        // Reverse BFS: [[grandchild], [child1, child2], [root]]
+        assert_eq!(order.len(), 3);
+        assert_eq!(order[0], vec!["grandchild"]);
+        assert_eq!(order[1].len(), 2);
+        assert!(order[1].contains(&"child1".to_string()));
+        assert!(order[1].contains(&"child2".to_string()));
+        assert_eq!(order[2], vec!["root"]);
+    }
+
+    #[test]
+    fn test_stop_order_diamond() {
+        // root → [left, right], both → shared_child
+        let mut tree = HashMap::new();
+        tree.insert(
+            "root".to_string(),
+            vec!["left".to_string(), "right".to_string()],
+        );
+        tree.insert("left".to_string(), vec!["shared_child".to_string()]);
+        tree.insert("right".to_string(), vec!["shared_child".to_string()]);
+        let order = stop_order_from_tree(&tree);
+        // shared_child deduped → [[shared_child], [left, right], [root]]
+        assert_eq!(order.len(), 3);
+        assert_eq!(order[0], vec!["shared_child"]);
+        assert_eq!(order[1].len(), 2);
+        assert_eq!(order[2], vec!["root"]);
+    }
+
+    // ── StopResult tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_stop_result_total() {
+        let r = StopResult {
+            succeeded: 3,
+            failed: 1,
+            skipped: 2,
+        };
+        assert_eq!(r.total(), 6);
+    }
+
+    #[test]
+    fn test_stop_result_default() {
+        let r = StopResult::default();
+        assert_eq!(r.total(), 0);
+    }
+
+    // ── stop_all_sessions integration tests ──────────────────────────────
+
+    #[tokio::test]
+    async fn test_stop_all_sessions_empty() {
+        let mgr = make_test_session_manager();
+        let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+        assert_eq!(result.total(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_stop_all_sessions_idle_session() {
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-1";
+        setup_parent_with_conv(&mgr, parent_id).await;
+        let child_id = "child-1";
+        register_child_only(&mgr, parent_id, child_id, "worker", SpawnMode::Session).await;
+        // Create a ConversationSession for the child
+        let cs = std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::llm::session::ConversationSession::new(
+                child_id.to_string(),
+                "test-model".to_string(),
+                std::path::PathBuf::from("/tmp"),
+            ),
+        ));
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert(child_id.to_string(), cs);
+        // Add child to sessions map (build_stop_tree filters on this)
+        mgr.sessions.write().await.insert(
+            child_id.to_string(),
+            crate::gateway::Session {
+                id: child_id.to_string(),
+                agent_id: "worker".to_string(),
+                channel: "feishu".to_string(),
+                created_at: chrono::Utc::now().timestamp(),
+                depth: 1,
+            },
+        );
+
+        let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+        // Both parent and child have ConversationSessions → both stopped.
+        assert!(result.succeeded >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_stop_all_sessions_forceful() {
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-2";
+        setup_parent_with_conv(&mgr, parent_id).await;
+
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        // Parent has no storage → persist_checkpoint returns Ok (no-op).
+        // Parent should be stopped.
+        assert!(result.succeeded >= 1);
+    }
+}

--- a/src/gateway/tests_plugin.rs
+++ b/src/gateway/tests_plugin.rs
@@ -213,13 +213,13 @@ async fn register_session_with_conv(
     sm: &SessionManager,
     session_id: &str,
     agent_id: &str,
-    chat_id: &str,
+    _chat_id: &str,
 ) {
     sm.sessions.write().await.insert(
         session_id.to_string(),
         Session {
             id: session_id.to_string(),
-            agent_id: chat_id.to_string(),
+            agent_id: agent_id.to_string(),
             channel: "test".to_string(),
             created_at: chrono::Utc::now().timestamp(),
             depth: 0,
@@ -234,7 +234,6 @@ async fn register_session_with_conv(
         .write()
         .await
         .insert(session_id.to_string(), cs);
-    let _ = agent_id;
 }
 
 /// Verify progress card has correct JSON structure in graceful mode.

--- a/src/gateway/tests_plugin.rs
+++ b/src/gateway/tests_plugin.rs
@@ -143,3 +143,260 @@ async fn test_register_plugin_uses_plugin_platform_as_key() {
     assert!(gw.get_plugin("BETA").await.is_none());
     assert!(gw.get_plugin("").await.is_none());
 }
+
+// ── Shutdown progress card tests (Step 1.4) ──────────────────────────────
+
+use crate::daemon::shutdown::ShutdownMode;
+use crate::gateway::Session;
+use crate::llm::session::ConversationSession;
+use std::path::PathBuf;
+use tokio::sync::RwLock;
+
+/// Mock plugin that captures the last card JSON sent via `send()`.
+struct CapturingPlugin {
+    platform_name: String,
+    last_card: RwLock<Option<serde_json::Value>>,
+}
+
+impl CapturingPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform_name: platform.to_string(),
+            last_card: RwLock::new(None),
+        }
+    }
+
+    async fn last_card(&self) -> Option<serde_json::Value> {
+        self.last_card.read().await.clone()
+    }
+}
+
+#[async_trait]
+impl IMPlugin for CapturingPlugin {
+    fn platform(&self) -> &str {
+        &self.platform_name
+    }
+
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
+        Ok(None)
+    }
+
+    fn render(
+        &self,
+        _content_blocks: &[ContentBlock],
+        _dsl_result: Option<&DslParseResult>,
+    ) -> RenderedOutput {
+        RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({}),
+        }
+    }
+
+    async fn send(
+        &self,
+        output: &RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), AdapterError> {
+        if output.msg_type == "interactive" {
+            *self.last_card.write().await = Some(output.payload.clone());
+        }
+        Ok(())
+    }
+}
+
+/// Register a session with a ConversationSession in the given SessionManager.
+async fn register_session_with_conv(
+    sm: &SessionManager,
+    session_id: &str,
+    agent_id: &str,
+    chat_id: &str,
+) {
+    sm.sessions.write().await.insert(
+        session_id.to_string(),
+        Session {
+            id: session_id.to_string(),
+            agent_id: chat_id.to_string(),
+            channel: "test".to_string(),
+            created_at: chrono::Utc::now().timestamp(),
+            depth: 0,
+        },
+    );
+    let cs = Arc::new(RwLock::new(ConversationSession::new(
+        session_id.to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    )));
+    sm.conversation_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), cs);
+    let _ = agent_id;
+}
+
+/// Verify progress card has correct JSON structure in graceful mode.
+#[tokio::test]
+async fn test_progress_card_graceful_structure() {
+    let (gw, sm) = make_gw(make_config());
+    register_session_with_conv(&sm, "sess-1", "agent-1", "chat-1").await;
+
+    let plugin = Arc::new(CapturingPlugin::new("test"));
+    let plugin_ref = plugin.clone();
+    gw.register_plugin(plugin).await;
+
+    gw.send_shutdown_progress_card(ShutdownMode::Graceful).await;
+
+    let card = plugin_ref.last_card().await.expect("card should be sent");
+
+    // Header must be blue for graceful
+    let header = card.get("header").expect("card must have header");
+    let template = header.get("template").expect("header must have template");
+    assert_eq!(template.as_str().unwrap(), "blue");
+
+    // Header title must mention graceful shutdown
+    let title = header.get("title").expect("header must have title");
+    let content = title.get("content").expect("title must have content");
+    assert!(content.as_str().unwrap().contains("\u{5173}\u{95ed}"));
+
+    // Elements must contain session list and action buttons
+    let elements = card
+        .get("elements")
+        .expect("card must have elements")
+        .as_array()
+        .expect("elements must be array");
+    assert!(!elements.is_empty(), "elements should not be empty");
+
+    // Last element should be action block with buttons
+    let last = elements.last().unwrap();
+    assert_eq!(last.get("tag").unwrap().as_str().unwrap(), "action");
+    let actions = last.get("actions").expect("action must have actions");
+    assert_eq!(actions.as_array().unwrap().len(), 2);
+}
+
+/// Verify progress card has correct JSON structure in forceful mode.
+#[tokio::test]
+async fn test_progress_card_forceful_structure() {
+    let (gw, sm) = make_gw(make_config());
+    register_session_with_conv(&sm, "sess-2", "agent-2", "chat-2").await;
+
+    let plugin = Arc::new(CapturingPlugin::new("test"));
+    let plugin_ref = plugin.clone();
+    gw.register_plugin(plugin).await;
+
+    gw.send_shutdown_progress_card(ShutdownMode::Forceful).await;
+
+    let card = plugin_ref.last_card().await.expect("card should be sent");
+
+    // Header must be red for forceful
+    let header = card.get("header").expect("card must have header");
+    let template = header.get("template").expect("header must have template");
+    assert_eq!(template.as_str().unwrap(), "red");
+
+    // Elements should NOT contain action buttons in forceful mode
+    let elements = card
+        .get("elements")
+        .expect("card must have elements")
+        .as_array()
+        .expect("elements must be array");
+    let has_action = elements.iter().any(|e| {
+        e.get("tag")
+            .map(|t| t.as_str() == Some("action"))
+            .unwrap_or(false)
+    });
+    assert!(!has_action, "forceful card should not have action buttons");
+}
+
+/// No card sent when there are no active sessions.
+#[tokio::test]
+async fn test_progress_card_no_sessions_no_card() {
+    let (gw, _sm) = make_gw(make_config());
+    // Register no sessions
+    let plugin = Arc::new(CapturingPlugin::new("test"));
+    let plugin_ref = plugin.clone();
+    gw.register_plugin(plugin).await;
+
+    gw.send_shutdown_progress_card(ShutdownMode::Graceful).await;
+
+    assert!(
+        plugin_ref.last_card().await.is_none(),
+        "no card should be sent when there are no sessions"
+    );
+}
+
+/// Card send failure does not panic (fault tolerance).
+#[tokio::test]
+async fn test_progress_card_send_failure_does_not_panic() {
+    let (gw, sm) = make_gw(make_config());
+    register_session_with_conv(&sm, "sess-3", "agent-3", "chat-3").await;
+
+    gw.register_plugin(Arc::new(MockPlugin::failing("failing")))
+        .await;
+
+    // Should not panic even though send fails
+    gw.send_shutdown_progress_card(ShutdownMode::Graceful).await;
+}
+
+/// Final card has correct JSON structure.
+#[tokio::test]
+async fn test_shutdown_final_card_structure() {
+    let (gw, sm) = make_gw(make_config());
+    register_session_with_conv(&sm, "sess-4", "agent-4", "chat-4").await;
+
+    let plugin = Arc::new(CapturingPlugin::new("test"));
+    let plugin_ref = plugin.clone();
+    gw.register_plugin(plugin).await;
+
+    let result = crate::gateway::session_manager::stop::StopResult {
+        succeeded: 2,
+        failed: 1,
+        skipped: 3,
+    };
+    gw.send_shutdown_final_card(&result).await;
+
+    let card = plugin_ref
+        .last_card()
+        .await
+        .expect("final card should be sent");
+
+    // Header should be green for completion
+    let header = card.get("header").expect("card must have header");
+    let template = header.get("template").expect("header must have template");
+    assert_eq!(template.as_str().unwrap(), "green");
+
+    // Elements should contain summary with counts
+    let elements = card
+        .get("elements")
+        .expect("card must have elements")
+        .as_array()
+        .expect("elements must be array");
+    assert_eq!(elements.len(), 1);
+    let text = elements[0]
+        .get("text")
+        .and_then(|t| t.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap();
+    assert!(text.contains("2")); // succeeded
+    assert!(text.contains("1")); // failed
+    assert!(text.contains("3")); // skipped
+}
+
+/// Final card not sent when no sessions.
+#[tokio::test]
+async fn test_shutdown_final_card_no_sessions() {
+    let (gw, _sm) = make_gw(make_config());
+    // Register no sessions
+    let plugin = Arc::new(CapturingPlugin::new("test"));
+    let plugin_ref = plugin.clone();
+    gw.register_plugin(plugin).await;
+
+    let result = crate::gateway::session_manager::stop::StopResult::default();
+    gw.send_shutdown_final_card(&result).await;
+
+    assert!(
+        plugin_ref.last_card().await.is_none(),
+        "no final card should be sent when there are no sessions"
+    );
+}

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -479,4 +479,18 @@ impl IMPlugin for FeishuPlugin {
             _ => Err(AdapterError::UnsupportedOperation),
         }
     }
+
+    async fn close_inbound(&self) -> Result<(), AdapterError> {
+        // Feishu uses stateless HTTP webhooks — nothing to disconnect.
+        // Clear the cached tenant token to release resources.
+        *self.adapter.cached_token.lock().await = None;
+        Ok(())
+    }
+
+    async fn close_outbound(&self) -> Result<(), AdapterError> {
+        // Feishu sends via stateless HTTP — no queue to drain.
+        // Clear the cached tenant token to release resources.
+        *self.adapter.cached_token.lock().await = None;
+        Ok(())
+    }
 }

--- a/src/im/feishu_tests.rs
+++ b/src/im/feishu_tests.rs
@@ -344,6 +344,58 @@ mod tests {
         assert_eq!(msg.thread_id, None);
     }
 
+    // ── lifecycle hook tests (Step 1.1) ──────────────────────────────
+
+    /// close_inbound on FeishuAdapter succeeds (clears cached token).
+    #[tokio::test]
+    async fn test_feishu_adapter_close_inbound_succeeds() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        // Trigger a token fetch attempt (will fail with bad creds, but
+        // that's fine — we just need close_inbound to not panic).
+        adapter.close_inbound().await.unwrap();
+    }
+
+    /// close_outbound on FeishuAdapter succeeds (clears cached token).
+    #[tokio::test]
+    async fn test_feishu_adapter_close_outbound_succeeds() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        adapter.close_outbound().await.unwrap();
+    }
+
+    /// close_inbound on FeishuPlugin delegates to adapter and succeeds.
+    #[tokio::test]
+    async fn test_feishu_plugin_close_inbound() {
+        let adapter = Arc::new(FeishuAdapter::new("a".into(), "s".into(), "t".into()));
+        let renderer = Arc::new(FeishuRenderer::new());
+        let plugin = FeishuPlugin::new(adapter, renderer);
+        plugin.close_inbound().await.unwrap();
+    }
+
+    /// close_outbound on FeishuPlugin delegates to adapter and succeeds.
+    #[tokio::test]
+    async fn test_feishu_plugin_close_outbound() {
+        let adapter = Arc::new(FeishuAdapter::new("a".into(), "s".into(), "t".into()));
+        let renderer = Arc::new(FeishuRenderer::new());
+        let plugin = FeishuPlugin::new(adapter, renderer);
+        plugin.close_outbound().await.unwrap();
+    }
+
+    /// close_inbound is idempotent — calling twice still succeeds.
+    #[tokio::test]
+    async fn test_feishu_adapter_close_inbound_idempotent() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        adapter.close_inbound().await.unwrap();
+        adapter.close_inbound().await.unwrap();
+    }
+
+    /// close_outbound is idempotent — calling twice still succeeds.
+    #[tokio::test]
+    async fn test_feishu_adapter_close_outbound_idempotent() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        adapter.close_outbound().await.unwrap();
+        adapter.close_outbound().await.unwrap();
+    }
+
     // ── root_id URL encoding test ──────────────────────────────────────
 
     #[test]

--- a/src/im/mod.rs
+++ b/src/im/mod.rs
@@ -50,4 +50,20 @@ pub trait IMAdapter: Send + Sync {
     ) -> Result<(), AdapterError> {
         Err(AdapterError::UnsupportedOperation)
     }
+
+    /// Close inbound connections (e.g. unsubscribe webhook, disconnect WebSocket).
+    ///
+    /// Called during daemon Phase 1 (inbound shutdown) to stop accepting new
+    /// messages from the platform. Default implementation is a no-op.
+    async fn close_inbound(&self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    /// Close outbound connections (e.g. drain send queue, disconnect API client).
+    ///
+    /// Called during daemon Phase 5 (outbound shutdown) to stop sending
+    /// messages to the platform. Default implementation is a no-op.
+    async fn close_outbound(&self) -> Result<(), AdapterError> {
+        Ok(())
+    }
 }

--- a/src/im/terminal_tests.rs
+++ b/src/im/terminal_tests.rs
@@ -284,6 +284,38 @@ mod tests {
     }
 
     // =========================================================================
+    // ── lifecycle hook tests (Step 1.1) ──────────────────────────────
+
+    /// TerminalPlugin close_inbound is a no-op (default from IMPlugin trait).
+    #[tokio::test]
+    async fn test_terminal_plugin_close_inbound_noop() {
+        let plugin = TerminalPlugin::new();
+        plugin.close_inbound().await.unwrap();
+    }
+
+    /// TerminalPlugin close_outbound is a no-op (default from IMPlugin trait).
+    #[tokio::test]
+    async fn test_terminal_plugin_close_outbound_noop() {
+        let plugin = TerminalPlugin::new();
+        plugin.close_outbound().await.unwrap();
+    }
+
+    /// TerminalPlugin close_inbound is idempotent.
+    #[tokio::test]
+    async fn test_terminal_plugin_close_inbound_idempotent() {
+        let plugin = TerminalPlugin::new();
+        plugin.close_inbound().await.unwrap();
+        plugin.close_inbound().await.unwrap();
+    }
+
+    /// TerminalPlugin close_outbound is idempotent.
+    #[tokio::test]
+    async fn test_terminal_plugin_close_outbound_idempotent() {
+        let plugin = TerminalPlugin::new();
+        plugin.close_outbound().await.unwrap();
+        plugin.close_outbound().await.unwrap();
+    }
+
     // DSL skip rendering tests (Step 1.7) — plugin-level
     // =========================================================================
 

--- a/src/im_adapter/plugin.rs
+++ b/src/im_adapter/plugin.rs
@@ -115,4 +115,20 @@ pub trait IMPlugin: Send + Sync {
         peer_id: &str,
         thread_id: Option<&str>,
     ) -> Result<(), AdapterError>;
+
+    /// Close inbound connections (e.g. unsubscribe webhook, disconnect WebSocket).
+    ///
+    /// Called during daemon Phase 1 (inbound shutdown) to stop accepting new
+    /// messages from the platform. Default implementation is a no-op.
+    async fn close_inbound(&self) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    /// Close outbound connections (e.g. drain send queue, disconnect API client).
+    ///
+    /// Called during daemon Phase 5 (outbound shutdown) to stop sending
+    /// messages to the platform. Default implementation is a no-op.
+    async fn close_outbound(&self) -> Result<(), AdapterError> {
+        Ok(())
+    }
 }

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -116,6 +116,10 @@ pub struct ConversationSession {
     /// Communication configuration for spawned child sessions.
     /// When set, restricts which agents the child may communicate with.
     communication_config: Option<CommunicationConfig>,
+    /// Last activity timestamp (Unix seconds) — updated on every message
+    /// push or state mutation.  Used by the shutdown progress card to
+    /// display accurate "elapsed since last activity" instead of session age.
+    last_activity_at: i64,
 }
 
 // `impl ConversationSession` is split across multiple blocks so each
@@ -152,6 +156,7 @@ impl ConversationSession {
             cancel_token: CancellationToken::new(),
             stopped: Arc::new(AtomicBool::new(false)),
             communication_config: None,
+            last_activity_at: Utc::now().timestamp(),
         }
     }
 
@@ -187,6 +192,12 @@ impl ConversationSession {
     /// Returns the Unix timestamp (seconds) when this session was created.
     pub fn session_created_at(&self) -> i64 {
         self.created_at
+    }
+
+    /// Returns the Unix timestamp (seconds) of the last activity.
+    /// Updated on every message push or significant state mutation.
+    pub fn last_activity_at(&self) -> i64 {
+        self.last_activity_at
     }
 
     /// Sets the reasoning level.
@@ -229,6 +240,7 @@ impl ConversationSession {
             content_blocks,
             timestamp: Utc::now(),
         });
+        self.last_activity_at = Utc::now().timestamp();
     }
 
     /// Sets the LLM busy state.

--- a/tests/e2e_daemon_shutdown_tests.rs
+++ b/tests/e2e_daemon_shutdown_tests.rs
@@ -110,7 +110,7 @@ async fn test_daemon_run_sigterm_shutdown() {
     write_mandatory_configs(&config_dir).expect("write mandatory config");
 
     // Do NOT set FEISHU/LLM env vars — Daemon::start will skip those components
-    let daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())
+    let mut daemon = closeclaw::daemon::Daemon::start(temp_dir.path().to_str().unwrap())
         .await
         .expect("daemon start");
 


### PR DESCRIPTION
Implement phase-based daemon shutdown (Phase 0-7) as described in docs/design/daemon/shutdown.md.

Changes:
- Add close_inbound()/close_outbound() lifecycle hooks to IMAdapter/IMPlugin traits (Step 1.1)
- Add SessionManager::stop_all_sessions() with leaf-to-root hierarchical shutdown and per-state behavior (Step 1.2)
- Refactor Daemon::run() into Phase 0-7 methods (Step 1.3)
- Add shutdown progress notification card via Gateway (Step 1.4)
- Unit tests for all new logic (Step 1.5)
- E2 review fixes: delete unused variable, explicit drop for watchers, non-Stopped session alert, card dedup (Step 1.6)
- E2 v2 review fixes: agent_id param usage, signal escalation edge case (Step 1.7)

Source: user
Type: refactor
