### PR TITLE
feat: shutdown progress notification and forceful escalation

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -602,9 +602,14 @@ impl Daemon {
         // Send initial progress card (no-op if no active sessions)
         self.gateway.send_shutdown_progress_card(mode).await;
 
+        // Create progress channel for real-time session stop updates
+        let (progress_tx, mut progress_rx) =
+            tokio::sync::mpsc::channel::<crate::gateway::session_manager::stop::StopProgress>(64);
+
         // Spawn session stop as a background task
         let sm = self.gateway.session_manager().clone();
-        let mut stop_handle = tokio::spawn(async move { sm.stop_all_sessions(mode).await });
+        let mut stop_handle =
+            tokio::spawn(async move { sm.stop_all_sessions(mode, Some(&progress_tx)).await });
 
         // Spawn fresh signal handlers for escalation monitoring during Phase 2.
         // Phase 1's handlers are consumed by its tokio::select! loop.
@@ -630,6 +635,8 @@ impl Daemon {
         let mut last_mode = mode;
         let mut stop_completed = false;
         let mut stop_result = None;
+        let mut last_card_update = std::time::Instant::now();
+        let throttle_interval = std::time::Duration::from_secs(2);
 
         while !stop_completed {
             tokio::select! {
@@ -649,6 +656,20 @@ impl Daemon {
                         }
                     }
                     stop_completed = true;
+                }
+
+                Some(progress) = progress_rx.recv() => {
+                    // Progress event: update card with throttle
+                    let now = std::time::Instant::now();
+                    if progress.remaining == 0
+                        || now.duration_since(last_card_update) >= throttle_interval
+                    {
+                        let current_mode = self.shutdown.mode();
+                        self.gateway
+                            .send_shutdown_progress_card(current_mode)
+                            .await;
+                        last_card_update = now;
+                    }
                 }
 
                 _ = async {
@@ -695,6 +716,7 @@ impl Daemon {
                     "shutdown mode changed, updating progress card"
                 );
                 self.gateway.send_shutdown_progress_card(current_mode).await;
+                last_card_update = std::time::Instant::now();
                 last_mode = current_mode;
             }
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -305,6 +305,23 @@ impl Gateway {
         sender_id: Option<&str>,
         channel: &str,
     ) -> Option<HandleResult> {
+        // ── Card action interception ─────────────────────────────────
+        // Must run before the approval command check so that Feishu card
+        // action callbacks (e.g. "Forceful shutdown" button) are handled
+        // even when the daemon is already shutting down.
+        if content.starts_with("/__card_action:forceful_shutdown") {
+            if let Some(sh) = self.get_shutdown_handle() {
+                if sh.is_shutting_down() {
+                    tracing::info!(
+                        session_id = %session_id,
+                        "card action: escalating to forceful shutdown"
+                    );
+                    sh.escalate_to_forceful();
+                }
+            }
+            return None;
+        }
+
         // ── Shutdown gate: reject new operations ──────────────────────
         if let Some(sh) = self.get_shutdown_handle() {
             if sh.is_shutting_down() {
@@ -597,7 +614,8 @@ impl Gateway {
                             "tag": "plain_text",
                             "content": "\u{5f3a}\u{5236}\u{5173}\u{95ed}"
                         }),
-                        "type": "danger"
+                        "type": "danger",
+                        "value": {"action": "forceful_shutdown"}
                     })
                 ]
             }));

--- a/src/gateway/session_manager/graceful_stop_tests.rs
+++ b/src/gateway/session_manager/graceful_stop_tests.rs
@@ -148,7 +148,7 @@ async fn test_graceful_stop_streaming_with_tool_calls() {
     )
     .await;
 
-    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
     assert!(
         result.succeeded >= 2,
         "expected >= 2 succeeded, got {:?}",
@@ -178,7 +178,7 @@ async fn test_graceful_stop_streaming_no_tool_calls() {
     )
     .await;
 
-    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
     assert!(result.succeeded >= 2);
     assert!(!mgr.has_session(&child_id).await);
 }
@@ -193,7 +193,7 @@ async fn test_graceful_stop_idle() {
     setup_child_with_conv(&mgr, parent_id, child_id).await;
 
     // Default: LlmState::Idle, no tools running.
-    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
     assert!(result.succeeded >= 2);
     assert!(!mgr.has_session(&child_id).await);
 }
@@ -236,7 +236,7 @@ async fn test_graceful_stop_tool_running() {
         tools.remove("tool_1");
     });
 
-    let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+    let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
     assert!(result.succeeded >= 2);
     assert!(!mgr.has_session(&child_id).await);
 }
@@ -255,7 +255,7 @@ async fn test_forceful_stop_unchanged() {
     set_tool_state(&mgr, child_id, "tool_f", ToolExecState::RunningForeground).await;
 
     let start = tokio::time::Instant::now();
-    let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+    let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
     let elapsed = start.elapsed();
 
     assert!(result.succeeded >= 2);

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -22,6 +22,20 @@ use crate::session::persistence::{
 
 use super::SessionManager;
 
+// ── progress reporting ──────────────────────────────────────────────────
+
+/// Progress event emitted by [`SessionManager::stop_all_sessions`]
+/// each time a single session stop completes.
+#[derive(Debug, Clone)]
+pub struct StopProgress {
+    /// ID of the session whose stop just completed.
+    pub session_id: String,
+    /// Whether the session was stopped successfully (true) or failed/skipped (false).
+    pub success: bool,
+    /// Number of sessions remaining to be stopped after this one.
+    pub remaining: usize,
+}
+
 /// Aggregated result of stopping all sessions.
 #[derive(Debug, Default)]
 pub struct StopResult {
@@ -50,7 +64,11 @@ impl SessionManager {
     /// concurrently via [`tokio::join!`].
     ///
     /// Returns a [`StopResult`] with succeeded / failed / skipped counts.
-    pub async fn stop_all_sessions(&self, mode: ShutdownMode) -> StopResult {
+    pub async fn stop_all_sessions(
+        &self,
+        mode: ShutdownMode,
+        progress_tx: Option<&tokio::sync::mpsc::Sender<StopProgress>>,
+    ) -> StopResult {
         let tree = self.build_stop_tree().await;
         let stop_order = stop_order_from_tree(&tree);
 
@@ -59,28 +77,27 @@ impl SessionManager {
             return StopResult::default();
         }
 
+        let total_sessions: usize = stop_order.iter().map(|l| l.len()).sum();
+
         tracing::info!(
-            count = stop_order.len(),
+            count = total_sessions,
             mode = ?mode,
             "stop_all_sessions: starting leaf-to-root shutdown"
         );
 
         let mut result = StopResult::default();
+        let mut processed = 0usize;
 
         for level in &stop_order {
-            let futures: Vec<_> = level
-                .iter()
-                .map(|sid| self.stop_single_session(sid, mode))
-                .collect();
-
-            let outcomes = futures::future::join_all(futures).await;
-            for outcome in outcomes {
-                match outcome {
-                    Ok(()) => result.succeeded += 1,
-                    Err(StopError::Skipped) => result.skipped += 1,
-                    Err(StopError::Failed) => result.failed += 1,
-                }
-            }
+            processed += self
+                .process_stop_level(
+                    level,
+                    mode,
+                    &mut result,
+                    progress_tx,
+                    total_sessions.saturating_sub(processed),
+                )
+                .await;
         }
 
         tracing::info!(
@@ -91,6 +108,74 @@ impl SessionManager {
         );
 
         result
+    }
+
+    /// Process a single level of sessions: stop all concurrently,
+    /// record outcomes, and send progress events.
+    ///
+    /// Returns the number of sessions processed in this level.
+    async fn process_stop_level(
+        &self,
+        level: &[String],
+        mode: ShutdownMode,
+        result: &mut StopResult,
+        progress_tx: Option<&tokio::sync::mpsc::Sender<StopProgress>>,
+        remaining: usize,
+    ) -> usize {
+        let futures: Vec<_> = level
+            .iter()
+            .map(|sid| self.stop_single_session(sid, mode))
+            .collect();
+
+        let outcomes = futures::future::join_all(futures).await;
+        let count = level.len();
+        for (idx, outcome) in outcomes.into_iter().enumerate() {
+            let success = Self::process_stop_outcome(result, outcome);
+            Self::notify_stop_progress(
+                progress_tx,
+                &level[idx],
+                success,
+                remaining.saturating_sub(count - idx - 1),
+            )
+            .await;
+        }
+        count
+    }
+
+    /// Send a stop progress event if a progress channel is provided.
+    async fn notify_stop_progress(
+        progress_tx: Option<&tokio::sync::mpsc::Sender<StopProgress>>,
+        session_id: &str,
+        success: bool,
+        remaining: usize,
+    ) {
+        if let Some(tx) = progress_tx {
+            let _ = tx
+                .send(StopProgress {
+                    session_id: session_id.to_string(),
+                    success,
+                    remaining,
+                })
+                .await;
+        }
+    }
+
+    /// Record a stop outcome and return whether the stop succeeded.
+    fn process_stop_outcome(result: &mut StopResult, outcome: Result<(), StopError>) -> bool {
+        match outcome {
+            Ok(()) => {
+                result.succeeded += 1;
+                true
+            }
+            Err(StopError::Skipped) => {
+                result.skipped += 1;
+                false
+            }
+            Err(StopError::Failed) => {
+                result.failed += 1;
+                false
+            }
+        }
     }
 }
 
@@ -528,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_all_sessions_empty() {
         let mgr = make_test_session_manager();
-        let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
         assert_eq!(result.total(), 0);
     }
 
@@ -563,7 +648,7 @@ mod tests {
             },
         );
 
-        let result = mgr.stop_all_sessions(ShutdownMode::Graceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Graceful, None).await;
         // Both parent and child have ConversationSessions → both stopped.
         assert!(result.succeeded >= 1);
     }
@@ -574,7 +659,7 @@ mod tests {
         let parent_id = "parent-2";
         setup_parent_with_conv(&mgr, parent_id).await;
 
-        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
         // Parent has no storage → persist_checkpoint returns Ok (no-op).
         // Parent should be stopped.
         assert!(result.succeeded >= 1);
@@ -676,7 +761,7 @@ mod tests {
 
         // Forceful mode should not wait for streaming to finish
         let start = tokio::time::Instant::now();
-        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
         let elapsed = start.elapsed();
 
         // Should complete quickly (not waiting for the full graceful timeout)
@@ -731,7 +816,7 @@ mod tests {
         );
 
         // Forceful mode should stop without waiting
-        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
         assert!(result.succeeded >= 1);
     }
 
@@ -739,7 +824,7 @@ mod tests {
     async fn test_stop_sessions_forceful_empty_sessions_map() {
         let mgr = make_test_session_manager();
         // No sessions registered at all
-        let result = mgr.stop_all_sessions(ShutdownMode::Forceful).await;
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
         assert_eq!(result.total(), 0);
     }
 
@@ -758,5 +843,65 @@ mod tests {
             skipped: 0,
         };
         assert_eq!(r.total(), usize::MAX);
+    }
+
+    // ── StopProgress callback tests ──────────────────────────────────
+
+    #[tokio::test]
+    async fn test_stop_all_sessions_with_progress_callback() {
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-prog";
+        setup_parent_with_conv(&mgr, parent_id).await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StopProgress>(16);
+
+        let result = mgr
+            .stop_all_sessions(ShutdownMode::Forceful, Some(&tx))
+            .await;
+        assert!(result.succeeded >= 1);
+
+        // Should have received at least one progress event
+        let mut events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            events.push(ev);
+        }
+        assert!(!events.is_empty(), "should receive progress events");
+
+        // Each event should have session_id = parent-prog
+        assert!(events.iter().any(|e| e.session_id == "parent-prog"));
+    }
+
+    #[tokio::test]
+    async fn test_stop_progress_remaining_accuracy() {
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-remaining";
+        setup_parent_with_conv(&mgr, parent_id).await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<StopProgress>(16);
+
+        let result = mgr
+            .stop_all_sessions(ShutdownMode::Forceful, Some(&tx))
+            .await;
+        assert_eq!(result.succeeded, 1);
+
+        // Collect all events
+        let mut events = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            events.push(ev);
+        }
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].remaining, 0, "last event should have remaining=0");
+        assert!(events[0].success, "parent should stop successfully");
+    }
+
+    #[tokio::test]
+    async fn test_stop_all_sessions_no_progress_callback() {
+        // Passing None for progress_tx should work the same as before
+        let mgr = make_test_session_manager();
+        let parent_id = "parent-noprogress";
+        setup_parent_with_conv(&mgr, parent_id).await;
+
+        let result = mgr.stop_all_sessions(ShutdownMode::Forceful, None).await;
+        assert!(result.succeeded >= 1);
     }
 }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -622,3 +622,84 @@ async fn test_shutdown_gate_rejects_message_busy_count_decremented() {
         "busy_count must remain 0 when message is rejected by gate"
     );
 }
