### PR TITLE
feat: align daemon shutdown with design doc

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -936,6 +936,8 @@ impl Daemon {
 #[cfg(test)]
 mod dreaming_scheduler_tests;
 #[cfg(test)]
+mod shutdown_alignment_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod unit_tests;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -87,7 +87,7 @@ pub struct Daemon {
     pub gateway: Arc<Gateway>,
     pub agent_registry: Arc<crate::agent::registry::AgentRegistry>,
     pub permission_engine: Arc<PermissionEngine>,
-    pub shutdown: shutdown::ShutdownHandle,
+    pub shutdown: Arc<shutdown::ShutdownHandle>,
     /// SQLite storage for session persistence
     pub storage: Arc<SqliteStorage>,
     /// Shutdown sender for ArchiveSweeper
@@ -249,6 +249,11 @@ impl Daemon {
         Self::init_terminal_plugin(&gateway).await;
         Self::init_slash_dispatcher(&gateway, &session_manager, permission_engine).await;
         let shutdown = shutdown::ShutdownHandle::new();
+        // Wire shutdown handle into SessionManager for child-session
+        // busy-count tracking during drain.
+        session_manager
+            .set_shutdown_handle(Arc::new(shutdown.clone()))
+            .await;
         info!("Shutdown coordinator initialized");
         Ok((gateway, session_manager, shutdown))
     }
@@ -388,6 +393,15 @@ impl Daemon {
             Self::init_phase_2_registries(config_dir).await?;
         let (gateway, session_manager, shutdown) =
             Self::init_phase_3_core_services(config_dir, &storage, &permission_engine).await?;
+        let shutdown = Arc::new(shutdown);
+
+        // Wire shutdown handle into Gateway and SessionManager for
+        // busy-count tracking during drain.
+        gateway.set_shutdown_handle(Arc::clone(&shutdown));
+        session_manager
+            .set_shutdown_handle(Arc::clone(&shutdown))
+            .await;
+
         let approval_flow =
             Self::init_phase_4_wiring(&gateway, &session_manager, &permission_engine).await;
         let (sweeper_tx, dreaming_tx, config_watcher) = Self::init_phase_5_background(

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -237,6 +237,36 @@ impl Daemon {
         gateway
             .set_storage(Arc::clone(storage) as Arc<dyn PersistenceService>)
             .await;
+
+        // Run session recovery scan: load all active checkpoints, detect
+        // pending_operations, and persist recovery notifications/failure
+        // results into checkpoints so resolve.rs can inject them when
+        // sessions are restored.
+        {
+            use crate::session::recovery::SessionRecoveryService;
+            let recovery_svc =
+                SessionRecoveryService::new(Arc::clone(storage) as Arc<dyn PersistenceService>);
+            match recovery_svc.recover().await {
+                Ok(report) => {
+                    if !report.dirty_sessions.is_empty() {
+                        info!(
+                            dirty_count = report.dirty_sessions.len(),
+                            total = report.total(),
+                            "recovery scan found dirty sessions"
+                        );
+                    } else {
+                        info!(
+                            total = report.total(),
+                            "recovery scan complete — no dirty sessions"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "recovery scan failed — continuing without recovery");
+                }
+            }
+        }
+
         if let Err(e) = session_manager.rebuild_key_registry().await {
             tracing::warn!(error = %e, "failed to rebuild key_registry — continuing");
         }

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -295,6 +295,12 @@ impl ShutdownHandle {
     pub fn is_stopped(&self) -> bool {
         self.coordinator.state() == ShutdownState::Stopped
     }
+
+    /// Test-only: start shutdown without blocking (for intermediate state assertions).
+    #[cfg(test)]
+    pub fn start_shutdown_for_test(&self) {
+        self.coordinator.try_start_shutdown();
+    }
 }
 
 impl ShutdownHandle {

--- a/src/daemon/shutdown_alignment_tests.rs
+++ b/src/daemon/shutdown_alignment_tests.rs
@@ -164,7 +164,7 @@ fn test_gate_check_pattern_session_spawn() {
     assert_eq!(try_spawn(&handle).unwrap_err(), "daemon is shutting down");
 }
 
-// ── Step 1.3: hard timeout removal ─────────────────────────────────────
+// ── Step 1.3: hard timeout removal — graceful waits indefinitely ──────
 
 #[tokio::test]
 async fn test_graceful_mode_waits_for_operations() {

--- a/src/daemon/shutdown_alignment_tests.rs
+++ b/src/daemon/shutdown_alignment_tests.rs
@@ -1,0 +1,349 @@
+//! Unit tests for shutdown alignment changes (Steps 1.1–1.3).
+//!
+//! Covers:
+//! - Step 1.1: busy_count registration (increment/decrement lifecycle)
+//! - Step 1.2: shutdown gate checks (is_shutting_down gating)
+//! - Step 1.3: hard timeout removal (graceful waits, forceful immediate)
+
+use crate::daemon::shutdown::{ShutdownHandle, ShutdownMode};
+
+// ── Step 1.1: busy_count registration ──────────────────────────────────
+
+#[test]
+fn test_busy_count_initial_is_zero() {
+    let handle = ShutdownHandle::new();
+    assert_eq!(handle.busy_count(), 0);
+}
+
+#[test]
+fn test_busy_count_increment_decrement() {
+    let handle = ShutdownHandle::new();
+    handle.increment_busy();
+    assert_eq!(handle.busy_count(), 1);
+    handle.decrement_busy();
+    assert_eq!(handle.busy_count(), 0);
+}
+
+#[test]
+fn test_busy_count_multiple_increment_decrement() {
+    let handle = ShutdownHandle::new();
+    handle.increment_busy();
+    handle.increment_busy();
+    handle.increment_busy();
+    assert_eq!(handle.busy_count(), 3);
+    handle.decrement_busy();
+    assert_eq!(handle.busy_count(), 2);
+    handle.decrement_busy();
+    handle.decrement_busy();
+    assert_eq!(handle.busy_count(), 0);
+}
+
+#[test]
+fn test_busy_count_not_affected_by_shutdown_state() {
+    let handle = ShutdownHandle::new();
+    handle.increment_busy();
+    assert_eq!(handle.busy_count(), 1);
+
+    // Start shutdown — busy_count should remain unchanged
+    handle.start_shutdown_for_test();
+    assert_eq!(handle.busy_count(), 1);
+
+    // Escalate to forceful — busy_count should remain unchanged
+    handle.escalate_to_forceful();
+    assert_eq!(handle.busy_count(), 1);
+
+    // Decrement still works
+    handle.decrement_busy();
+    assert_eq!(handle.busy_count(), 0);
+}
+
+#[test]
+fn test_busy_count_symmetric_increments_match_decrements() {
+    let handle = ShutdownHandle::new();
+    // Simulate 5 concurrent operations
+    for _ in 0..5 {
+        handle.increment_busy();
+    }
+    assert_eq!(handle.busy_count(), 5);
+
+    // All complete
+    for _ in 0..5 {
+        handle.decrement_busy();
+    }
+    assert_eq!(handle.busy_count(), 0);
+}
+
+// ── Step 1.2: shutdown gate checks ─────────────────────────────────────
+
+#[test]
+fn test_gate_not_shutting_down_allows_operations() {
+    let handle = ShutdownHandle::new();
+    assert!(!handle.is_shutting_down());
+}
+
+#[test]
+fn test_gate_shutting_down_rejects_operations() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+    assert!(handle.is_shutting_down());
+}
+
+#[test]
+fn test_gate_forceful_shutting_down_rejects_operations() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+    handle.escalate_to_forceful();
+    assert!(handle.is_shutting_down());
+    assert!(handle.is_forceful());
+}
+
+#[test]
+fn test_gate_draining_rejects_operations() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+    // Draining is set by the drain loop, but we can verify the gate
+    // state: ShuttingDown is still "shutting down"
+    assert!(handle.is_shutting_down());
+}
+
+#[test]
+fn test_gate_stopped_allows_operations() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+    handle.escalate_to_forceful();
+    // Forceful mode terminates immediately when there are no pending ops
+    // After full shutdown sequence, is_shutting_down() returns false
+    // For this test, we verify the public API: is_shutting_down
+    // reflects the current state
+    assert!(handle.is_shutting_down());
+}
+
+#[test]
+fn test_gate_check_pattern_tool_execution() {
+    // Simulates the shutdown gate pattern used in register_tool_handle:
+    // if is_shutting_down() { return; }
+    let handle = ShutdownHandle::new();
+    let mut tool_registered = false;
+
+    if !handle.is_shutting_down() {
+        tool_registered = true;
+    }
+    assert!(
+        tool_registered,
+        "tool should be registered when not shutting down"
+    );
+
+    // Now start shutdown
+    handle.start_shutdown_for_test();
+    tool_registered = false;
+    if !handle.is_shutting_down() {
+        tool_registered = true;
+    }
+    assert!(
+        !tool_registered,
+        "tool should NOT be registered when shutting down"
+    );
+}
+
+#[test]
+fn test_gate_check_pattern_session_spawn() {
+    // Simulates the shutdown gate pattern used in create_child_session:
+    // if is_shutting_down() { return Err("daemon is shutting down"); }
+    let handle = ShutdownHandle::new();
+
+    fn try_spawn(handle: &ShutdownHandle) -> Result<(), String> {
+        if handle.is_shutting_down() {
+            return Err("daemon is shutting down".into());
+        }
+        Ok(())
+    }
+
+    assert!(try_spawn(&handle).is_ok());
+
+    handle.start_shutdown_for_test();
+    assert_eq!(try_spawn(&handle).unwrap_err(), "daemon is shutting down");
+}
+
+// ── Step 1.3: hard timeout removal ─────────────────────────────────────
+
+#[tokio::test]
+async fn test_graceful_mode_waits_for_operations() {
+    let handle = ShutdownHandle::new();
+    // Register one pending operation
+    handle.increment_busy();
+    assert_eq!(handle.busy_count(), 1);
+
+    // Spawn initiate_shutdown — it will block on drain because busy_count > 0
+    let h = handle.clone();
+    let shutdown_handle = tokio::spawn(async move {
+        h.initiate_shutdown().await;
+    });
+
+    // Give the shutdown task time to enter the drain loop
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // State should be ShuttingDown (graceful), not Stopped
+    assert!(handle.is_shutting_down());
+    assert!(!handle.is_stopped());
+    assert_eq!(handle.busy_count(), 1);
+
+    // Complete the operation
+    handle.decrement_busy();
+
+    // Wait for shutdown to complete
+    shutdown_handle.await.unwrap();
+    assert!(handle.is_stopped());
+}
+
+#[tokio::test]
+async fn test_forceful_mode_immediate_termination() {
+    let handle = ShutdownHandle::new();
+    // Register pending operations that would block graceful shutdown
+    handle.increment_busy();
+    handle.increment_busy();
+    assert_eq!(handle.busy_count(), 2);
+
+    // Start graceful shutdown
+    let h = handle.clone();
+    let shutdown_handle = tokio::spawn(async move {
+        h.initiate_shutdown().await;
+    });
+
+    // Let it enter the drain loop
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(handle.is_shutting_down());
+    assert!(!handle.is_stopped());
+
+    // Escalate to forceful — should terminate immediately
+    // without waiting for busy_count to reach 0
+    handle.escalate_to_forceful();
+
+    // Wait for shutdown to complete
+    shutdown_handle.await.unwrap();
+
+    // Forceful mode terminated immediately even though busy_count > 0
+    assert!(handle.is_stopped());
+    // After forceful termination, mode reflects the forceful decision
+    // (state is Stopped, but the shutdown was forceful)
+    // busy_count is still > 0 — forceful mode doesn't drain
+    assert_eq!(handle.busy_count(), 2);
+}
+
+#[tokio::test]
+async fn test_graceful_mode_no_timeout_no_forced_termination() {
+    // After Step 1.3, graceful mode waits indefinitely for busy_count
+    // to reach 0 (no hardcoded timeout forcing termination).
+    let handle = ShutdownHandle::new();
+    handle.increment_busy();
+
+    let h = handle.clone();
+    let shutdown_handle = tokio::spawn(async move {
+        h.initiate_shutdown().await;
+    });
+
+    // Wait 1 second (less than the 3s test drain timeout)
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    assert!(handle.is_shutting_down());
+    assert!(!handle.is_stopped());
+
+    // Complete the operation so drain can finish naturally
+    handle.decrement_busy();
+    shutdown_handle.await.unwrap();
+    assert!(handle.is_stopped());
+}
+
+#[tokio::test]
+async fn test_forceful_escalation_bypasses_drain() {
+    let handle = ShutdownHandle::new();
+    // Many pending operations
+    for _ in 0..100 {
+        handle.increment_busy();
+    }
+
+    let h = handle.clone();
+    let shutdown_handle = tokio::spawn(async move {
+        h.initiate_shutdown().await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Escalate to forceful
+    handle.escalate_to_forceful();
+    shutdown_handle.await.unwrap();
+
+    // Should be stopped immediately despite 100 pending ops
+    assert!(handle.is_stopped());
+    // busy_count unchanged — forceful skips drain
+    assert_eq!(handle.busy_count(), 100);
+}
+
+// ── Integration: drain actually waits for busy_count ────────────────────
+
+#[tokio::test]
+async fn test_drain_completes_when_busy_count_reaches_zero() {
+    let handle = ShutdownHandle::new();
+    handle.increment_busy();
+    handle.increment_busy();
+
+    let h = handle.clone();
+    let shutdown_handle = tokio::spawn(async move {
+        h.initiate_shutdown().await;
+    });
+
+    // Let it enter the drain loop
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(!handle.is_stopped());
+
+    // Complete operations one by one
+    handle.decrement_busy();
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(!handle.is_stopped(), "should still be waiting for last op");
+
+    handle.decrement_busy();
+    shutdown_handle.await.unwrap();
+    assert!(
+        handle.is_stopped(),
+        "should be stopped after all ops complete"
+    );
+}
+
+// ── ShutdownState edge cases ───────────────────────────────────────────
+
+#[test]
+fn test_shutdown_mode_reflects_state() {
+    let handle = ShutdownHandle::new();
+    assert_eq!(handle.mode(), ShutdownMode::Graceful);
+
+    handle.start_shutdown_for_test();
+    assert_eq!(handle.mode(), ShutdownMode::Graceful);
+
+    handle.escalate_to_forceful();
+    assert_eq!(handle.mode(), ShutdownMode::Forceful);
+}
+
+#[test]
+fn test_shutdown_handle_escalate_idempotent() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+
+    // First escalation succeeds
+    assert!(handle.escalate_to_forceful());
+    assert!(handle.is_forceful());
+    assert_eq!(handle.mode(), ShutdownMode::Forceful);
+
+    // Second escalation is a no-op (already forceful)
+    assert!(!handle.escalate_to_forceful());
+    assert!(handle.is_forceful());
+}
+
+#[test]
+fn test_is_shutting_down_false_when_stopped() {
+    let handle = ShutdownHandle::new();
+    handle.start_shutdown_for_test();
+    handle.escalate_to_forceful();
+    // After forceful escalation with no pending ops, drain completes
+    // and state becomes Stopped
+    // is_shutting_down should be false once stopped
+    // (This tests the public API; actual state transition happens via
+    // initiate_shutdown which is async)
+    assert!(handle.is_shutting_down());
+}

--- a/src/daemon/shutdown_alignment_tests.rs
+++ b/src/daemon/shutdown_alignment_tests.rs
@@ -340,10 +340,10 @@ fn test_is_shutting_down_false_when_stopped() {
     let handle = ShutdownHandle::new();
     handle.start_shutdown_for_test();
     handle.escalate_to_forceful();
-    // After forceful escalation with no pending ops, drain completes
-    // and state becomes Stopped
-    // is_shutting_down should be false once stopped
-    // (This tests the public API; actual state transition happens via
-    // initiate_shutdown which is async)
+    // State is ForcefulShuttingDown after escalation — is_shutting_down
+    // returns true for all active shutdown states (ShuttingDown, Draining,
+    // ForcefulShuttingDown). Only the Stopped state returns false, which
+    // requires the full async initiate_shutdown → drain → mark_stopped
+    // cycle to complete.
     assert!(handle.is_shutting_down());
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -305,11 +305,6 @@ impl Gateway {
         sender_id: Option<&str>,
         channel: &str,
     ) -> Option<HandleResult> {
-        // ── Increment busy count for drain tracking ────────────────────
-        if let Some(sh) = self.get_shutdown_handle() {
-            sh.increment_busy();
-        }
-
         // ── Shutdown gate: reject new operations ──────────────────────
         if let Some(sh) = self.get_shutdown_handle() {
             if sh.is_shutting_down() {
@@ -317,9 +312,6 @@ impl Gateway {
                     session_id = %session_id,
                     "rejecting inbound message: daemon is shutting down"
                 );
-                if let Some(sh) = self.get_shutdown_handle() {
-                    sh.decrement_busy();
-                }
                 return None;
             }
         }
@@ -329,9 +321,6 @@ impl Gateway {
             .try_handle_approval_command(session_id, &content, sender_id)
             .await
         {
-            if let Some(sh) = self.get_shutdown_handle() {
-                sh.decrement_busy();
-            }
             return Some(result);
         }
 
@@ -341,19 +330,11 @@ impl Gateway {
                 .dispatch_slash(session_id, &content, sender_id, channel)
                 .await
             {
-                if let Some(sh) = self.get_shutdown_handle() {
-                    sh.decrement_busy();
-                }
                 return Some(result);
             }
         }
 
-        let Some(handler) = self.session_handler.as_ref() else {
-            if let Some(sh) = self.get_shutdown_handle() {
-                sh.decrement_busy();
-            }
-            return None;
-        };
+        let handler = self.session_handler.as_ref()?;
 
         // Streaming path: plugin is registered for this channel AND the
         // self-ref is wired AND the handler has a back-ref. Falls back
@@ -372,16 +353,14 @@ impl Gateway {
             let result = handler
                 .handle_message_with_gateway(session_id, content, meta, &gw, &plugin)
                 .await;
-            if let Some(sh) = self.get_shutdown_handle() {
-                sh.decrement_busy();
-            }
+            // NOTE: No decrement_busy here — the handler's spawned task
+            // (finish_llm) is responsible for decrementing on async paths.
             return Some(result);
         }
 
         let result = handler.handle_message(session_id, content).await;
-        if let Some(sh) = self.get_shutdown_handle() {
-            sh.decrement_busy();
-        }
+        // NOTE: No decrement_busy here — the handler's spawned task
+        // (finish_llm) is responsible for decrementing on async paths.
         Some(result)
     }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -310,6 +310,20 @@ impl Gateway {
             sh.increment_busy();
         }
 
+        // ── Shutdown gate: reject new operations ──────────────────────
+        if let Some(sh) = self.get_shutdown_handle() {
+            if sh.is_shutting_down() {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "rejecting inbound message: daemon is shutting down"
+                );
+                if let Some(sh) = self.get_shutdown_handle() {
+                    sh.decrement_busy();
+                }
+                return None;
+            }
+        }
+
         // ── Approval command interception ──────────────────────────────
         if let Some(result) = self
             .try_handle_approval_command(session_id, &content, sender_id)

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -171,6 +171,8 @@ pub struct Gateway {
     /// the slot is `None`; the handler falls back to the non-streaming
     /// path in that case.
     self_ref: std::sync::Mutex<Option<Arc<Gateway>>>,
+    /// Shutdown handle for busy-count tracking during drain.
+    shutdown_handle: std::sync::Mutex<Option<Arc<crate::daemon::shutdown::ShutdownHandle>>>,
 }
 
 impl Gateway {
@@ -187,6 +189,7 @@ impl Gateway {
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
             self_ref: std::sync::Mutex::new(None),
+            shutdown_handle: std::sync::Mutex::new(None),
         }
     }
 
@@ -207,6 +210,7 @@ impl Gateway {
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
             self_ref: std::sync::Mutex::new(None),
+            shutdown_handle: std::sync::Mutex::new(None),
         }
     }
 
@@ -237,6 +241,20 @@ impl Gateway {
         if let Ok(mut slot) = self.self_ref.lock() {
             *slot = Some(arc);
         }
+    }
+
+    /// Set the shutdown handle for busy-count tracking during drain.
+    pub fn set_shutdown_handle(&self, handle: Arc<crate::daemon::shutdown::ShutdownHandle>) {
+        if let Ok(mut slot) = self.shutdown_handle.lock() {
+            *slot = Some(handle);
+        }
+    }
+
+    /// Get a clone of the shutdown handle, if set.
+    pub(crate) fn get_shutdown_handle(
+        &self,
+    ) -> Option<Arc<crate::daemon::shutdown::ShutdownHandle>> {
+        self.shutdown_handle.lock().ok().and_then(|s| s.clone())
     }
 
     #[cfg(test)]
@@ -287,11 +305,19 @@ impl Gateway {
         sender_id: Option<&str>,
         channel: &str,
     ) -> Option<HandleResult> {
+        // ── Increment busy count for drain tracking ────────────────────
+        if let Some(sh) = self.get_shutdown_handle() {
+            sh.increment_busy();
+        }
+
         // ── Approval command interception ──────────────────────────────
         if let Some(result) = self
             .try_handle_approval_command(session_id, &content, sender_id)
             .await
         {
+            if let Some(sh) = self.get_shutdown_handle() {
+                sh.decrement_busy();
+            }
             return Some(result);
         }
 
@@ -301,6 +327,9 @@ impl Gateway {
                 .dispatch_slash(session_id, &content, sender_id, channel)
                 .await
             {
+                if let Some(sh) = self.get_shutdown_handle() {
+                    sh.decrement_busy();
+                }
                 return Some(result);
             }
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -348,7 +348,12 @@ impl Gateway {
             }
         }
 
-        let handler = self.session_handler.as_ref()?;
+        let Some(handler) = self.session_handler.as_ref() else {
+            if let Some(sh) = self.get_shutdown_handle() {
+                sh.decrement_busy();
+            }
+            return None;
+        };
 
         // Streaming path: plugin is registered for this channel AND the
         // self-ref is wired AND the handler has a back-ref. Falls back
@@ -364,14 +369,20 @@ impl Gateway {
                 channel: channel.to_string(),
                 timestamp: chrono::Utc::now().timestamp(),
             };
-            return Some(
-                handler
-                    .handle_message_with_gateway(session_id, content, meta, &gw, &plugin)
-                    .await,
-            );
+            let result = handler
+                .handle_message_with_gateway(session_id, content, meta, &gw, &plugin)
+                .await;
+            if let Some(sh) = self.get_shutdown_handle() {
+                sh.decrement_busy();
+            }
+            return Some(result);
         }
 
-        Some(handler.handle_message(session_id, content).await)
+        let result = handler.handle_message(session_id, content).await;
+        if let Some(sh) = self.get_shutdown_handle() {
+            sh.decrement_busy();
+        }
+        Some(result)
     }
 
     /// Configure the persistence storage backend (proxied to SessionManager).

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -10,6 +10,7 @@
 //! The `output_tx` channel is used to surface LLM response text to callers.
 
 use super::Gateway;
+use crate::daemon::shutdown::ShutdownHandle;
 use crate::gateway::session_manager::SessionManager;
 use crate::gateway::system_prompt_inject::{
     build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
@@ -77,6 +78,12 @@ pub struct SessionMessageHandler {
     /// paths; `handle_message_with_gateway` is the only entry point that
     /// can consume a streaming session and it requires this ref.
     pub(super) gateway: Option<Arc<std::sync::Weak<Gateway>>>,
+    /// Shutdown handle for busy-count tracking across components.
+    ///
+    /// Components increment the busy count before starting async work
+    /// and decrement when complete. The shutdown drain waits for the
+    /// count to reach zero before finalizing.
+    pub(super) shutdown_handle: Option<Arc<ShutdownHandle>>,
 }
 
 // ── Construction ──
@@ -97,6 +104,7 @@ impl SessionMessageHandler {
             ))),
             unified_fallback_client,
             gateway: None,
+            shutdown_handle: None,
         }
     }
     /// Create a new handler without an output channel (used in tests).
@@ -114,6 +122,7 @@ impl SessionMessageHandler {
             ))),
             unified_fallback_client,
             gateway: None,
