### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -103,5 +103,12 @@
     "commit_time": "",
     "confirmed_time": "2026-06-23T18:31:58.281698+08:00",
     "comment": "blocked: session_key hash vs format-string contradiction; account_id source mismatch; Immediate path distinction not implemented; rich text expansion missing"
+  },
+  {
+    "path": "docs/design/im_adapter/code-render.md",
+    "commit": "7cff111af671176aec722634fa183328a3d3d9f8",
+    "commit_time": "2026-06-24T00:32:37+08:00",
+    "confirmed_time": "2026-06-24T00:40:07.513102+08:00",
+    "comment": ""
   }
 ]


### PR DESCRIPTION
## DDT Records Update

- **Doc**: `docs/design/im_adapter/code-render.md`
- **Operation**: finished
- **Reason**: Mark design doc as finished in design-doc-tracker records