### PR TITLE
fix: graceful shutdown records pending tool calls and skips execution

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -513,6 +513,8 @@ mod bug904_tests;
 #[cfg(test)]
 mod flush_tests;
 #[cfg(test)]
+mod graceful_stop_tests;
+#[cfg(test)]
 mod model_priority_tests;
 #[cfg(test)]
 mod rebuild_spawn_tree_tests;

--- a/src/gateway/session_manager/graceful_stop_tests.rs
+++ b/src/gateway/session_manager/graceful_stop_tests.rs
@@ -1,0 +1,267 @@
+//! Tests for the graceful-shutdown state machine in `stop_single_session`.
+//!
+//! Covers Step 1.2 of the graceful-shutdown plan: the three sub-states
+//! (streaming, streaming-ended-with-tools, idle, tool-running) and
+//! their transitions during a graceful stop.
+//!
+//! Note on the `streaming_seen` path: `stop_single_session` holds a
+//! read-lock on the `Arc<RwLock<ConversationSession>>` for the entire
+//! polling loop. A background task that tries to write to the same
+//! session would deadlock.  Instead, tests for the streaming→idle
+//! transition pre-set the **end-state** (LlmState::Idle + ToolUse in
+//! the last assistant message) before calling `stop_all_sessions`.
+//! The polling loop immediately sees `is_streaming == false`,
+//! `streaming_seen == false`, `has_running_tools == false` and breaks.
+//! The `extract_pending_tool_calls` logic is covered by the Step 1.1
+//! unit tests; this file verifies the integration through
+//! `stop_all_sessions`.
+
+use crate::daemon::shutdown::ShutdownMode;
+use crate::gateway::session_manager::test_helpers::{register_child_only, setup_parent_with_conv};
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::Session;
+use crate::llm::session::{ChatSession, ConversationSession};
+use crate::llm::session_state::{LlmState, ToolExecState};
+use crate::llm::types::ContentBlock;
+use crate::session::bootstrap::BootstrapMode;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::spawn::SpawnMode;
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+fn make_test_session_manager() -> SessionManager {
+    let config = crate::gateway::GatewayConfig::default();
+    SessionManager::new(&config, None, None, BootstrapMode::Full, Default::default())
+}
+
+fn make_conversation_session(id: &str) -> Arc<tokio::sync::RwLock<ConversationSession>> {
+    Arc::new(tokio::sync::RwLock::new(ConversationSession::new(
+        id.to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    )))
+}
+
+/// Register a child session with a `ConversationSession` under the
+/// given parent.  Both the `sessions` map and `conversation_sessions`
+/// map are populated so `stop_all_sessions` can find and stop the
+/// child.
+async fn setup_child_with_conv(mgr: &SessionManager, parent_id: &str, child_id: &str) {
+    register_child_only(mgr, parent_id, child_id, "worker", SpawnMode::Session).await;
+    let cs = make_conversation_session(child_id);
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(child_id.to_string(), cs);
+    mgr.sessions.write().await.insert(
+        child_id.to_string(),
+        Session {
+            id: child_id.to_string(),
+            agent_id: "worker".to_string(),
+            channel: "feishu".to_string(),
+            created_at: chrono::Utc::now().timestamp(),
+            depth: 1,
+        },
+    );
+}
+
+/// Set the LLM state for a given session (via the `Arc`).
+async fn set_llm_state(mgr: &SessionManager, session_id: &str, state: LlmState) {
+    let cs = mgr.get_conversation_session(session_id).await.unwrap();
+    let guard = cs.read().await;
+    let mut llm = guard.llm_state.write().expect("llm_state lock poisoned");
+    *llm = state;
+}
+
+/// Set a tool state for a given session (via the `Arc`).
+async fn set_tool_state(
+    mgr: &SessionManager,
+    session_id: &str,
+    tool_id: &str,
+    state: ToolExecState,
+) {
+    let cs = mgr.get_conversation_session(session_id).await.unwrap();
+    let guard = cs.read().await;
+    let mut tools = guard
+        .tool_states
+        .write()
+        .expect("tool_states lock poisoned");
+    tools.insert(tool_id.to_string(), state);
+}
+
+/// Append an assistant message via `ChatSession::append_response`.
+async fn append_assistant_message(
+    mgr: &SessionManager,
+    session_id: &str,
+    blocks: Vec<ContentBlock>,
+) {
+    let cs = mgr.get_conversation_session(session_id).await.unwrap();
+    let mut guard = cs.write().await;
+    guard.append_response(crate::llm::types::UnifiedResponse {
+        content_blocks: blocks,
+        usage: crate::llm::types::UnifiedUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: None,
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".to_string()),
+    });
+}
+
+// ── Step 1.2: graceful stop scenarios ────────────────────────────────────
+
+/// Session ends with ToolUse in the last assistant message →
+/// `stop_all_sessions` should stop successfully and the child should
+/// be removed from active sessions.
+///
+/// We pre-set the end-state (LlmState::Idle, assistant with ToolUse)
+/// before calling `stop_all_sessions`.  The polling loop sees idle
+/// immediately and breaks.  The `extract_pending_tool_calls` path is
+/// exercised by the Step 1.1 unit tests.
+#[tokio::test]
+async fn test_graceful_stop_streaming_with_tool_calls() {
+    let mgr = make_test_session_manager();
+    let parent_id = "parent_gst_stream_tools";
+    setup_parent_with_conv(&mgr, parent_id).await;
+    let child_id = "child_gst_stream_tools";
+    setup_child_with_conv(&mgr, parent_id, child_id).await;
+
+    // Pre-set end-state: LLM idle, last assistant has ToolUse.
+    set_llm_state(&mgr, child_id, LlmState::Idle).await;
+    append_assistant_message(
+        &mgr,
+        child_id,
+        vec![
+            ContentBlock::Text("Let me check.".to_string()),
+            ContentBlock::ToolUse {
+                id: "call_gs_1".to_string(),
+                name: "get_weather".to_string(),
+                input: r#"{"city":"Tokyo"}"#.to_string(),
+            },
+        ],
+    )
+    .await;
+
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    assert!(
+        result.succeeded >= 2,
+        "expected >= 2 succeeded, got {:?}",
+        result
+    );
+    assert!(
+        !mgr.has_session(&child_id).await,
+        "child should be removed after graceful stop"
+    );
+}
+
+/// Streaming ends → assistant message has no ToolUse → normal stop.
+#[tokio::test]
+async fn test_graceful_stop_streaming_no_tool_calls() {
+    let mgr = make_test_session_manager();
+    let parent_id = "parent_gst_stream_notools";
+    setup_parent_with_conv(&mgr, parent_id).await;
+    let child_id = "child_gst_stream_notools";
+    setup_child_with_conv(&mgr, parent_id, child_id).await;
+
+    // Pre-set: LLM idle, assistant text only (no ToolUse).
+    set_llm_state(&mgr, child_id, LlmState::Idle).await;
+    append_assistant_message(
+        &mgr,
+        child_id,
+        vec![ContentBlock::Text("Done.".to_string())],
+    )
+    .await;
+
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    assert!(result.succeeded >= 2);
+    assert!(!mgr.has_session(&child_id).await);
+}
+
+/// Idle session → direct stop, pending_operations should be empty.
+#[tokio::test]
+async fn test_graceful_stop_idle() {
+    let mgr = make_test_session_manager();
+    let parent_id = "parent_gst_idle";
+    setup_parent_with_conv(&mgr, parent_id).await;
+    let child_id = "child_gst_idle";
+    setup_child_with_conv(&mgr, parent_id, child_id).await;
+
+    // Default: LlmState::Idle, no tools running.
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    assert!(result.succeeded >= 2);
+    assert!(!mgr.has_session(&child_id).await);
+}
+
+/// Tool is running → wait for tool to finish → pending_operations empty.
+///
+/// Set a tool in RunningForeground state.  The polling loop sees
+/// `has_running_tools == true` and enters the `continue` branch
+/// (new Step 1.4 fix).  A background task clears the tool state
+/// during the polling sleep, so the loop eventually sees
+/// `has_running_tools == false` and breaks.
+#[tokio::test]
+async fn test_graceful_stop_tool_running() {
+    let mgr = make_test_session_manager();
+    let parent_id = "parent_gst_tool_running";
+    setup_parent_with_conv(&mgr, parent_id).await;
+    let child_id = "child_gst_tool_running";
+    setup_child_with_conv(&mgr, parent_id, child_id).await;
+
+    // LLM idle, tool in RunningForeground state (actively running).
+    // The loop sees `has_running_tools == true` → continue (wait).
+    // A background task clears the tool state so the loop can break.
+    set_llm_state(&mgr, child_id, LlmState::Idle).await;
+    set_tool_state(&mgr, child_id, "tool_1", ToolExecState::RunningForeground).await;
+
+    // Spawn a task that clears the tool state after a brief delay,
+    // simulating tool completion.  The polling loop's sleep releases
+    // the read-lock, allowing this task to acquire it and write.
+    let cs_arc = mgr
+        .get_conversation_session(child_id)
+        .await
+        .expect("conversation session not found");
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let guard = cs_arc.read().await;
+        let mut tools = guard
+            .tool_states
+            .write()
+            .expect("tool_states lock poisoned");
+        tools.remove("tool_1");
+    });
+
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    assert!(result.succeeded >= 2);
+    assert!(!mgr.has_session(&child_id).await);
+}
+
+/// Forceful mode should not be affected by the graceful state machine.
+#[tokio::test]
+async fn test_forceful_stop_unchanged() {
+    let mgr = make_test_session_manager();
+    let parent_id = "parent_gst_forceful";
+    setup_parent_with_conv(&mgr, parent_id).await;
+    let child_id = "child_gst_forceful";
+    setup_child_with_conv(&mgr, parent_id, child_id).await;
+
+    // Streaming + tool running — forceful should not wait.
+    set_llm_state(&mgr, child_id, LlmState::Receiving).await;
+    set_tool_state(&mgr, child_id, "tool_f", ToolExecState::RunningForeground).await;
+
+    let start = tokio::time::Instant::now();
+    let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+    let elapsed = start.elapsed();
+
+    assert!(result.succeeded >= 2);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "forceful mode should complete quickly, took {:?}",
+        elapsed
+    );
+}

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -244,17 +244,25 @@ impl SessionManager {
             .await
             .ok_or(StopError::Skipped)?;
 
-        // Collect pending operations before stopping (for forceful mode).
-        let pending_ops: Vec<PendingOperation> = if mode == ShutdownMode::Forceful {
+        // Collect pending operations. Forceful mode collects from
+        // tool_states/child_states; graceful mode collects from the
+        // assistant message after the streaming loop below.
+        let mut pending_ops: Vec<PendingOperation> = if mode == ShutdownMode::Forceful {
             let guard = cs.read().await;
             guard.collect_pending_operations()
         } else {
             Vec::new()
         };
 
-        // Graceful: wait for LLM streaming and tool execution to finish.
+        // Graceful: state-aware loop that distinguishes three sub-states:
+        // 1. LLM streaming in progress → wait for stream to end.
+        // 2. Stream just ended → extract pending tool calls (if any);
+        //    do NOT wait for tools to execute.
+        // 3. Tools running (after stream ended) → wait for them to finish.
         // No hard timeout — the user decides when to escalate to forceful.
         if mode == ShutdownMode::Graceful {
+            let mut streaming_seen = false;
+
             loop {
                 let (is_streaming, has_running_tools) = {
                     let guard = cs.read().await;
@@ -271,8 +279,31 @@ impl SessionManager {
                     (streaming, tools)
                 };
 
-                if !is_streaming && !has_running_tools {
-                    break;
+                if is_streaming {
+                    streaming_seen = true;
+                } else if streaming_seen {
+                    // Stream just ended — extract pending tool calls
+                    // from the last assistant message.
+                    let ops = {
+                        let guard = cs.read().await;
+                        guard.extract_pending_tool_calls()
+                    };
+                    if !ops.is_empty() {
+                        pending_ops = ops;
+                        break;
+                    }
+                    // No tool calls requested — if tools are still
+                    // running, keep waiting; otherwise we are done.
+                    if !has_running_tools {
+                        break;
+                    }
+                    // Tools running but not from assistant tool_use;
+                    // fall through to next iteration.
+                } else {
+                    if has_running_tools {
+                        continue; // 工具执行中，等待完成
+                    }
+                    break; // 真正的 Idle
                 }
 
                 tracing::debug!(

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -386,6 +386,44 @@ impl ConversationSession {
         );
     }
 
+    /// Extract pending tool calls from the last assistant message.
+    ///
+    /// Scans `self.messages` for the most recent assistant message, then
+    /// collects every `ContentBlock::ToolUse` block into a
+    /// [`PendingOperation`] list. This is used by the graceful-shutdown
+    /// path to record tool calls that were requested but not yet executed.
+    ///
+    /// Unlike [`collect_pending_operations`](Self::collect_pending_operations)
+    /// (which inspects tool_states / child_states), this method reads
+    /// directly from the conversation history.
+    pub fn extract_pending_tool_calls(&self) -> Vec<crate::session::persistence::PendingOperation> {
+        use crate::session::persistence::{PendingOperation, PendingOperationType};
+
+        let last_assistant = self.messages.iter().rev().find(|m| m.role == "assistant");
+
+        let Some(msg) = last_assistant else {
+            return Vec::new();
+        };
+
+        let now = Utc::now();
+        msg.content_blocks
+            .iter()
+            .filter_map(|block| {
+                if let ContentBlock::ToolUse { id, name, input } = block {
+                    Some(PendingOperation {
+                        op_id: id.clone(),
+                        op_type: PendingOperationType::ToolCall,
+                        name: name.clone(),
+                        args: input.clone(),
+                        created_at: now,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Collect pending operations from the current session state.
     ///
     /// Scans tool_states, child_states, and pending_messages to build a

--- a/src/llm/session/tests/extract_pending_tool_calls_tests.rs
+++ b/src/llm/session/tests/extract_pending_tool_calls_tests.rs
@@ -1,0 +1,213 @@
+//! Tests for `ConversationSession::extract_pending_tool_calls`.
+//!
+//! Covers Step 1.1 of the graceful-shutdown plan: scanning the last
+//! assistant message for `ContentBlock::ToolUse` blocks and converting
+//! them into `PendingOperation` entries.
+
+use super::super::*;
+use crate::llm::types::ContentBlock;
+use crate::session::persistence::PendingOperationType;
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+fn make_session(id: &str) -> ConversationSession {
+    ConversationSession::new(id.to_string(), "gpt-4o".to_string(), tmp_path())
+}
+
+/// Append an assistant message with the given content blocks via
+/// `replace_messages` so we have full control over message history.
+fn set_messages(session: &mut ConversationSession, msgs: Vec<SessionMessage>) {
+    session.replace_messages(msgs);
+}
+
+fn assistant_msg(blocks: Vec<ContentBlock>) -> SessionMessage {
+    SessionMessage {
+        role: "assistant".to_string(),
+        content_blocks: blocks,
+        timestamp: Utc::now(),
+    }
+}
+
+fn user_msg(text: &str) -> SessionMessage {
+    SessionMessage {
+        role: "user".to_string(),
+        content_blocks: vec![ContentBlock::Text(text.to_string())],
+        timestamp: Utc::now(),
+    }
+}
+
+// ── Step 1.1: extract_pending_tool_calls ────────────────────────────────
+
+#[test]
+fn test_extract_pending_tool_calls_empty() {
+    let session = make_session("extract_empty");
+    let ops = session.extract_pending_tool_calls();
+    assert!(ops.is_empty(), "no messages → empty result");
+}
+
+#[test]
+fn test_extract_pending_tool_calls_no_tool_use() {
+    let mut session = make_session("extract_no_tools");
+    set_messages(
+        &mut session,
+        vec![
+            user_msg("hello"),
+            assistant_msg(vec![ContentBlock::Text("Hi there!".to_string())]),
+        ],
+    );
+    let ops = session.extract_pending_tool_calls();
+    assert!(ops.is_empty(), "text-only assistant message → empty result");
+}
+
+#[test]
+fn test_extract_pending_tool_calls_with_tools() {
+    let mut session = make_session("extract_with_tools");
+    set_messages(
+        &mut session,
+        vec![
+            user_msg("check the weather"),
+            assistant_msg(vec![
+                ContentBlock::Text("Let me check.".to_string()),
+                ContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "get_weather".to_string(),
+                    input: r#"{"city":"Tokyo"}"#.to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "call_2".to_string(),
+                    name: "get_time".to_string(),
+                    input: r#"{"tz":"Asia/Tokyo"}"#.to_string(),
+                },
+            ]),
+        ],
+    );
+    let ops = session.extract_pending_tool_calls();
+    assert_eq!(
+        ops.len(),
+        2,
+        "should return one PendingOperation per ToolUse"
+    );
+
+    assert_eq!(ops[0].op_id, "call_1");
+    assert!(matches!(ops[0].op_type, PendingOperationType::ToolCall));
+    assert_eq!(ops[0].name, "get_weather");
+    assert_eq!(ops[0].args, r#"{"city":"Tokyo"}"#);
+
+    assert_eq!(ops[1].op_id, "call_2");
+    assert!(matches!(ops[1].op_type, PendingOperationType::ToolCall));
+    assert_eq!(ops[1].name, "get_time");
+    assert_eq!(ops[1].args, r#"{"tz":"Asia/Tokyo"}"#);
+}
+
+#[test]
+fn test_extract_pending_tool_calls_only_last_assistant() {
+    let mut session = make_session("extract_only_last");
+    set_messages(
+        &mut session,
+        vec![
+            user_msg("first turn"),
+            // First assistant message — has a ToolUse, but should be ignored.
+            assistant_msg(vec![ContentBlock::ToolUse {
+                id: "old_call".to_string(),
+                name: "old_tool".to_string(),
+                input: "{}".to_string(),
+            }]),
+            user_msg("second turn"),
+            // Last assistant message — text only, no ToolUse.
+            assistant_msg(vec![ContentBlock::Text("Done.".to_string())]),
+        ],
+    );
+    let ops = session.extract_pending_tool_calls();
+    assert!(
+        ops.is_empty(),
+        "must only inspect the LAST assistant message"
+    );
+}
+
+#[test]
+fn test_extract_pending_tool_calls_last_has_mixed_blocks() {
+    let mut session = make_session("extract_mixed");
+    set_messages(
+        &mut session,
+        vec![
+            user_msg("do two things"),
+            assistant_msg(vec![
+                ContentBlock::Text("Thinking...".to_string()),
+                ContentBlock::ToolUse {
+                    id: "call_a".to_string(),
+                    name: "tool_a".to_string(),
+                    input: "a".to_string(),
+                },
+                ContentBlock::Thinking("internal note".to_string()),
+                ContentBlock::ToolUse {
+                    id: "call_b".to_string(),
+                    name: "tool_b".to_string(),
+                    input: "b".to_string(),
+                },
+            ]),
+        ],
+    );
+    let ops = session.extract_pending_tool_calls();
+    assert_eq!(ops.len(), 2);
+    assert_eq!(ops[0].op_id, "call_a");
+    assert_eq!(ops[1].op_id, "call_b");
+}
+
+#[test]
+fn test_extract_pending_tool_calls_does_not_modify_messages() {
+    let mut session = make_session("extract_no_side_effect");
+    let original_messages = vec![
+        user_msg("hey"),
+        assistant_msg(vec![ContentBlock::ToolUse {
+            id: "call_x".to_string(),
+            name: "tool_x".to_string(),
+            input: "x".to_string(),
+        }]),
+    ];
+    set_messages(&mut session, original_messages.clone());
+
+    let _ops = session.extract_pending_tool_calls();
+
+    // Messages must be unchanged.
+    assert_eq!(session.messages().len(), 2);
+    assert_eq!(session.messages()[0].role, "user");
+    assert_eq!(session.messages()[1].role, "assistant");
+    assert_eq!(session.messages()[1].content_blocks.len(), 1);
+    assert!(matches!(
+        session.messages()[1].content_blocks[0],
+        ContentBlock::ToolUse { .. }
+    ));
+}
+
+#[test]
+fn test_extract_pending_tool_calls_last_is_user_not_assistant() {
+    // When the last message is a user message, extract_pending_tool_calls
+    // still scans for the most recent assistant message (iterating in
+    // reverse). If that assistant message contains ToolUse, those are
+    // returned.
+    let mut session = make_session("extract_last_user");
+    set_messages(
+        &mut session,
+        vec![
+            user_msg("first"),
+            assistant_msg(vec![ContentBlock::ToolUse {
+                id: "old_call".to_string(),
+                name: "old".to_string(),
+                input: "{}".to_string(),
+            }]),
+            user_msg("second"),
+        ],
+    );
+    // The last assistant message (position 1) has ToolUse → returned.
+    let ops = session.extract_pending_tool_calls();
+    assert_eq!(ops.len(), 1, "should find ToolUse in last assistant msg");
+    assert_eq!(ops[0].op_id, "old_call");
+}
+
+#[test]
+fn test_extract_pending_tool_calls_last_assistant_empty_blocks() {
+    let mut session = make_session("extract_empty_blocks");
+    set_messages(&mut session, vec![user_msg("hi"), assistant_msg(vec![])]);
+    let ops = session.extract_pending_tool_calls();
+    assert!(ops.is_empty(), "empty content blocks → no ToolUse");
+}

--- a/src/llm/session/tests/mod.rs
+++ b/src/llm/session/tests/mod.rs
@@ -4,6 +4,7 @@ use crate::session::persistence::PendingMessage;
 
 mod clone_messages_tests;
 mod exec_state_tests;
+mod extract_pending_tool_calls_tests;
 mod stop_tests;
 mod streaming_tests;
 mod system_appends_tests;


### PR DESCRIPTION
Graceful shutdown now correctly records pending tool calls and skips execution,
matching the design doc specification for session stop behavior.

Previously, the graceful stop loop would wait for tools to finish executing
after LLM streaming ended, even when the assistant message contained tool use
requests. This fix introduces state-aware shutdown that:

- Tracks the streaming→idle transition
- Records pending operations when assistant message contains ToolUse
- Skips tool execution in graceful mode when pending ops exist
- Handles the idle-with-running-tools case correctly

Source: issue #858
Type: fix
