### PR TITLE
fix: add explicit placeholders for img/media/file tags in expand_element

### DIFF
--- a/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
+++ b/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
@@ -177,13 +177,43 @@ fn test_expand_post_with_title() {
 }
 
 #[test]
-fn test_expand_post_unknown_tag_with_text() {
+fn test_expand_post_img_tag_with_text() {
     let content = serde_json::json!({
         "content": [[
             {"tag": "img", "text": "alt text"}
         ]]
     });
-    assert_eq!(expand_post_content(&content), "alt text");
+    assert_eq!(expand_post_content(&content), "[图片]");
+}
+
+#[test]
+fn test_expand_post_media_tag() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "media"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "[视频]");
+}
+
+#[test]
+fn test_expand_post_file_tag() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "file"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "[文件]");
+}
+
+#[test]
+fn test_expand_post_unknown_tag_with_text() {
+    let content = serde_json::json!({
+        "content": [[
+            {"tag": "some_unknown", "text": "fallback text"}
+        ]]
+    });
+    assert_eq!(expand_post_content(&content), "fallback text");
 }
 
 #[test]
@@ -193,7 +223,7 @@ fn test_expand_post_unknown_tag_without_text() {
             {"tag": "unknown"}
         ]]
     });
-    assert_eq!(expand_post_content(&content), "");
+    assert_eq!(expand_post_content(&content), "[未知消息]");
 }
 
 #[test]

--- a/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
+++ b/src/im_adapter/platforms/feishu/adapter/adapter_tests.rs
@@ -249,6 +249,25 @@ fn test_expand_post_multiple_rows() {
     assert_eq!(expand_post_content(&content), "line1\nline2");
 }
 
+#[test]
+fn test_expand_post_title_with_mixed_elements() {
+    let content = serde_json::json!({
+        "title": "Mixed Post",
+        "content": [
+            [{"tag": "text", "text": "Hello "}, {"tag": "at", "name": "Bob"}],
+            [{"tag": "img"}],
+            [{"tag": "text", "text": "Caption"}],
+            [{"tag": "file"}],
+            [{"tag": "media"}],
+            [{"tag": "a", "text": "link", "href": "https://x.com"}]
+        ]
+    });
+    assert_eq!(
+        expand_post_content(&content),
+        "Mixed Post\nHello @Bob\n[图片]\nCaption\n[文件]\n[视频]\nlink"
+    );
+}
+
 // ===========================================================================
 // parse_message_event tests
 // ===========================================================================

--- a/src/im_adapter/platforms/feishu/adapter/mod.rs
+++ b/src/im_adapter/platforms/feishu/adapter/mod.rs
@@ -135,23 +135,45 @@ fn expand_post_content(content: &serde_json::Value) -> String {
 
 #[allow(dead_code)]
 /// Expand a single post content element into plain text based on its tag.
+///
+/// Supported tags:
+/// - `text`, `a` → text content
+/// - `at` → `@name` or `@user_id`
+/// - `img` → `[图片]`
+/// - `media` → `[视频]`
+/// - `file` → `[文件]`
+/// - unknown tags → text if available, otherwise `[未知消息]`
 fn expand_element(elem: &serde_json::Value) -> String {
     let tag = elem.get("tag").and_then(|t| t.as_str()).unwrap_or("");
-    let base = match tag {
-        "text" | "a" => elem.get("text").and_then(|t| t.as_str()).unwrap_or(""),
-        _ => elem.get("text").and_then(|t| t.as_str()).unwrap_or(""),
-    };
     match tag {
+        "text" | "a" => elem
+            .get("text")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .to_string(),
         "at" => {
             if let Some(name) = elem.get("name").and_then(|n| n.as_str()) {
                 format!("@{}", name)
             } else if let Some(user_id) = elem.get("user_id").and_then(|u| u.as_str()) {
                 format!("@{}", user_id)
             } else {
-                base.to_string()
+                elem.get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string()
             }
         }
-        _ => base.to_string(),
+        "img" => "[图片]".to_string(),
+        "media" => "[视频]".to_string(),
+        "file" => "[文件]".to_string(),
+        _ => {
+            let text = elem.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            if text.is_empty() {
+                "[未知消息]".to_string()
+            } else {
+                text.to_string()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
飞书 adapter 的 `expand_element` 函数仅处理 `text`、`a`、`at` 三种 tag，其他 tag（如 `img`、`media`、`file`）静默丢弃或返回空字符串。

为已知的飞书 post 内容元素类型添加显式占位符输出：
- `img` → `[图片]`
- `media` → `[视频]`
- `file` → `[文件]`
- 未知 tag 且无 text → `[未知消息]`

同时补充了 `expand_element` 所有分支和 `expand_post_content` 集成场景的单元测试。

Source: design-doc
Type: fix
