### PR TITLE
fix: correct remaining count calculation in stop progress reporting

### DIFF
--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -135,7 +135,7 @@ impl SessionManager {
                 progress_tx,
                 &level[idx],
                 success,
-                remaining.saturating_sub(count - idx - 1),
+                remaining.saturating_sub(idx + 1),
             )
             .await;
         }


### PR DESCRIPTION
CI 测试 `test_stop_progress_remaining_accuracy` 失败，根因在 `process_stop_level` 中 `remaining` 计算公式错误。

`remaining` 参数传入的是包含当前 level 的未处理 session 总数，但公式 `remaining.saturating_sub(count - idx - 1)` 语义反向，导致单 session 场景下报告 remaining=1 而非 0。

修复为 `remaining.saturating_sub(idx + 1)`，正确反映当前 session 之后的剩余数。

Source: CI
Type: fix
