### PR TITLE
feat: add feishu tools registration and tool group scaffolding

### DIFF
--- a/src/daemon/registries.rs
+++ b/src/daemon/registries.rs
@@ -134,4 +134,5 @@ async fn spawn_builtin_tools(ctx: &RegistryContext<'_>, disk_reg: &Arc<DiskSkill
         session_manager: Arc::clone(ctx.session_manager),
     });
     register_builtin_tools(ctx.tool_registry, builtin_ctx).await;
+    crate::im_adapter::platforms::feishu::tools::register_tools(ctx.tool_registry).await;
 }

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -8,6 +8,7 @@ pub mod cleaner;
 #[cfg(test)]
 mod cleaner_tests;
 pub mod renderer;
+pub mod tools;
 
 use crate::gateway::Message;
 use crate::im_adapter::error::AdapterError;

--- a/src/im_adapter/platforms/feishu/tools/bitable.rs
+++ b/src/im_adapter/platforms/feishu/tools/bitable.rs
@@ -1,0 +1,57 @@
+//! Feishu Bitable tool group — multi-dimensional table operations.
+//!
+//! Covers creating, reading, updating, and deleting records in
+//! Feishu Bitable (multi-dimensional tables).
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Bitable (multi-dimensional table) tool.
+///
+/// Provides record CRUD, table management, and field operations
+/// for the Feishu Bitable platform.
+pub struct FeishuBitableTool;
+
+impl FeishuBitableTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuBitableTool {
+    fn name(&self) -> &str {
+        "FeishuBitable"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_bitable"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu Bitable table operations".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Create, read, update, and delete records in Feishu Bitable. \
+         Supports table and field management, view configuration, \
+         and batch operations."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/bitable.rs
+++ b/src/im_adapter/platforms/feishu/tools/bitable.rs
@@ -13,6 +13,12 @@ use serde_json::Value;
 /// for the Feishu Bitable platform.
 pub struct FeishuBitableTool;
 
+impl Default for FeishuBitableTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuBitableTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/calendar.rs
+++ b/src/im_adapter/platforms/feishu/tools/calendar.rs
@@ -1,0 +1,56 @@
+//! Feishu Calendar tool group — calendar management operations.
+//!
+//! Covers creating, updating, deleting, and querying calendar events.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Calendar management tool.
+///
+/// Provides calendar event create, update, delete, and query
+/// capabilities for the Feishu calendar platform.
+pub struct FeishuCalendarTool;
+
+impl FeishuCalendarTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuCalendarTool {
+    fn name(&self) -> &str {
+        "FeishuCalendar"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_calendar"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu calendar management".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Create, update, delete, and query Feishu calendar events. \
+         Supports attendee management, recurring events, and \
+         calendar list operations."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/calendar.rs
+++ b/src/im_adapter/platforms/feishu/tools/calendar.rs
@@ -12,6 +12,12 @@ use serde_json::Value;
 /// capabilities for the Feishu calendar platform.
 pub struct FeishuCalendarTool;
 
+impl Default for FeishuCalendarTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuCalendarTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/doc.rs
+++ b/src/im_adapter/platforms/feishu/tools/doc.rs
@@ -12,6 +12,12 @@ use serde_json::Value;
 /// capabilities for the Feishu document platform.
 pub struct FeishuDocTool;
 
+impl Default for FeishuDocTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuDocTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/doc.rs
+++ b/src/im_adapter/platforms/feishu/tools/doc.rs
@@ -1,0 +1,56 @@
+//! Feishu Doc tool group — document operations.
+//!
+//! Covers creating, reading, updating, and managing Feishu documents.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Document tool.
+///
+/// Provides document create, read, update, and management
+/// capabilities for the Feishu document platform.
+pub struct FeishuDocTool;
+
+impl FeishuDocTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuDocTool {
+    fn name(&self) -> &str {
+        "FeishuDoc"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_doc"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu document operations".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Create, read, update, and manage Feishu documents. \
+         Supports content editing, permission management, \
+         and document metadata."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/drive.rs
+++ b/src/im_adapter/platforms/feishu/tools/drive.rs
@@ -13,6 +13,12 @@ use serde_json::Value;
 /// capabilities for the Feishu Drive platform.
 pub struct FeishuDriveTool;
 
+impl Default for FeishuDriveTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuDriveTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/drive.rs
+++ b/src/im_adapter/platforms/feishu/tools/drive.rs
@@ -1,0 +1,57 @@
+//! Feishu Drive tool group — cloud storage operations.
+//!
+//! Covers file upload, download, listing, and management in
+//! Feishu Drive.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Drive (cloud storage) tool.
+///
+/// Provides file upload, download, listing, and management
+/// capabilities for the Feishu Drive platform.
+pub struct FeishuDriveTool;
+
+impl FeishuDriveTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuDriveTool {
+    fn name(&self) -> &str {
+        "FeishuDrive"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_drive"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu Drive file operations".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Upload, download, list, and manage files in Feishu Drive. \
+         Supports folder operations, file sharing, and \
+         permission management."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/im.rs
+++ b/src/im_adapter/platforms/feishu/tools/im.rs
@@ -1,0 +1,56 @@
+//! Feishu IM tool group — messaging operations.
+//!
+//! Covers sending, recalling, editing, and reacting to messages.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu IM message operations tool.
+///
+/// Provides message send, recall, edit, and reaction capabilities
+/// for the Feishu messaging platform.
+pub struct FeishuImTool;
+
+impl FeishuImTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuImTool {
+    fn name(&self) -> &str {
+        "FeishuIm"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_im"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu IM message operations".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Send, recall, edit, and react to Feishu messages. \
+         Supports text and card message formats, thread replies, \
+         and message deletion."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/im.rs
+++ b/src/im_adapter/platforms/feishu/tools/im.rs
@@ -12,6 +12,12 @@ use serde_json::Value;
 /// for the Feishu messaging platform.
 pub struct FeishuImTool;
 
+impl Default for FeishuImTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuImTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/mod.rs
+++ b/src/im_adapter/platforms/feishu/tools/mod.rs
@@ -1,0 +1,33 @@
+//! Feishu tool registration — wires all platform-specific tools
+//! into the [`ToolRegistry`] at daemon startup.
+
+pub mod bitable;
+pub mod calendar;
+pub mod doc;
+pub mod drive;
+pub mod im;
+pub mod sheet;
+pub mod task;
+
+use crate::tools::ToolRegistry;
+use bitable::FeishuBitableTool;
+use calendar::FeishuCalendarTool;
+use doc::FeishuDocTool;
+use drive::FeishuDriveTool;
+use im::FeishuImTool;
+use sheet::FeishuSheetTool;
+use task::FeishuTaskTool;
+
+/// Register all Feishu tool groups into the provided registry.
+///
+/// Each tool group is registered with `is_deferred_by_default = true`
+/// per the design doc requirement that all Feishu tools load lazily.
+pub(crate) async fn register_tools(registry: &ToolRegistry) {
+    registry.register(FeishuImTool::new()).await.ok();
+    registry.register(FeishuCalendarTool::new()).await.ok();
+    registry.register(FeishuTaskTool::new()).await.ok();
+    registry.register(FeishuBitableTool::new()).await.ok();
+    registry.register(FeishuDocTool::new()).await.ok();
+    registry.register(FeishuDriveTool::new()).await.ok();
+    registry.register(FeishuSheetTool::new()).await.ok();
+}

--- a/src/im_adapter/platforms/feishu/tools/mod.rs
+++ b/src/im_adapter/platforms/feishu/tools/mod.rs
@@ -9,6 +9,9 @@ pub mod im;
 pub mod sheet;
 pub mod task;
 
+#[cfg(test)]
+mod tools_tests;
+
 use crate::tools::ToolRegistry;
 use bitable::FeishuBitableTool;
 use calendar::FeishuCalendarTool;

--- a/src/im_adapter/platforms/feishu/tools/sheet.rs
+++ b/src/im_adapter/platforms/feishu/tools/sheet.rs
@@ -12,6 +12,12 @@ use serde_json::Value;
 /// capabilities for the Feishu Sheet platform.
 pub struct FeishuSheetTool;
 
+impl Default for FeishuSheetTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuSheetTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/sheet.rs
+++ b/src/im_adapter/platforms/feishu/tools/sheet.rs
@@ -1,0 +1,56 @@
+//! Feishu Sheet tool group — spreadsheet operations.
+//!
+//! Covers reading, writing, and managing Feishu spreadsheets.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Sheet (spreadsheet) tool.
+///
+/// Provides spreadsheet read, write, and management
+/// capabilities for the Feishu Sheet platform.
+pub struct FeishuSheetTool;
+
+impl FeishuSheetTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuSheetTool {
+    fn name(&self) -> &str {
+        "FeishuSheet"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_sheet"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu spreadsheet operations".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Read, write, and manage Feishu spreadsheets. \
+         Supports cell operations, sheet management, \
+         and data range manipulation."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/task.rs
+++ b/src/im_adapter/platforms/feishu/tools/task.rs
@@ -12,6 +12,12 @@ use serde_json::Value;
 /// capabilities for the Feishu task platform.
 pub struct FeishuTaskTool;
 
+impl Default for FeishuTaskTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FeishuTaskTool {
     pub fn new() -> Self {
         Self

--- a/src/im_adapter/platforms/feishu/tools/task.rs
+++ b/src/im_adapter/platforms/feishu/tools/task.rs
@@ -1,0 +1,55 @@
+//! Feishu Task tool group — task management operations.
+//!
+//! Covers creating, updating, completing, and querying tasks.
+
+use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Feishu Task management tool.
+///
+/// Provides task create, update, complete, and query
+/// capabilities for the Feishu task platform.
+pub struct FeishuTaskTool;
+
+impl FeishuTaskTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Tool for FeishuTaskTool {
+    fn name(&self) -> &str {
+        "FeishuTask"
+    }
+
+    fn group(&self) -> &str {
+        "feishu_task"
+    }
+
+    fn summary(&self) -> String {
+        "Feishu task management".to_string()
+    }
+
+    fn detail(&self) -> String {
+        "Create, update, complete, and query Feishu tasks. \
+         Supports task lists, reminders, and collaborator management."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({})
+    }
+
+    async fn call(&self, _args: Value, _ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
+        Err(ToolCallError::NotImplemented)
+    }
+
+    fn flags(&self) -> ToolFlags {
+        ToolFlags {
+            is_deferred_by_default: true,
+            ..ToolFlags::default()
+        }
+    }
+}

--- a/src/im_adapter/platforms/feishu/tools/tools_tests.rs
+++ b/src/im_adapter/platforms/feishu/tools/tools_tests.rs
@@ -1,0 +1,198 @@
+use super::*;
+use crate::tools::{Tool, ToolContext, ToolRegistry};
+
+fn make_ctx() -> ToolContext {
+    ToolContext {
+        agent_id: "test-agent".to_string(),
+        workdir: None,
+        session_id: None,
+        call_id: None,
+        session: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Individual tool struct tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_feishu_im_tool_name() {
+    let tool = FeishuImTool::new();
+    assert_eq!(tool.name(), "FeishuIm");
+}
+
+#[test]
+fn test_feishu_im_tool_group() {
+    let tool = FeishuImTool::new();
+    assert_eq!(tool.group(), "feishu_im");
+}
+
+#[test]
+fn test_feishu_im_tool_flags() {
+    let tool = FeishuImTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_calendar_tool_name() {
+    let tool = FeishuCalendarTool::new();
+    assert_eq!(tool.name(), "FeishuCalendar");
+}
+
+#[test]
+fn test_feishu_calendar_tool_group() {
+    let tool = FeishuCalendarTool::new();
+    assert_eq!(tool.group(), "feishu_calendar");
+}
+
+#[test]
+fn test_feishu_calendar_tool_flags() {
+    let tool = FeishuCalendarTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_task_tool_name() {
+    let tool = FeishuTaskTool::new();
+    assert_eq!(tool.name(), "FeishuTask");
+}
+
+#[test]
+fn test_feishu_task_tool_group() {
+    let tool = FeishuTaskTool::new();
+    assert_eq!(tool.group(), "feishu_task");
+}
+
+#[test]
+fn test_feishu_task_tool_flags() {
+    let tool = FeishuTaskTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_bitable_tool_name() {
+    let tool = FeishuBitableTool::new();
+    assert_eq!(tool.name(), "FeishuBitable");
+}
+
+#[test]
+fn test_feishu_bitable_tool_group() {
+    let tool = FeishuBitableTool::new();
+    assert_eq!(tool.group(), "feishu_bitable");
+}
+
+#[test]
+fn test_feishu_bitable_tool_flags() {
+    let tool = FeishuBitableTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_doc_tool_name() {
+    let tool = FeishuDocTool::new();
+    assert_eq!(tool.name(), "FeishuDoc");
+}
+
+#[test]
+fn test_feishu_doc_tool_group() {
+    let tool = FeishuDocTool::new();
+    assert_eq!(tool.group(), "feishu_doc");
+}
+
+#[test]
+fn test_feishu_doc_tool_flags() {
+    let tool = FeishuDocTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_drive_tool_name() {
+    let tool = FeishuDriveTool::new();
+    assert_eq!(tool.name(), "FeishuDrive");
+}
+
+#[test]
+fn test_feishu_drive_tool_group() {
+    let tool = FeishuDriveTool::new();
+    assert_eq!(tool.group(), "feishu_drive");
+}
+
+#[test]
+fn test_feishu_drive_tool_flags() {
+    let tool = FeishuDriveTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+#[test]
+fn test_feishu_sheet_tool_name() {
+    let tool = FeishuSheetTool::new();
+    assert_eq!(tool.name(), "FeishuSheet");
+}
+
+#[test]
+fn test_feishu_sheet_tool_group() {
+    let tool = FeishuSheetTool::new();
+    assert_eq!(tool.group(), "feishu_sheet");
+}
+
+#[test]
+fn test_feishu_sheet_tool_flags() {
+    let tool = FeishuSheetTool::new();
+    let flags = tool.flags();
+    assert!(flags.is_deferred_by_default);
+}
+
+// ---------------------------------------------------------------------------
+// register_tools() integration test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_register_tools_populates_registry() {
+    let registry = ToolRegistry::new();
+    register_tools(&registry).await;
+
+    // Registry should contain exactly 7 tools
+    let ctx = make_ctx();
+    let descriptors = registry.list_descriptors(&ctx).await;
+    assert_eq!(descriptors.len(), 7, "expected 7 feishu tools registered");
+
+    // Every tool should be deferred
+    for desc in &descriptors {
+        assert!(desc.is_deferred, "tool '{}' should be deferred", desc.name);
+    }
+
+    // Verify all group names present
+    let groups: Vec<&str> = descriptors.iter().map(|d| d.group.as_str()).collect();
+    for expected_group in &[
+        "feishu_im",
+        "feishu_calendar",
+        "feishu_task",
+        "feishu_bitable",
+        "feishu_doc",
+        "feishu_drive",
+        "feishu_sheet",
+    ] {
+        assert!(
+            groups.contains(expected_group),
+            "group '{}' not found in registered tools",
+            expected_group
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_register_tools_no_duplicates() {
+    let registry = ToolRegistry::new();
+    register_tools(&registry).await;
+
+    // Calling register_tools again should hit AlreadyRegistered errors
+    // (silently ignored via .ok()) but the count should stay at 7
+    register_tools(&registry).await;
+    assert_eq!(registry.len_for_test().await, 7);
+}


### PR DESCRIPTION
feat: add feishu tools registration and tool group scaffolding

Add `tools/` subdirectory under `src/im_adapter/platforms/feishu/` with 7
tool group files (im, calendar, task, bitable, doc, drive, sheet) that
implement the `Tool` trait with deferred loading. Each tool struct returns
`NotImplemented` for `call()` — actual operation logic is out of scope for
this phase.

- Register all 7 tools via `register_tools()` called from daemon startup
- Add unit tests covering `name()`, `group()`, `flags()` for each tool
  and `register_tools()` registration logic

Source: design-doc
Type: feat
