### PR TITLE
fix: align Feishu adapter with design doc — NormalizedMessage output and inline detection

### DIFF
--- a/src/gateway/tests_archive.rs
+++ b/src/gateway/tests_archive.rs
@@ -194,7 +194,7 @@ impl IMAdapter for MockAdapter {
     async fn handle_webhook(
         &self,
         _payload: &[u8],
-    ) -> Result<Option<Message>, crate::im::AdapterError> {
+    ) -> Result<Option<crate::im_adapter::NormalizedMessage>, crate::im::AdapterError> {
         unimplemented!()
     }
 

--- a/src/gateway/tests_checkpoint.rs
+++ b/src/gateway/tests_checkpoint.rs
@@ -5,6 +5,7 @@
 
 use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
 use crate::im::{AdapterError, IMAdapter};
+use crate::im_adapter::NormalizedMessage;
 use crate::session::checkpoint_manager::CheckpointManager;
 use crate::session::persistence::ReasoningLevel;
 use crate::session::persistence::{PendingMessage, PersistenceService, SessionCheckpoint};
@@ -39,7 +40,10 @@ impl IMAdapter for MockAdapter {
         "mock"
     }
 
-    async fn handle_webhook(&self, _payload: &[u8]) -> Result<Option<Message>, AdapterError> {
+    async fn handle_webhook(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
         unimplemented!()
     }
 

--- a/src/im_adapter/mod.rs
+++ b/src/im_adapter/mod.rs
@@ -32,7 +32,10 @@ pub trait IMAdapter: Send + Sync {
     /// Returns `Ok(Some(message))` for recognized message events,
     /// `Ok(None)` for events that should be silently ignored
     /// (e.g. unknown card actions), or `Err` on parse failure.
-    async fn handle_webhook(&self, payload: &[u8]) -> Result<Option<Message>, AdapterError>;
+    async fn handle_webhook(
+        &self,
+        payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError>;
 
     /// Send message to IM platform.
     ///

--- a/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
+++ b/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
@@ -229,7 +229,7 @@ fn test_parse_message_event_text_type() {
     let event = make_message_event("text", &serde_json::json!({"text": "hello"}).to_string());
     let msg = adapter.parse_message_event(event).unwrap().unwrap();
     assert_eq!(msg.content, "hello");
-    assert_eq!(msg.metadata.get("message_type").unwrap(), "text");
+    assert_eq!(msg.message_type, "text");
 }
 
 #[test]
@@ -242,7 +242,7 @@ fn test_parse_message_event_post_type() {
     let event = make_message_event("post", &content.to_string());
     let msg = adapter.parse_message_event(event).unwrap().unwrap();
     assert_eq!(msg.content, "T\nbody");
-    assert_eq!(msg.metadata.get("message_type").unwrap(), "post");
+    assert_eq!(msg.message_type, "post");
 }
 
 #[test]
@@ -272,7 +272,7 @@ fn test_parse_message_event_metadata_account_id() {
     let adapter = make_test_adapter();
     let event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
     let msg = adapter.parse_message_event(event).unwrap().unwrap();
-    assert_eq!(msg.metadata.get("account_id").unwrap(), "test_app_id");
+    assert_eq!(msg.account_id.as_deref(), Some("test_app_id"));
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn test_parse_message_event_thread_id_from_root_id() {
     let mut event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
     event.event.root_id = Some("om_root123".to_string());
     let msg = adapter.parse_message_event(event).unwrap().unwrap();
-    assert_eq!(msg.metadata.get("thread_id").unwrap(), "om_root123");
+    assert_eq!(msg.thread_id.as_deref(), Some("om_root123"));
 }
 
 // ===========================================================================
@@ -353,6 +353,104 @@ async fn test_send_message_and_card_use_consistent_receive_id_type() {
         .await
         .unwrap();
     assert_eq!(received.lock().await.as_deref(), Some("chat_id"));
+}
+
+// ===========================================================================
+// handle_webhook card action tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_handle_webhook_card_action_forceful_shutdown() {
+    let adapter = make_test_adapter();
+    let payload = serde_json::json!({
+        "schema": "2.0",
+        "header": {
+            "event_id": "evt_card_1",
+            "event_type": "card.action.trigger",
+            "create_time": "1234567890",
+            "token": "tok",
+            "app_id": "test_app_id"
+        },
+        "operator": {
+            "open_id": "ou_operator"
+        },
+        "token": "card_token",
+        "action": {
+            "value": {"action": "forceful_shutdown", "chat_id": "oc_chat123"},
+            "tag": "button"
+        }
+    });
+    let result = adapter
+        .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    let msg = result.expect("expected Some(NormalizedMessage) for forceful_shutdown");
+    assert_eq!(msg.sender_id, "ou_operator");
+    assert_eq!(msg.content, "/__card_action:forceful_shutdown");
+    assert_eq!(msg.message_type, "text");
+    assert_eq!(msg.card_action, Some(true));
+    assert_eq!(msg.platform, "feishu");
+    assert_eq!(msg.peer_id, "oc_chat123");
+    assert_eq!(msg.account_id.as_deref(), Some("test_app_id"));
+}
+
+#[tokio::test]
+async fn test_handle_webhook_card_action_unknown_returns_none() {
+    let adapter = make_test_adapter();
+    let payload = serde_json::json!({
+        "schema": "2.0",
+        "header": {
+            "event_id": "evt_card_2",
+            "event_type": "card.action.trigger",
+            "create_time": "1234567890",
+            "token": "tok",
+            "app_id": "test_app_id"
+        },
+        "operator": {
+            "open_id": "ou_operator"
+        },
+        "token": "card_token",
+        "action": {
+            "value": {"action": "some_other_action"},
+            "tag": "button"
+        }
+    });
+    let result = adapter
+        .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    assert!(result.is_none(), "unknown card action should return None");
+}
+
+#[tokio::test]
+async fn test_handle_webhook_card_action_no_value_returns_none() {
+    let adapter = make_test_adapter();
+    let payload = serde_json::json!({
+        "schema": "2.0",
+        "header": {
+            "event_id": "evt_card_3",
+            "event_type": "card.action.trigger",
+            "create_time": "1234567890",
+            "token": "tok",
+            "app_id": "test_app_id"
+        },
+        "operator": {
+            "open_id": "ou_operator"
+        },
+        "token": "card_token",
+        "action": {
+            "value": null,
+            "tag": "button"
+        }
+    });
+    let result = adapter
+        .handle_webhook(&serde_json::to_vec(&payload).unwrap())
+        .await
+        .unwrap();
+    assert!(
+        result.is_none(),
+        "card action with null value should return None"
+    );
 }
 
 // ===========================================================================

--- a/src/im_adapter/platforms/feishu/adapter/mod.rs
+++ b/src/im_adapter/platforms/feishu/adapter/mod.rs
@@ -3,6 +3,7 @@
 use crate::gateway::Message;
 use crate::im::IMAdapter;
 use crate::im_adapter::error::AdapterError;
+use crate::im_adapter::normalized::NormalizedMessage;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -314,10 +315,10 @@ impl FeishuAdapter {
     /// Handle a card.action.trigger event.
     pub(super) fn handle_card_action(
         &self,
-        event_id: String,
+        _event_id: String,
         app_id: String,
         card_event: &FeishuCardActionEvent,
-    ) -> Result<Option<Message>, AdapterError> {
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
         let action_value = card_event
             .action
             .value
@@ -340,15 +341,18 @@ impl FeishuAdapter {
                 {
                     metadata.insert("chat_id".to_string(), chat_id.to_string());
                 }
-                Ok(Some(Message {
-                    id: event_id,
-                    from: card_event.operator.open_id.clone(),
-                    to: String::new(),
+                Ok(Some(NormalizedMessage {
+                    platform: "feishu".to_string(),
+                    sender_id: card_event.operator.open_id.clone(),
+                    peer_id: metadata.get("chat_id").cloned().unwrap_or_default(),
                     content: "/__card_action:forceful_shutdown".to_string(),
-                    channel: "feishu".to_string(),
                     timestamp: chrono::Utc::now().timestamp(),
-                    metadata,
+                    message_type: "text".to_string(),
+                    media_refs: vec![],
+                    quoted_message: None,
                     thread_id: None,
+                    account_id: metadata.get("account_id").cloned(),
+                    card_action: Some(true),
                 }))
             }
             _ => Ok(None),
@@ -358,18 +362,24 @@ impl FeishuAdapter {
     /// Parse a regular message event into a Message.
     ///
     /// Returns `Ok(None)` for non-text message types (image, file, audio, etc.).
-    fn parse_message_event(&self, event: FeishuEvent) -> Result<Option<Message>, AdapterError> {
+    fn parse_message_event(
+        &self,
+        event: FeishuEvent,
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
         let content: serde_json::Value = serde_json::from_str(&event.event.content)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 
-        let text = match event.event.message_type.as_str() {
-            "text" => content
-                .get("text")
-                .and_then(|t| t.as_str())
-                .unwrap_or("")
-                .to_string(),
-            "post" => expand_post_content(&content),
-            _ => return Ok(None),
+        let (text, message_type) = match event.event.message_type.as_str() {
+            "text" => (
+                content
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                "text".to_string(),
+            ),
+            "post" => (expand_post_content(&content), "post".to_string()),
+            _other => return Ok(None),
         };
 
         let thread_id = event
@@ -378,23 +388,18 @@ impl FeishuAdapter {
             .or(event.event.root_id)
             .or(event.event.parent_id);
 
-        let mut metadata = HashMap::from([
-            ("account_id".to_string(), event.header.app_id.clone()),
-            ("message_type".to_string(), event.event.message_type.clone()),
-        ]);
-        if let Some(tid) = thread_id {
-            metadata.insert("thread_id".to_string(), tid);
-        }
-
-        Ok(Some(Message {
-            id: event.header.event_id,
-            from: event.event.sender.sender_id.open_id,
-            to: String::new(),
+        Ok(Some(NormalizedMessage {
+            platform: "feishu".to_string(),
+            sender_id: event.event.sender.sender_id.open_id,
+            peer_id: event.event.chat_id,
             content: text,
-            channel: "feishu".to_string(),
             timestamp: chrono::Utc::now().timestamp(),
-            metadata,
-            thread_id: None,
+            message_type,
+            media_refs: vec![],
+            quoted_message: None,
+            thread_id,
+            account_id: Some(event.header.app_id),
+            card_action: None,
         }))
     }
 }
@@ -405,7 +410,10 @@ impl IMAdapter for FeishuAdapter {
         "feishu"
     }
 
-    async fn handle_webhook(&self, payload: &[u8]) -> Result<Option<Message>, AdapterError> {
+    async fn handle_webhook(
+        &self,
+        payload: &[u8],
+    ) -> Result<Option<NormalizedMessage>, AdapterError> {
         let raw: serde_json::Value = serde_json::from_slice(payload)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -48,27 +48,7 @@ impl IMPlugin for FeishuPlugin {
         &self,
         payload: &[u8],
     ) -> Result<Option<NormalizedMessage>, AdapterError> {
-        let message = match self.adapter.handle_webhook(payload).await? {
-            Some(m) => m,
-            None => return Ok(None),
-        };
-        Ok(Some(NormalizedMessage {
-            platform: message.channel,
-            sender_id: message.from,
-            peer_id: message.to,
-            content: message.content,
-            timestamp: message.timestamp,
-            message_type: message
-                .metadata
-                .get("message_type")
-                .cloned()
-                .unwrap_or_else(|| "text".to_string()),
-            media_refs: vec![],
-            quoted_message: None,
-            thread_id: message.metadata.get("thread_id").cloned(),
-            account_id: message.metadata.get("account_id").cloned(),
-            card_action: message.metadata.get("card_action").map(|v| v == "true"),
-        }))
+        self.adapter.handle_webhook(payload).await
     }
 
     async fn validate_signature(&self, signature: &str, payload: &[u8]) -> bool {

--- a/src/im_adapter/platforms/feishu/renderer.rs
+++ b/src/im_adapter/platforms/feishu/renderer.rs
@@ -39,6 +39,12 @@ pub(crate) enum CardElement {
     Action { actions: Vec<CardAction> },
     #[serde(rename = "note")]
     Note { elements: Vec<CardNoteElement> },
+    #[serde(rename = "collapsible_panel")]
+    #[allow(dead_code)]
+    CollapsiblePanel {
+        header: CollapsiblePanelHeader,
+        elements: Vec<CardElement>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -68,8 +74,14 @@ pub(crate) struct CardAction {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct CardText {
-    tag: String,
-    content: String,
+    pub(crate) tag: String,
+    pub(crate) content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CollapsiblePanelHeader {
+    pub(crate) title: CardText,
+    pub(crate) icon_tag: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -143,25 +155,31 @@ fn to_elements(content: &str) -> Vec<CardElement> {
         .collect()
 }
 
-/// Render a Thinking block as a Feishu markdown quote block.
+/// Render a Thinking block as a Feishu collapsible panel.
+///
+/// The panel defaults to collapsed; users click the header to expand.
+/// When `content` is empty, a placeholder is shown inside the panel.
 fn render_thinking_block(content: &str) -> CardElement {
-    let quoted = content
-        .lines()
-        .map(|line| {
-            if line.is_empty() {
-                ">".to_string()
-            } else {
-                format!("> {line}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let body = if quoted.is_empty() {
-        "> 💭 Thinking".to_string()
-    } else {
-        format!("> 💭 Thinking\n{quoted}")
+    let header = CollapsiblePanelHeader {
+        title: CardText {
+            tag: "plain_text".into(),
+            content: "💭 Thinking".into(),
+        },
+        icon_tag: "down_small_with_solid_bg".into(),
     };
-    CardElement::Markdown { content: body }
+    let inner = if content.is_empty() {
+        vec![CardElement::Markdown {
+            content: "_（无思考内容）_".into(),
+        }]
+    } else {
+        vec![CardElement::Markdown {
+            content: content.to_string(),
+        }]
+    };
+    CardElement::CollapsiblePanel {
+        header,
+        elements: inner,
+    }
 }
 
 /// Render a ToolUse block as a Feishu `note` element.
@@ -318,4 +336,165 @@ fn contains_inline(s: &str) -> bool {
         || s.contains('_')
         || s.contains('`')
         || (s.contains('[') && s.contains("]("))
+        || has_list_or_quote(s)
+}
+
+/// Returns true when any line starts with a list marker (`- `, `* `, `1. `)
+/// or a blockquote marker (`> `).
+fn has_list_or_quote(s: &str) -> bool {
+    s.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("- ")
+            || trimmed.starts_with("* ")
+            || trimmed.starts_with("> ")
+            || starts_with_ordered_list(trimmed)
+    })
+}
+
+/// Checks whether a line starts with an ordered list marker like `1. `,
+/// `12. `, etc.
+fn starts_with_ordered_list(line: &str) -> bool {
+    let digits: String = line.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return false;
+    }
+    line[digits.len()..].starts_with(". ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::types::ContentBlock;
+
+    #[test]
+    fn thinking_block_with_content_produces_collapsible_panel() {
+        let el = render_thinking_block("Let me reason...");
+        match &el {
+            CardElement::CollapsiblePanel { header, elements } => {
+                assert_eq!(header.title.content, "💭 Thinking");
+                assert_eq!(header.icon_tag, "down_small_with_solid_bg");
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CardElement::Markdown { content } => {
+                        assert_eq!(content, "Let me reason...");
+                    }
+                    other => panic!("expected Markdown inside panel, got {other:?}"),
+                }
+            }
+            other => panic!("expected CollapsiblePanel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thinking_block_empty_content_produces_collapsible_panel_with_placeholder() {
+        let el = render_thinking_block("");
+        match &el {
+            CardElement::CollapsiblePanel { header, elements } => {
+                assert_eq!(header.title.content, "💭 Thinking");
+                assert_eq!(elements.len(), 1);
+                match &elements[0] {
+                    CardElement::Markdown { content } => {
+                        assert!(content.contains("无思考内容"));
+                    }
+                    other => panic!("expected Markdown placeholder, got {other:?}"),
+                }
+            }
+            other => panic!("expected CollapsiblePanel, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dispatch_blocks_with_thinking_includes_collapsible_panel() {
+        let blocks = vec![
+            ContentBlock::Thinking("reasoning here".into()),
+            ContentBlock::Text("Hello".into()),
+        ];
+        let (_, elements) = dispatch_blocks(&blocks, None);
+        let has_panel = elements
+            .iter()
+            .any(|e| matches!(e, CardElement::CollapsiblePanel { .. }));
+        assert!(has_panel, "expected a CollapsiblePanel in elements");
+    }
+
+    #[test]
+    fn thinking_block_serializes_with_collapsible_panel_tag() {
+        let el = render_thinking_block("some thought");
+        let json = serde_json::to_value(&el).unwrap();
+        assert_eq!(json["tag"], "collapsible_panel");
+        assert_eq!(json["header"]["title"]["content"], "💭 Thinking");
+        assert_eq!(json["header"]["icon_tag"], "down_small_with_solid_bg");
+        assert!(json["elements"].is_array());
+        assert_eq!(json["elements"][0]["tag"], "markdown");
+    }
+
+    // ================================================================
+    // should_use_card — list and quote marker detection
+    // ================================================================
+
+    #[test]
+    fn should_use_card_unordered_list_dash() {
+        assert!(should_use_card("- buy milk", false));
+    }
+
+    #[test]
+    fn should_use_card_unordered_list_star() {
+        assert!(should_use_card("* item", false));
+    }
+
+    #[test]
+    fn should_use_card_ordered_list() {
+        assert!(should_use_card("1. first item", false));
+        assert!(should_use_card("12. twelfth item", false));
+    }
+
+    #[test]
+    fn should_use_card_blockquote() {
+        assert!(should_use_card("> hello", false));
+    }
+
+    #[test]
+    fn should_use_card_plain_text_returns_false() {
+        assert!(!should_use_card("hello world", false));
+    }
+
+    #[test]
+    fn should_use_card_bold_marker_returns_true() {
+        assert!(should_use_card("**bold**", false));
+    }
+
+    #[test]
+    fn should_use_card_italic_marker_returns_true() {
+        assert!(should_use_card("_italic_", false));
+    }
+
+    #[test]
+    fn should_use_card_code_marker_returns_true() {
+        assert!(should_use_card("`code`", false));
+    }
+
+    #[test]
+    fn should_use_card_link_marker_returns_true() {
+        assert!(should_use_card("[link](https://example.com)", false));
+    }
+
+    #[test]
+    fn should_use_card_multiline_returns_true() {
+        assert!(should_use_card("line1\nline2", false));
+    }
+
+    #[test]
+    fn should_use_card_with_dsl_returns_true() {
+        assert!(should_use_card("hello", true));
+    }
+
+    #[test]
+    fn should_use_card_empty_returns_false() {
+        assert!(!should_use_card("", false));
+    }
+
+    #[test]
+    fn has_list_or_quote_leading_whitespace() {
+        assert!(should_use_card("  - indented item", false));
+        assert!(should_use_card("  > indented quote", false));
+    }
 }

--- a/tests/feishu_adapter_tests.rs
+++ b/tests/feishu_adapter_tests.rs
@@ -67,10 +67,10 @@ async fn test_handle_webhook_valid() {
         .await
         .unwrap()
         .expect("expected Some(message)");
-    assert_eq!(msg.id, "evt_1");
-    assert_eq!(msg.from, "ou_abc");
+    assert_eq!(msg.sender_id, "ou_abc");
     assert_eq!(msg.content, "hello");
-    assert_eq!(msg.metadata.get("account_id"), Some(&"a".to_string()));
+    assert_eq!(msg.account_id.as_deref(), Some("a"));
+    assert_eq!(msg.platform, "feishu");
 }
 
 #[tokio::test]
@@ -92,7 +92,7 @@ async fn test_handle_webhook_empty_text() {
         .unwrap()
         .expect("expected Some(message)");
     assert_eq!(msg.content, "");
-    assert_eq!(msg.metadata.get("account_id"), Some(&"a".to_string()));
+    assert_eq!(msg.account_id.as_deref(), Some("a"));
 }
 
 #[tokio::test]

--- a/tests/gateway_send_outbound_basic.rs
+++ b/tests/gateway_send_outbound_basic.rs
@@ -349,7 +349,10 @@ async fn test_feishu_adapter_send_card_json_default() {
         fn name(&self) -> &str {
             "dummy"
         }
-        async fn handle_webhook(&self, _: &[u8]) -> Result<Option<Message>, AdapterError> {
+        async fn handle_webhook(
+            &self,
+            _: &[u8],
+        ) -> Result<Option<NormalizedMessage>, AdapterError> {
             Err(AdapterError::InvalidPayload("x".into()))
         }
         async fn send_message(&self, _: &Message, _: Option<&str>) -> Result<(), AdapterError> {


### PR DESCRIPTION
Align Feishu adapter behavior with design doc (`docs/design/im_adapter/platforms/feishu.md`):

1. **Adapter output type**: Refactor `IMAdapter` trait so `handle_webhook` returns `NormalizedMessage` directly, removing the intermediate `Message` step in `FeishuPlugin::parse_inbound`.

2. **Inline detection completeness**: Add list (`- `, `* `, `\d+. `) and quote (`> `) marker detection to `contains_inline`, ensuring single-line list/quote messages trigger interactive card output as specified in the design doc.

Source: user
Type: fix