+            shutdown_handle: None,
         }
     }
     /// Attach a back-reference (weak) to the owning [`Gateway`].
@@ -123,6 +132,16 @@ impl SessionMessageHandler {
     /// [`Gateway::send_outbound_streaming`].
     pub fn with_gateway_ref(mut self, gateway: std::sync::Weak<Gateway>) -> Self {
         self.gateway = Some(Arc::new(gateway));
+        self
+    }
+
+    /// Set the shutdown handle for busy-count tracking.
+    ///
+    /// When set, the handler increments the busy count before starting
+    /// async work and decrements when complete. The shutdown drain
+    /// waits for the count to reach zero before finalizing.
+    pub fn with_shutdown_handle(mut self, handle: Arc<ShutdownHandle>) -> Self {
+        self.shutdown_handle = Some(handle);
         self
     }
 }

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -51,10 +51,10 @@ impl SessionMessageHandler {
         )
         .await;
 
-        // ── Decrement busy count for drain tracking ────────────────────
-        if let Some(sh) = session_manager.get_shutdown_handle().await {
-            sh.decrement_busy();
-        }
+        // NOTE: Decrement is handled by the caller (spawned task in
+        // `session_handler_dispatch.rs`), NOT here. This avoids a
+        // double-decrement when both `finish_llm` and the spawned task
+        // call `decrement_busy()`.
 
         // NOTE: Cascade-termination of child sessions is NOT done here.
         // `finish_llm` is called after every LLM turn — cascading here

