### PR TITLE
refactor: implement compile-time platform plugin auto-discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
+ "inventory",
  "libc",
  "mockito",
  "notify",
@@ -1245,6 +1246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,9 @@ async-stream = "0.3.6"
 tree-sitter = "0.24"
 tree-sitter-bash = "0.23"
 
+# Plugin auto-discovery (inventory collects platform entries at compile time)
+inventory = "0.3"
+
 
 [dev-dependencies]
 # Testing

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 fn main() {
     let platforms_dir = Path::new("src/im_adapter/platforms");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     // Re-run when the platforms directory changes.
     println!("cargo:rerun-if-changed=src/im_adapter/platforms");
@@ -16,7 +17,14 @@ fn main() {
             if path.is_dir() {
                 if let Some(name) = path.file_name() {
                     if let Some(name_str) = name.to_str() {
-                        mods.push(format!("pub mod {};", name_str));
+                        // Use #[path] with absolute path so module resolution
+                        // works correctly when included via include!() from
+                        // a different file context (OUT_DIR).
+                        let abs_path = format!(
+                            "{}/src/im_adapter/platforms/{}/mod.rs",
+                            manifest_dir, name_str
+                        );
+                        mods.push(format!("#[path = \"{}\"]\npub mod {};", abs_path, name_str));
                     }
                 }
             }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,32 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let platforms_dir = Path::new("src/im_adapter/platforms");
+
+    // Re-run when the platforms directory changes.
+    println!("cargo:rerun-if-changed=src/im_adapter/platforms");
+
+    let mut mods = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(platforms_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name) = path.file_name() {
+                    if let Some(name_str) = name.to_str() {
+                        mods.push(format!("pub mod {};", name_str));
+                    }
+                }
+            }
+        }
+    }
+
+    mods.sort();
+    let content = mods.join("\n") + "\n";
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("platforms_gen.rs");
+    fs::write(dest_path, content).unwrap();
+}

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -23,11 +23,22 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::info;
 
+use super::PlatformEntry;
+
 pub use adapter::CachedToken;
 pub use adapter::FeishuAdapter;
 use renderer::build_card;
 pub use renderer::build_text;
 pub use renderer::should_use_card_for_blocks;
+
+inventory::submit!(PlatformEntry {
+    name: "feishu",
+    register: |gw, cfg| {
+        let gw = gw.clone();
+        let cfg = cfg.to_string();
+        Box::pin(async move { register(&gw, &cfg).await })
+    },
+});
 
 /// Register the Feishu plugin with the Gateway.
 ///

--- a/src/im_adapter/platforms/mod.rs
+++ b/src/im_adapter/platforms/mod.rs
@@ -16,6 +16,12 @@ use std::sync::Arc;
 // Auto-generated module declarations (from build.rs).
 include!(concat!(env!("OUT_DIR"), "/platforms_gen.rs"));
 
+/// Registration function type for platform plugins.
+///
+/// Receives the Gateway handle and the configuration directory path.
+pub type RegisterFn =
+    fn(&Arc<crate::gateway::Gateway>, &str) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+
 /// A platform plugin entry discovered at compile time via [`inventory`].
 ///
 /// Each platform module calls [`inventory::submit!`] with a `PlatformEntry`
@@ -26,8 +32,7 @@ pub struct PlatformEntry {
     pub name: &'static str,
     /// Registration function.  Receives the Gateway handle and the
     /// configuration directory path.
-    pub register:
-        fn(&Arc<crate::gateway::Gateway>, &str) -> Pin<Box<dyn Future<Output = ()> + Send>>,
+    pub register: RegisterFn,
 }
 
 inventory::collect!(PlatformEntry);

--- a/src/im_adapter/platforms/mod.rs
+++ b/src/im_adapter/platforms/mod.rs
@@ -1,21 +1,45 @@
 //! Platform-specific IM plugins.
 //!
 //! Each sub-module implements the [`IMPlugin`](super::plugin::IMPlugin) trait
-//! for a messaging platform.
+//! for a messaging platform.  Modules are auto-discovered at compile time by
+//! `build.rs`, which scans this directory and writes `pub mod <name>;` lines
+//! into `$OUT_DIR/platforms_gen.rs`.
 //!
-//! [`register_platform_plugins`] iterates over all platform modules and
-//! delegates to each module's `register()` function so that new platforms
-//! can be added by a single line change here.
+//! [`register_platform_plugins`] iterates over all [`PlatformEntry`] values
+//! collected via [`inventory`] and delegates to each module's `register()`
+//! function, so adding a new platform requires no changes here.
 
