### PR TITLE
fix: remove drain hard timeout in graceful shutdown

### DIFF
--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -564,4 +564,28 @@ mod tests {
         assert!(!handle.is_shutting_down());
         assert!(!handle.is_forceful());
     }
+
+    #[tokio::test]
+    async fn test_graceful_drain_no_timeout_waits_indefinitely() {
+        // After removing the drain timeout, graceful mode waits for busy_count
+        // to reach 0 with no time limit.
+        let handle = ShutdownHandle::new();
+        handle.increment_busy();
+
+        let h = handle.clone();
+        let shutdown_handle = tokio::spawn(async move {
+            h.initiate_shutdown().await;
+        });
+
+        // Wait 800ms — well beyond any reasonable test timeout,
+        // but the drain should still be waiting.
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        assert!(handle.is_shutting_down());
+        assert!(!handle.is_stopped());
+
+        // Release the busy count — drain should complete naturally.
+        handle.decrement_busy();
+        shutdown_handle.await.unwrap();
+        assert!(handle.is_stopped());
+    }
 }

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -220,7 +220,10 @@ impl ShutdownHandle {
             return;
         }
 
-        info!("Graceful shutdown initiated — waiting for in-flight operations (forceful via repeated signal)");
+        info!(
+            "Graceful shutdown initiated — waiting for in-flight operations \
+                (forceful via repeated signal)"
+        );
 
         let _ = self.drain_done_tx.send(());
         self.wait_for_drain().await;

--- a/src/daemon/shutdown.rs
+++ b/src/daemon/shutdown.rs
@@ -10,7 +10,7 @@
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::broadcast;
-use tracing::{info, warn};
+use tracing::info;
 
 /// Shutdown mode — distinguishes graceful from forceful shutdown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -68,18 +68,6 @@ impl ShutdownState {
             _ => ShutdownMode::Graceful,
         }
     }
-}
-
-/// Returns the drain timeout in seconds.
-#[cfg(not(test))]
-const fn drain_timeout_secs() -> u64 {
-    30
-}
-
-/// Returns the drain timeout in seconds (test mode: 3s).
-#[cfg(test)]
-const fn drain_timeout_secs() -> u64 {
-    3
 }
 
 /// Returns the drain poll interval.
@@ -218,11 +206,11 @@ impl ShutdownHandle {
     /// Initiate graceful shutdown — called when SIGTERM/SIGINT is received.
     ///
     /// 1. Transition to ShuttingDown
-    /// 2. Wait up to DRAIN_TIMEOUT_SECS for in-flight work to complete
+    /// 2. Wait for in-flight work to complete (no timeout)
     /// 3. Transition to Draining → Stopped
     ///
     /// If already shutting down, escalates to forceful.
-    /// If timeout is exceeded, force-exit.
+    /// Only a forceful upgrade or busy_count reaching 0 can end the wait.
     pub async fn initiate_shutdown(&self) {
         if !self.coordinator.try_start_shutdown() {
             // Already shutting down — escalate to forceful on repeated signal
@@ -232,20 +220,15 @@ impl ShutdownHandle {
             return;
         }
 
-        info!(
-            "Graceful shutdown initiated (timeout={}s)",
-            drain_timeout_secs()
-        );
+        info!("Graceful shutdown initiated — waiting for in-flight operations (forceful via repeated signal)");
 
         let _ = self.drain_done_tx.send(());
         self.wait_for_drain().await;
     }
 
-    /// Wait for busy_count to reach 0 or timeout, then finalize shutdown.
-    /// In forceful mode, skip the timeout and finalize immediately.
+    /// Wait for busy_count to reach 0, then finalize shutdown.
+    /// In forceful mode, finalize immediately without waiting.
     async fn wait_for_drain(&self) {
-        let started_at = std::time::Instant::now();
-
         loop {
             // If upgraded to forceful mid-drain, finalize immediately
             if self.is_forceful() {
@@ -263,24 +246,7 @@ impl ShutdownHandle {
                 return;
             }
 
-            let elapsed = started_at.elapsed().as_secs();
-            if elapsed >= drain_timeout_secs() {
-                warn!(
-                    "Drain timeout exceeded ({}s) — forcing shutdown (busy_count={})",
-                    drain_timeout_secs(),
-                    count
-                );
-                self.coordinator.start_drain();
-                self.coordinator.mark_stopped();
-                return;
-            }
-
-            info!(
-                "Waiting for in-flight operations... ({}s / {}s, busy_count={})",
-                elapsed,
-                drain_timeout_secs(),
-                count
-            );
+            info!("Waiting for in-flight operations... (busy_count={})", count);
 
             tokio::time::sleep(drain_poll_interval()).await;
         }
@@ -502,12 +468,6 @@ mod tests {
     fn test_shutdown_mode_debug() {
         assert_eq!(format!("{:?}", ShutdownMode::Graceful), "Graceful");
         assert_eq!(format!("{:?}", ShutdownMode::Forceful), "Forceful");
-    }
-
-    #[test]
-    fn test_drain_timeout_secs_test_mode() {
-        // In test mode, drain_timeout_secs should return 3 (not 30)
-        assert_eq!(drain_timeout_secs(), 3);
     }
 
     #[test]

--- a/src/daemon/shutdown_alignment_tests.rs
+++ b/src/daemon/shutdown_alignment_tests.rs
@@ -240,7 +240,7 @@ async fn test_graceful_mode_no_timeout_no_forced_termination() {
         h.initiate_shutdown().await;
     });
 
-    // Wait 1 second (less than the 3s test drain timeout)
+    // Wait 1 second — drain should still be running (no timeout)
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     assert!(handle.is_shutting_down());
     assert!(!handle.is_stopped());


### PR DESCRIPTION
Remove hard drain timeout in graceful shutdown mode

## What

Remove the hardcoded 30s drain timeout in `wait_for_drain()` for graceful shutdown. Graceful drain now waits indefinitely for `busy_count` to reach zero, consistent with the design doc's "双模关闭" specification.

## Why

The design doc explicitly states that Daemon should not rely on a hardcoded timeout to escalate shutdown — tool execution time is unpredictable. The implementation violated this by forcing a 30s timeout that degraded graceful shutdown into bounded timeout behavior. Users should decide when to escalate via repeated signal (forceful mode).

## Changes

- `shutdown.rs`: Remove `drain_timeout_secs()` const fn and all timeout-related logic in `wait_for_drain()`; update shutdown initiation log message
- `shutdown.rs`: Remove the `started_at`/`elapsed` tracking and timeout branch, preserving only `busy_count == 0` and `is_forceful()` exit conditions
- `shutdown_alignment_tests.rs`: Fix stale comment referencing the removed timeout

Source: design-doc
Type: fix