--- a/src/gateway/session_handler_announce.rs
+++ b/src/gateway/session_handler_announce.rs
@@ -51,6 +51,11 @@ impl SessionMessageHandler {
         )
         .await;
 
+        // ── Decrement busy count for drain tracking ────────────────────
+        if let Some(sh) = session_manager.get_shutdown_handle().await {
+            sh.decrement_busy();
+        }
+
         // NOTE: Cascade-termination of child sessions is NOT done here.
         // `finish_llm` is called after every LLM turn — cascading here
         // would prematurely kill session-mode children that are designed

--- a/src/gateway/session_handler_dispatch.rs
+++ b/src/gateway/session_handler_dispatch.rs
@@ -69,8 +69,16 @@ impl SessionMessageHandler {
         // fall back to the non-streaming path with a warning.
         let gw_for_task = gateway.map(Arc::clone);
         let plugin_for_task = plugin.map(Arc::clone);
+        // Clone the shutdown handle for busy-count tracking inside the
+        // spawned task. The handle is optional (tests may not set one).
+        let shutdown_handle = self.shutdown_handle.clone();
 
         tokio::spawn(async move {
+            // Increment busy count at message dequeue (start of processing).
+            if let Some(ref h) = shutdown_handle {
+                h.increment_busy();
+            }
+
             // Check if streaming is enabled for this session
             let stream_enabled = if let Some(cs) = sm.get_conversation_session(&session_id).await {
                 cs.read().await.stream_enabled()
@@ -106,6 +114,11 @@ impl SessionMessageHandler {
                     .map(Into::into)
             };
             Self::finish_llm(&sm, &session_id, result, &ufc, &output_tx).await;
+
+            // Decrement busy count after response sent + pending drained.
+            if let Some(ref h) = shutdown_handle {
+                h.decrement_busy();
+            }
         });
 
         HandleResult::LlmStarted

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -5,7 +5,7 @@
 
 use crate::config::manager::{ConfigManager, ConfigSnapshot};
 use crate::config::ConfigSection;
-use crate::daemon::shutdown::ShutdownMode;
+use crate::daemon::shutdown::{ShutdownHandle, ShutdownMode};
 use crate::gateway::{DmScope, GatewayConfig, Message, Session};
 use crate::im::processor::ProcessError;
 use crate::im::IMAdapter;
@@ -76,6 +76,8 @@ pub struct SessionManager {
     /// Latest config snapshot; swapped atomically on each hot-reload.
     /// The old snapshot is released when all Arc references are dropped.
     config_snapshot: RwLock<Option<ConfigSnapshot>>,
+    /// Shutdown handle for busy-count tracking during drain.
+    shutdown_handle: RwLock<Option<Arc<ShutdownHandle>>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -114,6 +116,7 @@ impl SessionManager {
             config_manager: RwLock::new(None),
             agent_registry: RwLock::new(None),
             config_snapshot: RwLock::new(None),
+            shutdown_handle: RwLock::new(None),
         }
     }
 
@@ -162,6 +165,16 @@ impl SessionManager {
     #[allow(dead_code)] // used in tests
     pub(crate) async fn get_config_snapshot(&self) -> Option<ConfigSnapshot> {
         self.config_snapshot.read().await.clone()
+    }
+
+    /// Set the shutdown handle for busy-count tracking.
+    pub async fn set_shutdown_handle(&self, handle: Arc<ShutdownHandle>) {
+        *self.shutdown_handle.write().await = Some(handle);
+    }
+
+    /// Get a clone of the shutdown handle, if set.
+    pub(crate) async fn get_shutdown_handle(&self) -> Option<Arc<ShutdownHandle>> {
+        self.shutdown_handle.read().await.clone()
     }
 
     /// Set the tool registry for building system prompt ToolsSection.

--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -151,6 +151,14 @@ impl SessionManager {
             );
         }
 
+        // ── Decrement busy count for drain tracking ────────────────────
+        // The child session result has been injected into the parent;
+        // decrement the parent's busy count that was incremented in
+        // `create_child_session`.
+        if let Some(sh) = self.get_shutdown_handle().await {
+            sh.decrement_busy();
+        }
+
         // Unregister child handle from parent's ConversationSession.
         // This cleans up the Weak reference so the parent's child_handles
         // map does not accumulate stale entries for completed children.

--- a/src/gateway/session_manager/channel.rs
+++ b/src/gateway/session_manager/channel.rs
@@ -49,9 +49,13 @@ impl SessionManager {
         };
 
         // Create ConversationSession
-        let conv_session =
+        let mut conv_session =
             ConversationSession::new(session_id.clone(), "default".to_string(), workdir_path)
                 .with_reasoning_level(self.default_reasoning_level);
+        // Wire shutdown handle for busy-count tracking.
+        if let Some(sh) = self.get_shutdown_handle().await {
+            conv_session.set_shutdown_handle(sh);
+        }
         {
             let mut conv_sessions = self.conversation_sessions.write().await;
             conv_sessions.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -16,7 +16,7 @@ use crate::session::workspace;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::warn;
+use tracing::{info, warn};
 
 impl SessionManager {
     /// Extract tool/skill filter configuration from an agent config.
@@ -130,6 +130,35 @@ impl SessionManager {
                                 let mut cs = cs.write().await;
                                 cs.restore_pending_messages(cp.pending_messages.clone());
                                 cs.restore_system_appends(cp.system_appends.clone());
+                            }
+                        }
+
+                        // Inject recovery notifications and tool failure results
+                        // from checkpoint (set by SessionRecoveryService during startup).
+                        if let Some(ref notification) = cp.recovery_notification {
+                            let cs = self.conversation_sessions.read().await;
+                            if let Some(cs) = cs.get(&session_id) {
+                                let mut cs = cs.write().await;
+                                cs.inject_system_message(notification.clone());
+                                for failure in &cp.pending_tool_failures {
+                                    // Extract op_id from the JSON failure string to use
+                                    // as tool_call_id.  Falls back to "recovery" if parsing
+                                    // fails (defensive — the JSON is built by the recovery
+                                    // service and always contains op_id).
+                                    let tool_call_id =
+                                        serde_json::from_str::<serde_json::Value>(failure)
+                                            .ok()
+                                            .and_then(|v| {
+                                                v.get("op_id")?.as_str().map(String::from)
+                                            })
+                                            .unwrap_or_else(|| "recovery".to_string());
+                                    cs.inject_tool_result(&tool_call_id, failure);
+                                }
+                                info!(
+                                    session_id = %session_id,
+                                    "injected recovery notification and {} tool failure(s)",
+                                    cp.pending_tool_failures.len()
+                                );
                             }
                         }
 

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -106,13 +106,17 @@ impl SessionManager {
                             )
                             .await;
 
-                            let conv_session = ConversationSession::new(
+                            let mut conv_session = ConversationSession::new(
                                 session_id.clone(),
                                 "default".to_string(),
                                 workdir_path,
                             )
                             .with_system_prompt(prompt)
                             .with_reasoning_level(self.default_reasoning_level);
+                            // Wire shutdown handle for busy-count tracking.
+                            if let Some(sh) = self.get_shutdown_handle().await {
+                                conv_session.set_shutdown_handle(sh);
+                            }
                             {
                                 let mut cs = self.conversation_sessions.write().await;
                                 cs.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));
@@ -203,10 +207,14 @@ impl SessionManager {
         };
 
         // Create ConversationSession
-        let conv_session =
+        let mut conv_session =
             ConversationSession::new(session_id.clone(), "default".to_string(), workdir_path)
                 .with_system_prompt(prompt)
                 .with_reasoning_level(self.default_reasoning_level);
+        // Wire shutdown handle for busy-count tracking.
+        if let Some(sh) = self.get_shutdown_handle().await {
+            conv_session.set_shutdown_handle(sh);
+        }
         {
             let mut conv_sessions = self.conversation_sessions.write().await;
             conv_sessions.insert(session_id.clone(), Arc::new(RwLock::new(conv_session)));

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -127,6 +127,20 @@ impl SessionManager {
             sh.increment_busy();
         }
 
+        // ── Shutdown gate: reject new child session creation ──────────
+        if let Some(sh) = self.get_shutdown_handle().await {
+            if sh.is_shutting_down() {
+                tracing::warn!(
+                    parent_session_id = %parent_session_id,
+                    "rejecting child session creation: daemon is shutting down"
+                );
+                if let Some(sh) = self.get_shutdown_handle().await {
+                    sh.decrement_busy();
+                }
+                return Err("daemon is shutting down".into());
+            }
+        }
+
         // Apply tool whitelist override: when allowed_tools is provided,
         // replace the config's tools list so the child session only has
         // access to the specified tools.

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -122,6 +122,11 @@ impl SessionManager {
         parent_subagents_model: Option<&str>,
         max_spawn_depth: u32,
     ) -> Result<String, String> {
+        // ── Increment busy count for drain tracking ────────────────────
+        if let Some(sh) = self.get_shutdown_handle().await {
+            sh.increment_busy();
+        }
+
         // Apply tool whitelist override: when allowed_tools is provided,
         // replace the config's tools list so the child session only has
         // access to the specified tools.
@@ -241,6 +246,11 @@ impl SessionManager {
         )
         .with_system_prompt(prompt)
         .with_reasoning_level(self.default_reasoning_level);
+
+        // Wire shutdown handle for busy-count tracking.
+        if let Some(sh) = self.get_shutdown_handle().await {
+            cs.set_shutdown_handle(sh);
+        }
 
         // 5b. Generate communication config: child may only
         //     communicate with its parent agent.

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -134,9 +134,7 @@ impl SessionManager {
                     parent_session_id = %parent_session_id,
                     "rejecting child session creation: daemon is shutting down"
                 );
-                if let Some(sh) = self.get_shutdown_handle().await {
-                    sh.decrement_busy();
-                }
+                sh.decrement_busy();
                 return Err("daemon is shutting down".into());
             }
         }

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -8,7 +8,8 @@
 //!    parents last.  Same-level sessions stop concurrently.
 //! 3. Per-session behaviour depends on [`ShutdownMode`]:
 //!    - **Graceful**: wait for LLM streaming / tool execution to finish,
-//!      then persist checkpoint.  Skipped if busy timeout exceeded.
+//!      then persist checkpoint.  No hard timeout — the user decides
+//!      when to escalate to forceful mode.
 //!    - **Forceful**: stop immediately, persist checkpoint.
 
 use std::collections::{HashMap, VecDeque};
@@ -36,10 +37,6 @@ impl StopResult {
         self.succeeded + self.failed + self.skipped
     }
 }
-
-/// Default per-session grace period (seconds) in graceful mode.
-/// After this, a still-busy session is force-stopped.
-const GRACEFUL_TIMEOUT_SECS: u64 = 10;
 
 // ── public API ──────────────────────────────────────────────────────────
 
@@ -231,8 +228,9 @@ impl SessionManager {
     /// Stop a single session and persist its checkpoint.
     ///
     /// Behaviour depends on `mode`:
-    /// - Graceful: if LLM is streaming, poll for idle (up to
-    ///   [`GRACEFUL_TIMEOUT_SECS`]) before stopping.
+    /// - Graceful: wait for LLM streaming and tool execution to
+    ///   finish naturally (no hard timeout — the user decides when
+    ///   to escalate to forceful mode).
     /// - Forceful: stop immediately regardless of state.
     async fn stop_single_session(
         &self,
@@ -245,9 +243,8 @@ impl SessionManager {
             .ok_or(StopError::Skipped)?;
 
         // Graceful: wait for LLM streaming and tool execution to finish.
+        // No hard timeout — the user decides when to escalate to forceful.
         if mode == ShutdownMode::Graceful {
-            let deadline = tokio::time::Instant::now()
-                + tokio::time::Duration::from_secs(GRACEFUL_TIMEOUT_SECS);
             loop {
                 let (is_streaming, has_running_tools) = {
                     let guard = cs.read().await;
@@ -268,17 +265,12 @@ impl SessionManager {
                     break;
                 }
 
-                if tokio::time::Instant::now() >= deadline {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        streaming = is_streaming,
-                        running_tools = has_running_tools,
-                        "graceful stop: session still active after {}s, force-stopping",
-                        GRACEFUL_TIMEOUT_SECS
-                    );
-                    break;
-                }
-
+                tracing::debug!(
+                    session_id = %session_id,
+                    streaming = is_streaming,
+                    running_tools = has_running_tools,
+                    "graceful stop: session still active, waiting for completion"
+                );
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         }

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -16,7 +16,9 @@ use std::collections::{HashMap, VecDeque};
 
 use crate::daemon::shutdown::ShutdownMode;
 use crate::llm::session_state::LlmState;
-use crate::session::persistence::{PersistenceError, SessionCheckpoint, SessionStatus};
+use crate::session::persistence::{
+    PendingOperation, PersistenceError, SessionCheckpoint, SessionStatus,
+};
 
 use super::SessionManager;
 
@@ -242,6 +244,14 @@ impl SessionManager {
             .await
             .ok_or(StopError::Skipped)?;
 
+        // Collect pending operations before stopping (for forceful mode).
+        let pending_ops: Vec<PendingOperation> = if mode == ShutdownMode::Forceful {
+            let guard = cs.read().await;
+            guard.collect_pending_operations()
+        } else {
+            Vec::new()
+        };
+
         // Graceful: wait for LLM streaming and tool execution to finish.
         // No hard timeout — the user decides when to escalate to forceful.
         if mode == ShutdownMode::Graceful {
@@ -279,7 +289,10 @@ impl SessionManager {
         cs.read().await.stop(false).await;
 
         // Persist checkpoint.
-        if let Err(e) = self.persist_checkpoint(session_id).await {
+        if let Err(e) = self
+            .persist_checkpoint_with_pending(session_id, pending_ops)
+            .await
+        {
             tracing::warn!(
                 session_id = %session_id,
                 error = %e,
@@ -294,12 +307,16 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Persist a session checkpoint to storage.
+    /// Persist a session checkpoint with optional pending operations.
     ///
-    /// Mirrors the persist logic in `flush_all` — loads existing
-    /// checkpoint (preserving fields like `thread_id`) or creates
-    /// a fresh one, then saves.
-    async fn persist_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
+    /// When `pending_ops` is non-empty (forceful shutdown), the operations
+    /// are recorded in the checkpoint so the recovery service can inject
+    /// failure results on restart.
+    async fn persist_checkpoint_with_pending(
+        &self,
+        session_id: &str,
+        pending_ops: Vec<PendingOperation>,
+    ) -> Result<(), PersistenceError> {
         let storage = {
             let guard = self.storage.read().await;
             match guard.as_ref() {
@@ -359,6 +376,11 @@ impl SessionManager {
                 let guard = cs.read().await;
                 cp.system_appends = guard.system_appends().to_vec();
             }
+        }
+
+        // Record pending operations from forceful shutdown.
+        if !pending_ops.is_empty() {
+            cp.pending_operations = pending_ops;
         }
 
         storage.save_checkpoint(&cp).await

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -494,3 +494,131 @@ async fn test_feishu_session_isolation() {
     assert!(ids[0].starts_with("agent-1_"), "bad format: {}", ids[0]);
     assert!(ids[1].starts_with("agent-1_"), "bad format: {}", ids[1]);
 }
+
+// ── Shutdown alignment tests (Step 1.1–1.2) ──────────────────────────────
+
+use crate::daemon::shutdown::ShutdownHandle;
+
+/// Helper: create a gateway with a shutdown handle wired in.
+async fn setup_with_shutdown(
+    channel: &str,
+) -> (
+    crate::gateway::Gateway,
+    Arc<SessionManager>,
+    Arc<ShutdownHandle>,
+) {
+    let (gw, sm) = setup(make_config(), channel).await;
+    let sh = Arc::new(ShutdownHandle::new());
+    gw.set_shutdown_handle(Arc::clone(&sh));
+    (gw, sm, sh)
+}
+
+#[tokio::test]
+async fn test_shutdown_gate_rejects_inbound_message() {
+    let (gw, sm, sh) = setup_with_shutdown("mock").await;
+
+    // Start shutdown
+    sh.start_shutdown_for_test();
+
+    // Create a session so we have a valid session_id
+    let mut msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    msg.metadata.insert("session_id".into(), sid.clone());
+
+    // handle_inbound_message should return None (rejected) when shutting down
+    let result = gw
+        .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
+        .await;
+    assert!(
+        result.is_none(),
+        "message should be rejected during shutdown"
+    );
+}
+
+#[tokio::test]
+async fn test_shutdown_gate_rejects_inbound_message_forceful() {
+    let (gw, sm, sh) = setup_with_shutdown("mock").await;
+
+    // Start forceful shutdown
+    sh.start_shutdown_for_test();
+    sh.escalate_to_forceful();
+
+    let mut msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    msg.metadata.insert("session_id".into(), sid.clone());
+
+    let result = gw
+        .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
+        .await;
+    assert!(
+        result.is_none(),
+        "message should be rejected during forceful shutdown"
+    );
+}
+
+#[tokio::test]
+async fn test_shutdown_gate_allows_inbound_message_when_running() {
+    let (gw, sm, _sh) = setup_with_shutdown("mock").await;
+
+    let mut msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    msg.metadata.insert("session_id".into(), sid.clone());
+
+    // When not shutting down, handle_inbound_message should proceed.
+    // Without a SessionMessageHandler configured, this returns None.
+    // The key assertion is that it does NOT early-return due to gate.
+    let result = gw
+        .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
+        .await;
+    // Result is None (no handler configured) — that's expected.
+    // The gate check did NOT block the message.
+    assert!(
+        result.is_none(),
+        "no handler configured, should return None"
+    );
+}
+
+#[tokio::test]
+async fn test_inbound_message_increments_busy_count() {
+    let (gw, sm, sh) = setup_with_shutdown("mock").await;
+
+    let mut msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    msg.metadata.insert("session_id".into(), sid.clone());
+
+    // Before calling handle_inbound_message, busy_count is 0
+    assert_eq!(sh.busy_count(), 0);
+
+    // Call handle_inbound_message. The gateway increments busy_count
+    // at entry (Step 1.1). The spawned LLM task also increments,
+    // so after completion busy_count may be > 0 due to the
+    // double-increment pattern. We verify the mechanism works by
+    // checking that the shutdown gate correctly decrements on rejection.
+    let _ = gw
+        .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
+        .await;
+    // At minimum, busy_count should have been incremented during processing
+    // (the exact final value depends on the double-increment pattern)
+}
+
+#[tokio::test]
+async fn test_shutdown_gate_rejects_message_busy_count_decremented() {
+    let (gw, sm, sh) = setup_with_shutdown("mock").await;
+
+    sh.start_shutdown_for_test();
+
+    let mut msg = make_message("agent-1", "hello");
+    let sid = sm.find_or_create("mock", &msg, None).await.unwrap();
+    msg.metadata.insert("session_id".into(), sid.clone());
+
+    let _ = gw
+        .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
+        .await;
+
+    // busy_count should be 0 even though the message was rejected
+    assert_eq!(
+        sh.busy_count(),
+        0,
+        "busy_count must be decremented when message is rejected by gate"
+    );
+}

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -589,13 +589,14 @@ async fn test_inbound_message_increments_busy_count() {
     // Before calling handle_inbound_message, busy_count is 0
     assert_eq!(sh.busy_count(), 0);
 
-    // Call handle_inbound_message. The gateway increments busy_count
-    // at entry and decrements it when returning, so after completion
-    // busy_count should be back to 0.
+    // Call handle_inbound_message. The gateway no longer manages
+    // busy_count directly on async handler paths — the handler's
+    // spawned task (finish_llm) handles increment/decrement.
+    // With no handler configured, returns None with busy_count unchanged.
     let _ = gw
         .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
         .await;
-    // Gateway-level increment/decrement must be balanced
+    // No handler → no busy_count change
     assert_eq!(sh.busy_count(), 0);
 }
 
@@ -613,10 +614,11 @@ async fn test_shutdown_gate_rejects_message_busy_count_decremented() {
         .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
         .await;
 
-    // busy_count should be 0 even though the message was rejected
+    // busy_count should be 0 — the message was rejected by the gate
+    // before any busy_count tracking was needed.
     assert_eq!(
         sh.busy_count(),
         0,
-        "busy_count must be decremented when message is rejected by gate"
+        "busy_count must remain 0 when message is rejected by gate"
     );
 }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -590,15 +590,13 @@ async fn test_inbound_message_increments_busy_count() {
     assert_eq!(sh.busy_count(), 0);
 
     // Call handle_inbound_message. The gateway increments busy_count
-    // at entry (Step 1.1). The spawned LLM task also increments,
-    // so after completion busy_count may be > 0 due to the
-    // double-increment pattern. We verify the mechanism works by
-    // checking that the shutdown gate correctly decrements on rejection.
+    // at entry and decrements it when returning, so after completion
+    // busy_count should be back to 0.
     let _ = gw
         .handle_inbound_message(&sid, "hello".into(), Some("sender"), "mock")
         .await;
-    // At minimum, busy_count should have been incremented during processing
-    // (the exact final value depends on the double-increment pattern)
+    // Gateway-level increment/decrement must be balanced
+    assert_eq!(sh.busy_count(), 0);
 }
 
 #[tokio::test]

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -371,6 +371,75 @@ impl ConversationSession {
     pub fn inject_system_message(&mut self, text: String) {
         self.push_message("system", vec![ContentBlock::Text(text)]);
     }
+
+    /// Collect pending operations from the current session state.
+    ///
+    /// Scans tool_states, child_states, and pending_messages to build a
+    /// list of operations that were in progress when the session stopped.
+    /// Used by the shutdown path to record what needs recovery on restart.
+    pub fn collect_pending_operations(&self) -> Vec<crate::session::persistence::PendingOperation> {
+        use crate::llm::session_state::{ChildSessionState, ToolExecState};
+        use crate::session::persistence::{PendingOperation, PendingOperationType};
+        use chrono::Utc;
+
+        let mut ops = Vec::new();
+        let now = Utc::now();
+
+        // Tool calls in progress or pending
+        {
+            let tool_states = self.tool_states.read().expect("tool_states lock poisoned");
+            for (tool_id, state) in tool_states.iter() {
+                if matches!(
+                    state,
+                    ToolExecState::RunningForeground
+                        | ToolExecState::RunningBackground
+                        | ToolExecState::Pending
+                ) {
+                    ops.push(PendingOperation {
+                        op_id: tool_id.clone(),
+                        op_type: PendingOperationType::ToolCall,
+                        name: tool_id.clone(),
+                        args: String::new(),
+                        created_at: now,
+                    });
+                }
+            }
+        }
+
+        // Child sessions in progress
+        {
+            let child_states = self
+                .child_states
+                .read()
+                .expect("child_states lock poisoned");
+            for (child_id, state) in child_states.iter() {
+                if matches!(state, ChildSessionState::Running) {
+                    ops.push(PendingOperation {
+                        op_id: child_id.clone(),
+                        op_type: PendingOperationType::SubSessionSpawn,
+                        name: child_id.clone(),
+                        args: String::new(),
+                        created_at: now,
+                    });
+                }
+            }
+        }
+
+        // Unsold pending messages (outbound)
+        for pm in &self.pending_messages {
+            if !pm.sent {
+                ops.push(PendingOperation {
+                    op_id: pm.message_id.clone(),
+                    op_type: PendingOperationType::OutboundMessage,
+                    name: pm.message_id.clone(),
+                    args: pm.content.clone(),
+                    created_at: pm.created_at,
+                });
+            }
+        }
+
+        ops
+    }
 }
 
 /// Per-session append-section items (managed by `/system` subcommand).

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -372,6 +372,20 @@ impl ConversationSession {
         self.push_message("system", vec![ContentBlock::Text(text)]);
     }
 
+    /// Inject a tool result into the conversation history.
+    ///
+    /// Used by the recovery path to inject failure results for pending
+    /// tool calls so the LLM sees a natural tool-result response.
+    pub fn inject_tool_result(&mut self, tool_call_id: &str, content: &str) {
+        self.push_message(
+            "tool",
+            vec![ContentBlock::ToolResult {
+                tool_call_id: tool_call_id.to_string(),
+                content: content.to_string(),
+            }],
+        );
+    }
+
     /// Collect pending operations from the current session state.
     ///
     /// Scans tool_states, child_states, and pending_messages to build a

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -120,6 +120,8 @@ pub struct ConversationSession {
     /// push or state mutation.  Used by the shutdown progress card to
     /// display accurate "elapsed since last activity" instead of session age.
     last_activity_at: i64,
+    /// Shutdown handle for busy-count tracking during tool execution.
+    shutdown_handle: Option<Arc<crate::daemon::shutdown::ShutdownHandle>>,
 }
 
 // `impl ConversationSession` is split across multiple blocks so each
@@ -157,6 +159,7 @@ impl ConversationSession {
             stopped: Arc::new(AtomicBool::new(false)),
             communication_config: None,
             last_activity_at: Utc::now().timestamp(),
+            shutdown_handle: None,
         }
     }
 
@@ -215,6 +218,18 @@ impl ConversationSession {
     /// Returns the communication configuration, if set.
     pub fn communication_config(&self) -> Option<&CommunicationConfig> {
         self.communication_config.as_ref()
+    }
+
+    /// Set the shutdown handle for busy-count tracking during tool execution.
+    pub fn set_shutdown_handle(&mut self, handle: Arc<crate::daemon::shutdown::ShutdownHandle>) {
+        self.shutdown_handle = Some(handle);
+    }
+
+    /// Get a clone of the shutdown handle, if set.
+    pub(crate) fn get_shutdown_handle(
+        &self,
+    ) -> Option<Arc<crate::daemon::shutdown::ShutdownHandle>> {
+        self.shutdown_handle.clone()
     }
 
     /// Returns the current reasoning level.

--- a/src/llm/session_handles.rs
+++ b/src/llm/session_handles.rs
@@ -81,6 +81,11 @@ impl ConversationSession {
             .write()
             .expect("tool_handles lock poisoned");
         map.insert(id, handle);
+
+        // Increment busy count for drain tracking while tool is running.
+        if let Some(sh) = self.get_shutdown_handle() {
+            sh.increment_busy();
+        }
     }
 
     /// Remove a previously-registered tool-process kill handle.
@@ -99,6 +104,11 @@ impl ConversationSession {
                 call_id = %call_id,
                 "unregister_tool_handle: call_id not registered"
             );
+        }
+
+        // Decrement busy count for drain tracking when tool exits.
+        if let Some(sh) = self.get_shutdown_handle() {
+            sh.decrement_busy();
         }
     }
 

--- a/src/llm/session_handles.rs
+++ b/src/llm/session_handles.rs
@@ -76,6 +76,17 @@ impl ConversationSession {
         handle: Arc<dyn KillHandle>,
     ) {
         let id = call_id.into();
+
+        // ── Shutdown gate: reject new tool execution ───────────────────
+        if let Some(sh) = self.get_shutdown_handle() {
+            if sh.is_shutting_down() {
+                tracing::warn!(
+                    call_id = %id,
+                    "rejecting tool execution: daemon is shutting down"
+                );
+                return;
+            }
+        }
         let mut map = self
             .tool_handles
             .write()

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,6 +18,8 @@ pub mod compaction_async_tests;
 #[cfg(test)]
 pub mod compaction_tests;
 pub mod events;
+#[cfg(test)]
+pub mod pending_operations_tests;
 pub mod persistence;
 #[cfg(test)]
 pub mod persistence_tests;

--- a/src/session/pending_operations_tests.rs
+++ b/src/session/pending_operations_tests.rs
@@ -406,15 +406,17 @@ async fn test_recovery_inject_calls_restore_callback_for_dirty_session() {
     let restored_clone = Arc::clone(&restored);
 
     service
-        .set_restore_callback(move |session_id, checkpoint| {
-            // The callback is called even for dirty sessions — it can
-            // inspect pending_operations to inject recovery notifications
-            restored_clone
-                .lock()
-                .unwrap()
-                .push((session_id.to_string(), checkpoint.pending_operations.len()));
-            Ok(())
-        })
+        .set_restore_callback(
+            move |session_id, checkpoint, _notification, _tool_failures| {
+                // The callback is called even for dirty sessions — it can
+                // inspect pending_operations to inject recovery notifications
+                restored_clone
+                    .lock()
+                    .unwrap()
+                    .push((session_id.to_string(), checkpoint.pending_operations.len()));
+                Ok(())
+            },
+        )
         .await;
 
     let report = service.recover().await.unwrap();
@@ -496,4 +498,68 @@ async fn test_recovery_report_dirty_sessions_count() {
     assert_eq!(report.recovered.len(), 5);
     assert_eq!(report.dirty_sessions.len(), 3);
     assert!(report.is_full_success());
+}
+
+#[tokio::test]
+async fn test_recovery_callback_receives_notification_and_tool_failures() {
+    use crate::session::persistence::{
+        PendingOperation, PendingOperationType, PersistenceService, SessionCheckpoint,
+    };
+    use crate::session::storage::memory::MemoryStorage;
+    use std::sync::Arc;
+
+    let storage = Arc::new(MemoryStorage::new());
+    let now = chrono::Utc::now();
+    let cp = SessionCheckpoint::new("notif_cb".into()).with_pending_operations(vec![
+        PendingOperation {
+            op_id: "tool_1".into(),
+            op_type: PendingOperationType::ToolCall,
+            name: "bash".into(),
+            args: r#"{"cmd":"ls"}"#.into(),
+            created_at: now,
+        },
+        PendingOperation {
+            op_id: "child_1".into(),
+            op_type: PendingOperationType::SubSessionSpawn,
+            name: "sub-agent".into(),
+            args: String::new(),
+            created_at: now,
+        },
+    ]);
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+
+    let captured = Arc::new(std::sync::Mutex::new((
+        None::<String>,
+        Vec::<String>::new(),
+    )));
+    let captured_clone = Arc::clone(&captured);
+
+    service
+        .set_restore_callback(
+            move |_session_id, _checkpoint, notification, tool_failures| {
+                *captured_clone.lock().unwrap() =
+                    (notification.map(String::from), tool_failures.to_vec());
+                Ok(())
+            },
+        )
+        .await;
+
+    let report = service.recover().await.unwrap();
+    assert_eq!(report.recovered.len(), 1);
+
+    let (notif, failures) = captured.lock().unwrap().clone();
+    // Notification should contain the pending tool call
+    assert!(notif.is_some());
+    let notif = notif.unwrap();
+    assert!(notif.contains("网关已重启"));
+    assert!(notif.contains("工具调用: bash"));
+    assert!(notif.contains("子 Session: sub-agent"));
+
+    // Only ToolCall ops produce failure results
+    assert_eq!(failures.len(), 1);
+    assert!(failures[0].contains("进程中断：网关重启"));
+    assert!(failures[0].contains("bash"));
+    assert!(failures[0].contains("tool_1"));
 }

--- a/src/session/pending_operations_tests.rs
+++ b/src/session/pending_operations_tests.rs
@@ -1,0 +1,499 @@
+//! Unit tests for pending_operations recovery mechanism (Step 1.4).
+//!
+//! Covers:
+//! - collect_pending_operations collects three op_types
+//! - Checkpoint serialization/deserialization of pending_operations
+//! - Recovery injection with non-empty pending_operations
+//! - Recovery flow unaffected when pending_operations is empty
+
+use crate::llm::session::ConversationSession;
+use crate::llm::session_state::{ChildSessionState, ToolExecState};
+use crate::session::persistence::{
+    PendingOperation, PendingOperationType, PersistenceService, SessionCheckpoint,
+};
+
+// ── Step 1.4: collect_pending_operations ────────────────────────────────
+
+#[test]
+fn test_collect_pending_operations_empty() {
+    let cs = ConversationSession::new(
+        "sess_empty".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    let ops = cs.collect_pending_operations();
+    assert!(ops.is_empty(), "fresh session should have no pending ops");
+}
+
+#[test]
+fn test_collect_pending_operations_tool_calls() {
+    let cs = ConversationSession::new(
+        "sess_tools".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+
+    // Simulate running tool calls via pub(crate) field
+    {
+        let mut tool_states = cs.tool_states.write().unwrap();
+        tool_states.insert("call_1".to_string(), ToolExecState::RunningForeground);
+        tool_states.insert("call_2".to_string(), ToolExecState::RunningBackground);
+        tool_states.insert("call_3".to_string(), ToolExecState::Pending);
+    }
+
+    let ops = cs.collect_pending_operations();
+    let tool_ops: Vec<_> = ops
+        .iter()
+        .filter(|op| op.op_type == PendingOperationType::ToolCall)
+        .collect();
+    assert_eq!(tool_ops.len(), 3, "should collect 3 tool call ops");
+
+    let ids: Vec<&str> = tool_ops.iter().map(|op| op.op_id.as_str()).collect();
+    assert!(ids.contains(&"call_1"));
+    assert!(ids.contains(&"call_2"));
+    assert!(ids.contains(&"call_3"));
+}
+
+#[test]
+fn test_collect_pending_operations_skips_completed_tools() {
+    let cs = ConversationSession::new(
+        "sess_completed".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+
+    {
+        let mut tool_states = cs.tool_states.write().unwrap();
+        tool_states.insert("done".to_string(), ToolExecState::Completed);
+        tool_states.insert("running".to_string(), ToolExecState::RunningForeground);
+    }
+
+    let ops = cs.collect_pending_operations();
+    // Only the RunningForeground tool should be collected
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].op_id, "running");
+    assert_eq!(ops[0].op_type, PendingOperationType::ToolCall);
+}
+
+#[test]
+fn test_collect_pending_operations_child_sessions() {
+    let cs = ConversationSession::new(
+        "sess_children".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+
+    {
+        let mut child_states = cs.child_states.write().unwrap();
+        child_states.insert("child_1".to_string(), ChildSessionState::Running);
+        child_states.insert("child_2".to_string(), ChildSessionState::Running);
+    }
+
+    let ops = cs.collect_pending_operations();
+    let child_ops: Vec<_> = ops
+        .iter()
+        .filter(|op| op.op_type == PendingOperationType::SubSessionSpawn)
+        .collect();
+    assert_eq!(child_ops.len(), 2, "should collect 2 child session ops");
+}
+
+#[test]
+fn test_collect_pending_operations_outbound_messages() {
+    let mut cs = ConversationSession::new(
+        "sess_outbound".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+
+    // Use restore_pending_messages to add unsent messages
+    use crate::session::persistence::PendingMessage;
+    let messages = vec![
+        {
+            let mut pm = PendingMessage::new("msg_1".into(), "content_1".into());
+            pm.sent = false;
+            pm
+        },
+        {
+            let mut pm = PendingMessage::new("msg_2".into(), "content_2".into());
+            pm.sent = true; // This one is sent — should be skipped
+            pm
+        },
+        {
+            let mut pm = PendingMessage::new("msg_3".into(), "content_3".into());
+            pm.sent = false;
+            pm
+        },
+    ];
+    cs.restore_pending_messages(messages);
+
+    let ops = cs.collect_pending_operations();
+    let outbound_ops: Vec<_> = ops
+        .iter()
+        .filter(|op| op.op_type == PendingOperationType::OutboundMessage)
+        .collect();
+    // Only unsent messages should be collected
+    assert_eq!(
+        outbound_ops.len(),
+        2,
+        "should collect 2 unsent outbound message ops"
+    );
+    let ids: Vec<&str> = outbound_ops.iter().map(|op| op.op_id.as_str()).collect();
+    assert!(ids.contains(&"msg_1"));
+    assert!(ids.contains(&"msg_3"));
+}
+
+#[test]
+fn test_collect_pending_operations_mixed_types() {
+    let mut cs = ConversationSession::new(
+        "sess_mixed".into(),
+        "test-model".into(),
+        std::path::PathBuf::from("/tmp"),
+    );
+
+    // Add one of each type
+    {
+        let mut tool_states = cs.tool_states.write().unwrap();
+        tool_states.insert("tool_1".to_string(), ToolExecState::RunningForeground);
+    }
+    {
+        let mut child_states = cs.child_states.write().unwrap();
+        child_states.insert("child_1".to_string(), ChildSessionState::Running);
+    }
+    {
+        use crate::session::persistence::PendingMessage;
+        let mut pm = PendingMessage::new("msg_1".into(), "content".into());
+        pm.sent = false;
+        cs.restore_pending_messages(vec![pm]);
+    }
+
+    let ops = cs.collect_pending_operations();
+    assert_eq!(ops.len(), 3, "should collect one of each op_type");
+
+    let op_types: Vec<&PendingOperationType> = ops.iter().map(|op| &op.op_type).collect();
+    assert!(op_types.contains(&&PendingOperationType::ToolCall));
+    assert!(op_types.contains(&&PendingOperationType::SubSessionSpawn));
+    assert!(op_types.contains(&&PendingOperationType::OutboundMessage));
+}
+
+// ── Step 1.4: checkpoint serialization/deserialization ──────────────────
+
+#[test]
+fn test_checkpoint_pending_operations_roundtrip_empty() {
+    let cp = SessionCheckpoint::new("sess_rt_empty".into());
+    assert!(cp.pending_operations.is_empty());
+
+    let json = serde_json::to_string(&cp).unwrap();
+    let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+    assert!(parsed.pending_operations.is_empty());
+}
+
+#[test]
+fn test_checkpoint_pending_operations_roundtrip_with_ops() {
+    let now = chrono::Utc::now();
+    let ops = vec![
+        PendingOperation {
+            op_id: "tool_call_1".into(),
+            op_type: PendingOperationType::ToolCall,
+            name: "bash".into(),
+            args: r#"{"command":"ls"}"#.into(),
+            created_at: now,
+        },
+        PendingOperation {
+            op_id: "child_1".into(),
+            op_type: PendingOperationType::SubSessionSpawn,
+            name: "sub-agent-1".into(),
+            args: String::new(),
+            created_at: now,
+        },
+        PendingOperation {
+            op_id: "msg_1".into(),
+            op_type: PendingOperationType::OutboundMessage,
+            name: "outbound-chat".into(),
+            args: "hello world".into(),
+            created_at: now,
+        },
+    ];
+
+    let cp = SessionCheckpoint::new("sess_rt_ops".into()).with_pending_operations(ops);
+    let json = serde_json::to_string(&cp).unwrap();
+    let parsed: SessionCheckpoint = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed.pending_operations.len(), 3);
+    assert_eq!(
+        parsed.pending_operations[0].op_type,
+        PendingOperationType::ToolCall
+    );
+    assert_eq!(parsed.pending_operations[0].name, "bash");
+    assert_eq!(parsed.pending_operations[0].args, r#"{"command":"ls"}"#);
+    assert_eq!(
+        parsed.pending_operations[1].op_type,
+        PendingOperationType::SubSessionSpawn
+    );
+    assert_eq!(
+        parsed.pending_operations[2].op_type,
+        PendingOperationType::OutboundMessage
+    );
+    assert_eq!(parsed.pending_operations[2].args, "hello world");
+}
+
+#[test]
+fn test_checkpoint_pending_operations_missing_json_defaults_empty() {
+    // Old checkpoint JSON without pending_operations field should default
+    // to empty Vec
+    let cp = SessionCheckpoint::new("sess_old".into());
+    let mut json_value: serde_json::Value = serde_json::to_value(&cp).unwrap();
+    json_value
+        .as_object_mut()
+        .unwrap()
+        .remove("pending_operations");
+    let json_str = serde_json::to_string(&json_value).unwrap();
+    let parsed: SessionCheckpoint = serde_json::from_str(&json_str).unwrap();
+    assert!(
+        parsed.pending_operations.is_empty(),
+        "old data without pending_operations should default to empty Vec"
+    );
+}
+
+#[test]
+fn test_pending_operation_type_serde_roundtrip() {
+    for op_type in [
+        PendingOperationType::ToolCall,
+        PendingOperationType::SubSessionSpawn,
+        PendingOperationType::OutboundMessage,
+    ] {
+        let json = serde_json::to_string(&op_type).unwrap();
+        let parsed: PendingOperationType = serde_json::from_str(&json).unwrap();
+        assert_eq!(op_type, parsed);
+    }
+}
+
+#[test]
+fn test_pending_operation_type_serde_values() {
+    assert_eq!(
+        serde_json::to_string(&PendingOperationType::ToolCall).unwrap(),
+        "\"tool_call\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PendingOperationType::SubSessionSpawn).unwrap(),
+        "\"sub_session_spawn\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PendingOperationType::OutboundMessage).unwrap(),
+        "\"outbound_message\""
+    );
+}
+
+#[test]
+fn test_checkpoint_with_pending_operations_builder() {
+    let ops = vec![PendingOperation {
+        op_id: "op_1".into(),
+        op_type: PendingOperationType::ToolCall,
+        name: "test_tool".into(),
+        args: String::new(),
+        created_at: chrono::Utc::now(),
+    }];
+
+    let cp = SessionCheckpoint::new("sess_builder".into()).with_pending_operations(ops);
+    assert_eq!(cp.pending_operations.len(), 1);
+    assert_eq!(cp.pending_operations[0].op_id, "op_1");
+}
+
+// ── Step 1.4: recovery injection ────────────────────────────────────────
+
+use crate::session::recovery::SessionRecoveryService;
+use crate::session::storage::memory::MemoryStorage;
+use std::sync::Arc;
+
+fn make_checkpoint_with_pending_ops(session_id: &str) -> SessionCheckpoint {
+    let now = chrono::Utc::now();
+    SessionCheckpoint::new(session_id.into()).with_pending_operations(vec![
+        PendingOperation {
+            op_id: "tool_1".into(),
+            op_type: PendingOperationType::ToolCall,
+            name: "bash".into(),
+            args: r#"{"cmd":"echo"}"#.into(),
+            created_at: now,
+        },
+        PendingOperation {
+            op_id: "child_1".into(),
+            op_type: PendingOperationType::SubSessionSpawn,
+            name: "sub-agent".into(),
+            args: String::new(),
+            created_at: now,
+        },
+        PendingOperation {
+            op_id: "msg_1".into(),
+            op_type: PendingOperationType::OutboundMessage,
+            name: "chat-output".into(),
+            args: "pending reply".into(),
+            created_at: now,
+        },
+    ])
+}
+
+#[tokio::test]
+async fn test_recovery_with_pending_operations_marks_dirty() {
+    let storage = Arc::new(MemoryStorage::new());
+    storage
+        .save_checkpoint(&make_checkpoint_with_pending_ops("dirty_session"))
+        .await
+        .unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 1);
+    assert!(
+        report.dirty_sessions.contains(&"dirty_session".to_string()),
+        "session with pending_operations should be in dirty_sessions"
+    );
+}
+
+#[tokio::test]
+async fn test_recovery_without_pending_operations_not_dirty() {
+    let storage = Arc::new(MemoryStorage::new());
+    let cp = SessionCheckpoint::new("clean_session".into());
+    assert!(cp.pending_operations.is_empty());
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 1);
+    assert!(
+        report.dirty_sessions.is_empty(),
+        "session without pending_operations should NOT be dirty"
+    );
+}
+
+#[tokio::test]
+async fn test_recovery_mixed_dirty_and_clean_sessions() {
+    let storage = Arc::new(MemoryStorage::new());
+    storage
+        .save_checkpoint(&make_checkpoint_with_pending_ops("dirty_1"))
+        .await
+        .unwrap();
+    storage
+        .save_checkpoint(&SessionCheckpoint::new("clean_1".into()))
+        .await
+        .unwrap();
+    storage
+        .save_checkpoint(&make_checkpoint_with_pending_ops("dirty_2"))
+        .await
+        .unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 3);
+    assert_eq!(report.dirty_sessions.len(), 2);
+    assert!(report.dirty_sessions.contains(&"dirty_1".to_string()));
+    assert!(report.dirty_sessions.contains(&"dirty_2".into()));
+    assert!(!report.dirty_sessions.contains(&"clean_1".to_string()));
+}
+
+#[tokio::test]
+async fn test_recovery_inject_calls_restore_callback_for_dirty_session() {
+    let storage = Arc::new(MemoryStorage::new());
+    storage
+        .save_checkpoint(&make_checkpoint_with_pending_ops("dirty_cb"))
+        .await
+        .unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+
+    let restored = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let restored_clone = Arc::clone(&restored);
+
+    service
+        .set_restore_callback(move |session_id, checkpoint| {
+            // The callback is called even for dirty sessions — it can
+            // inspect pending_operations to inject recovery notifications
+            restored_clone
+                .lock()
+                .unwrap()
+                .push((session_id.to_string(), checkpoint.pending_operations.len()));
+            Ok(())
+        })
+        .await;
+
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 1);
+    let restored_sessions = restored.lock().unwrap();
+    assert_eq!(restored_sessions.len(), 1);
+    assert_eq!(restored_sessions[0].0, "dirty_cb");
+    assert_eq!(
+        restored_sessions[0].1, 3,
+        "callback should see 3 pending operations"
+    );
+}
+
+#[tokio::test]
+async fn test_recovery_empty_pending_operations_no_dirty() {
+    let storage = Arc::new(MemoryStorage::new());
+    let mut cp = SessionCheckpoint::new("empty_pending".into());
+    cp.pending_operations = Vec::new();
+    storage.save_checkpoint(&cp).await.unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 1);
+    assert!(report.dirty_sessions.is_empty());
+}
+
+#[tokio::test]
+async fn test_recovery_pending_operations_preserved_in_checkpoint() {
+    // Verify that the checkpoint's pending_operations survive the recovery
+    // flow (save → load → check)
+    let storage = Arc::new(MemoryStorage::new());
+    let original = make_checkpoint_with_pending_ops("preserved");
+    storage.save_checkpoint(&original).await.unwrap();
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+    assert_eq!(report.recovered.len(), 1);
+
+    // Load checkpoint and verify pending_operations are intact
+    let loaded = storage.load_checkpoint("preserved").await.unwrap().unwrap();
+    assert_eq!(loaded.pending_operations.len(), 3);
+    assert_eq!(
+        loaded.pending_operations[0].op_type,
+        PendingOperationType::ToolCall
+    );
+    assert_eq!(
+        loaded.pending_operations[1].op_type,
+        PendingOperationType::SubSessionSpawn
+    );
+    assert_eq!(
+        loaded.pending_operations[2].op_type,
+        PendingOperationType::OutboundMessage
+    );
+}
+
+#[tokio::test]
+async fn test_recovery_report_dirty_sessions_count() {
+    let storage = Arc::new(MemoryStorage::new());
+    // 5 sessions, 3 with pending ops
+    for i in 0..5u32 {
+        if i < 3 {
+            storage
+                .save_checkpoint(&make_checkpoint_with_pending_ops(&format!("s_{}", i)))
+                .await
+                .unwrap();
+        } else {
+            storage
+                .save_checkpoint(&SessionCheckpoint::new(format!("s_{}", i)))
+                .await
+                .unwrap();
+        }
+    }
+
+    let service = SessionRecoveryService::new(Arc::clone(&storage));
+    let report = service.recover().await.unwrap();
+
+    assert_eq!(report.recovered.len(), 5);
+    assert_eq!(report.dirty_sessions.len(), 3);
+    assert!(report.is_full_success());
+}

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -101,6 +101,24 @@ pub struct SessionCheckpoint {
     /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为空 Vec）。
     #[serde(default)]
     pub pending_operations: Vec<PendingOperation>,
+    /// Recovery notification text to inject into the conversation transcript.
+    ///
+    /// Built by the recovery service when `pending_operations` is non-empty.
+    /// The restore callback reads this field and injects it as a system message
+    /// into the session's conversation flow.
+    ///
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为 None）。
+    #[serde(default)]
+    pub recovery_notification: Option<String>,
+    /// Tool failure results to inject into the conversation transcript.
+    ///
+    /// For each pending ToolCall operation, a corresponding tool_result message
+    /// is built and stored here. The restore callback reads these and injects
+    /// them as tool_result entries so the LLM sees natural tool failure responses.
+    ///
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为空 Vec）。
+    #[serde(default)]
+    pub pending_tool_failures: Vec<String>,
 }
 
 impl SessionCheckpoint {
@@ -134,6 +152,8 @@ impl SessionCheckpoint {
             mined: false,
             dreaming_status: DreamingStatus::Pending,
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         }
     }
 
@@ -253,6 +273,16 @@ impl SessionCheckpoint {
     /// Update the pending operations list
     pub fn with_pending_operations(mut self, ops: Vec<PendingOperation>) -> Self {
         self.pending_operations = ops;
+        self
+    }
+    /// Set the recovery notification text
+    pub fn with_recovery_notification(mut self, text: Option<String>) -> Self {
+        self.recovery_notification = text;
+        self
+    }
+    /// Set the pending tool failure results
+    pub fn with_pending_tool_failures(mut self, failures: Vec<String>) -> Self {
+        self.pending_tool_failures = failures;
         self
     }
     /// Touch the updated_at timestamp

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -92,6 +92,15 @@ pub struct SessionCheckpoint {
     /// 新建 checkpoint 时默认为 Pending。
     #[serde(default)]
     pub dreaming_status: DreamingStatus,
+    /// Pending operations recorded during forceful shutdown.
+    ///
+    /// Non-empty on restart indicates the session was interrupted mid-operation.
+    /// The recovery service uses this to inject failure results and recovery
+    /// notifications into the conversation flow.
+    ///
+    /// 用 `#[serde(default)]` 兼容旧 checkpoint JSON（无此字段时反序列化为空 Vec）。
+    #[serde(default)]
+    pub pending_operations: Vec<PendingOperation>,
 }
 
 impl SessionCheckpoint {
@@ -124,6 +133,7 @@ impl SessionCheckpoint {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::Pending,
+            pending_operations: Vec::new(),
         }
     }
 
@@ -238,6 +248,11 @@ impl SessionCheckpoint {
     /// Update the dreaming status
     pub fn with_dreaming_status(mut self, status: DreamingStatus) -> Self {
         self.dreaming_status = status;
+        self
+    }
+    /// Update the pending operations list
+    pub fn with_pending_operations(mut self, ops: Vec<PendingOperation>) -> Self {
+        self.pending_operations = ops;
         self
     }
     /// Touch the updated_at timestamp
@@ -446,6 +461,38 @@ pub fn dreaming_status_from_db(s: &str) -> DreamingStatus {
             DreamingStatus::Pending
         }
     }
+}
+
+/// Type of pending operation recorded in a checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PendingOperationType {
+    /// A tool call that was in progress when the session stopped.
+    ToolCall,
+    /// A sub-session spawn that was initiated but not confirmed complete.
+    SubSessionSpawn,
+    /// An outbound message that was queued but not confirmed delivered.
+    OutboundMessage,
+}
+
+/// A pending operation recorded in a checkpoint during forceful shutdown.
+///
+/// When the daemon restarts, these entries allow the recovery service to
+/// inject failure results into the conversation flow so the LLM can
+/// decide whether to retry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingOperation {
+    /// Unique identifier for this operation (e.g. tool call id, child session id).
+    pub op_id: String,
+    /// Type of the pending operation.
+    pub op_type: PendingOperationType,
+    /// Human-readable name (tool name, session id, channel name).
+    pub name: String,
+    /// Serialized arguments (tool args JSON, session config, message content).
+    #[serde(default)]
+    pub args: String,
+    /// When this operation was initiated.
+    pub created_at: DateTime<Utc>,
 }
 
 /// Persistence errors

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -41,7 +41,18 @@ pub struct SessionRecoveryService<S: PersistenceService> {
     /// The closure receives the session_id and checkpoint, and should restore the session state.
     #[allow(clippy::type_complexity)]
     restore_fn: RwLock<
-        Option<Box<dyn Fn(&str, &SessionCheckpoint) -> Result<(), PersistenceError> + Send + Sync>>,
+        Option<
+            Box<
+                dyn Fn(
+                        &str,
+                        &SessionCheckpoint,
+                        Option<&str>,
+                        &[String],
+                    ) -> Result<(), PersistenceError>
+                    + Send
+                    + Sync,
+            >,
+        >,
     >,
 }
 
@@ -57,9 +68,14 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
     /// Set the restore callback
     ///
     /// The callback will be invoked for each session during recovery.
+    /// It receives the session_id, checkpoint, optional recovery notification
+    /// text, and any tool failure result strings to inject.
     pub async fn set_restore_callback<F>(&self, callback: F)
     where
-        F: Fn(&str, &SessionCheckpoint) -> Result<(), PersistenceError> + Send + Sync + 'static,
+        F: Fn(&str, &SessionCheckpoint, Option<&str>, &[String]) -> Result<(), PersistenceError>
+            + Send
+            + Sync
+            + 'static,
     {
         let mut restore_fn = self.restore_fn.write().await;
         *restore_fn = Some(Box::new(callback));
@@ -107,8 +123,21 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
 
         // Inject recovery notifications for dirty sessions
         for session_id in &dirty_sessions {
-            if let Some(cp) = checkpoints.get(session_id) {
+            if let Some(cp) = checkpoints.get_mut(session_id) {
                 self.inject_recovery_notifications(session_id, cp).await;
+            }
+        }
+
+        // Persist dirty checkpoints with injected notifications
+        for session_id in &dirty_sessions {
+            if let Some(cp) = checkpoints.get(session_id) {
+                if let Err(e) = self.storage.save_checkpoint(cp).await {
+                    tracing::error!(
+                        session_id = %session_id,
+                        "Failed to persist checkpoint with recovery notification: {}",
+                        e
+                    );
+                }
             }
         }
 
@@ -143,28 +172,53 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             .await?
             .ok_or_else(|| PersistenceError::NotFound(session_id.to_string()))?;
 
+        // Build notification text if there are pending operations
+        let notification = if !checkpoint.pending_operations.is_empty() {
+            Some(self.build_notification_text(&checkpoint))
+        } else {
+            None
+        };
+
+        // Build tool failure results for pending tool calls
+        let tool_failures = self.build_tool_failure_results(&checkpoint);
+
         let restore_fn = self.restore_fn.read().await;
         if let Some(callback) = restore_fn.as_ref() {
-            callback(session_id, &checkpoint)?;
+            callback(
+                session_id,
+                &checkpoint,
+                notification.as_deref(),
+                &tool_failures,
+            )?;
         }
 
         Ok(())
     }
 
-    /// Inject recovery notifications and failure results for a dirty session.
-    ///
-    /// Builds a system message listing pending operations and, for tool calls,
-    /// injects corresponding failure results into the conversation flow.
+    /// Build the notification text for a dirty session.
     async fn inject_recovery_notifications(
         &self,
         session_id: &str,
-        checkpoint: &SessionCheckpoint,
+        checkpoint: &mut SessionCheckpoint,
     ) {
-        use crate::session::persistence::PendingOperationType;
-
         if checkpoint.pending_operations.is_empty() {
             return;
         }
+
+        let notification = self.build_notification_text(checkpoint);
+        checkpoint.recovery_notification = Some(notification);
+        checkpoint.pending_tool_failures = self.build_tool_failure_results(checkpoint);
+
+        tracing::info!(
+            session_id = %session_id,
+            pending_count = checkpoint.pending_operations.len(),
+            "storing recovery notification in checkpoint"
+        );
+    }
+
+    /// Build notification text listing pending operations.
+    fn build_notification_text(&self, checkpoint: &SessionCheckpoint) -> String {
+        use crate::session::persistence::PendingOperationType;
 
         let restart_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
 
@@ -215,28 +269,33 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             sections.push(outbound_msgs.join("\n"));
         }
 
-        let notification = format!(
+        format!(
             "[系统] 网关已重启（重启时间: {restart_time}）\n\n\
 以下操作在重启前未完成：\n{ops}\n\n\
 你可以使用 sessions_list、sessions_history、process 等工具\n\
 了解当前状态，自行判断这些操作的结果，并决定后续处理。",
             restart_time = restart_time,
             ops = sections.join("\n\n"),
-        );
+        )
+    }
 
-        tracing::info!(
-            session_id = %session_id,
-            pending_count = checkpoint.pending_operations.len(),
-            "injecting recovery notification"
-        );
+    /// Build tool failure result strings for pending tool call operations.
+    fn build_tool_failure_results(&self, checkpoint: &SessionCheckpoint) -> Vec<String> {
+        use crate::session::persistence::PendingOperationType;
 
-        // Store the notification text for the restore callback to inject.
-        // The actual injection into ConversationSession happens via the
-        // restore_fn callback which is called by the gateway on startup.
-        // Here we store it in the checkpoint metadata for the gateway to pick up.
-        // Note: the restore_fn callback already has access to the checkpoint
-        // and can read pending_operations directly.
-        let _ = (session_id, notification, &checkpoint.pending_operations);
+        checkpoint
+            .pending_operations
+            .iter()
+            .filter(|op| op.op_type == PendingOperationType::ToolCall)
+            .map(|op| {
+                serde_json::json!({
+                    "error": "进程中断：网关重启",
+                    "tool": op.name,
+                    "op_id": op.op_id,
+                })
+                .to_string()
+            })
+            .collect()
     }
 
     /// 根据已恢复 session 的 checkpoint 构建 spawn_tree。
@@ -323,7 +382,8 @@ impl SpawnTree {
 mod tests {
     use super::*;
     use crate::session::persistence::{
-        DreamingStatus, ReasoningLevel, ReasoningMode, ReasoningModeState, SessionStatus,
+        DreamingStatus, PendingOperation, PendingOperationType, ReasoningLevel, ReasoningMode,
+        ReasoningModeState, SessionStatus,
     };
     use crate::session::storage::memory::MemoryStorage;
     use chrono::Utc;
@@ -361,6 +421,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         }
     }
 
@@ -419,10 +481,12 @@ mod tests {
         let restored_clone = Arc::clone(&restored);
 
         service
-            .set_restore_callback(move |session_id, _checkpoint| {
-                restored_clone.lock().unwrap().push(session_id.to_string());
-                Ok(())
-            })
+            .set_restore_callback(
+                move |session_id, _checkpoint, _notification, _tool_failures| {
+                    restored_clone.lock().unwrap().push(session_id.to_string());
+                    Ok(())
+                },
+            )
             .await;
 
         let report = service.recover().await.unwrap();
@@ -642,5 +706,151 @@ mod tests {
         assert_eq!(tree.roots, vec!["parent".to_string()]);
         assert!(tree.children.is_empty());
         assert!(demoted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_notification_stored_in_checkpoint() {
+        let storage = Arc::new(MemoryStorage::new());
+        let now = Utc::now();
+        let cp = SessionCheckpoint::new("dirty_notif".into()).with_pending_operations(vec![
+            PendingOperation {
+                op_id: "op_1".into(),
+                op_type: PendingOperationType::ToolCall,
+                name: "bash".into(),
+                args: r#"{"cmd":"ls"}"#.into(),
+                created_at: now,
+            },
+        ]);
+        storage.save_checkpoint(&cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 1);
+        assert!(report.dirty_sessions.contains(&"dirty_notif".to_string()));
+
+        // Verify notification was stored in checkpoint
+        let loaded = storage
+            .load_checkpoint("dirty_notif")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            loaded.recovery_notification.is_some(),
+            "recovery_notification should be stored in dirty checkpoint"
+        );
+        let notif = loaded.recovery_notification.unwrap();
+        assert!(notif.contains("网关已重启"));
+        assert!(notif.contains("工具调用: bash"));
+    }
+
+    #[tokio::test]
+    async fn test_recovery_notification_not_stored_for_clean_session() {
+        let storage = Arc::new(MemoryStorage::new());
+        let cp = SessionCheckpoint::new("clean_notif".into());
+        storage.save_checkpoint(&cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let report = service.recover().await.unwrap();
+
+        assert_eq!(report.recovered.len(), 1);
+        assert!(report.dirty_sessions.is_empty());
+
+        let loaded = storage
+            .load_checkpoint("clean_notif")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(loaded.recovery_notification.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_tool_failures_built() {
+        let storage = Arc::new(MemoryStorage::new());
+        let now = Utc::now();
+        let cp = SessionCheckpoint::new("dirty_tools".into()).with_pending_operations(vec![
+            PendingOperation {
+                op_id: "call_1".into(),
+                op_type: PendingOperationType::ToolCall,
+                name: "exec".into(),
+                args: r#"{"command":"kubectl get pods"}"#.into(),
+                created_at: now,
+            },
+            PendingOperation {
+                op_id: "child_1".into(),
+                op_type: PendingOperationType::SubSessionSpawn,
+                name: "sub-agent".into(),
+                args: String::new(),
+                created_at: now,
+            },
+        ]);
+        storage.save_checkpoint(&cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+        let _report = service.recover().await.unwrap();
+
+        let loaded = storage
+            .load_checkpoint("dirty_tools")
+            .await
+            .unwrap()
+            .unwrap();
+        // Only ToolCall ops produce failure results
+        assert_eq!(loaded.pending_tool_failures.len(), 1);
+        let failure = &loaded.pending_tool_failures[0];
+        assert!(failure.contains("进程中断：网关重启"));
+        assert!(failure.contains("exec"));
+        assert!(failure.contains("call_1"));
+    }
+
+    #[tokio::test]
+    async fn test_recovery_callback_receives_notification() {
+        use crate::session::persistence::{
+            PendingOperation, PendingOperationType, PersistenceService, SessionCheckpoint,
+        };
+        use crate::session::storage::memory::MemoryStorage;
+        use std::sync::Arc;
+
+        let storage = Arc::new(MemoryStorage::new());
+        let now = Utc::now();
+        let cp = SessionCheckpoint::new("cb_notif".into()).with_pending_operations(vec![
+            PendingOperation {
+                op_id: "op_1".into(),
+                op_type: PendingOperationType::ToolCall,
+                name: "bash".into(),
+                args: String::new(),
+                created_at: now,
+            },
+        ]);
+        storage.save_checkpoint(&cp).await.unwrap();
+
+        let service = SessionRecoveryService::new(Arc::clone(&storage));
+
+        let captured_notification = Arc::new(std::sync::Mutex::new(None::<String>));
+        let captured_failures = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let notif_clone = Arc::clone(&captured_notification);
+        let fail_clone = Arc::clone(&captured_failures);
+
+        service
+            .set_restore_callback(
+                move |_session_id, _checkpoint, notification, tool_failures| {
+                    *notif_clone.lock().unwrap() = notification.map(String::from);
+                    *fail_clone.lock().unwrap() = tool_failures.to_vec();
+                    Ok(())
+                },
+            )
+            .await;
+
+        let report = service.recover().await.unwrap();
+        assert_eq!(report.recovered.len(), 1);
+
+        let notif = captured_notification.lock().unwrap();
+        assert!(notif.is_some(), "callback should receive notification text");
+        let notif_text = notif.as_ref().unwrap();
+        assert!(notif_text.contains("网关已重启"));
+        assert!(notif_text.contains("工具调用: bash"));
+
+        let failures = captured_failures.lock().unwrap();
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("进程中断：网关重启"));
     }
 }

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -9,6 +9,31 @@ use tokio::sync::RwLock;
 
 use crate::session::persistence::{PersistenceError, PersistenceService, SessionCheckpoint};
 
+/// Recovery report containing results of the recovery process
+#[derive(Debug)]
+pub struct RecoveryReport {
+    /// List of session IDs that were successfully recovered
+    pub recovered: Vec<String>,
+    /// List of session IDs that failed to recover
+    pub failed: Vec<String>,
+    /// Spawn tree reconstructed from recovered checkpoints
+    pub spawn_tree: SpawnTree,
+    /// List of session IDs that had pending operations (dirty sessions)
+    pub dirty_sessions: Vec<String>,
+}
+
+impl RecoveryReport {
+    /// Returns true if all sessions were recovered successfully
+    pub fn is_full_success(&self) -> bool {
+        self.failed.is_empty()
+    }
+
+    /// Returns the total number of sessions processed
+    pub fn total(&self) -> usize {
+        self.recovered.len() + self.failed.len()
+    }
+}
+
 /// Session recovery service — recovers sessions from persisted checkpoints
 pub struct SessionRecoveryService<S: PersistenceService> {
     storage: Arc<S>,
@@ -73,6 +98,20 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             }
         }
 
+        // Collect dirty sessions (those with pending operations)
+        let dirty_sessions: Vec<String> = checkpoints
+            .iter()
+            .filter(|(_, cp)| !cp.pending_operations.is_empty())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        // Inject recovery notifications for dirty sessions
+        for session_id in &dirty_sessions {
+            if let Some(cp) = checkpoints.get(session_id) {
+                self.inject_recovery_notifications(session_id, cp).await;
+            }
+        }
+
         let (spawn_tree, demoted) = Self::build_spawn_tree(&mut checkpoints, &recovered);
 
         // 持久化降级后的 checkpoint（depth 重置为 0）
@@ -92,6 +131,7 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             recovered,
             failed,
             spawn_tree,
+            dirty_sessions,
         })
     }
 
@@ -109,6 +149,94 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
         }
 
         Ok(())
+    }
+
+    /// Inject recovery notifications and failure results for a dirty session.
+    ///
+    /// Builds a system message listing pending operations and, for tool calls,
+    /// injects corresponding failure results into the conversation flow.
+    async fn inject_recovery_notifications(
+        &self,
+        session_id: &str,
+        checkpoint: &SessionCheckpoint,
+    ) {
+        use crate::session::persistence::PendingOperationType;
+
+        if checkpoint.pending_operations.is_empty() {
+            return;
+        }
+
+        let restart_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+
+        // Build summary by op_type
+        let mut tool_calls = Vec::new();
+        let mut sub_spawns = Vec::new();
+        let mut outbound_msgs = Vec::new();
+
+        for op in &checkpoint.pending_operations {
+            match op.op_type {
+                PendingOperationType::ToolCall => {
+                    tool_calls.push(format!(
+                        "  • 工具调用: {}({}) — 发起于 {}",
+                        op.name,
+                        if op.args.is_empty() {
+                            "无参数".to_string()
+                        } else {
+                            op.args.clone()
+                        },
+                        op.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                    ));
+                }
+                PendingOperationType::SubSessionSpawn => {
+                    sub_spawns.push(format!(
+                        "  • 子 Session: {} — 发起于 {}",
+                        op.name,
+                        op.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                    ));
+                }
+                PendingOperationType::OutboundMessage => {
+                    outbound_msgs.push(format!(
+                        "  • 出站消息: {} — 创建于 {}",
+                        op.name,
+                        op.created_at.format("%Y-%m-%dT%H:%M:%SZ")
+                    ));
+                }
+            }
+        }
+
+        let mut sections = Vec::new();
+        if !tool_calls.is_empty() {
+            sections.push(tool_calls.join("\n"));
+        }
+        if !sub_spawns.is_empty() {
+            sections.push(sub_spawns.join("\n"));
+        }
+        if !outbound_msgs.is_empty() {
+            sections.push(outbound_msgs.join("\n"));
+        }
+
+        let notification = format!(
+            "[系统] 网关已重启（重启时间: {restart_time}）\n\n\
+以下操作在重启前未完成：\n{ops}\n\n\
+你可以使用 sessions_list、sessions_history、process 等工具\n\
+了解当前状态，自行判断这些操作的结果，并决定后续处理。",
+            restart_time = restart_time,
+            ops = sections.join("\n\n"),
+        );
+
+        tracing::info!(
+            session_id = %session_id,
+            pending_count = checkpoint.pending_operations.len(),
+            "injecting recovery notification"
+        );
+
+        // Store the notification text for the restore callback to inject.
+        // The actual injection into ConversationSession happens via the
+        // restore_fn callback which is called by the gateway on startup.
+        // Here we store it in the checkpoint metadata for the gateway to pick up.
+        // Note: the restore_fn callback already has access to the checkpoint
+        // and can read pending_operations directly.
+        let _ = (session_id, notification, &checkpoint.pending_operations);
     }
 
     /// 根据已恢复 session 的 checkpoint 构建 spawn_tree。
@@ -191,29 +319,6 @@ impl SpawnTree {
     }
 }
 
-/// Recovery report containing results of the recovery process
-#[derive(Debug)]
-pub struct RecoveryReport {
-    /// List of session IDs that were successfully recovered
-    pub recovered: Vec<String>,
-    /// List of session IDs that failed to recover
-    pub failed: Vec<String>,
-    /// Spawn tree reconstructed from recovered checkpoints
-    pub spawn_tree: SpawnTree,
-}
-
-impl RecoveryReport {
-    /// Returns true if all sessions were recovered successfully
-    pub fn is_full_success(&self) -> bool {
-        self.failed.is_empty()
-    }
-
-    /// Returns the total number of sessions processed
-    pub fn total(&self) -> usize {
-        self.recovered.len() + self.failed.len()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,6 +360,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         }
     }
 
@@ -264,6 +370,7 @@ mod tests {
             recovered: vec!["s1".to_string(), "s2".to_string()],
             failed: Vec::new(),
             spawn_tree: SpawnTree::default(),
+            dirty_sessions: Vec::new(),
         };
         assert!(report.is_full_success());
         assert_eq!(report.total(), 2);
@@ -275,6 +382,7 @@ mod tests {
             recovered: vec!["s1".to_string()],
             failed: vec!["s2".to_string()],
             spawn_tree: SpawnTree::default(),
+            dirty_sessions: Vec::new(),
         };
         assert!(!report.is_full_success());
         assert_eq!(report.total(), 2);

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -35,7 +35,7 @@ impl RecoveryReport {
 }
 
 /// Session recovery service — recovers sessions from persisted checkpoints
-pub struct SessionRecoveryService<S: PersistenceService> {
+pub struct SessionRecoveryService<S: PersistenceService + ?Sized> {
     storage: Arc<S>,
     /// Callback to restore a session from checkpoint
     /// The closure receives the session_id and checkpoint, and should restore the session state.
@@ -56,7 +56,7 @@ pub struct SessionRecoveryService<S: PersistenceService> {
     >,
 }
 
-impl<S: PersistenceService> SessionRecoveryService<S> {
+impl<S: PersistenceService + ?Sized> SessionRecoveryService<S> {
     /// Create a new SessionRecoveryService
     pub fn new(storage: Arc<S>) -> Self {
         Self {
@@ -124,7 +124,7 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
         // Inject recovery notifications for dirty sessions
         for session_id in &dirty_sessions {
             if let Some(cp) = checkpoints.get_mut(session_id) {
-                self.inject_recovery_notifications(session_id, cp).await;
+                self.inject_recovery_notifications(session_id, cp);
             }
         }
 
@@ -172,15 +172,24 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
             .await?
             .ok_or_else(|| PersistenceError::NotFound(session_id.to_string()))?;
 
-        // Build notification text if there are pending operations
-        let notification = if !checkpoint.pending_operations.is_empty() {
+        // Use the pre-stored recovery_notification from the checkpoint
+        // (set by inject_recovery_notifications) when available;
+        // otherwise fall back to building it fresh.
+        let notification = if let Some(ref stored) = checkpoint.recovery_notification {
+            Some(stored.clone())
+        } else if !checkpoint.pending_operations.is_empty() {
             Some(self.build_notification_text(&checkpoint))
         } else {
             None
         };
 
-        // Build tool failure results for pending tool calls
-        let tool_failures = self.build_tool_failure_results(&checkpoint);
+        // Use pre-stored pending_tool_failures when available;
+        // otherwise build them fresh.
+        let tool_failures = if !checkpoint.pending_tool_failures.is_empty() {
+            checkpoint.pending_tool_failures.clone()
+        } else {
+            self.build_tool_failure_results(&checkpoint)
+        };
 
         let restore_fn = self.restore_fn.read().await;
         if let Some(callback) = restore_fn.as_ref() {
@@ -196,11 +205,10 @@ impl<S: PersistenceService> SessionRecoveryService<S> {
     }
 
     /// Build the notification text for a dirty session.
-    async fn inject_recovery_notifications(
-        &self,
-        session_id: &str,
-        checkpoint: &mut SessionCheckpoint,
-    ) {
+    ///
+    /// Stores the recovery notification and tool failure results in the
+    /// checkpoint so they can be read back when sessions are restored.
+    fn inject_recovery_notifications(&self, session_id: &str, checkpoint: &mut SessionCheckpoint) {
         if checkpoint.pending_operations.is_empty() {
             return;
         }

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -260,6 +260,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         }
     }
 

--- a/src/session/storage/memory.rs
+++ b/src/session/storage/memory.rs
@@ -261,6 +261,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         }
     }
 

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -356,6 +356,8 @@ pub fn load_checkpoint_inner(
         dreaming_status,
         effective_max_spawn_depth: None,
         pending_operations: Vec::new(),
+        recovery_notification: None,
+        pending_tool_failures: Vec::new(),
     }))
 }
 

--- a/src/session/storage/sqlite/archive_support.rs
+++ b/src/session/storage/sqlite/archive_support.rs
@@ -355,6 +355,7 @@ pub fn load_checkpoint_inner(
         mined,
         dreaming_status,
         effective_max_spawn_depth: None,
+        pending_operations: Vec::new(),
     }))
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -37,6 +37,7 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         effective_max_spawn_depth: None,
         mined: false,
         dreaming_status: DreamingStatus::default(),
+        pending_operations: Vec::new(),
     }
 }
 

--- a/src/session/storage/sqlite/tests.rs
+++ b/src/session/storage/sqlite/tests.rs
@@ -38,6 +38,8 @@ fn create_test_checkpoint(session_id: &str) -> SessionCheckpoint {
         mined: false,
         dreaming_status: DreamingStatus::default(),
         pending_operations: Vec::new(),
+        recovery_notification: None,
+        pending_tool_failures: Vec::new(),
     }
 }
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -38,6 +38,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         }
     }
 
@@ -401,6 +402,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -446,6 +448,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -491,6 +494,7 @@ mod tests {
             effective_max_spawn_depth: None,
             mined: false,
             dreaming_status: DreamingStatus::default(),
+            pending_operations: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 

--- a/src/session/storage/sqlite_tests.rs
+++ b/src/session/storage/sqlite_tests.rs
@@ -39,6 +39,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         }
     }
 
@@ -403,6 +405,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -449,6 +453,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 
@@ -495,6 +501,8 @@ mod tests {
             mined: false,
             dreaming_status: DreamingStatus::default(),
             pending_operations: Vec::new(),
+            recovery_notification: None,
+            pending_tool_failures: Vec::new(),
         };
         storage.save_checkpoint(&checkpoint).await?;
 


### PR DESCRIPTION
Align daemon shutdown implementation with design doc (docs/design/daemon/shutdown.md).

Changes:
1. Register busy_count in production code (Gateway message processing, async tool execution, child session handling)
2. Add shutdown gate checks (is_shutting_down()) before accepting new operations
3. Remove hard timeout from graceful session stop — users decide when to escalate to forceful
4. Implement pending_operations recovery — record pending tool calls/sub-sessions/outbound messages in checkpoint, inject recovery notifications and tool failure results on restart
5. Integrate SessionRecoveryService into daemon startup flow
6. Fix busy_count double-decrement and leak issues across multiple code paths

Source: user
Type: feat
