### PR TITLE
fix: render Thinking block as collapsible panel in feishu card

### DIFF
--- a/src/im_adapter/platforms/feishu/renderer.rs
+++ b/src/im_adapter/platforms/feishu/renderer.rs
@@ -337,3 +337,70 @@ fn contains_inline(s: &str) -> bool {
         || s.contains('`')
         || (s.contains('[') && s.contains("]("))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::types::ContentBlock;
+
+    #[test]
+    fn thinking_block_with_content_produces_collapsible_panel() {
+        let el = render_thinking_block("Let me reason...");
+        match &el {
+            CardElement::CollapsiblePanel { header, elements } => {
+                assert_eq!(header.title.content, "💭 Thinking");
+                assert_eq!(header.icon_tag, "down_small_with_solid_bg");
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CardElement::Markdown { content } => {
+                        assert_eq!(content, "Let me reason...");
+                    }
+                    other => panic!("expected Markdown inside panel, got {other:?}"),
+                }
+            }
+            other => panic!("expected CollapsiblePanel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thinking_block_empty_content_produces_collapsible_panel_with_placeholder() {
+        let el = render_thinking_block("");
+        match &el {
+            CardElement::CollapsiblePanel { header, elements } => {
+                assert_eq!(header.title.content, "💭 Thinking");
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CardElement::Markdown { content } => {
+                        assert!(content.contains("无思考内容"));
+                    }
+                    other => panic!("expected Markdown placeholder, got {other:?}"),
+                }
+            }
+            other => panic!("expected CollapsiblePanel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_blocks_with_thinking_includes_collapsible_panel() {
+        let blocks = vec![
+            ContentBlock::Thinking("reasoning here".into()),
+            ContentBlock::Text("Hello".into()),
+        ];
+        let (_, elements) = dispatch_blocks(&blocks, None);
+        let has_panel = elements
+            .iter()
+            .any(|e| matches!(e, CardElement::CollapsiblePanel { .. }));
+        assert!(has_panel, "expected a CollapsiblePanel in elements");
+    }
+
+    #[test]
+    fn thinking_block_serializes_with_collapsible_panel_tag() {
+        let el = render_thinking_block("some thought");
+        let json = serde_json::to_value(&el).unwrap();
+        assert_eq!(json["tag"], "collapsible_panel");
+        assert_eq!(json["header"]["title"]["content"], "💭 Thinking");
+        assert_eq!(json["header"]["icon_tag"], "down_small_with_solid_bg");
+        assert!(json["elements"].is_array());
+        assert_eq!(json["elements"][0]["tag"], "markdown");
+    }
+}

--- a/src/im_adapter/platforms/feishu/renderer.rs
+++ b/src/im_adapter/platforms/feishu/renderer.rs
@@ -155,25 +155,31 @@ fn to_elements(content: &str) -> Vec<CardElement> {
         .collect()
 }
 
-/// Render a Thinking block as a Feishu markdown quote block.
+/// Render a Thinking block as a Feishu collapsible panel.
+///
+/// The panel defaults to collapsed; users click the header to expand.
+/// When `content` is empty, a placeholder is shown inside the panel.
 fn render_thinking_block(content: &str) -> CardElement {
-    let quoted = content
-        .lines()
-        .map(|line| {
-            if line.is_empty() {
-                ">".to_string()
-            } else {
-                format!("> {line}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let body = if quoted.is_empty() {
-        "> 💭 Thinking".to_string()
-    } else {
-        format!("> 💭 Thinking\n{quoted}")
+    let header = CollapsiblePanelHeader {
+        title: CardText {
+            tag: "plain_text".into(),
+            content: "💭 Thinking".into(),
+        },
+        icon_tag: "down_small_with_solid_bg".into(),
     };
-    CardElement::Markdown { content: body }
+    let inner = if content.is_empty() {
+        vec![CardElement::Markdown {
+            content: "_（无思考内容）_".into(),
+        }]
+    } else {
+        vec![CardElement::Markdown {
+            content: content.to_string(),
+        }]
+    };
+    CardElement::CollapsiblePanel {
+        header,
+        elements: inner,
+    }
 }
 
 /// Render a ToolUse block as a Feishu `note` element.

--- a/src/im_adapter/platforms/feishu/renderer.rs
+++ b/src/im_adapter/platforms/feishu/renderer.rs
@@ -39,6 +39,12 @@ pub(crate) enum CardElement {
     Action { actions: Vec<CardAction> },
     #[serde(rename = "note")]
     Note { elements: Vec<CardNoteElement> },
+    #[serde(rename = "collapsible_panel")]
+    #[allow(dead_code)]
+    CollapsiblePanel {
+        header: CollapsiblePanelHeader,
+        elements: Vec<CardElement>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -68,8 +74,14 @@ pub(crate) struct CardAction {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct CardText {
-    tag: String,
-    content: String,
+    pub(crate) tag: String,
+    pub(crate) content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CollapsiblePanelHeader {
+    pub(crate) title: CardText,
+    pub(crate) icon_tag: String,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
飞书卡片 Thinking 块渲染方式与设计文档不一致。`render_thinking_block` 原本将 Thinking 内容渲染为 markdown 引用块（`> content`），不符合设计文档要求的"折叠推理区块"。

本次修改将 Thinking 块渲染改为飞书卡片的 `collapsible_panel` 组件：
- 新增 `CollapsiblePanel` / `CollapsiblePanelHeader` 类型到 `CardElement` enum
- 修改 `render_thinking_block` 生成折叠面板，默认折叠、用户可手动展开
- 补充 UT 覆盖 Thinking 块渲染逻辑

Source: design-doc
Type: fix