-pub mod feishu;
-
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+
+// Auto-generated module declarations (from build.rs).
+include!(concat!(env!("OUT_DIR"), "/platforms_gen.rs"));
+
+/// A platform plugin entry discovered at compile time via [`inventory`].
+///
+/// Each platform module calls [`inventory::submit!`] with a `PlatformEntry`
+/// to register itself.  [`register_platform_plugins`] then iterates over
+/// all collected entries and invokes their `register` function.
+pub struct PlatformEntry {
+    /// Platform identifier (e.g. `"feishu"`).
+    pub name: &'static str,
+    /// Registration function.  Receives the Gateway handle and the
+    /// configuration directory path.
+    pub register:
+        fn(&Arc<crate::gateway::Gateway>, &str) -> Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+inventory::collect!(PlatformEntry);
 
 /// Register all platform IM plugins with the Gateway.
 ///
-/// Plugins that live under `platforms/` are discovered here.  Plugins that
-/// do **not** belong in this directory (e.g. `TerminalPlugin`) are registered
-/// explicitly elsewhere (design doc: "不在 `platforms/` 下的插件通过显式注册").
+/// Iterates over every [`PlatformEntry`] collected by [`inventory`] and
+/// calls its `register` function.  Plugins that do **not** belong in
+/// `platforms/` (e.g. `TerminalPlugin`) are registered explicitly elsewhere
+/// (design doc: "不在 `platforms/` 下的插件通过显式注册").
 pub async fn register_platform_plugins(gateway: &Arc<crate::gateway::Gateway>, config_dir: &str) {
-    feishu::register(gateway, config_dir).await;
+    for entry in inventory::iter::<PlatformEntry> {
+        (entry.register)(gateway, config_dir).await;
+    }
 }

--- a/src/im_adapter/plugin_tests.rs
+++ b/src/im_adapter/plugin_tests.rs
@@ -897,4 +897,59 @@ mod tests {
         assert!(out.text_messages.is_empty());
         assert!(out.render_blocks.is_empty());
     }
+
+    // =====================================================================
+    // Auto-discovery mechanism tests (Step 1.5)
+    // =====================================================================
+
+    use crate::im_adapter::platforms::{register_platform_plugins, PlatformEntry};
+
+    /// Verify that `inventory::iter::<PlatformEntry>` collects at least one
+    /// entry with `name == "feishu"` — i.e. the feishu platform module was
+    /// discovered at compile time via `inventory::submit!`.
+    #[test]
+    fn test_platform_entry_inventory_collects_feishu() {
+        let found = inventory::iter::<PlatformEntry>().any(|entry| entry.name == "feishu");
+        assert!(
+            found,
+            "inventory must contain at least one PlatformEntry with name \"feishu\""
+        );
+    }
+
+    /// Verify that `register_platform_plugins` calls the feishu register
+    /// function so that `gateway.get_plugin("feishu")` returns `Some`.
+    /// Skipped when Feishu credentials are not available.
+    #[tokio::test]
+    async fn test_register_platform_plugins_registers_feishu() {
+        use crate::gateway::{Gateway, GatewayConfig, SessionManager};
+        use crate::session::bootstrap::BootstrapMode;
+        use crate::session::persistence::ReasoningLevel;
+
+        if std::env::var("FEISHU_APP_ID").is_err()
+            || std::env::var("FEISHU_APP_SECRET").is_err()
+            || std::env::var("FEISHU_VERIFICATION_TOKEN").is_err()
+        {
+            eprintln!("skipping: Feishu credentials not set");
+            return;
+        }
+
+        let config = GatewayConfig::default();
+        let sm = Arc::new(SessionManager::new(
+            &config,
+            None,
+            None,
+            BootstrapMode::Minimal,
+            ReasoningLevel::default(),
+        ));
+        let gw = Arc::new(Gateway::new(config, sm));
+        let tmp = tempfile::tempdir().unwrap();
+        register_platform_plugins(&gw, tmp.path().to_str().unwrap()).await;
+
+        let plugin = gw.get_plugin("feishu").await;
+        assert!(
+            plugin.is_some(),
+            "register_platform_plugins must register feishu so get_plugin returns Some"
+        );
+        assert_eq!(plugin.unwrap().platform(), "feishu");
+    }
 }


### PR DESCRIPTION
实现编译期自动发现机制：Gateway 启动时自动扫描 platforms/ 目录发现并加载所有 IMPlugin 插件，新增平台只需在 platforms/ 下创建目录并实现 trait + inventory::submit!，无需修改任何现有代码。

主要变更：
- 添加 inventory 依赖
- 新增 build.rs：编译时扫描 platforms/ 子目录，自动生成 pub mod 声明
- 重构 platforms/mod.rs：使用 include! 引入自动生成的模块声明，通过 inventory::iter 自动调用所有注册函数
- feishu/mod.rs：通过 inventory::submit! 自注册，无需手动调用
- 添加单元测试验证自动发现机制
- 提取 RegisterFn type alias 修复 clippy type_complexity lint

Source: design doc scan
Type: refactor
