### PR TITLE
refactor: align inbound flow implementation with design doc

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -82,5 +82,12 @@
     "commit_time": "",
     "confirmed_time": "2026-06-22T18:44:05.434607+08:00",
     "comment": "blocked: dependency declarations place SystemPromptBuilder at Layer 3 but layer table says Layer 4"
+  },
+  {
+    "path": "docs/design/daemon/shutdown.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-23T12:18:20.902842+08:00",
+    "comment": "blocked: Phase 1 flowchart contradicts architecture section on drain timeout semantics"
   }
 ]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -64,7 +64,7 @@ pub enum DmScope {
 #[allow(clippy::derivable_impls)]
 impl Default for DmScope {
     fn default() -> Self {
-        DmScope::PerChannelPeer
+        DmScope::PerAccountChannelPeer
     }
 }
 

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -225,8 +225,29 @@ fn test_dm_scope_per_channel_sender_serde_roundtrip() {
 }
 
 #[test]
-fn test_dm_scope_default_is_per_channel_peer() {
-    assert_eq!(DmScope::default(), DmScope::PerChannelPeer);
+fn test_dm_scope_default_is_per_account_channel_peer() {
+    assert_eq!(DmScope::default(), DmScope::PerAccountChannelPeer);
+}
+
+#[test]
+fn test_dm_scope_default_session_key_contains_four_fields() {
+    // Verify default DmScope session_key = hash(platform, sender_id, peer_id, account_id)
+    let key = DmScope::default().compute_session_key(
+        "feishu",
+        &msg("ou_sender", "oc_peer"),
+        Some("t_account"),
+    );
+    // PerAccountChannelPeer format: {account_id}:{platform}:{sender_id}:{peer_id}
+    assert!(
+        key.contains("t_account"),
+        "key should contain account_id: {key}"
+    );
+    assert!(key.contains("feishu"), "key should contain platform: {key}");
+    assert!(
+        key.contains("ou_sender"),
+        "key should contain sender_id: {key}"
+    );
+    assert!(key.contains("oc_peer"), "key should contain peer_id: {key}");
 }
 
 // ── GatewayConfig serde: dm_scope values ─────────────────────────────────────
@@ -249,7 +270,7 @@ fn test_gateway_config_dm_scope_values() {
         assert_eq!(cfg.dm_scope, expected);
     }
     let cfg: GatewayConfig = serde_json::from_str("{\"name\":\"g\"}").unwrap();
-    assert_eq!(cfg.dm_scope, DmScope::PerChannelPeer);
+    assert_eq!(cfg.dm_scope, DmScope::PerAccountChannelPeer);
     assert_eq!(cfg.rate_limit_per_minute, 0);
     assert_eq!(cfg.max_message_size, 0);
 }

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -448,9 +448,9 @@ async fn test_process_inbound_chain_with_session_router() {
         .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-1")
         .await;
     assert_eq!(result.content, "hi");
-    // SessionRouter injects session_key = "terminal:user1:peer1" (PerChannelPeer)
+    // SessionRouter injects session_key = "default:terminal:user1:peer1" (PerAccountChannelPeer)
     let key = result.metadata.get("session_key").and_then(|v| v.as_str());
-    assert_eq!(key, Some("terminal:user1:peer1"));
+    assert_eq!(key, Some("default:terminal:user1:peer1"));
 }
 
 /// When a processor returns an error, `process_inbound_chain` falls back to

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -5,6 +5,9 @@
 //! `session_key` via [`DmScope::compute_session_key`] and writes it
 //! to the message metadata.
 //!
+//! By default uses [`DmScope::PerAccountChannelPeer`] mode, producing
+//! keys in the format `{account_id}:{channel}:{from}:{to}`.
+//!
 //! Runs at priority 20, before [`FeishuMessageCleaner`] (priority 30).
 
 use super::{MessageContext, MessageProcessor, ProcessError, ProcessPhase, ProcessedMessage};

--- a/src/processor_chain/content_normalizer.rs
+++ b/src/processor_chain/content_normalizer.rs
@@ -2,12 +2,14 @@
 //! and normalizes Markdown formatting.
 //!
 //! Processing order:
-//! 1. `strip_control_chars` — remove ANSI escape sequences and invisible
+//! 1. `strip_platform_residue` — remove platform-specific XML tags (e.g.
+//!    `<at>` mentions) and convert them to plain-text equivalents
+//! 2. `strip_control_chars` — remove ANSI escape sequences and invisible
 //!    control characters (preserving `\n`, `\t`, `\r`)
-//! 2. `normalize_empty_lines` — compress consecutive blank lines
-//! 3. `trim_trailing_whitespace` — strip trailing spaces per line
-//! 4. `normalize_urls` — ensure all bare URLs have `https://` prefix
-//! 5. `add_code_block_language_hint` — annotate code fences without language
+//! 3. `normalize_empty_lines` — compress consecutive blank lines
+//! 4. `trim_trailing_whitespace` — strip trailing spaces per line
+//! 5. `normalize_urls` — ensure all bare URLs have `https://` prefix
+//! 6. `add_code_block_language_hint` — annotate code fences without language
 
 use crate::processor_chain::context::{MessageContext, ProcessedMessage};
 use crate::processor_chain::error::ProcessError;
@@ -16,6 +18,22 @@ use async_trait::async_trait;
 use std::sync::LazyLock;
 
 use regex::Regex;
+
+// ---------------------------------------------------------------------------
+// Platform residue stripping
+// ---------------------------------------------------------------------------
+
+/// Strips platform-specific XML-style tags from message text.
+///
+/// Converts `<at user_id="xxx">name</at>` to `@name`, removing the
+/// platform-specific at-mention markup while preserving the display name.
+/// Handles multiple and nested tags; non-matching text passes through
+/// unchanged.
+pub fn strip_platform_residue(text: &str) -> String {
+    static AT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"<at\s+user_id="[^"]*">([^<]*)</at>"#).unwrap());
+    AT_RE.replace_all(text, "@$1").to_string()
+}
 
 // ---------------------------------------------------------------------------
 // Control character stripping
@@ -168,15 +186,16 @@ pub fn add_code_block_language_hint(text: &str) -> String {
 // ContentNormalizer
 // ---------------------------------------------------------------------------
 
-/// ContentNormalizer strips control characters and normalizes Markdown
-/// formatting in message content.
+/// ContentNormalizer strips platform residue, control characters, and
+/// normalizes Markdown formatting in message content.
 ///
 /// Processing order:
-/// 1. `strip_control_chars` — remove ANSI sequences and invisible characters
-/// 2. `normalize_empty_lines` — compress consecutive blank lines
-/// 3. `trim_trailing_whitespace` — strip trailing spaces per line
-/// 4. `normalize_urls` — ensure bare URLs have `https://` prefix
-/// 5. `add_code_block_language_hint` — annotate unlabeled code fences
+/// 1. `strip_platform_residue` — remove platform XML tags (e.g. `<at>`)
+/// 2. `strip_control_chars` — remove ANSI sequences and invisible characters
+/// 3. `normalize_empty_lines` — compress consecutive blank lines
+/// 4. `trim_trailing_whitespace` — strip trailing spaces per line
+/// 5. `normalize_urls` — ensure bare URLs have `https://` prefix
+/// 6. `add_code_block_language_hint` — annotate unlabeled code fences
 #[derive(Debug)]
 pub struct ContentNormalizer;
 
@@ -210,7 +229,8 @@ impl MessageProcessor for ContentNormalizer {
         &self,
         ctx: &MessageContext,
     ) -> Result<Option<ProcessedMessage>, ProcessError> {
-        let mut normalized = strip_control_chars(&ctx.content);
+        let mut normalized = strip_platform_residue(&ctx.content);
+        normalized = strip_control_chars(&normalized);
         normalized = normalize_empty_lines(&normalized);
         normalized = trim_trailing_whitespace(&normalized);
         normalized = normalize_urls(&normalized);

--- a/src/processor_chain/content_normalizer_tests.rs
+++ b/src/processor_chain/content_normalizer_tests.rs
@@ -247,3 +247,89 @@ fn test_add_code_block_normal_text_unchanged() {
     let out = add_code_block_language_hint(input);
     assert_eq!(out, "just some plain text");
 }
+
+// -------------------------------------------------------------------------
+// strip_platform_residue
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_strip_platform_residue_single_at_tag() {
+    let input = r#"Hello <at user_id="u123">Alice</at>, how are you?"#;
+    assert_eq!(strip_platform_residue(input), "Hello @Alice, how are you?");
+}
+
+#[test]
+fn test_strip_platform_residue_multiple_at_tags() {
+    let input = r#"<at user_id="u1">Alice</at> and <at user_id="u2">Bob</at> are here"#;
+    assert_eq!(strip_platform_residue(input), "@Alice and @Bob are here");
+}
+
+#[test]
+fn test_strip_platform_residue_adjacent_at_tags() {
+    let input = r#"<at user_id="u1">A</at><at user_id="u2">B</at>"#;
+    assert_eq!(strip_platform_residue(input), "@A@B");
+}
+
+#[test]
+fn test_strip_platform_residue_plain_text_unchanged() {
+    let input = "Hello world, no tags here.";
+    assert_eq!(strip_platform_residue(input), input);
+}
+
+#[test]
+fn test_strip_platform_residue_empty_string() {
+    assert_eq!(strip_platform_residue(""), "");
+}
+
+#[test]
+fn test_strip_platform_residue_incomplete_tag_no_close() {
+    let input = r#"Hello <at user_id="u1">Alice"#;
+    assert_eq!(strip_platform_residue(input), input);
+}
+
+#[test]
+fn test_strip_platform_residue_incomplete_tag_no_content() {
+    let input = r#"Hello <at user_id="u1"></at>world"#;
+    assert_eq!(strip_platform_residue(input), "Hello @world");
+}
+
+#[test]
+fn test_strip_platform_residue_special_chars_in_name() {
+    let input = r#"<at user_id="u1">O'Brien & Co.</at> said hi"#;
+    assert_eq!(strip_platform_residue(input), "@O'Brien & Co. said hi");
+}
+
+#[test]
+fn test_strip_platform_residue_unicode_name() {
+    let input = r#"<at user_id="u1">张三</at> posted"#;
+    assert_eq!(strip_platform_residue(input), "@张三 posted");
+}
+
+#[test]
+fn test_strip_platform_residue_emoji_name() {
+    let input = r#"<at user_id="u1">🎉 Party</at> time"#;
+    assert_eq!(strip_platform_residue(input), "@🎉 Party time");
+}
+
+#[test]
+fn test_strip_platform_residue_at_in_other_context() {
+    // An @ that is NOT inside an <at> tag should be left alone
+    let input = "email user@example.com or ping <at user_id=\"u1\">Alice</at>";
+    assert_eq!(
+        strip_platform_residue(input),
+        "email user@example.com or ping @Alice"
+    );
+}
+
+#[test]
+fn test_strip_platform_residue_only_at_tag() {
+    let input = r#"<at user_id="u1">Solo</at>"#;
+    assert_eq!(strip_platform_residue(input), "@Solo");
+}
+
+#[test]
+fn test_strip_platform_residue_nested_xml_like_surrounding() {
+    // <at> tag embedded in other XML-like text — the regex should still match
+    let input = r#"<root><at user_id="u1">Alice</at></root>"#;
+    assert_eq!(strip_platform_residue(input), "<root>@Alice</root>");
+}

--- a/src/processor_chain/session_router.rs
+++ b/src/processor_chain/session_router.rs
@@ -6,6 +6,10 @@
 //! consumers (e.g. [`Gateway::route_message`]) can resolve sessions via
 //! [`SessionManager::resolve`].
 //!
+//! By default uses [`DmScope::PerAccountChannelPeer`] mode, producing
+//! keys in the format `{account_id}:{platform}:{sender_id}:{peer_id}`.
+//! The scope can be overridden via the [`DmScope`] configuration.
+//!
 //! This processor is channel-agnostic — it works for any platform that
 //! populates `RawMessage` correctly (terminal, feishu, discord, …).
 


### PR DESCRIPTION
Align inbound flow implementation with design doc (`docs/design/gateway/inbound-flow.md`).

Changes:
- Add `strip_platform_residue` to `ContentNormalizer` for generic platform tag cleanup (e.g. Feishu `<at>` XML tags → `@name`)
- Change `DmScope` default from `PerChannelPeer` to `PerAccountChannelPeer` so the default `session_key` matches the design doc formula: `hash(platform, sender_id, peer_id, account_id)`
- Add unit tests for both changes

Source: user
Type: refactor
