### PR TITLE
fix: compute session_key with SHA-256 hash per design doc

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -36,6 +36,8 @@ pub use crate::processor_chain::ProcessorRegistry;
 pub use session_handler::{HandleResult, SessionMessageHandler};
 pub use session_manager::SessionManager;
 
+use sha2::{Digest, Sha256};
+
 use crate::llm::types::ContentBlock;
 
 /// Type alias for the output channel sender used across session handler modules.
@@ -72,7 +74,7 @@ impl Default for DmScope {
 impl DmScope {
     /// Compute a session key for the given context.
     ///
-    /// Format: `{timestamp_ms}-{routing_fields}:{timestamp_ms}`
+    /// Format: `{timestamp_ms}-{sha256_hex(routing_fields)}`
     /// where `routing_fields` varies by scope variant.
     pub fn compute_session_key(
         &self,
@@ -81,39 +83,32 @@ impl DmScope {
         account_id: Option<&str>,
         timestamp_ms: i64,
     ) -> String {
-        match self {
+        let routing_fields = match self {
             DmScope::Main => {
-                format!(
-                    "{}-{}:{}:{}",
-                    timestamp_ms, channel, message.to, timestamp_ms
-                )
+                format!("{}:{}:{}", channel, message.to, timestamp_ms)
             }
             DmScope::PerPeer => {
-                format!(
-                    "{}-{}:{}:{}",
-                    timestamp_ms, message.from, message.to, timestamp_ms
-                )
+                format!("{}:{}:{}", message.from, message.to, timestamp_ms)
             }
             DmScope::PerChannelPeer => {
                 format!(
-                    "{}-{}:{}:{}:{}",
-                    timestamp_ms, channel, message.from, message.to, timestamp_ms
+                    "{}:{}:{}:{}",
+                    channel, message.from, message.to, timestamp_ms
                 )
             }
             DmScope::PerAccountChannelPeer => {
                 let acc = account_id.unwrap_or("default");
                 format!(
-                    "{}-{}:{}:{}:{}:{}",
-                    timestamp_ms, acc, channel, message.from, message.to, timestamp_ms
+                    "{}:{}:{}:{}:{}",
+                    acc, channel, message.from, message.to, timestamp_ms
                 )
             }
             DmScope::PerChannelSender => {
-                format!(
-                    "{}-{}:{}:{}",
-                    timestamp_ms, channel, message.from, timestamp_ms
-                )
+                format!("{}:{}:{}", channel, message.from, timestamp_ms)
             }
-        }
+        };
+        let hash = Sha256::digest(routing_fields.as_bytes());
+        format!("{}-{:x}", timestamp_ms, hash)
     }
 }
 

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -225,19 +225,13 @@ impl SessionManager {
             .compute_session_key(channel, message, account_id, timestamp_ms)
     }
 
-    /// Strip the `{timestamp_ms}-` prefix and `:{timestamp_ms}` suffix from a
-    /// session key, returning only the routing-key portion.
+    /// Strip the `{timestamp_ms}-` prefix from a session key, returning
+    /// only the sha256 hash portion.
     ///
-    /// Given a key in the format `{ts}-{routing_fields}:{ts}`, this returns
-    /// `{routing_fields}`.  Used by both `resolve` and `rebuild_key_registry`.
+    /// Given a key in the format `{ts}-{sha256_hex}`, this returns
+    /// `{sha256_hex}`.  Used by both `resolve` and `rebuild_key_registry`.
     pub(crate) fn strip_timestamp_from_session_key(key: &str) -> &str {
-        // Strip "{timestamp_ms}-" prefix
-        let without_prefix = key.find('-').map(|i| &key[i + 1..]).unwrap_or(key);
-        // Strip ":{timestamp_ms}" suffix
-        without_prefix
-            .rfind(':')
-            .map(|i| &without_prefix[..i])
-            .unwrap_or(without_prefix)
+        key.find('-').map(|i| &key[i + 1..]).unwrap_or(key)
     }
 
     /// Attempt to restore an archived session.

--- a/src/gateway/session_manager/key_registry.rs
+++ b/src/gateway/session_manager/key_registry.rs
@@ -5,6 +5,7 @@
 
 use super::SessionManager;
 use crate::session::persistence::PersistenceError;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::warn;
@@ -86,16 +87,17 @@ impl SessionManager {
                 }
             };
 
-            // Reconstruct the routing_key matching `compute_session_key(PerAccountChannelPeer)`
+            // Reconstruct the routing fields matching `compute_session_key(PerAccountChannelPeer)`
             // format: "{account_id}:{platform}:{sender_id}:{peer_id}".
-            // This is the routing portion of the full session key, with timestamps
-            // stripped, so it matches what `resolve` looks up in the registry.
+            // Hash them to produce the same registry key as `resolve`.
             let account_id = cp.account_id.as_deref().unwrap_or("default");
             let from = cp
                 .sender_id
                 .as_deref()
                 .unwrap_or_else(|| cp.agent_id.as_deref().unwrap_or(peer_id));
-            let session_key = format!("{}:{}:{}:{}", account_id, platform, from, peer_id);
+            let routing_fields = format!("{}:{}:{}:{}", account_id, platform, from, peer_id);
+            let hash = Sha256::digest(routing_fields.as_bytes());
+            let session_key = format!("{:x}", hash);
 
             let created = cp.created_at;
             match key_best.get(&session_key) {

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -41,8 +41,8 @@ impl SessionManager {
         message: &Message,
         account_id: Option<&str>,
     ) -> Result<String, ProcessError> {
-        // Extract routing_key (without timestamps) for registry lookups.
-        // Format: {ts}-{routing_fields}:{ts} → {routing_fields}
+        // Extract routing_key (sha256 hash) for registry lookups.
+        // Format: {ts}-{sha256_hex} → {sha256_hex}
         let routing_key = Self::strip_timestamp_from_session_key(session_key);
 
         // Path 1: key_registry hit — check if session is active

--- a/src/gateway/session_manager/resolve_tests.rs
+++ b/src/gateway/session_manager/resolve_tests.rs
@@ -226,11 +226,15 @@ async fn test_rebuild_key_registry() {
     mgr.rebuild_key_registry().await.unwrap();
 
     let reg = mgr.key_registry.read().await;
-    // Both sessions share the same reconstructed routing_key:
+    // Both sessions share the same reconstructed routing fields:
     // "default:feishu:agent-a:agent-a" (PerAccountChannelPeer, no sender_id → uses agent_id)
-    // The newer one (sid_new) should win
-    let key = "default:feishu:agent-a:agent-a";
-    assert_eq!(reg.get(key).unwrap(), "sid_new");
+    // The registry key is now the sha256 hash of the routing fields.
+    // The newer one (sid_new) should win.
+    use sha2::{Digest, Sha256};
+    let routing_fields = "default:feishu:agent-a:agent-a";
+    let hash = Sha256::digest(routing_fields.as_bytes());
+    let key = format!("{:x}", hash);
+    assert_eq!(reg.get(&key).unwrap(), "sid_new");
 }
 
 // ── find_or_create delegates to resolve ──────────────────────────────────────

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -195,38 +195,95 @@ fn msg(from: &str, to: &str) -> Message {
 #[test]
 fn test_dm_scope_main_session_key() {
     let key = DmScope::Main.compute_session_key("ch_x", &msg("a", "b"), None, 0);
-    assert_eq!(key, "0-ch_x:b:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
+    // Deterministic: same input → same key
+    let key2 = DmScope::Main.compute_session_key("ch_x", &msg("a", "b"), None, 0);
+    assert_eq!(key, key2, "same input should produce same key");
 }
 
 #[test]
 fn test_dm_scope_per_peer_session_key() {
     let key = DmScope::PerPeer.compute_session_key("ch_x", &msg("a", "b"), None, 0);
-    assert_eq!(key, "0-a:b:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 #[test]
 fn test_dm_scope_per_channel_peer_session_key() {
     let key = DmScope::PerChannelPeer.compute_session_key("ch_x", &msg("a", "b"), None, 0);
-    assert_eq!(key, "0-ch_x:a:b:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 #[test]
 fn test_dm_scope_per_account_channel_peer_with_account() {
     let key =
         DmScope::PerAccountChannelPeer.compute_session_key("ch_x", &msg("a", "b"), Some("acc1"), 0);
-    assert_eq!(key, "0-acc1:ch_x:a:b:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 #[test]
 fn test_dm_scope_per_account_channel_peer_without_account() {
     let key = DmScope::PerAccountChannelPeer.compute_session_key("ch_x", &msg("a", "b"), None, 0);
-    assert_eq!(key, "0-default:ch_x:a:b:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 #[test]
 fn test_dm_scope_per_channel_sender_session_key() {
     let key = DmScope::PerChannelSender.compute_session_key("ch_x", &msg("a", "b"), None, 0);
-    assert_eq!(key, "0-ch_x:a:0");
+    assert!(
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
+    );
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 #[test]
@@ -251,17 +308,25 @@ fn test_dm_scope_default_session_key_contains_four_fields() {
         Some("t_account"),
         0,
     );
-    // PerAccountChannelPeer format: {timestamp_ms}-{account_id}:{platform}:{sender_id}:{peer_id}:{timestamp_ms}
+    // PerAccountChannelPeer format: {timestamp_ms}-{sha256_hex}
     assert!(
-        key.contains("t_account"),
-        "key should contain account_id: {key}"
+        key.starts_with("0-"),
+        "key should start with timestamp prefix: {key}"
     );
-    assert!(key.contains("feishu"), "key should contain platform: {key}");
+    let hash_part = &key[2..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
     assert!(
-        key.contains("ou_sender"),
-        "key should contain sender_id: {key}"
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
     );
-    assert!(key.contains("oc_peer"), "key should contain peer_id: {key}");
+    // Deterministic: same input → same key
+    let key2 = DmScope::default().compute_session_key(
+        "feishu",
+        &msg("ou_sender", "oc_peer"),
+        Some("t_account"),
+        0,
+    );
+    assert_eq!(key, key2, "same input should produce same key");
 }
 
 // ── GatewayConfig serde: dm_scope values ─────────────────────────────────────

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -485,12 +485,15 @@ async fn test_process_inbound_chain_with_session_router() {
         .await;
     assert_eq!(result.content, "hi");
     // SessionRouter injects session_key with real timestamp.
-    // Verify the routing fields are present in the key.
+    // Verify the key has the expected format: {ts_ms}-{sha256_hex}
     let key = result.metadata.get("session_key").and_then(|v| v.as_str());
     let key = key.expect("session_key should be set");
-    // Strip timestamp prefix and suffix to get routing fields
-    let routing_fields = SessionManager::strip_timestamp_from_session_key(key);
-    assert_eq!(routing_fields, "default:terminal:user1:peer1");
+    let hash_part = SessionManager::strip_timestamp_from_session_key(key);
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 /// When a processor returns an error, `process_inbound_chain` falls back to
@@ -571,11 +574,15 @@ async fn test_e2e_inbound_full_stack_strips_ansi_and_injects_session_key() {
     assert_eq!(result.content, "helloworld!");
     assert!(!result.suppress);
 
-    // SessionRouter uses real timestamp — verify routing fields in the key.
+    // SessionRouter uses real timestamp — verify key format.
     let key = result.metadata.get("session_key").and_then(|v| v.as_str());
     let key = key.expect("session_key should be set");
-    let routing_fields = SessionManager::strip_timestamp_from_session_key(key);
-    assert_eq!(routing_fields, "default:terminal:user1:peer1");
+    let hash_part = SessionManager::strip_timestamp_from_session_key(key);
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+    assert!(
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
+    );
 }
 
 /// After processing through the inbound chain, the cleaned content is

--- a/src/im/processor/session_router.rs
+++ b/src/im/processor/session_router.rs
@@ -280,7 +280,7 @@ mod tests {
             .unwrap();
         let key = result.metadata.get("session_key").unwrap();
         assert!(!key.is_empty(), "session_key should not be empty");
-        // Key format: {timestamp_ms}-{routing_fields}:{timestamp_ms}
+        // Key format: {timestamp_ms}-{sha256_hex}
         assert!(
             key.contains("-"),
             "key should contain timestamp separator '-': {key}"
@@ -289,8 +289,12 @@ mod tests {
             key.starts_with("1777229589621-"),
             "key should start with timestamp prefix: {key}"
         );
-        assert!(key.contains("ou_user_a"), "key should contain from: {key}");
-        assert!(key.contains("oc_agent_b"), "key should contain to: {key}");
+        let hash_part = &key[key.find('-').unwrap() + 1..];
+        assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+        assert!(
+            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash should be hex: {key}"
+        );
     }
 
     #[tokio::test]
@@ -403,8 +407,12 @@ mod tests {
             key.starts_with("1777229589621-"),
             "key should start with timestamp prefix: {key}"
         );
-        assert!(key.contains("ou_user_a"));
-        assert!(key.contains("oc_agent_b"));
+        let hash_part = &key[key.find('-').unwrap() + 1..];
+        assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+        assert!(
+            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash should be hex: {key}"
+        );
         assert_eq!(result.content, "{\"text\":\"hello\"}");
     }
 
@@ -446,8 +454,12 @@ mod tests {
             key.starts_with("1777229589621-"),
             "key should start with timestamp prefix: {key}"
         );
-        assert!(key.contains("ou_thread_user"));
-        assert!(key.contains("oc_thread_chat"));
+        let hash_part = &key[key.find('-').unwrap() + 1..];
+        assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
+        assert!(
+            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash should be hex: {key}"
+        );
         assert_eq!(result.content, "{\"text\":\"original\"}");
     }
 

--- a/src/processor_chain/session_router_tests.rs
+++ b/src/processor_chain/session_router_tests.rs
@@ -29,21 +29,16 @@ async fn test_terminal_session_key_computed() {
         .and_then(|v| v.as_str())
         .unwrap();
     assert!(!key.is_empty(), "session_key should not be empty");
-    // Key format: {timestamp_ms}-terminal:1000:cli:{timestamp_ms}
+    // Key format: {timestamp_ms}-{sha256_hex}
     assert!(
         key.starts_with(&format!("{ts_ms}-")),
         "key should start with timestamp prefix: {key}"
     );
-    assert!(key.contains("1000"), "key should contain sender_id: {key}");
-    assert!(key.contains("cli"), "key should contain peer_id: {key}");
+    let hash_part = &key[key.find('-').unwrap() + 1..];
+    assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");
     assert!(
-        key.contains("terminal"),
-        "key should contain platform: {key}"
-    );
-    // Should end with :{timestamp_ms}
-    assert!(
-        key.ends_with(&format!(":{ts_ms}")),
-        "key should end with timestamp suffix: {key}"
+        hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
     );
 }
 
@@ -218,7 +213,7 @@ async fn test_different_timestamps_produce_different_keys() {
         .to_string();
 
     assert_ne!(k1, k2, "different timestamps must produce different keys");
-    // Verify each key starts with its own timestamp
+    // Verify each key starts with its own timestamp and has 64-hex-char hash
     assert!(
         k1.starts_with(&format!("{}-", ts1.timestamp_millis())),
         "k1 should start with ts1: {k1}"
@@ -226,6 +221,18 @@ async fn test_different_timestamps_produce_different_keys() {
     assert!(
         k2.starts_with(&format!("{}-", ts2.timestamp_millis())),
         "k2 should start with ts2: {k2}"
+    );
+    let h1 = &k1[k1.find('-').unwrap() + 1..];
+    let h2 = &k2[k2.find('-').unwrap() + 1..];
+    assert_eq!(h1.len(), 64, "k1 hash should be 64 hex chars: {k1}");
+    assert_eq!(h2.len(), 64, "k2 hash should be 64 hex chars: {k2}");
+    assert!(
+        h1.chars().all(|c| c.is_ascii_hexdigit()),
+        "k1 hash should be hex: {k1}"
+    );
+    assert!(
+        h2.chars().all(|c| c.is_ascii_hexdigit()),
+        "k2 hash should be hex: {k2}"
     );
 }
 
@@ -275,9 +282,25 @@ async fn test_same_routing_different_timestamps_different_keys() {
         ka, kb,
         "same routing fields with different timestamps must differ"
     );
-    // Both should contain the routing fields
-    assert!(ka.contains("user_99"), "ka should contain sender: {ka}");
-    assert!(ka.contains("dm_1"), "ka should contain peer: {ka}");
-    assert!(kb.contains("user_99"), "kb should contain sender: {kb}");
-    assert!(kb.contains("dm_1"), "kb should contain peer: {kb}");
+    // Both should have timestamp prefix and 64-hex-char hash
+    assert!(
+        ka.starts_with(&format!("{}-", ts_a.timestamp_millis())),
+        "ka should start with ts_a: {ka}"
+    );
+    assert!(
+        kb.starts_with(&format!("{}-", ts_b.timestamp_millis())),
+        "kb should start with ts_b: {kb}"
+    );
+    let ha = &ka[ka.find('-').unwrap() + 1..];
+    let hb = &kb[kb.find('-').unwrap() + 1..];
+    assert_eq!(ha.len(), 64, "ka hash should be 64 hex chars: {ka}");
+    assert_eq!(hb.len(), 64, "kb hash should be 64 hex chars: {kb}");
+    assert!(
+        ha.chars().all(|c| c.is_ascii_hexdigit()),
+        "ka hash should be hex: {ka}"
+    );
+    assert!(
+        hb.chars().all(|c| c.is_ascii_hexdigit()),
+        "kb hash should be hex: {kb}"
+    );
 }


### PR DESCRIPTION
Align session_key computation with design doc specification.

The design doc (`docs/design/gateway/inbound-flow.md`) specifies that session_key should use a SHA-256 hash of routing fields, but the code was using raw string concatenation. This PR closes the gap:

- `DmScope::compute_session_key()` now hashes routing_fields with SHA-256
- Format changed from `{ts}-{raw_fields}:{ts}` to `{ts}-{sha256_hex}`
- `strip_timestamp_from_session_key()` simplified for new format
- `key_registry` rebuild updated to hash routing fields
- All gateway and session_router tests updated to verify hash format

Source: design doc docs/design/gateway/inbound-flow.md
Type: fix
