### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -89,5 +89,12 @@
     "commit_time": "",
     "confirmed_time": "2026-06-23T12:18:20.902842+08:00",
     "comment": "blocked: Phase 1 flowchart contradicts architecture section on drain timeout semantics"
+  },
+  {
+    "path": "docs/design/gateway/inbound-flow.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-23T18:31:58.281698+08:00",
+    "comment": "blocked: session_key hash vs format-string contradiction; account_id source mismatch; Immediate path distinction not implemented; rich text expansion missing"
   }
 ]


### PR DESCRIPTION
## Design Doc Tracker Update

**操作类型**: `blocked`
**Doc 路径**: `docs/design/gateway/inbound-flow.md`
**原因简述**: 标记 inbound-flow 设计文档为 blocked 状态

> 本 PR 仅更新 `scripts/design-doc-tracker/records.json` 元数据变更，不包含任何代码改动。