### PR TITLE
refactor: align IM adapter with design doc

### DIFF
--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -695,6 +695,7 @@ fn current_timestamp() -> i64 {
 pub struct TerminalPlugin {
     adapter: TerminalAdapter,
     ansi: bool,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl TerminalPlugin {
@@ -703,6 +704,9 @@ impl TerminalPlugin {
         Self {
             adapter: TerminalAdapter::new(),
             ansi: crate::platform::terminal::supports_ansi(),
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 
@@ -713,6 +717,9 @@ impl TerminalPlugin {
         Self {
             adapter: TerminalAdapter::new(),
             ansi,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 
@@ -926,5 +933,11 @@ impl IMPlugin for TerminalPlugin {
             .map_err(|e| AdapterError::SendFailed(e.to_string()))?;
         Write::flush(&mut stdout).map_err(|e| AdapterError::SendFailed(e.to_string()))?;
         Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -23,7 +23,6 @@ type StartupPlan = (
 );
 use crate::cli::terminal::TerminalPlugin;
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
-use crate::im_adapter::platforms::feishu::{FeishuAdapter, FeishuPlugin};
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{ReasoningHandler, SystemHandler, WorkdirHandler};
 use crate::slash::registry::HandlerRegistry;
@@ -274,7 +273,7 @@ impl Daemon {
         }
         let gateway = Arc::new(gateway);
         gateway.set_self_ref(Arc::clone(&gateway));
-        Self::init_feishu_plugin(config_dir, &gateway).await?;
+        crate::im_adapter::platforms::register_platform_plugins(&gateway, config_dir).await;
         Self::init_terminal_plugin(&gateway).await;
         Self::init_slash_dispatcher(&gateway, &session_manager, permission_engine).await;
         let shutdown = shutdown::ShutdownHandle::new();
@@ -893,24 +892,6 @@ impl Daemon {
 
 // --- Service init helpers ---
 impl Daemon {
-    /// Initialize Feishu IM plugin from env or config.
-    async fn init_feishu_plugin(_config_dir: &str, gateway: &Arc<Gateway>) -> anyhow::Result<()> {
-        let app_id = std::env::var("FEISHU_APP_ID").ok();
-        let app_secret = std::env::var("FEISHU_APP_SECRET").ok();
-        let verification_token = std::env::var("FEISHU_VERIFICATION_TOKEN").ok();
-        if let (Some(app_id), Some(app_secret), Some(verification_token)) =
-            (app_id, app_secret, verification_token)
-        {
-            let adapter = Arc::new(FeishuAdapter::new(app_id, app_secret, verification_token));
-            let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(FeishuPlugin::new(adapter));
-            gateway.register_plugin(plugin).await;
-            info!("Feishu plugin registered");
-        } else {
-            info!("Feishu credentials not found in env — Feishu plugin not registered");
-        }
-        Ok(())
-    }
-
     /// Initialize the terminal (CLI) IM plugin and register with Gateway.
     async fn init_terminal_plugin(gateway: &Arc<Gateway>) {
         let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(TerminalPlugin::new());

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -11,7 +11,7 @@ use crate::llm::types::{
 };
 use crate::processor_chain::dsl_parser::DslParser;
 use crate::processor_chain::{DslParseResult, ProcessedMessage};
-use crate::renderer::streaming::{DefaultStreamingRenderer, StreamingOutput, StreamingRenderer};
+use crate::renderer::streaming::StreamingOutput;
 use crate::renderer::RenderedOutput;
 use futures::StreamExt;
 
@@ -361,10 +361,8 @@ impl Gateway {
         match event {
             StreamEvent::BlockDelta { delta, .. } => {
                 let is_text_delta = matches!(delta, ContentDelta::Text { .. });
-                // Reconstruct event for the renderer (index is unused for BlockDelta).
-                let out = state
-                    .renderer
-                    .handle_event(StreamEvent::BlockDelta { index: 0, delta });
+                // Delegate to the plugin's streaming method.
+                let out = plugin.handle_stream_event(StreamEvent::BlockDelta { index: 0, delta });
                 // For Text deltas, the renderer may emit completed text lines
                 // and dsl lines; non-Text deltas only update internal state.
                 if is_text_delta {
@@ -372,7 +370,7 @@ impl Gateway {
                 }
             }
             StreamEvent::BlockEnd { block_type, .. } => {
-                let mut out = state.renderer.handle_event(event);
+                let mut out = plugin.handle_stream_event(event);
                 if block_type != ContentBlockType::Text {
                     let render_blocks = std::mem::take(&mut out.render_blocks);
                     for block in render_blocks {
@@ -383,7 +381,7 @@ impl Gateway {
                 dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
             }
             StreamEvent::MessageEnd { usage, .. } => {
-                let mut out = state.renderer.flush();
+                let mut out = plugin.flush_stream();
                 let render_blocks = std::mem::take(&mut out.render_blocks);
                 dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
                 for block in render_blocks {
@@ -399,7 +397,7 @@ impl Gateway {
                 return Err(GatewayError::OutboundError(message));
             }
             StreamEvent::BlockStart { .. } => {
-                state.renderer.handle_event(event);
+                plugin.handle_stream_event(event);
             }
         }
         Ok(())
@@ -412,7 +410,6 @@ impl Gateway {
 
 /// Mutable state carried across stream events in `send_outbound_streaming`.
 struct StreamState {
-    renderer: DefaultStreamingRenderer,
     content_blocks: Vec<ContentBlock>,
     dsl_lines: Vec<String>,
     usage: UnifiedUsage,
@@ -421,7 +418,6 @@ struct StreamState {
 impl StreamState {
     fn new() -> Self {
         Self {
-            renderer: DefaultStreamingRenderer::new(),
             content_blocks: Vec::new(),
             dsl_lines: Vec::new(),
             usage: UnifiedUsage {

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 struct MockPlugin {
     platform: String,
     should_fail: bool,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl MockPlugin {
@@ -29,6 +30,9 @@ impl MockPlugin {
         Self {
             platform: platform.to_string(),
             should_fail: false,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 
@@ -36,6 +40,9 @@ impl MockPlugin {
         Self {
             platform: platform.to_string(),
             should_fail: true,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 }
@@ -74,6 +81,12 @@ impl IMPlugin for MockPlugin {
             return Err(AdapterError::SendFailed("mock error".into()));
         }
         Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }
 

--- a/src/gateway/tests_dmscope.rs
+++ b/src/gateway/tests_dmscope.rs
@@ -20,6 +20,7 @@ struct MockPlugin {
     platform: String,
     #[allow(dead_code)]
     should_fail: bool,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl MockPlugin {
@@ -27,6 +28,9 @@ impl MockPlugin {
         Self {
             platform: platform.to_string(),
             should_fail: false,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 }
@@ -62,6 +66,12 @@ impl IMPlugin for MockPlugin {
         _thread_id: Option<&str>,
     ) -> Result<(), AdapterError> {
         Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }
 

--- a/src/gateway/tests_plugin.rs
+++ b/src/gateway/tests_plugin.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 struct MockPlugin {
     platform_name: String,
     fail: bool,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl MockPlugin {
@@ -22,12 +23,18 @@ impl MockPlugin {
         Self {
             platform_name: platform.to_string(),
             fail: false,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
     fn failing(platform: &str) -> Self {
         Self {
             platform_name: platform.to_string(),
             fail: true,
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 }
@@ -64,6 +71,12 @@ impl IMPlugin for MockPlugin {
         } else {
             Ok(())
         }
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }
 
@@ -156,6 +169,7 @@ use tokio::sync::RwLock;
 struct CapturingPlugin {
     platform_name: String,
     last_card: RwLock<Option<serde_json::Value>>,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl CapturingPlugin {
@@ -163,6 +177,9 @@ impl CapturingPlugin {
         Self {
             platform_name: platform.to_string(),
             last_card: RwLock::new(None),
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 
@@ -205,6 +222,12 @@ impl IMPlugin for CapturingPlugin {
             *self.last_card.write().await = Some(output.payload.clone());
         }
         Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }
 

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -84,7 +84,9 @@ fn make_gw(config: GatewayConfig) -> (crate::gateway::Gateway, Arc<SessionManage
     (gw, sm)
 }
 
-struct MockAdapter;
+struct MockAdapter {
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
+}
 
 #[async_trait]
 impl IMPlugin for MockAdapter {
@@ -118,13 +120,24 @@ impl IMPlugin for MockAdapter {
     ) -> Result<(), crate::im::AdapterError> {
         Ok(())
     }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
+    }
 }
 
 /// Scenario 1: No registry → Gateway behaviour unchanged (bypass).
 #[tokio::test]
 async fn test_processor_chain_bypass_no_registry() {
     let (gw, sm) = make_gw(make_config());
-    gw.register_plugin(Arc::new(MockAdapter)).await;
+    gw.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
     let msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
     let result = gw.route_message("mock", msg, None).await;
     assert!(result.is_ok(), "expected ok, got {result:?}");
@@ -151,12 +164,22 @@ async fn test_processor_chain_bypass_empty_registry() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_plugin(Arc::new(MockAdapter)).await;
+    gw.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
     let msg = msg_with_session(&sm, "mock", "agent-1", "plain text").await;
     let content_before = msg.content.clone();
     gw.route_message("mock", msg, None).await.unwrap();
     let (gw2, sm2) = make_gw(make_config());
-    gw2.register_plugin(Arc::new(MockAdapter)).await;
+    gw2.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
     let msg2 = msg_with_session(&sm2, "mock", "agent-1", "plain text").await;
     assert_eq!(msg2.content, content_before);
 }
@@ -187,7 +210,12 @@ async fn test_processor_chain_applies_processors() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_plugin(Arc::new(MockAdapter)).await;
+    gw.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
     let msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
     let result = gw.route_message("mock", msg, None).await;
     assert!(result.is_ok(), "expected ok, got {result:?}");
@@ -221,7 +249,12 @@ async fn test_processor_chain_execution_order_by_priority() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_plugin(Arc::new(MockAdapter)).await;
+    gw.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
 
     let raw_feishu = r#"{"msg_type":"text","text":{"text":"hello"}}"#;
     let mut msg = Message {
@@ -295,7 +328,12 @@ async fn test_processor_chain_metadata_merge() {
         Arc::clone(&sm),
         Arc::new(registry),
     );
-    gw.register_plugin(Arc::new(MockAdapter)).await;
+    gw.register_plugin(Arc::new(MockAdapter {
+        renderer: std::sync::Mutex::new(
+            crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+        ),
+    }))
+    .await;
 
     let mut msg = msg_with_session(&sm, "mock", "agent-1", "hello").await;
     msg.content = r#"{"msg_type":"text","text":{"text":"hello"}}"#.into();

--- a/src/gateway/tests_thread.rs
+++ b/src/gateway/tests_thread.rs
@@ -44,6 +44,7 @@ fn make_message(to: &str, content: &str) -> Message {
 struct CapturingPlugin {
     platform: String,
     captured_thread_id: std::sync::Mutex<Option<String>>,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
 }
 
 impl CapturingPlugin {
@@ -51,6 +52,9 @@ impl CapturingPlugin {
         Self {
             platform: platform.to_string(),
             captured_thread_id: std::sync::Mutex::new(None),
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
         }
     }
 
@@ -91,6 +95,12 @@ impl IMPlugin for CapturingPlugin {
     ) -> Result<(), AdapterError> {
         *self.captured_thread_id.lock().unwrap() = thread_id.map(|s| s.to_string());
         Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
     }
 }
 

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -14,6 +14,7 @@ use crate::gateway::Message;
 use crate::im_adapter::error::AdapterError;
 use crate::im_adapter::normalized::NormalizedMessage;
 use crate::im_adapter::plugin::{IMPlugin, RenderedOutput};
+use crate::im_adapter::streaming::DefaultStreamingRenderer;
 use crate::im_adapter::IMAdapter;
 use crate::llm::types::ContentBlock;
 use crate::processor_chain::DslParseResult;
@@ -51,11 +52,15 @@ pub async fn register(gateway: &Arc<crate::gateway::Gateway>, _config_dir: &str)
 /// Unified IM plugin for Feishu.
 pub struct FeishuPlugin {
     adapter: Arc<FeishuAdapter>,
+    renderer: std::sync::Mutex<DefaultStreamingRenderer>,
 }
 
 impl FeishuPlugin {
     pub(crate) fn new(adapter: Arc<FeishuAdapter>) -> Self {
-        Self { adapter }
+        Self {
+            adapter,
+            renderer: std::sync::Mutex::new(DefaultStreamingRenderer::new()),
+        }
     }
 }
 
@@ -149,5 +154,9 @@ impl IMPlugin for FeishuPlugin {
 
     fn clean_content(&self, raw: &str) -> String {
         cleaner::clean_feishu_content(raw)
+    }
+
+    fn streaming_renderer(&self) -> &std::sync::Mutex<DefaultStreamingRenderer> {
+        &self.renderer
     }
 }

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -20,12 +20,33 @@ use crate::processor_chain::DslParseResult;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::info;
 
 pub use adapter::CachedToken;
 pub use adapter::FeishuAdapter;
 use renderer::build_card;
 pub use renderer::build_text;
 pub use renderer::should_use_card_for_blocks;
+
+/// Register the Feishu plugin with the Gateway.
+///
+/// Reads credentials from environment variables.  If any required
+/// variable is missing the plugin is silently not registered.
+pub async fn register(gateway: &Arc<crate::gateway::Gateway>, _config_dir: &str) {
+    let app_id = std::env::var("FEISHU_APP_ID").ok();
+    let app_secret = std::env::var("FEISHU_APP_SECRET").ok();
+    let verification_token = std::env::var("FEISHU_VERIFICATION_TOKEN").ok();
+    if let (Some(app_id), Some(app_secret), Some(verification_token)) =
+        (app_id, app_secret, verification_token)
+    {
+        let adapter = Arc::new(FeishuAdapter::new(app_id, app_secret, verification_token));
+        let plugin: Arc<dyn crate::im::IMPlugin> = Arc::new(FeishuPlugin::new(adapter));
+        gateway.register_plugin(plugin).await;
+        info!("Feishu plugin registered");
+    } else {
+        info!("Feishu credentials not found in env — Feishu plugin not registered");
+    }
+}
 
 /// Unified IM plugin for Feishu.
 pub struct FeishuPlugin {

--- a/src/im_adapter/platforms/mod.rs
+++ b/src/im_adapter/platforms/mod.rs
@@ -2,5 +2,20 @@
 //!
 //! Each sub-module implements the [`IMPlugin`](super::plugin::IMPlugin) trait
 //! for a messaging platform.
+//!
+//! [`register_platform_plugins`] iterates over all platform modules and
+//! delegates to each module's `register()` function so that new platforms
+//! can be added by a single line change here.
 
 pub mod feishu;
+
+use std::sync::Arc;
+
+/// Register all platform IM plugins with the Gateway.
+///
+/// Plugins that live under `platforms/` are discovered here.  Plugins that
+/// do **not** belong in this directory (e.g. `TerminalPlugin`) are registered
+/// explicitly elsewhere (design doc: "不在 `platforms/` 下的插件通过显式注册").
+pub async fn register_platform_plugins(gateway: &Arc<crate::gateway::Gateway>, config_dir: &str) {
+    feishu::register(gateway, config_dir).await;
+}

--- a/src/im_adapter/plugin.rs
+++ b/src/im_adapter/plugin.rs
@@ -12,10 +12,12 @@
 use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
 use crate::im_adapter::error::AdapterError;
 use crate::im_adapter::normalized::NormalizedMessage;
-use crate::llm::types::ContentBlock;
+use crate::im_adapter::streaming::{DefaultStreamingRenderer, StreamingOutput, StreamingRenderer};
+use crate::llm::types::{ContentBlock, StreamEvent};
 use crate::processor_chain::DslParseResult;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
 
 // ---------------------------------------------------------------------------
 // Output type
@@ -226,5 +228,40 @@ pub trait IMPlugin: Send + Sync {
     /// Plugins that do not need cleanup can use the default no-op.
     async fn shutdown(&self) -> Result<(), AdapterError> {
         Ok(())
+    }
+
+    /// Process a single streaming [`StreamEvent`] and return incremental
+    /// output.
+    ///
+    /// The default implementation delegates to a [`DefaultStreamingRenderer`]
+    /// stored in a [`Mutex`] inside the implementor. Plugins that need
+    /// different rendering logic should override this method.
+    ///
+    /// [`Mutex`] is used because [`IMPlugin`] requires `Send + Sync`.
+    fn handle_stream_event(&self, event: StreamEvent) -> StreamingOutput {
+        self.streaming_renderer()
+            .lock()
+            .unwrap()
+            .handle_event(event)
+    }
+
+    /// Flush the streaming renderer and return any remaining buffered content.
+    ///
+    /// Called at stream end (e.g. `MessageEnd`) to drain partial lines and
+    /// accumulated blocks.
+    fn flush_stream(&self) -> StreamingOutput {
+        self.streaming_renderer().lock().unwrap().flush()
+    }
+
+    /// Access the plugin's streaming renderer.
+    ///
+    /// The default implementation panics — implementors must override this
+    /// to return a [`Mutex<DefaultStreamingRenderer>`] (or a custom renderer
+    /// wrapped in one).
+    fn streaming_renderer(&self) -> &Mutex<DefaultStreamingRenderer> {
+        panic!(
+            "IMPlugin::streaming_renderer() not implemented; \
+             override handle_stream_event / flush_stream or provide streaming_renderer"
+        )
     }
 }

--- a/src/im_adapter/plugin_tests.rs
+++ b/src/im_adapter/plugin_tests.rs
@@ -6,6 +6,8 @@
 //! - Mock plugin verifying plain-text fallback path
 //! - Edge cases: empty blocks, single/multi blocks, unclosed code fences,
 //!   no language annotation
+//! - `register_platform_plugins` auto-discovery (Step 1.1)
+//! - IMPlugin streaming default methods (Step 1.2)
 
 #[cfg(test)]
 mod tests {
@@ -13,9 +15,10 @@ mod tests {
     use crate::im_adapter::code_block::{parse_content_segments, ContentSegment};
     use crate::im_adapter::platforms::feishu::{FeishuAdapter, FeishuPlugin};
     use crate::im_adapter::plugin::{IMPlugin, RenderedOutput};
+    use crate::im_adapter::streaming::DefaultStreamingRenderer;
     use crate::im_adapter::AdapterError;
     use crate::im_adapter::NormalizedMessage;
-    use crate::llm::types::ContentBlock;
+    use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent};
     use async_trait::async_trait;
     use std::sync::Arc;
 
@@ -627,5 +630,271 @@ mod tests {
         let cloned = output.clone();
         assert_eq!(cloned.msg_type, output.msg_type);
         assert_eq!(cloned.payload, output.payload);
+    }
+
+    // =========================================================================
+    // IMPlugin streaming default method tests (Step 1.2)
+    // =========================================================================
+
+    /// Mock plugin with a real streaming renderer for testing default methods.
+    struct StreamingMockPlugin {
+        renderer: std::sync::Mutex<DefaultStreamingRenderer>,
+    }
+
+    impl StreamingMockPlugin {
+        fn new() -> Self {
+            Self {
+                renderer: std::sync::Mutex::new(DefaultStreamingRenderer::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl IMPlugin for StreamingMockPlugin {
+        fn platform(&self) -> &str {
+            "streaming-mock"
+        }
+
+        async fn parse_inbound(
+            &self,
+            _payload: &[u8],
+        ) -> Result<Option<NormalizedMessage>, AdapterError> {
+            Ok(None)
+        }
+
+        async fn send(
+            &self,
+            _output: &RenderedOutput,
+            _peer_id: &str,
+            _thread_id: Option<&str>,
+        ) -> Result<(), AdapterError> {
+            Ok(())
+        }
+
+        fn streaming_renderer(&self) -> &std::sync::Mutex<DefaultStreamingRenderer> {
+            &self.renderer
+        }
+    }
+
+    #[test]
+    fn test_streaming_text_delta_completes_line() {
+        let plugin = StreamingMockPlugin::new();
+
+        // BlockStart + delta with a sentence terminator → should emit a complete line.
+        let out = plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+        assert!(out.text_messages.is_empty());
+
+        let out = plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "Hello world.".to_string(),
+            },
+        });
+        assert_eq!(out.text_messages, vec!["Hello world."]);
+        assert!(out.render_blocks.is_empty());
+    }
+
+    #[test]
+    fn test_streaming_text_delta_buffered_no_terminator() {
+        let plugin = StreamingMockPlugin::new();
+
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+
+        // No terminator → nothing emitted yet.
+        let out = plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "partial text".to_string(),
+            },
+        });
+        assert!(out.text_messages.is_empty());
+
+        // Flush should return the buffered content.
+        let out = plugin.flush_stream();
+        assert_eq!(out.text_messages, vec!["partial text"]);
+    }
+
+    #[test]
+    fn test_streaming_non_text_block_emits_render_block() {
+        let plugin = StreamingMockPlugin::new();
+
+        // Thinking block → accumulates and emits on BlockEnd.
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Thinking,
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Thinking {
+                thinking: "reasoning...".to_string(),
+            },
+        });
+        let out = plugin.handle_stream_event(StreamEvent::BlockEnd {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Thinking,
+        });
+        assert!(out.text_messages.is_empty());
+        assert_eq!(out.render_blocks.len(), 1);
+        assert_eq!(
+            out.render_blocks[0],
+            ContentBlock::Thinking("reasoning...".to_string())
+        );
+    }
+
+    #[test]
+    fn test_streaming_tool_use_block_emits_render_block() {
+        let plugin = StreamingMockPlugin::new();
+
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::ToolUse,
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseId {
+                id: "call_1".to_string(),
+            },
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseName {
+                name: "exec".to_string(),
+            },
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseInputChunk {
+                input: r#"{"cmd":"ls"}"#.to_string(),
+            },
+        });
+        let out = plugin.handle_stream_event(StreamEvent::BlockEnd {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::ToolUse,
+        });
+        assert_eq!(out.render_blocks.len(), 1);
+        assert_eq!(
+            out.render_blocks[0],
+            ContentBlock::ToolUse {
+                id: "call_1".to_string(),
+                name: "exec".to_string(),
+                input: r#"{"cmd":"ls"}"#.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_streaming_flush_empty_buffer() {
+        let plugin = StreamingMockPlugin::new();
+        let out = plugin.flush_stream();
+        assert!(out.text_messages.is_empty());
+        assert!(out.render_blocks.is_empty());
+        assert!(out.dsl_lines.is_empty());
+    }
+
+    #[test]
+    fn test_streaming_end_to_end_text_only() {
+        let plugin = StreamingMockPlugin::new();
+
+        // Full lifecycle: start → delta → delta → end → flush.
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "First line. ".to_string(),
+            },
+        });
+        // The trailing space after '.' stays in the line buffer;
+        // the second delta appends to it.
+        let out = plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "Second line.".to_string(),
+            },
+        });
+        // " " + "Second line." → emitted on '.' terminator.
+        assert_eq!(out.text_messages, vec![" Second line."]);
+
+        // BlockEnd drains remaining buffer (empty here).
+        plugin.handle_stream_event(StreamEvent::BlockEnd {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+
+        // Flush after BlockEnd should be empty.
+        let out = plugin.flush_stream();
+        assert!(out.text_messages.is_empty());
+    }
+
+    #[test]
+    fn test_streaming_end_to_end_mixed_blocks() {
+        let plugin = StreamingMockPlugin::new();
+
+        // Text block — first delta emits on terminator, second continues.
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text {
+                text: "Hello.".to_string(),
+            },
+        });
+
+        // Thinking block in between.
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 1,
+            block_type: crate::llm::types::ContentBlockType::Thinking,
+        });
+        plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 1,
+            delta: ContentDelta::Thinking {
+                thinking: "hmm".to_string(),
+            },
+        });
+        let out = plugin.handle_stream_event(StreamEvent::BlockEnd {
+            index: 1,
+            block_type: crate::llm::types::ContentBlockType::Thinking,
+        });
+        assert_eq!(out.render_blocks.len(), 1);
+
+        // Another text block.
+        plugin.handle_stream_event(StreamEvent::BlockStart {
+            index: 2,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+        let out = plugin.handle_stream_event(StreamEvent::BlockDelta {
+            index: 2,
+            delta: ContentDelta::Text {
+                text: "World.".to_string(),
+            },
+        });
+        assert_eq!(out.text_messages, vec!["World."]);
+
+        // End first text block.
+        plugin.handle_stream_event(StreamEvent::BlockEnd {
+            index: 0,
+            block_type: crate::llm::types::ContentBlockType::Text,
+        });
+    }
+
+    #[test]
+    fn test_streaming_message_end_is_noop() {
+        let plugin = StreamingMockPlugin::new();
+        let out = plugin.handle_stream_event(StreamEvent::MessageEnd {
+            usage: None,
+            finish_reason: Some("end_turn".to_string()),
+        });
+        assert!(out.text_messages.is_empty());
+        assert!(out.render_blocks.is_empty());
     }
 }


### PR DESCRIPTION
Align IM adapter code with design document (design doc diff scan)

Three must-fix items identified by comparing code against design docs:

1. Auto-scan plugin registration: Gateway now discovers platform plugins
   via `platforms::register_platform_plugins()` instead of manual
   `init_feishu_plugin()` in daemon. New platforms require a single line
   in `platforms/mod.rs`.

2. Streaming as IMPlugin default methods: `handle_stream_event` and
   `flush_stream` are now IMPlugin trait default methods backed by a
   per-plugin `DefaultStreamingRenderer` (Mutex). Gateway outbound
   delegates to plugin streaming methods directly. Plugins can override
   for custom rendering.

3. card_action field (code_extra): Already present in code, no changes
   needed.

Source: CI
Type: refactor
