### PR TITLE
fix: align Feishu adapter message parsing with design doc

### DIFF
--- a/src/im_adapter/platforms/feishu/adapter.rs
+++ b/src/im_adapter/platforms/feishu/adapter.rs
@@ -90,6 +90,71 @@ pub(super) struct FeishuCardAction {
 const FEISHU_API_BASE: &str = "https://open.feishu.cn/open-apis";
 
 // ---------------------------------------------------------------------------
+// Post content expansion
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+/// Expand a Feishu post-type content JSON value into plain text.
+///
+/// The `content` parameter is the parsed JSON object with `title` (optional)
+/// and `content` (2D array of elements, each element has a `tag` field).
+///
+/// - `title` becomes the first line (if present).
+/// - Each sub-array in `content` becomes one line; elements are concatenated.
+/// - Supported tags: `text`, `a`, `at`, unknown tags use `text` if available.
+fn expand_post_content(content: &serde_json::Value) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Extract title as the first line if present.
+    if let Some(title) = content.get("title").and_then(|t| t.as_str()) {
+        if !title.is_empty() {
+            lines.push(title.to_string());
+        }
+    }
+
+    // Iterate over the 2D content array.
+    if let Some(rows) = content.get("content").and_then(|c| c.as_array()) {
+        for row in rows {
+            let row_text: String = row
+                .as_array()
+                .map(|elements| {
+                    elements
+                        .iter()
+                        .map(expand_element)
+                        .collect::<Vec<_>>()
+                        .join("")
+                })
+                .unwrap_or_default();
+            lines.push(row_text);
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[allow(dead_code)]
+/// Expand a single post content element into plain text based on its tag.
+fn expand_element(elem: &serde_json::Value) -> String {
+    let tag = elem.get("tag").and_then(|t| t.as_str()).unwrap_or("");
+    let base = match tag {
+        "text" | "a" => elem.get("text").and_then(|t| t.as_str()).unwrap_or(""),
+        _ => elem.get("text").and_then(|t| t.as_str()).unwrap_or(""),
+    };
+    match tag {
+        "at" => {
+            if let Some(name) = elem.get("name").and_then(|n| n.as_str()) {
+                format!("@{}", name)
+            } else if let Some(user_id) = elem.get("user_id").and_then(|u| u.as_str()) {
+                format!("@{}", user_id)
+            } else {
+                base.to_string()
+            }
+        }
+        _ => base.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // CachedToken
 // ---------------------------------------------------------------------------
 

--- a/src/im_adapter/platforms/feishu/adapter.rs
+++ b/src/im_adapter/platforms/feishu/adapter.rs
@@ -354,15 +354,21 @@ impl FeishuAdapter {
     }
 
     /// Parse a regular message event into a Message.
-    fn parse_message_event(&self, event: FeishuEvent) -> Result<Message, AdapterError> {
+    ///
+    /// Returns `Ok(None)` for non-text message types (image, file, audio, etc.).
+    fn parse_message_event(&self, event: FeishuEvent) -> Result<Option<Message>, AdapterError> {
         let content: serde_json::Value = serde_json::from_str(&event.event.content)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 
-        let text = content
-            .get("text")
-            .and_then(|t| t.as_str())
-            .unwrap_or("")
-            .to_string();
+        let text = match event.event.message_type.as_str() {
+            "text" => content
+                .get("text")
+                .and_then(|t| t.as_str())
+                .unwrap_or("")
+                .to_string(),
+            "post" => expand_post_content(&content),
+            _ => return Ok(None),
+        };
 
         let thread_id = event
             .event
@@ -370,12 +376,15 @@ impl FeishuAdapter {
             .or(event.event.root_id)
             .or(event.event.parent_id);
 
-        let mut metadata = HashMap::from([("account_id".to_string(), event.header.app_id.clone())]);
+        let mut metadata = HashMap::from([
+            ("account_id".to_string(), event.header.app_id.clone()),
+            ("message_type".to_string(), event.event.message_type.clone()),
+        ]);
         if let Some(tid) = thread_id {
             metadata.insert("thread_id".to_string(), tid);
         }
 
-        Ok(Message {
+        Ok(Some(Message {
             id: event.header.event_id,
             from: event.event.sender.sender_id.open_id,
             to: String::new(),
@@ -384,7 +393,7 @@ impl FeishuAdapter {
             timestamp: chrono::Utc::now().timestamp(),
             metadata,
             thread_id: None,
-        })
+        }))
     }
 }
 
@@ -427,7 +436,7 @@ impl IMAdapter for FeishuAdapter {
             _ => {
                 let event: FeishuEvent = serde_json::from_value(raw)
                     .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
-                Ok(Some(self.parse_message_event(event)?))
+                self.parse_message_event(event)
             }
         }
     }

--- a/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
+++ b/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
@@ -1,0 +1,276 @@
+//! Unit tests for Feishu adapter: expand_post_content, parse_message_event,
+//! and parse_inbound (message_type propagation).
+
+use super::*;
+use crate::im_adapter::platforms::feishu::FeishuPlugin;
+use crate::im_adapter::plugin::IMPlugin;
+
+/// Create a test FeishuAdapter (no real HTTP — only sync methods are exercised).
+fn make_test_adapter() -> FeishuAdapter {
+    let http_client = reqwest::Client::new();
+    FeishuAdapter {
+        app_id: "test_app_id".to_string(),
+        app_secret: "test_secret".to_string(),
+        verification_token: "test_token".to_string(),
+        http_client,
+        cached_token: Arc::new(tokio::sync::Mutex::new(None)),
+    }
+}
+
+/// Build a minimal FeishuEvent for a message event.
+fn make_message_event(message_type: &str, content_json: &str) -> FeishuEvent {
+    FeishuEvent {
+        schema: "2.0".to_string(),
+        header: FeishuHeader {
+            event_id: "ev_test".to_string(),
+            event_type: "im.message.receive_v1".to_string(),
+            create_time: "1234567890".to_string(),
+            token: "tok".to_string(),
+            app_id: "test_app_id".to_string(),
+        },
+        event: FeishuMessageEvent {
+            sender: FeishuSender {
+                sender_id: FeishuSenderId {
+                    open_id: "ou_sender".to_string(),
+                },
+                sender_type: "user".to_string(),
+            },
+            content: content_json.to_string(),
+            chat_id: "oc_chat".to_string(),
+            message_type: message_type.to_string(),
+            thread_id: None,
+            root_id: None,
+            parent_id: None,
+        },
+    }
+}
+
+/// Build a webhook payload JSON from a message event.
+fn make_webhook_payload(message_type: &str, content_json: &str) -> Vec<u8> {
+    let event = make_message_event(message_type, content_json);
+    let payload = serde_json::json!({
+        "schema": event.schema,
+        "header": {
+            "event_id": event.header.event_id,
+            "event_type": event.header.event_type,
+            "create_time": event.header.create_time,
+            "token": event.header.token,
+            "app_id": event.header.app_id,
+        },
+        "event": {
+            "sender": {
+                "sender_id": { "open_id": event.event.sender.sender_id.open_id },
+                "sender_type": event.event.sender.sender_type,
+            },
+            "content": event.event.content,
+            "chat_id": event.event.chat_id,
+            "message_type": event.event.message_type,
+        },
+    });
+    serde_json::to_vec(&payload).unwrap()
+}
+
+// ===========================================================================
+// expand_post_content tests
+// ===========================================================================
+
+#[test]
+fn test_expand_post_pure_text() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "text", "text": "hello "},
+            {"tag": "text", "text": "world"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "hello world");
+}
+
+#[test]
+fn test_expand_post_with_link() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "text", "text": "visit "},
+            {"tag": "a", "text": "click here", "href": "https://example.com"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "visit click here");
+}
+
+#[test]
+fn test_expand_post_with_at() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "at", "name": "Alice", "user_id": "ou_123"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "@Alice");
+}
+
+#[test]
+fn test_expand_post_at_without_name() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "at", "user_id": "ou_456"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "@ou_456");
+}
+
+#[test]
+fn test_expand_post_with_title() {
+    let content = serde_json::json!({
+        "title": "My Title",
+        "content": [[
+            {"tag": "text", "text": "body"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "My Title\nbody");
+}
+
+#[test]
+fn test_expand_post_unknown_tag_with_text() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "img", "text": "alt text"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "alt text");
+}
+
+#[test]
+fn test_expand_post_unknown_tag_without_text() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "unknown"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "");
+}
+
+#[test]
+fn test_expand_post_empty_content() {
+    let content = serde_json::json!({"content": []});
+    assert_eq!(expand_post_content(&content), "");
+}
+
+#[test]
+fn test_expand_post_no_content_key() {
+    let content = serde_json::json!({});
+    assert_eq!(expand_post_content(&content), "");
+}
+
+#[test]
+fn test_expand_post_multiple_rows() {
+    let content = serde_json::json!({
+        "content": [
+            [{"tag": "text", "text": "line1"}],
+            [{"tag": "text", "text": "line2"}]
+        ]
+    });
+    assert_eq!(expand_post_content(&content), "line1\nline2");
+}
+
+// ===========================================================================
+// parse_message_event tests
+// ===========================================================================
+
+#[test]
+fn test_parse_message_event_text_type() {
+    let adapter = make_test_adapter();
+    let event = make_message_event("text", &serde_json::json!({"text": "hello"}).to_string());
+    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    assert_eq!(msg.content, "hello");
+    assert_eq!(msg.metadata.get("message_type").unwrap(), "text");
+}
+
+#[test]
+fn test_parse_message_event_post_type() {
+    let adapter = make_test_adapter();
+    let content = serde_json::json!({
+        "title": "T",
+        "content": [[{"tag": "text", "text": "body"}]]
+    });
+    let event = make_message_event("post", &content.to_string());
+    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    assert_eq!(msg.content, "T\nbody");
+    assert_eq!(msg.metadata.get("message_type").unwrap(), "post");
+}
+
+#[test]
+fn test_parse_message_event_image_returns_none() {
+    let adapter = make_test_adapter();
+    let event = make_message_event(
+        "image",
+        &serde_json::json!({"image_key": "img_xxx"}).to_string(),
+    );
+    let result = adapter.parse_message_event(event).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_parse_message_event_file_returns_none() {
+    let adapter = make_test_adapter();
+    let event = make_message_event(
+        "file",
+        &serde_json::json!({"file_key": "file_xxx"}).to_string(),
+    );
+    let result = adapter.parse_message_event(event).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_parse_message_event_metadata_account_id() {
+    let adapter = make_test_adapter();
+    let event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
+    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    assert_eq!(msg.metadata.get("account_id").unwrap(), "test_app_id");
+}
+
+#[test]
+fn test_parse_message_event_thread_id_from_root_id() {
+    let adapter = make_test_adapter();
+    let mut event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
+    event.event.root_id = Some("om_root123".to_string());
+    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    assert_eq!(msg.metadata.get("thread_id").unwrap(), "om_root123");
+}
+
+// ===========================================================================
+// parse_inbound tests (message_type propagation)
+// ===========================================================================
+
+#[tokio::test]
+async fn test_parse_inbound_text_type() {
+    let adapter = Arc::new(make_test_adapter());
+    let plugin = FeishuPlugin::new(adapter);
+    let payload = make_webhook_payload("text", &serde_json::json!({"text": "hi"}).to_string());
+    let normalized = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    assert_eq!(normalized.message_type, "text");
+    assert_eq!(normalized.content, "hi");
+}
+
+#[tokio::test]
+async fn test_parse_inbound_post_type() {
+    let adapter = Arc::new(make_test_adapter());
+    let plugin = FeishuPlugin::new(adapter);
+    let content = serde_json::json!({
+        "title": "Post",
+        "content": [[{"tag": "text", "text": "body"}]]
+    });
+    let payload = make_webhook_payload("post", &content.to_string());
+    let normalized = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    assert_eq!(normalized.message_type, "post");
+    assert_eq!(normalized.content, "Post\nbody");
+}
+
+#[tokio::test]
+async fn test_parse_inbound_image_returns_none() {
+    let adapter = Arc::new(make_test_adapter());
+    let plugin = FeishuPlugin::new(adapter);
+    let payload = make_webhook_payload(
+        "image",
+        &serde_json::json!({"image_key": "img_xxx"}).to_string(),
+    );
+    let result = plugin.parse_inbound(&payload).await.unwrap();
+    assert!(result.is_none());
+}

--- a/src/im_adapter/platforms/feishu/adapter/mod.rs
+++ b/src/im_adapter/platforms/feishu/adapter/mod.rs
@@ -561,3 +561,6 @@ impl IMAdapter for FeishuAdapter {
         expected == signature
     }
 }
+
+#[cfg(test)]
+mod adapter_tests;

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -58,7 +58,11 @@ impl IMPlugin for FeishuPlugin {
             peer_id: message.to,
             content: message.content,
             timestamp: message.timestamp,
-            message_type: "text".to_string(),
+            message_type: message
+                .metadata
+                .get("message_type")
+                .cloned()
+                .unwrap_or_else(|| "text".to_string()),
             media_refs: vec![],
             quoted_message: None,
             thread_id: message.metadata.get("thread_id").cloned(),


### PR DESCRIPTION
Fix Feishu adapter message parsing to align with design doc:

- Expand post-type messages into plain text (title + content blocks)
- Filter out non-text messages (image/file/audio) instead of passing them through
- Propagate actual message_type from Feishu event instead of hardcoding "text"

Source: user
Type: fix