+
+// ── Card action interception tests (Step 1.5) ──────────────────────────
+
+#[tokio::test]
+async fn test_card_action_forceful_shutdown_intercept() {
+    let (gw, _sm, sh) = setup_with_shutdown("mock").await;
+
+    // Start shutdown so escalate_to_forceful has effect
+    sh.start_shutdown_for_test();
+
+    // Simulate a card action message
+    let result = gw
+        .handle_inbound_message(
+            "session-card",
+            "/__card_action:forceful_shutdown".to_string(),
+            Some("ou_user"),
+            "feishu",
+        )
+        .await;
+
+    // Should return None (card action is intercepted, not forwarded)
+    assert!(result.is_none(), "card action should return None");
+    // Should have escalated to forceful
+    assert!(
+        sh.is_forceful(),
+        "should escalate to forceful shutdown on card action"
+    );
+}
+
+#[tokio::test]
+async fn test_card_action_forceful_shutdown_no_shutdown_handle() {
+    let (gw, _sm) = setup(make_config(), "mock").await;
+    // No shutdown handle wired — card action should be ignored gracefully
+    let result = gw
+        .handle_inbound_message(
+            "session-card-nohandle",
+            "/__card_action:forceful_shutdown".to_string(),
+            Some("ou_user"),
+            "feishu",
+        )
+        .await;
+    // Returns None — no shutdown handle, no crash
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn test_card_action_forceful_shutdown_not_shutting_down() {
+    let (gw, _sm, sh) = setup_with_shutdown("mock").await;
+    // Shutdown handle exists but shutdown hasn't started
+    let result = gw
+        .handle_inbound_message(
+            "session-card-notshutdown",
+            "/__card_action:forceful_shutdown".to_string(),
+            Some("ou_user"),
+            "feishu",
+        )
+        .await;
+    // Returns None but should NOT escalate (not shutting down)
+    assert!(result.is_none());
+    assert!(!sh.is_shutting_down(), "should not start shutdown");
+}
+
+#[test]
+fn test_shutdown_progress_card_button_value() {
+    // Verify that the forceful button in the progress card has
+    // the correct value attribute for card action routing.
+    let card = json!({
+        "tag": "button",
+        "text": json!({
+            "tag": "plain_text",
+            "content": "\u{5f3a}\u{5236}\u{5173}\u{95ed}"
+        }),
+        "type": "danger",
+        "value": {"action": "forceful_shutdown"}
+    });
+    let action_value = card
+        .get("value")
+        .and_then(|v| v.get("action"))
+        .and_then(|a| a.as_str());
+    assert_eq!(action_value, Some("forceful_shutdown"));
+}

--- a/src/gateway/tests_archive.rs
+++ b/src/gateway/tests_archive.rs
@@ -191,7 +191,10 @@ impl IMAdapter for MockAdapter {
         "mock"
     }
 
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Message, crate::im::AdapterError> {
+    async fn handle_webhook(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<Message>, crate::im::AdapterError> {
         unimplemented!()
     }
 

--- a/src/gateway/tests_checkpoint.rs
+++ b/src/gateway/tests_checkpoint.rs
@@ -39,7 +39,7 @@ impl IMAdapter for MockAdapter {
         "mock"
     }
 
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Message, AdapterError> {
+    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Option<Message>, AdapterError> {
         unimplemented!()
     }
 

--- a/src/im/feishu.rs
+++ b/src/im/feishu.rs
@@ -66,6 +66,34 @@ struct FeishuSenderId {
     open_id: String,
 }
 
+/// Feishu card action event payload (card.action.trigger)
+///
+/// Fields are populated by serde during deserialization and consumed
+/// indirectly via [`FeishuAdapter::handle_card_action`]; not all fields
+/// are read directly in Rust code.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // fields used by serde deserialization, consumed indirectly
+struct FeishuCardActionEvent {
+    operator: FeishuCardOperator,
+    token: String,
+    action: FeishuCardAction,
+}
+
+/// Operator who triggered the card action.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // fields used by serde deserialization, consumed indirectly
+struct FeishuCardOperator {
+    open_id: String,
+}
+
+/// Action payload from a Feishu card button click.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)] // fields used by serde deserialization, consumed indirectly
+struct FeishuCardAction {
+    value: Option<serde_json::Value>,
+    tag: Option<String>,
+}
+
 /// Feishu API base URL
 const FEISHU_API_BASE: &str = "https://open.feishu.cn/open-apis";
 
@@ -222,18 +250,56 @@ impl FeishuAdapter {
 
         Ok(())
     }
-}
 
-#[async_trait]
-impl IMAdapter for FeishuAdapter {
-    fn name(&self) -> &str {
-        "feishu"
+    /// Handle a card.action.trigger event.
+    ///
+    /// Returns `Some(Message)` for recognized actions (e.g. `forceful_shutdown`),
+    /// or `None` for unknown/unsupported actions.
+    fn handle_card_action(
+        &self,
+        event_id: String,
+        app_id: String,
+        card_event: &FeishuCardActionEvent,
+    ) -> Result<Option<Message>, AdapterError> {
+        let action_value = card_event
+            .action
+            .value
+            .as_ref()
+            .and_then(|v| v.get("action"))
+            .and_then(|a| a.as_str());
+
+        match action_value {
+            Some("forceful_shutdown") => {
+                let mut metadata = HashMap::from([
+                    ("account_id".to_string(), app_id),
+                    ("card_action".to_string(), "true".to_string()),
+                ]);
+                if let Some(chat_id) = card_event
+                    .action
+                    .value
+                    .as_ref()
+                    .and_then(|v| v.get("chat_id"))
+                    .and_then(|c| c.as_str())
+                {
+                    metadata.insert("chat_id".to_string(), chat_id.to_string());
+                }
+                Ok(Some(Message {
+                    id: event_id,
+                    from: card_event.operator.open_id.clone(),
+                    to: String::new(),
+                    content: "/__card_action:forceful_shutdown".to_string(),
+                    channel: "feishu".to_string(),
+                    timestamp: chrono::Utc::now().timestamp(),
+                    metadata,
+                    thread_id: None,
+                }))
+            }
+            _ => Ok(None),
+        }
     }
 
-    async fn handle_webhook(&self, payload: &[u8]) -> Result<Message, AdapterError> {
-        let event: FeishuEvent = serde_json::from_slice(payload)
-            .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
-
+    /// Parse a regular message event (im.message.receive_v1) into a Message.
+    fn parse_message_event(&self, event: FeishuEvent) -> Result<Message, AdapterError> {
         let content: serde_json::Value = serde_json::from_str(&event.event.content)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 
@@ -265,6 +331,53 @@ impl IMAdapter for FeishuAdapter {
             metadata,
             thread_id: None,
         })
+    }
+}
+
+#[async_trait]
+impl IMAdapter for FeishuAdapter {
+    fn name(&self) -> &str {
+        "feishu"
+    }
+
+    async fn handle_webhook(&self, payload: &[u8]) -> Result<Option<Message>, AdapterError> {
+        // First, peek at the event_type to decide how to parse.
+        let raw: serde_json::Value = serde_json::from_slice(payload)
+            .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
+
+        let event_type = raw
+            .get("header")
+            .and_then(|h| h.get("event_type"))
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+
+        let event_id = raw
+            .get("header")
+            .and_then(|h| h.get("event_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let app_id = raw
+            .get("header")
+            .and_then(|h| h.get("app_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        match event_type {
+            "card.action.trigger" => {
+                let card_event: FeishuCardActionEvent = serde_json::from_value(raw)
+                    .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
+                self.handle_card_action(event_id, app_id, &card_event)
+            }
+            _ => {
+                // Regular message event — parse as before.
+                let event: FeishuEvent = serde_json::from_value(raw)
+                    .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
+                Ok(Some(self.parse_message_event(event)?))
+            }
+        }
     }
 
     async fn send_message(
@@ -419,7 +532,10 @@ impl IMPlugin for FeishuPlugin {
         &self,
         payload: &[u8],
     ) -> Result<Option<NormalizedMessage>, AdapterError> {
-        let message = self.adapter.handle_webhook(payload).await?;
+        let message = match self.adapter.handle_webhook(payload).await? {
+            Some(m) => m,
+            None => return Ok(None),
+        };
         Ok(Some(NormalizedMessage {
             platform: message.channel,
             sender_id: message.from,
@@ -428,6 +544,7 @@ impl IMPlugin for FeishuPlugin {
             timestamp: message.timestamp,
             thread_id: message.metadata.get("thread_id").cloned(),
             account_id: message.metadata.get("account_id").cloned(),
+            card_action: message.metadata.get("card_action").map(|v| v == "true"),
         }))
     }
 

--- a/src/im/feishu_tests.rs
+++ b/src/im/feishu_tests.rs
@@ -79,7 +79,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(msg.id, "evt_1");
         assert_eq!(msg.from, "ou_abc");
         assert_eq!(msg.content, "hello");
@@ -117,7 +118,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(msg.content, "");
         assert_eq!(msg.metadata.get("account_id"), Some(&"a".to_string()));
     }
@@ -167,7 +169,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(
             msg.metadata.get("thread_id"),
             Some(&"omt_thread_abc".to_string())
@@ -191,7 +194,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(
             msg.metadata.get("thread_id"),
             Some(&"omt_root_123".to_string())
@@ -215,7 +219,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(
             msg.metadata.get("thread_id"),
             Some(&"omt_parent_456".to_string())
@@ -238,7 +243,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert!(!msg.metadata.contains_key("thread_id"));
     }
 
@@ -262,7 +268,8 @@ mod tests {
         let msg = adapter
             .handle_webhook(&serde_json::to_vec(&payload).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(
             msg.metadata.get("thread_id"),
             Some(&"omt_direct".to_string())
@@ -284,7 +291,8 @@ mod tests {
         let msg2 = adapter
             .handle_webhook(&serde_json::to_vec(&payload2).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .expect("expected Some(message)");
         assert_eq!(
             msg2.metadata.get("thread_id"),
             Some(&"omt_root2".to_string())
@@ -413,5 +421,129 @@ mod tests {
             "URL should contain percent-encoded root_id, got: {}",
             url
         );
+    }
+
+    // ── card.action.trigger tests ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_handle_webhook_card_action_forceful_shutdown() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "header": {
+                "event_id": "evt_card_1",
+                "event_type": "card.action.trigger",
+                "create_time": "0",
+                "token": "t",
+                "app_id": "a"
+            },
+            "operator": {
+                "open_id": "ou_operator_1"
+            },
+            "token": "verify_token",
+            "action": {
+                "value": {"action": "forceful_shutdown", "chat_id": "oc_chat_1"},
+                "tag": "button"
+            }
+        });
+        let msg = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap()
+            .expect("forceful_shutdown should return Some(message)");
+        assert_eq!(msg.content, "/__card_action:forceful_shutdown");
+        assert_eq!(msg.from, "ou_operator_1");
+        assert_eq!(msg.id, "evt_card_1");
+        assert_eq!(msg.metadata.get("card_action"), Some(&"true".to_string()));
+        assert_eq!(msg.metadata.get("chat_id"), Some(&"oc_chat_1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_card_action_unknown() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        let payload = serde_json::json!({
+            "header": {
+                "event_id": "evt_card_2",
+                "event_type": "card.action.trigger",
+                "create_time": "0",
+                "token": "t",
+                "app_id": "a"
+            },
+            "operator": {
+                "open_id": "ou_operator_2"
+            },
+            "token": "verify_token",
+            "action": {
+                "value": {"action": "unknown_action"},
+                "tag": "button"
+            }
+        });
+        let result = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert!(result.is_none(), "unknown card action should return None");
+    }
+
+    #[tokio::test]
+    async fn test_handle_webhook_card_action_no_value() {
+        let adapter = FeishuAdapter::new("a".into(), "s".into(), "t".into());
+        // Card action with no value field
+        let payload = serde_json::json!({
+            "header": {
+                "event_id": "evt_card_3",
+                "event_type": "card.action.trigger",
+                "create_time": "0",
+                "token": "t",
+                "app_id": "a"
+            },
+            "operator": {
+                "open_id": "ou_operator_3"
+            },
+            "token": "verify_token",
+            "action": {
+                "tag": "button"
+            }
+        });
+        let result = adapter
+            .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "card action without value should return None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_inbound_card_action() {
+        let adapter = Arc::new(FeishuAdapter::new("a".into(), "s".into(), "t".into()));
+        let renderer = Arc::new(FeishuRenderer::new());
+        let plugin = FeishuPlugin::new(adapter, renderer);
+
+        let payload = serde_json::json!({
+            "header": {
+                "event_id": "evt_card_pi",
+                "event_type": "card.action.trigger",
+                "create_time": "0",
+                "token": "t",
+                "app_id": "a"
+            },
+            "operator": {
+                "open_id": "ou_operator_pi"
+            },
+            "token": "verify_token",
+            "action": {
+                "value": {"action": "forceful_shutdown"},
+                "tag": "button"
+            }
+        });
+        let msg = plugin
+            .parse_inbound(&serde_json::to_vec(&payload).unwrap())
+            .await
+            .unwrap()
+            .expect("card action should return Some");
+        assert_eq!(msg.content, "/__card_action:forceful_shutdown");
+        assert!(msg.card_action.unwrap_or(false));
+        assert_eq!(msg.platform, "feishu");
     }
 }

--- a/src/im/mod.rs
+++ b/src/im/mod.rs
@@ -22,8 +22,12 @@ pub trait IMAdapter: Send + Sync {
     /// Platform name (e.g., "feishu", "discord")
     fn name(&self) -> &str;
 
-    /// Handle incoming message from IM platform
-    async fn handle_webhook(&self, payload: &[u8]) -> Result<Message, AdapterError>;
+    /// Handle incoming event from IM platform.
+    ///
+    /// Returns `Ok(Some(message))` for recognized message events,
+    /// `Ok(None)` for events that should be silently ignored
+    /// (e.g. unknown card actions), or `Err` on parse failure.
+    async fn handle_webhook(&self, payload: &[u8]) -> Result<Option<Message>, AdapterError>;
 
     /// Send message to IM platform.
     ///

--- a/src/im/terminal.rs
+++ b/src/im/terminal.rs
@@ -79,6 +79,7 @@ impl TerminalAdapter {
             timestamp: current_timestamp(),
             thread_id: None,
             account_id: None,
+            card_action: None,
         }
     }
 }

--- a/src/im/terminal_tests.rs
+++ b/src/im/terminal_tests.rs
@@ -41,6 +41,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         assert_eq!(msg.platform, "terminal");
         assert_eq!(msg.peer_id, "cli");
@@ -57,6 +58,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         assert!(msg.thread_id.is_none());
         assert!(msg.account_id.is_none());
@@ -72,6 +74,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         // Timestamp is a valid Unix timestamp (after 2023)
         assert!(msg.timestamp > 1672531200);
@@ -87,6 +90,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let deserialized: NormalizedMessage = serde_json::from_str(&json).unwrap();
@@ -104,6 +108,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         assert!(msg.content.is_empty());
     }
@@ -118,6 +123,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
         let lines: Vec<&str> = msg.content.lines().collect();
         assert_eq!(lines.len(), 3);

--- a/src/im_adapter/normalized.rs
+++ b/src/im_adapter/normalized.rs
@@ -28,6 +28,13 @@ pub struct NormalizedMessage {
 
     /// Optional tenant/account identifier for multi-tenant session isolation.
     pub account_id: Option<String>,
+
+    /// Whether this message is a card action (e.g. button click).
+    ///
+    /// `Some(true)` when the inbound event is a card action trigger;
+    /// `None` (default) for regular text messages.
+    #[serde(default)]
+    pub card_action: Option<bool>,
 }
 
 #[cfg(test)]
@@ -44,6 +51,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: Some("omt_thread789".to_string()),
             account_id: Some("tenant_001".to_string()),
+            card_action: None,
         };
 
         let json = serde_json::to_string(&msg).expect("serialization failed");
@@ -57,6 +65,7 @@ mod tests {
         assert_eq!(deserialized.timestamp, 1700000000);
         assert_eq!(deserialized.thread_id.as_deref(), Some("omt_thread789"));
         assert_eq!(deserialized.account_id.as_deref(), Some("tenant_001"));
+        assert_eq!(deserialized.card_action, None);
     }
 
     #[test]
@@ -69,6 +78,7 @@ mod tests {
             timestamp: 1700000000,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
 
         let json = serde_json::to_string(&msg).expect("serialization failed");
@@ -82,6 +92,7 @@ mod tests {
         assert_eq!(deserialized.timestamp, 1700000000);
         assert!(deserialized.thread_id.is_none());
         assert!(deserialized.account_id.is_none());
+        assert_eq!(deserialized.card_action, None);
     }
 
     #[test]
@@ -94,6 +105,7 @@ mod tests {
             timestamp: 42,
             thread_id: None,
             account_id: None,
+            card_action: None,
         };
 
         let json = serde_json::to_value(&msg).expect("serialization to value failed");
@@ -106,6 +118,7 @@ mod tests {
         assert!(obj.contains_key("timestamp"));
         assert!(obj.contains_key("thread_id"));
         assert!(obj.contains_key("account_id"));
-        assert_eq!(obj.len(), 7);
+        assert!(obj.contains_key("card_action"));
+        assert_eq!(obj.len(), 8);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -26,6 +26,8 @@ pub mod persistence_tests;
 pub mod recovery;
 pub mod storage;
 pub mod sweeper;
+#[cfg(test)]
+pub mod sweeper_tests;
 pub mod workspace;
 
 // Re-export commonly used types

--- a/src/session/sweeper.rs
+++ b/src/session/sweeper.rs
@@ -12,6 +12,10 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tracing::{error, info, warn};
 
+/// Grace period (in seconds) to wait for a running sweep to finish
+/// before forcibly aborting it on shutdown.
+pub(crate) const SWEEPER_GRACE_PERIOD_SECS: u64 = 5;
+
 use crate::config::session::SessionConfigProvider;
 use crate::gateway::session_manager::SessionManager;
 use crate::session::persistence::{AgentRole, PersistenceError, PersistenceService};
@@ -57,6 +61,10 @@ impl ArchiveSweeper {
 
     /// Run the sweeper loop until `shutdown` signal is received.
     ///
+    /// When shutdown arrives, if a sweep is in progress the sweeper
+    /// waits up to [`SWEEPER_GRACE_PERIOD_SECS`] for it to finish
+    /// before forcibly aborting the task.
+    ///
     /// # Arguments
     /// * `shutdown` — watch receiver that will be closed when the sweeper
     ///   should exit gracefully
@@ -68,6 +76,7 @@ impl ArchiveSweeper {
         self.lower_priority();
 
         let mut next_fire = Instant::now() + interval;
+        let mut running_task: Option<tokio::task::JoinHandle<()>> = None;
 
         loop {
             tokio::select! {
@@ -75,15 +84,69 @@ impl ArchiveSweeper {
                     info!("ArchiveSweeper received shutdown signal, exiting");
                     break;
                 }
-                _ = tokio::time::sleep_until(next_fire) => {
-                    if let Err(e) = self.run_once().await {
-                        error!(%e, "run_once returned error, continuing loop");
-                    }
+                _ = tokio::time::sleep_until(next_fire), if running_task.is_none() => {
+                    let sweeper = Self {
+                        storage: Arc::clone(&self.storage),
+                        config: Arc::clone(&self.config),
+                        session_manager: self.session_manager.clone(),
+                    };
+                    let task = tokio::task::spawn(async move {
+                        if let Err(e) = sweeper.run_once().await {
+                            error!(%e, "run_once returned error");
+                        }
+                    });
+                    running_task = Some(task);
                     next_fire += interval;
                     if Instant::now() > next_fire + interval {
                         next_fire = Instant::now() + interval;
                     }
                 }
+                result = async {
+                    match running_task.as_mut() {
+                        Some(t) => t.await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    running_task = None;
+                    if let Err(e) = result {
+                        error!(%e, "run_once task panicked, continuing");
+                    }
+                }
+            }
+        }
+
+        // Grace period: if a sweep is still running, wait then abort
+        Self::wait_grace_period(running_task).await;
+    }
+
+    /// Wait up to [`SWEEPER_GRACE_PERIOD_SECS`] for a running sweep to
+    /// finish, then abort it if it does not complete in time.
+    async fn wait_grace_period(task: Option<tokio::task::JoinHandle<()>>) {
+        let Some(mut task) = task else {
+            return;
+        };
+        let grace = tokio::time::Duration::from_secs(SWEEPER_GRACE_PERIOD_SECS);
+        info!(
+            secs = SWEEPER_GRACE_PERIOD_SECS,
+            "ArchiveSweeper waiting for running sweep to finish before shutdown"
+        );
+        tokio::select! {
+            result = &mut task => {
+                match result {
+                    Ok(()) => {
+                        info!("Running sweep completed within grace period");
+                    }
+                    Err(e) => {
+                        error!(%e, "Run-once task panicked during graceful shutdown");
+                    }
+                }
+            }
+            _ = tokio::time::sleep(grace) => {
+                task.abort();
+                warn!(
+                    secs = SWEEPER_GRACE_PERIOD_SECS,
+                    "Grace period expired, aborting running sweep"
+                );
             }
         }
     }
@@ -221,7 +284,7 @@ impl ArchiveSweeper {
     }
 
     /// Archive a session and invalidate its local cache.
-    async fn archive_and_invalidate_impl(
+    pub(crate) async fn archive_and_invalidate_impl(
         storage: Arc<dyn PersistenceService>,
         session_id: String,
     ) -> Result<(), ArchiveSweeperError> {
@@ -241,7 +304,7 @@ impl ArchiveSweeper {
     /// When a runtime [`SessionManager`] is available, also cleans up
     /// child sessions from the runtime tracking tables (design doc
     /// §生命周期联动: "父 session 超时清理: 级联终止所有子 session").
-    async fn cascade_archive_impl(
+    pub(crate) async fn cascade_archive_impl(
         storage: Arc<dyn PersistenceService>,
         session_id: String,
         session_manager: Option<&Arc<SessionManager>>,
@@ -264,7 +327,7 @@ impl ArchiveSweeper {
 
     /// 删除 `parent_session_id` 的所有后代 session（先深后浅）。
     /// 使用 BFS 收集所有后代及其深度，按深度降序删除（叶节点优先）。
-    async fn cascade_kill_children(
+    pub(crate) async fn cascade_kill_children(
         storage: &dyn PersistenceService,
         parent_session_id: &str,
     ) -> Result<(), ArchiveSweeperError> {
@@ -298,7 +361,7 @@ impl ArchiveSweeper {
     }
 
     /// Purge an archived session and invalidate its local cache (impl version with Arc).
-    async fn purge_and_invalidate_impl(
+    pub(crate) async fn purge_and_invalidate_impl(
         storage: Arc<dyn PersistenceService>,
         session_id: String,
     ) -> Result<(), ArchiveSweeperError> {
@@ -312,521 +375,5 @@ impl ArchiveSweeper {
 impl std::fmt::Debug for ArchiveSweeper {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArchiveSweeper").finish()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::session::PerAgentSessionConfig;
-    use crate::session::persistence::SessionCheckpoint;
-    use async_trait::async_trait;
-    use std::sync::Mutex;
-
-    /// In-memory storage suitable for tests.
-    #[derive(Debug, Default)]
-    struct MemStorage {
-        checkpoints: Mutex<Vec<SessionCheckpoint>>,
-        _archived: Mutex<Vec<String>>,
-        invalidated: Mutex<Vec<String>>,
-        archive_called: Mutex<Vec<String>>,
-        purge_called: Mutex<Vec<String>>,
-        /// Session IDs returned from `list_idle_sessions_for_agent`.
-        idle_sessions: Mutex<Vec<String>>,
-        /// Session IDs returned from `list_expired_archived_sessions_for_agent`.
-        expired_sessions: Mutex<Vec<String>>,
-        /// Session IDs deleted via `delete_checkpoint`.
-        deleted: Mutex<Vec<String>>,
-    }
-
-    impl MemStorage {
-        /// Add a session ID to be returned as idle by `list_idle_sessions_for_agent`.
-        fn add_idle_session(&self, session_id: String) {
-            self.idle_sessions.lock().unwrap().push(session_id);
-        }
-
-        /// Add a session ID to be returned as expired by
-        /// `list_expired_archived_sessions_for_agent`.
-        fn add_expired_session(&self, session_id: String) {
-            self.expired_sessions.lock().unwrap().push(session_id);
-        }
-
-        /// Add a checkpoint so it can be loaded by `load_checkpoint`.
-        fn add_checkpoint(&self, checkpoint: SessionCheckpoint) {
-            self.checkpoints.lock().unwrap().push(checkpoint);
-        }
-
-        /// Get IDs of sessions deleted via `delete_checkpoint`.
-        fn deleted_ids(&self) -> Vec<String> {
-            self.deleted.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl PersistenceService for MemStorage {
-        async fn save_checkpoint(
-            &self,
-            checkpoint: &SessionCheckpoint,
-        ) -> Result<(), PersistenceError> {
-            self.checkpoints.lock().unwrap().push(checkpoint.clone());
-            Ok(())
-        }
-
-        async fn load_checkpoint(
-            &self,
-            session_id: &str,
-        ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
-            let checkpoints = self.checkpoints.lock().unwrap();
-            Ok(checkpoints
-                .iter()
-                .find(|cp| cp.session_id == session_id)
-                .cloned())
-        }
-
-        async fn delete_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
-            self.deleted.lock().unwrap().push(session_id.into());
-            self.checkpoints
-                .lock()
-                .unwrap()
-                .retain(|cp| cp.session_id != session_id);
-            Ok(())
-        }
-
-        async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
-            Ok(Vec::new())
-        }
-
-        async fn archive_checkpoint(
-            &self,
-            checkpoint: &SessionCheckpoint,
-        ) -> Result<(), PersistenceError> {
-            self.archive_called
-                .lock()
-                .unwrap()
-                .push(checkpoint.session_id.clone());
-            Ok(())
-        }
-
-        async fn purge_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
-            self.purge_called.lock().unwrap().push(session_id.into());
-            Ok(())
-        }
-
-        async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
-            Ok(Vec::new())
-        }
-
-        async fn invalidate_session(&self, session_id: &str) -> Result<(), PersistenceError> {
-            self.invalidated.lock().unwrap().push(session_id.into());
-            Ok(())
-        }
-
-        async fn list_idle_sessions_for_agent(
-            &self,
-            _agent_id: &str,
-            _role: AgentRole,
-            _idle_minutes: i64,
-        ) -> Result<Vec<String>, PersistenceError> {
-            Ok(self.idle_sessions.lock().unwrap().clone())
-        }
-
-        async fn list_expired_archived_sessions_for_agent(
-            &self,
-            _agent_id: &str,
-            _role: AgentRole,
-            _purge_after_minutes: i64,
-        ) -> Result<Vec<String>, PersistenceError> {
-            Ok(self.expired_sessions.lock().unwrap().clone())
-        }
-
-        async fn list_children_sessions(
-            &self,
-            parent_session_id: &str,
-        ) -> Result<Vec<String>, PersistenceError> {
-            let checkpoints = self.checkpoints.lock().unwrap();
-            let children: Vec<String> = checkpoints
-                .iter()
-                .filter(|cp| cp.parent_session_id.as_deref() == Some(parent_session_id))
-                .map(|cp| cp.session_id.clone())
-                .collect();
-            Ok(children)
-        }
-    }
-
-    /// Mock config provider for tests.
-    #[derive(Debug, Default)]
-    struct MockConfig {
-        agents: Mutex<Vec<String>>,
-        session_config: Mutex<PerAgentSessionConfig>,
-        interval_secs: Mutex<u64>,
-    }
-
-    impl MockConfig {
-        fn with_agents(agents: Vec<String>) -> Self {
-            Self {
-                agents: Mutex::new(agents),
-                ..Default::default()
-            }
-        }
-    }
-
-    impl SessionConfigProvider for MockConfig {
-        fn session_config_for(&self, _agent_id: &str, _role: AgentRole) -> PerAgentSessionConfig {
-            self.session_config.lock().unwrap().clone()
-        }
-
-        fn sweeper_interval_secs(&self) -> u64 {
-            *self.interval_secs.lock().unwrap()
-        }
-
-        fn dreaming_interval_secs(&self) -> u64 {
-            600
-        }
-
-        fn list_agents(&self) -> Vec<String> {
-            self.agents.lock().unwrap().clone()
-        }
-
-        fn compact_config(&self) -> crate::session::CompactConfig {
-            crate::session::CompactConfig::default()
-        }
-    }
-
-    // -----------------------------------------------------------------
-    // Test: run_once calls archive for idle sessions
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_run_once_calls_archive() {
-        let mem = Arc::new(MemStorage::default());
-        mem.add_idle_session("session-1".into());
-        mem.add_checkpoint(SessionCheckpoint::new("session-1".into()));
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let config: Arc<dyn SessionConfigProvider> =
-            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
-
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-        sweeper.run_once().await.unwrap();
-
-        let archive_called = mem.archive_called.lock().unwrap();
-        assert!(archive_called.contains(&"session-1".into()));
-    }
-
-    // -----------------------------------------------------------------
-    // Test: run_once calls purge for expired archived sessions
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_run_once_calls_purge() {
-        let mem = Arc::new(MemStorage::default());
-        mem.add_expired_session("session-2".into());
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let config: Arc<dyn SessionConfigProvider> =
-            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
-
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-        sweeper.run_once().await.unwrap();
-
-        let purge_called = mem.purge_called.lock().unwrap();
-        assert!(purge_called.contains(&"session-2".into()));
-    }
-
-    // -----------------------------------------------------------------
-    // Test: purge_after_minutes = 0 skips purge scan
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_purge_after_zero_skips_purge() {
-        let mem = Arc::new(MemStorage::default());
-        mem.add_expired_session("session-x".into());
-
-        let mock_config = MockConfig::with_agents(vec!["agent-x".into()]);
-        *mock_config.session_config.lock().unwrap() = PerAgentSessionConfig::new(30, 0);
-        let config: Arc<dyn SessionConfigProvider> = Arc::new(mock_config);
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-        let result = sweeper.run_once().await;
-
-        assert!(result.is_ok());
-        let purge_called = mem.purge_called.lock().unwrap();
-        assert!(purge_called.is_empty());
-    }
-
-    // -----------------------------------------------------------------
-    // Test: no agents returns Ok without error
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_no_agents_no_error() {
-        let mem = Arc::new(MemStorage::default());
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let config: Arc<dyn SessionConfigProvider> = Arc::new(MockConfig::with_agents(vec![]));
-
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-        let result = sweeper.run_once().await;
-
-        assert!(result.is_ok());
-    }
-
-    // -----------------------------------------------------------------
-    // Test: run_once error does not stop loop (panic is caught)
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_run_once_error_does_not_stop_loop() {
-        let mem = Arc::new(MemStorage::default());
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let config: Arc<dyn SessionConfigProvider> =
-            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
-
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-
-        let result1 = sweeper.run_once().await;
-        assert!(result1.is_ok());
-
-        let result2 = sweeper.run_once().await;
-        assert!(result2.is_ok());
-    }
-
-    // -----------------------------------------------------------------
-    // Test: shutdown signal causes run() to exit
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_shutdown_exits_loop() {
-        let mem = Arc::new(MemStorage::default());
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        let config: Arc<dyn SessionConfigProvider> = Arc::new(MockConfig::with_agents(vec![]));
-
-        let (tx, rx) = watch::channel(());
-
-        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
-
-        let handle = tokio::spawn(async move {
-            sweeper.run(rx).await;
-        });
-
-        let _ = tx.send(());
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
-    }
-
-    // -----------------------------------------------------------------
-    // Test: cascade_kill_children deletes all descendants
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_cascade_kill_children_deletes_descendants() {
-        let mem = Arc::new(MemStorage::default());
-
-        // Build a 3-level tree: parent -> child1 -> grandchild
-        let mut parent = SessionCheckpoint::new("parent".into());
-        parent.parent_session_id = None;
-        parent.depth = 0;
-        mem.add_checkpoint(parent);
-
-        let mut child1 = SessionCheckpoint::new("child1".into());
-        child1.parent_session_id = Some("parent".into());
-        child1.depth = 1;
-        mem.add_checkpoint(child1);
-
-        let mut grandchild = SessionCheckpoint::new("grandchild".into());
-        grandchild.parent_session_id = Some("child1".into());
-        grandchild.depth = 2;
-        mem.add_checkpoint(grandchild);
-
-        // Run cascade
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
-            .await
-            .unwrap();
-
-        // Both descendants should be deleted
-        let deleted = mem.deleted_ids();
-        assert!(deleted.contains(&"child1".to_string()));
-        assert!(deleted.contains(&"grandchild".to_string()));
-        // Parent itself should NOT be deleted by cascade_kill_children
-        assert!(!deleted.contains(&"parent".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_cascade_kill_children_no_children_noop() {
-        let mem = Arc::new(MemStorage::default());
-        mem.add_checkpoint(SessionCheckpoint::new("leaf".into()));
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "leaf")
-            .await
-            .unwrap();
-
-        // No children to delete
-        let deleted = mem.deleted_ids();
-        assert!(deleted.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_cascade_kill_children_siblings_only() {
-        let mem = Arc::new(MemStorage::default());
-
-        let mut parent = SessionCheckpoint::new("parent".into());
-        parent.parent_session_id = None;
-        mem.add_checkpoint(parent);
-
-        let mut child_a = SessionCheckpoint::new("child_a".into());
-        child_a.parent_session_id = Some("parent".into());
-        mem.add_checkpoint(child_a);
-
-        let mut child_b = SessionCheckpoint::new("child_b".into());
-        child_b.parent_session_id = Some("parent".into());
-        mem.add_checkpoint(child_b);
-
-        // Unrelated child under a different parent
-        let mut other_child = SessionCheckpoint::new("other_child".into());
-        other_child.parent_session_id = Some("other_parent".into());
-        mem.add_checkpoint(other_child);
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
-            .await
-            .unwrap();
-
-        let deleted = mem.deleted_ids();
-        assert!(deleted.contains(&"child_a".to_string()));
-        assert!(deleted.contains(&"child_b".to_string()));
-        // other_child should NOT be deleted
-        assert!(!deleted.contains(&"other_child".to_string()));
-    }
-
-    // -----------------------------------------------------------------
-    // Test: cascade_archive kills children then archives parent
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_cascade_archive_kills_children_then_archives_parent() {
-        let mem = Arc::new(MemStorage::default());
-
-        let mut parent = SessionCheckpoint::new("parent-archive".into());
-        parent.parent_session_id = None;
-        mem.add_checkpoint(parent);
-
-        let mut child = SessionCheckpoint::new("child-archive".into());
-        child.parent_session_id = Some("parent-archive".into());
-        mem.add_checkpoint(child);
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_archive_impl(storage, "parent-archive".into(), None)
-            .await
-            .unwrap();
-
-        // Child should be deleted
-        let deleted = mem.deleted_ids();
-        assert!(deleted.contains(&"child-archive".to_string()));
-
-        // Parent should be archived
-        let archive_called = mem.archive_called.lock().unwrap();
-        assert!(archive_called.contains(&"parent-archive".into()));
-    }
-
-    #[tokio::test]
-    async fn test_cascade_archive_no_children_archives_parent() {
-        let mem = Arc::new(MemStorage::default());
-        mem.add_checkpoint(SessionCheckpoint::new("solo-parent".into()));
-
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_archive_impl(storage, "solo-parent".into(), None)
-            .await
-            .unwrap();
-
-        // No children deleted
-        let deleted = mem.deleted_ids();
-        assert!(deleted.is_empty());
-
-        // Parent should be archived
-        let archive_called = mem.archive_called.lock().unwrap();
-        assert!(archive_called.contains(&"solo-parent".into()));
-    }
-
-    // -----------------------------------------------------------------
-    // Test: multi-branch tree — leaf nodes deleted before branch nodes
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_cascade_kill_children_multi_branch_tree() {
-        let mem = Arc::new(MemStorage::default());
-
-        // Build a multi-branch tree:
-        //       root
-        //      /    \
-        //    child_a  child_b
-        //    /    \        \
-        //  gc_a1  gc_a2    gc_b1
-        let mut root = SessionCheckpoint::new("root".into());
-        root.parent_session_id = None;
-        root.depth = 0;
-        mem.add_checkpoint(root);
-
-        let mut child_a = SessionCheckpoint::new("child_a".into());
-        child_a.parent_session_id = Some("root".into());
-        child_a.depth = 1;
-        mem.add_checkpoint(child_a);
-
-        let mut child_b = SessionCheckpoint::new("child_b".into());
-        child_b.parent_session_id = Some("root".into());
-        child_b.depth = 1;
-        mem.add_checkpoint(child_b);
-
-        let mut gc_a1 = SessionCheckpoint::new("gc_a1".into());
-        gc_a1.parent_session_id = Some("child_a".into());
-        gc_a1.depth = 2;
-        mem.add_checkpoint(gc_a1);
-
-        let mut gc_a2 = SessionCheckpoint::new("gc_a2".into());
-        gc_a2.parent_session_id = Some("child_a".into());
-        gc_a2.depth = 2;
-        mem.add_checkpoint(gc_a2);
-
-        let mut gc_b1 = SessionCheckpoint::new("gc_b1".into());
-        gc_b1.parent_session_id = Some("child_b".into());
-        gc_b1.depth = 2;
-        mem.add_checkpoint(gc_b1);
-
-        // Run cascade
-        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
-        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "root")
-            .await
-            .unwrap();
-
-        // All 5 descendants should be deleted
-        let deleted = mem.deleted_ids();
-        assert!(deleted.contains(&"child_a".to_string()));
-        assert!(deleted.contains(&"child_b".to_string()));
-        assert!(deleted.contains(&"gc_a1".to_string()));
-        assert!(deleted.contains(&"gc_a2".to_string()));
-        assert!(deleted.contains(&"gc_b1".to_string()));
-        // Root itself should NOT be deleted
-        assert!(!deleted.contains(&"root".to_string()));
-        assert_eq!(deleted.len(), 5);
-
-        // Verify deletion order: all depth-2 nodes before depth-1 nodes
-        let pos_gc_a1 = deleted.iter().position(|id| id == "gc_a1").unwrap();
-        let pos_gc_a2 = deleted.iter().position(|id| id == "gc_a2").unwrap();
-        let pos_gc_b1 = deleted.iter().position(|id| id == "gc_b1").unwrap();
-        let pos_child_a = deleted.iter().position(|id| id == "child_a").unwrap();
-        let pos_child_b = deleted.iter().position(|id| id == "child_b").unwrap();
-
-        assert!(
-            pos_gc_a1 < pos_child_a,
-            "gc_a1 must be deleted before child_a"
-        );
-        assert!(
-            pos_gc_a2 < pos_child_a,
-            "gc_a2 must be deleted before child_a"
-        );
-        assert!(
-            pos_gc_b1 < pos_child_b,
-            "gc_b1 must be deleted before child_b"
-        );
     }
 }

--- a/src/session/sweeper_tests.rs
+++ b/src/session/sweeper_tests.rs
@@ -1,0 +1,709 @@
+#[cfg(test)]
+mod tests {
+    use crate::config::session::PerAgentSessionConfig;
+    use crate::config::SessionConfigProvider;
+    use crate::session::persistence::{
+        AgentRole, PersistenceError, PersistenceService, SessionCheckpoint,
+    };
+    use crate::session::sweeper::*;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::watch;
+
+    /// In-memory storage suitable for tests.
+    #[derive(Debug, Default)]
+    struct MemStorage {
+        checkpoints: Mutex<Vec<SessionCheckpoint>>,
+        _archived: Mutex<Vec<String>>,
+        invalidated: Mutex<Vec<String>>,
+        archive_called: Mutex<Vec<String>>,
+        purge_called: Mutex<Vec<String>>,
+        /// Session IDs returned from `list_idle_sessions_for_agent`.
+        idle_sessions: Mutex<Vec<String>>,
+        /// Session IDs returned from `list_expired_archived_sessions_for_agent`.
+        expired_sessions: Mutex<Vec<String>>,
+        /// Session IDs deleted via `delete_checkpoint`.
+        deleted: Mutex<Vec<String>>,
+    }
+
+    impl MemStorage {
+        /// Add a session ID to be returned as idle by `list_idle_sessions_for_agent`.
+        fn add_idle_session(&self, session_id: String) {
+            self.idle_sessions.lock().unwrap().push(session_id);
+        }
+
+        /// Add a session ID to be returned as expired by
+        /// `list_expired_archived_sessions_for_agent`.
+        fn add_expired_session(&self, session_id: String) {
+            self.expired_sessions.lock().unwrap().push(session_id);
+        }
+
+        /// Add a checkpoint so it can be loaded by `load_checkpoint`.
+        fn add_checkpoint(&self, checkpoint: SessionCheckpoint) {
+            self.checkpoints.lock().unwrap().push(checkpoint);
+        }
+
+        /// Get IDs of sessions deleted via `delete_checkpoint`.
+        fn deleted_ids(&self) -> Vec<String> {
+            self.deleted.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PersistenceService for MemStorage {
+        async fn save_checkpoint(
+            &self,
+            checkpoint: &SessionCheckpoint,
+        ) -> Result<(), PersistenceError> {
+            self.checkpoints.lock().unwrap().push(checkpoint.clone());
+            Ok(())
+        }
+
+        async fn load_checkpoint(
+            &self,
+            session_id: &str,
+        ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+            let checkpoints = self.checkpoints.lock().unwrap();
+            Ok(checkpoints
+                .iter()
+                .find(|cp| cp.session_id == session_id)
+                .cloned())
+        }
+
+        async fn delete_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
+            self.deleted.lock().unwrap().push(session_id.into());
+            self.checkpoints
+                .lock()
+                .unwrap()
+                .retain(|cp| cp.session_id != session_id);
+            Ok(())
+        }
+
+        async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+            Ok(Vec::new())
+        }
+
+        async fn archive_checkpoint(
+            &self,
+            checkpoint: &SessionCheckpoint,
+        ) -> Result<(), PersistenceError> {
+            self.archive_called
+                .lock()
+                .unwrap()
+                .push(checkpoint.session_id.clone());
+            Ok(())
+        }
+
+        async fn purge_checkpoint(&self, session_id: &str) -> Result<(), PersistenceError> {
+            self.purge_called.lock().unwrap().push(session_id.into());
+            Ok(())
+        }
+
+        async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+            Ok(Vec::new())
+        }
+
+        async fn invalidate_session(&self, session_id: &str) -> Result<(), PersistenceError> {
+            self.invalidated.lock().unwrap().push(session_id.into());
+            Ok(())
+        }
+
+        async fn list_idle_sessions_for_agent(
+            &self,
+            _agent_id: &str,
+            _role: AgentRole,
+            _idle_minutes: i64,
+        ) -> Result<Vec<String>, PersistenceError> {
+            Ok(self.idle_sessions.lock().unwrap().clone())
+        }
+
+        async fn list_expired_archived_sessions_for_agent(
+            &self,
+            _agent_id: &str,
+            _role: AgentRole,
+            _purge_after_minutes: i64,
+        ) -> Result<Vec<String>, PersistenceError> {
+            Ok(self.expired_sessions.lock().unwrap().clone())
+        }
+
+        async fn list_children_sessions(
+            &self,
+            parent_session_id: &str,
+        ) -> Result<Vec<String>, PersistenceError> {
+            let checkpoints = self.checkpoints.lock().unwrap();
+            let children: Vec<String> = checkpoints
+                .iter()
+                .filter(|cp| cp.parent_session_id.as_deref() == Some(parent_session_id))
+                .map(|cp| cp.session_id.clone())
+                .collect();
+            Ok(children)
+        }
+    }
+
+    /// Mock config provider for tests.
+    #[derive(Debug, Default)]
+    struct MockConfig {
+        agents: Mutex<Vec<String>>,
+        session_config: Mutex<PerAgentSessionConfig>,
+        interval_secs: Mutex<u64>,
+    }
+
+    impl MockConfig {
+        fn with_agents(agents: Vec<String>) -> Self {
+            Self {
+                agents: Mutex::new(agents),
+                ..Default::default()
+            }
+        }
+    }
+
+    impl SessionConfigProvider for MockConfig {
+        fn session_config_for(&self, _agent_id: &str, _role: AgentRole) -> PerAgentSessionConfig {
+            self.session_config.lock().unwrap().clone()
+        }
+
+        fn sweeper_interval_secs(&self) -> u64 {
+            *self.interval_secs.lock().unwrap()
+        }
+
+        fn dreaming_interval_secs(&self) -> u64 {
+            600
+        }
+
+        fn list_agents(&self) -> Vec<String> {
+            self.agents.lock().unwrap().clone()
+        }
+
+        fn compact_config(&self) -> crate::session::CompactConfig {
+            crate::session::CompactConfig::default()
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Test: run_once calls archive for idle sessions
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_run_once_calls_archive() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_idle_session("session-1".into());
+        mem.add_checkpoint(SessionCheckpoint::new("session-1".into()));
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> =
+            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
+
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+        sweeper.run_once().await.unwrap();
+
+        let archive_called = mem.archive_called.lock().unwrap();
+        assert!(archive_called.contains(&"session-1".into()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: run_once calls purge for expired archived sessions
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_run_once_calls_purge() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_expired_session("session-2".into());
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> =
+            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
+
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+        sweeper.run_once().await.unwrap();
+
+        let purge_called = mem.purge_called.lock().unwrap();
+        assert!(purge_called.contains(&"session-2".into()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: purge_after_minutes = 0 skips purge scan
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_purge_after_zero_skips_purge() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_expired_session("session-x".into());
+
+        let mock_config = MockConfig::with_agents(vec!["agent-x".into()]);
+        *mock_config.session_config.lock().unwrap() = PerAgentSessionConfig::new(30, 0);
+        let config: Arc<dyn SessionConfigProvider> = Arc::new(mock_config);
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+        let result = sweeper.run_once().await;
+
+        assert!(result.is_ok());
+        let purge_called = mem.purge_called.lock().unwrap();
+        assert!(purge_called.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Test: no agents returns Ok without error
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_no_agents_no_error() {
+        let mem = Arc::new(MemStorage::default());
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> = Arc::new(MockConfig::with_agents(vec![]));
+
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+        let result = sweeper.run_once().await;
+
+        assert!(result.is_ok());
+    }
+
+    // -----------------------------------------------------------------
+    // Test: run_once error does not stop loop (panic is caught)
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_run_once_error_does_not_stop_loop() {
+        let mem = Arc::new(MemStorage::default());
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> =
+            Arc::new(MockConfig::with_agents(vec!["agent-x".into()]));
+
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+
+        let result1 = sweeper.run_once().await;
+        assert!(result1.is_ok());
+
+        let result2 = sweeper.run_once().await;
+        assert!(result2.is_ok());
+    }
+
+    // -----------------------------------------------------------------
+    // Test: shutdown signal causes run() to exit
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_shutdown_exits_loop() {
+        let mem = Arc::new(MemStorage::default());
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> = Arc::new(MockConfig::with_agents(vec![]));
+
+        let (tx, rx) = watch::channel(());
+
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+
+        let handle = tokio::spawn(async move {
+            sweeper.run(rx).await;
+        });
+
+        let _ = tx.send(());
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
+
+    // -----------------------------------------------------------------
+    // Test: cascade_kill_children deletes all descendants
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_deletes_descendants() {
+        let mem = Arc::new(MemStorage::default());
+
+        // Build a 3-level tree: parent -> child1 -> grandchild
+        let mut parent = SessionCheckpoint::new("parent".into());
+        parent.parent_session_id = None;
+        parent.depth = 0;
+        mem.add_checkpoint(parent);
+
+        let mut child1 = SessionCheckpoint::new("child1".into());
+        child1.parent_session_id = Some("parent".into());
+        child1.depth = 1;
+        mem.add_checkpoint(child1);
+
+        let mut grandchild = SessionCheckpoint::new("grandchild".into());
+        grandchild.parent_session_id = Some("child1".into());
+        grandchild.depth = 2;
+        mem.add_checkpoint(grandchild);
+
+        // Run cascade
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
+            .await
+            .unwrap();
+
+        // Both descendants should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child1".to_string()));
+        assert!(deleted.contains(&"grandchild".to_string()));
+        // Parent itself should NOT be deleted by cascade_kill_children
+        assert!(!deleted.contains(&"parent".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_no_children_noop() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_checkpoint(SessionCheckpoint::new("leaf".into()));
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "leaf")
+            .await
+            .unwrap();
+
+        // No children to delete
+        let deleted = mem.deleted_ids();
+        assert!(deleted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_siblings_only() {
+        let mem = Arc::new(MemStorage::default());
+
+        let mut parent = SessionCheckpoint::new("parent".into());
+        parent.parent_session_id = None;
+        mem.add_checkpoint(parent);
+
+        let mut child_a = SessionCheckpoint::new("child_a".into());
+        child_a.parent_session_id = Some("parent".into());
+        mem.add_checkpoint(child_a);
+
+        let mut child_b = SessionCheckpoint::new("child_b".into());
+        child_b.parent_session_id = Some("parent".into());
+        mem.add_checkpoint(child_b);
+
+        // Unrelated child under a different parent
+        let mut other_child = SessionCheckpoint::new("other_child".into());
+        other_child.parent_session_id = Some("other_parent".into());
+        mem.add_checkpoint(other_child);
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "parent")
+            .await
+            .unwrap();
+
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child_a".to_string()));
+        assert!(deleted.contains(&"child_b".to_string()));
+        // other_child should NOT be deleted
+        assert!(!deleted.contains(&"other_child".to_string()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: cascade_archive kills children then archives parent
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_cascade_archive_kills_children_then_archives_parent() {
+        let mem = Arc::new(MemStorage::default());
+
+        let mut parent = SessionCheckpoint::new("parent-archive".into());
+        parent.parent_session_id = None;
+        mem.add_checkpoint(parent);
+
+        let mut child = SessionCheckpoint::new("child-archive".into());
+        child.parent_session_id = Some("parent-archive".into());
+        mem.add_checkpoint(child);
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_archive_impl(storage, "parent-archive".into(), None)
+            .await
+            .unwrap();
+
+        // Child should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child-archive".to_string()));
+
+        // Parent should be archived
+        let archive_called = mem.archive_called.lock().unwrap();
+        assert!(archive_called.contains(&"parent-archive".into()));
+    }
+
+    #[tokio::test]
+    async fn test_cascade_archive_no_children_archives_parent() {
+        let mem = Arc::new(MemStorage::default());
+        mem.add_checkpoint(SessionCheckpoint::new("solo-parent".into()));
+
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_archive_impl(storage, "solo-parent".into(), None)
+            .await
+            .unwrap();
+
+        // No children deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.is_empty());
+
+        // Parent should be archived
+        let archive_called = mem.archive_called.lock().unwrap();
+        assert!(archive_called.contains(&"solo-parent".into()));
+    }
+
+    // -----------------------------------------------------------------
+    // Test: multi-branch tree — leaf nodes deleted before branch nodes
+    // -----------------------------------------------------------------
+
+    // ── shutdown grace period tests ─────────────────────────────────
+
+    /// Shutdown signal with no running task → exits immediately.
+    #[tokio::test]
+    async fn test_shutdown_no_running_task_exits_immediately() {
+        let mem = Arc::new(MemStorage::default());
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        let config: Arc<dyn SessionConfigProvider> = Arc::new(MockConfig::with_agents(vec![]));
+        let (tx, rx) = watch::channel(());
+        let sweeper = ArchiveSweeper::new(Arc::clone(&storage), Arc::clone(&config));
+        let handle = tokio::spawn(async move {
+            sweeper.run(rx).await;
+        });
+        // Send shutdown immediately — no task running
+        let _ = tx.send(());
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        assert!(
+            result.is_ok(),
+            "sweeper should exit quickly when no task is running"
+        );
+    }
+
+    /// Shutdown signal with running task that completes within grace period → exits cleanly.
+    #[tokio::test]
+    async fn test_shutdown_grace_period_completes_within_deadline() {
+        use tokio::sync::watch;
+
+        // Fake sweeper that spawns a task taking ~100ms (well under grace period).
+        struct FakeSweeper {
+            storage: Arc<dyn PersistenceService>,
+        }
+
+        impl FakeSweeper {
+            async fn run(&self, mut shutdown: watch::Receiver<()>) {
+                let mut running_task: Option<tokio::task::JoinHandle<()>> = None;
+                let interval = tokio::time::Duration::from_millis(50);
+                let mut next_fire = tokio::time::Instant::now() + interval;
+                loop {
+                    tokio::select! {
+                        _ = shutdown.changed() => break,
+                        _ = tokio::time::sleep_until(next_fire),
+                            if running_task.is_none() =>
+                        {
+                            let storage = Arc::clone(&self.storage);
+                            let task = tokio::task::spawn(async move {
+                                // Simulate a task that finishes quickly
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).
+                                    await;
+                                let _ = storage;
+                            });
+                            running_task = Some(task);
+                            next_fire += interval;
+                        }
+                        result = async {
+                            match running_task.as_mut() {
+                                Some(t) => t.await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            running_task = None;
+                            if result.is_err() {
+                                tracing::error!("task panicked");
+                            }
+                        }
+                    }
+                }
+                // Grace period: same logic as real sweeper
+                if let Some(mut task) = running_task {
+                    let grace = tokio::time::Duration::from_secs(SWEEPER_GRACE_PERIOD_SECS);
+                    tokio::select! {
+                        result = &mut task => {
+                            let _ = result;
+                        }
+                        _ = tokio::time::sleep(grace) => {
+                            task.abort();
+                        }
+                    }
+                }
+            }
+        }
+
+        let mem = Arc::new(MemStorage::default());
+        let sweeper = FakeSweeper {
+            storage: mem.clone() as _,
+        };
+        let (tx, rx) = watch::channel(());
+
+        // Spawn the sweeper
+        let handle = tokio::spawn(async move {
+            sweeper.run(rx).await;
+        });
+
+        // Wait long enough for the sweeper to fire and start a task
+        tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
+        // Send shutdown — task is running but will finish within grace period
+        let _ = tx.send(());
+        let result = tokio::time::timeout(std::time::Duration::from_secs(3), handle).await;
+        assert!(
+            result.is_ok(),
+            "sweeper should exit after task completes within grace period"
+        );
+    }
+
+    /// Shutdown signal with running task that exceeds grace period → abort.
+    #[tokio::test]
+    async fn test_shutdown_grace_period_expires_aborts() {
+        use tokio::sync::watch;
+
+        struct FakeSweeper {
+            storage: Arc<dyn PersistenceService>,
+        }
+
+        impl FakeSweeper {
+            async fn run(&self, mut shutdown: watch::Receiver<()>) {
+                let mut running_task: Option<tokio::task::JoinHandle<()>> = None;
+                let interval = tokio::time::Duration::from_millis(50);
+                let mut next_fire = tokio::time::Instant::now() + interval;
+                loop {
+                    tokio::select! {
+                        _ = shutdown.changed() => break,
+                        _ = tokio::time::sleep_until(next_fire),
+                            if running_task.is_none() =>
+                        {
+                            let storage = Arc::clone(&self.storage);
+                            let task = tokio::task::spawn(async move {
+                                // Simulate a task that takes longer than grace period
+                                tokio::time::sleep(std::time::Duration::from_secs(30)).
+                                    await;
+                                let _ = storage;
+                            });
+                            running_task = Some(task);
+                            next_fire += interval;
+                        }
+                        result = async {
+                            match running_task.as_mut() {
+                                Some(t) => t.await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            running_task = None;
+                            if result.is_err() {
+                                tracing::error!("task panicked");
+                            }
+                        }
+                    }
+                }
+                if let Some(mut task) = running_task {
+                    let grace = tokio::time::Duration::from_secs(SWEEPER_GRACE_PERIOD_SECS);
+                    tokio::select! {
+                        result = &mut task => {
+                            let _ = result;
+                        }
+                        _ = tokio::time::sleep(grace) => {
+                            task.abort();
+                            tracing::warn!("grace period expired, aborting");
+                        }
+                    }
+                }
+            }
+        }
+
+        let mem = Arc::new(MemStorage::default());
+        let sweeper = FakeSweeper {
+            storage: mem.clone() as _,
+        };
+        let (tx, rx) = watch::channel(());
+        let handle = tokio::spawn(async move {
+            sweeper.run(rx).await;
+        });
+
+        // Wait for the sweeper to start a task
+        tokio::time::sleep(tokio::time::Duration::from_millis(80)).await;
+        // Send shutdown — task will NOT finish within grace period
+        let _ = tx.send(());
+        let start = tokio::time::Instant::now();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), handle).await;
+        let elapsed = start.elapsed();
+        assert!(
+            result.is_ok(),
+            "sweeper should exit after grace period abort"
+        );
+        // The sweeper should exit within ~grace_period (5s) + overhead, not
+        // the full 30s of the task.
+        assert!(
+            elapsed < std::time::Duration::from_secs(8),
+            "sweeper should exit within grace period, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cascade_kill_children_multi_branch_tree() {
+        let mem = Arc::new(MemStorage::default());
+
+        // Build a multi-branch tree:
+        //       root
+        //      /    \
+        //    child_a  child_b
+        //    /    \        \
+        //  gc_a1  gc_a2    gc_b1
+        let mut root = SessionCheckpoint::new("root".into());
+        root.parent_session_id = None;
+        root.depth = 0;
+        mem.add_checkpoint(root);
+
+        let mut child_a = SessionCheckpoint::new("child_a".into());
+        child_a.parent_session_id = Some("root".into());
+        child_a.depth = 1;
+        mem.add_checkpoint(child_a);
+
+        let mut child_b = SessionCheckpoint::new("child_b".into());
+        child_b.parent_session_id = Some("root".into());
+        child_b.depth = 1;
+        mem.add_checkpoint(child_b);
+
+        let mut gc_a1 = SessionCheckpoint::new("gc_a1".into());
+        gc_a1.parent_session_id = Some("child_a".into());
+        gc_a1.depth = 2;
+        mem.add_checkpoint(gc_a1);
+
+        let mut gc_a2 = SessionCheckpoint::new("gc_a2".into());
+        gc_a2.parent_session_id = Some("child_a".into());
+        gc_a2.depth = 2;
+        mem.add_checkpoint(gc_a2);
+
+        let mut gc_b1 = SessionCheckpoint::new("gc_b1".into());
+        gc_b1.parent_session_id = Some("child_b".into());
+        gc_b1.depth = 2;
+        mem.add_checkpoint(gc_b1);
+
+        // Run cascade
+        let storage: Arc<dyn PersistenceService> = mem.clone() as _;
+        ArchiveSweeper::cascade_kill_children(storage.as_ref(), "root")
+            .await
+            .unwrap();
+
+        // All 5 descendants should be deleted
+        let deleted = mem.deleted_ids();
+        assert!(deleted.contains(&"child_a".to_string()));
+        assert!(deleted.contains(&"child_b".to_string()));
+        assert!(deleted.contains(&"gc_a1".to_string()));
+        assert!(deleted.contains(&"gc_a2".to_string()));
+        assert!(deleted.contains(&"gc_b1".to_string()));
+        // Root itself should NOT be deleted
+        assert!(!deleted.contains(&"root".to_string()));
+        assert_eq!(deleted.len(), 5);
+
+        // Verify deletion order: all depth-2 nodes before depth-1 nodes
+        let pos_gc_a1 = deleted.iter().position(|id| id == "gc_a1").unwrap();
+        let pos_gc_a2 = deleted.iter().position(|id| id == "gc_a2").unwrap();
+        let pos_gc_b1 = deleted.iter().position(|id| id == "gc_b1").unwrap();
+        let pos_child_a = deleted.iter().position(|id| id == "child_a").unwrap();
+        let pos_child_b = deleted.iter().position(|id| id == "child_b").unwrap();
+
+        assert!(
+            pos_gc_a1 < pos_child_a,
+            "gc_a1 must be deleted before child_a"
+        );
+        assert!(
+            pos_gc_a2 < pos_child_a,
+            "gc_a2 must be deleted before child_a"
+        );
+        assert!(
+            pos_gc_b1 < pos_child_b,
+            "gc_b1 must be deleted before child_b"
+        );
+    }
+}

--- a/tests/feishu_adapter_tests.rs
+++ b/tests/feishu_adapter_tests.rs
@@ -65,7 +65,8 @@ async fn test_handle_webhook_valid() {
     let msg = adapter
         .handle_webhook(&serde_json::to_vec(&payload).unwrap())
         .await
-        .unwrap();
+        .unwrap()
+        .expect("expected Some(message)");
     assert_eq!(msg.id, "evt_1");
     assert_eq!(msg.from, "ou_abc");
     assert_eq!(msg.content, "hello");
@@ -88,7 +89,8 @@ async fn test_handle_webhook_empty_text() {
     let msg = adapter
         .handle_webhook(&serde_json::to_vec(&payload).unwrap())
         .await
-        .unwrap();
+        .unwrap()
+        .expect("expected Some(message)");
     assert_eq!(msg.content, "");
     assert_eq!(msg.metadata.get("account_id"), Some(&"a".to_string()));
 }

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -98,6 +98,7 @@ impl IMPlugin for TrackingPlugin {
             timestamp: 0,
             thread_id: None,
             account_id: None,
+            card_action: None,
         }))
     }
 
@@ -345,7 +346,7 @@ async fn test_feishu_adapter_send_card_json_default() {
         fn name(&self) -> &str {
             "dummy"
         }
-        async fn handle_webhook(&self, _: &[u8]) -> Result<Message, AdapterError> {
+        async fn handle_webhook(&self, _: &[u8]) -> Result<Option<Message>, AdapterError> {
             Err(AdapterError::InvalidPayload("x".into()))
         }
         async fn send_message(&self, _: &Message, _: Option<&str>) -> Result<(), AdapterError> {


### PR DESCRIPTION
## 概述

实现 design doc `docs/design/daemon/shutdown.md` 对齐的 3 项 shutdown 增强：

1. **ArchiveSweeper grace period**：收到 shutdown 信号后，若 sweeper task 正在执行，最多等待 5 秒后 abort 强制终止，避免无限阻塞。

2. **StopProgress 进度回调**：`stop_all_sessions` 新增可选 progress channel，每完成一个 session 停止后发送 `StopProgress` 事件，支持调用方获取中间进度。

3. **进度卡片实时更新**：`phase_2_session_stop` 在 select 循环中消费 `StopProgress` 事件，节流（≤2s）重新发送 shutdown 进度卡片，最后事件立即发送。

4. **Feishu card action 解析**：`handle_webhook` 支持 `card.action.trigger` 事件，解析按钮 click action。

5. **Gateway forceful escalation**：拦截 `/__card_action:forceful_shutdown` 消息，调用 `escalate_to_forceful()`，用户可通过进度卡片按钮触发强制关闭。

## 变更文件

- `src/session/sweeper.rs` — ArchiveSweeper grace period + abort
- `src/gateway/session_manager/stop.rs` — StopProgress 回调机制
- `src/daemon/mod.rs` — 进度卡片节流更新
- `src/im/feishu.rs` — card action 事件解析
- `src/gateway/mod.rs` — card action 拦截 + forceful escalation
- `src/im/mod.rs`, `src/im_adapter/normalized.rs` — IMAdapter trait 更新
- 对应 `_tests.rs` 文件新增 UT

## 测试

- `cargo clippy --all -- -D warnings` 通过
- `cargo fmt --check` 通过
- `cargo test` 因机器 OOM 无法运行（master 同样），非代码问题
