### PR TITLE
fix: use message.timestamp in session tests for consistency

### DIFF
--- a/src/gateway/session_manager/resolve_tests.rs
+++ b/src/gateway/session_manager/resolve_tests.rs
@@ -61,7 +61,7 @@ fn test_generate_session_id_uniqueness() {
 async fn test_resolve_path1_active_hit() {
     let mgr = make_test_mgr(None);
     let msg = test_message();
-    let session_key = mgr.compute_session_key("feishu", &msg, None, 0);
+    let session_key = mgr.compute_session_key("feishu", &msg, None, msg.timestamp);
     // resolve() strips timestamps before registry lookup — insert routing_key.
     let routing_key = SessionManager::strip_timestamp_from_session_key(&session_key);
     let session_id = "active_session_1";
@@ -108,7 +108,7 @@ async fn test_resolve_path2_archived_hit_restore() {
         ReasoningLevel::default(),
     );
     let msg = test_message();
-    let session_key = mgr.compute_session_key("feishu", &msg, None, 0);
+    let session_key = mgr.compute_session_key("feishu", &msg, None, msg.timestamp);
     // resolve() strips timestamps before registry lookup — insert routing_key.
     let routing_key = SessionManager::strip_timestamp_from_session_key(&session_key);
     {
@@ -128,7 +128,7 @@ async fn test_resolve_path2_archived_hit_restore() {
 async fn test_resolve_path3_miss_creates_new() {
     let mgr = make_test_mgr(None);
     let msg = test_message();
-    let session_key = mgr.compute_session_key("feishu", &msg, None, 0);
+    let session_key = mgr.compute_session_key("feishu", &msg, None, msg.timestamp);
     // key_registry is empty → miss → create new
     let result = mgr
         .resolve(&session_key, "feishu", &msg, None)

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -81,7 +81,7 @@ async fn test_archived_session_restoration() {
     let msg = test_message();
     // Populate key_registry so resolve can look up the session.
     // resolve() strips timestamps before registry lookup — insert routing_key.
-    let session_key = mgr.compute_session_key("feishu", &msg, None, 0);
+    let session_key = mgr.compute_session_key("feishu", &msg, None, msg.timestamp);
     let routing_key = SessionManager::strip_timestamp_from_session_key(&session_key);
     {
         let mut reg = mgr.key_registry.write().await;


### PR DESCRIPTION
修复 `test_archived_session_restoration` 及 resolve 测试中 timestamp 不一致导致的 CI 失败。

根因：测试 setup 使用 `compute_session_key("feishu", &msg, None, 0)` 算 routing_key（timestamp=0），但 `find_or_create` 内部用 `message.timestamp`（当前时间）算 session_key → routing_key 不同 → key_registry 找不到 → 走 Path 3 创建新 session。

修复：所有测试统一使用 `msg.timestamp` 替代硬编码 `0`，确保 routing_key 计算一致。

Source: CI
Type: fix
