### PR TITLE
fix: make AgentConfig.id a required field during deserialization

### DIFF
--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -19,7 +19,6 @@ use crate::session::bootstrap::BootstrapMode;
 #[serde(rename_all = "camelCase")]
 pub struct AgentConfig {
     /// Unique identifier for this agent.
-    #[serde(default)]
     pub id: String,
     /// Human-readable name.
     #[serde(default)]

--- a/src/config/agents/directory.rs
+++ b/src/config/agents/directory.rs
@@ -157,21 +157,15 @@ impl AgentDirectoryProvider {
             .map(Some)
     }
 
-    /// Backfill the agent's `id` from the directory name when missing,
-    /// and warn when the file's `id` disagrees with the directory name.
+    /// Warn when the file's `id` disagrees with the directory name.
     ///
-    /// `AgentConfig.id` deserializes as an empty string by default, so a
-    /// config.json that omits `id` is not an error here — the directory
-    /// name from the registration list is the canonical id. A non-empty
-    /// `id` that differs from the directory name is almost always a
-    /// misconfiguration, so we log it at WARN level and keep the file's
-    /// value (the downstream merge / `from_single` will use whatever
-    /// `id` is on the config object).
+    /// The `id` field in config.json is now required. If it differs from
+    /// the directory name we log a WARN but keep the file's value (the
+    /// downstream merge / `from_single` will use whatever `id` is on the
+    /// config object).
     fn inject_dirname_id(config: &mut Option<AgentConfig>, dirname: &str) {
         if let Some(cfg) = config.as_mut() {
-            if cfg.id.is_empty() {
-                cfg.id = dirname.to_string();
-            } else if cfg.id != dirname {
+            if cfg.id != dirname {
                 warn!(
                     agent_id = %cfg.id,
                     dirname = %dirname,

--- a/src/config/agents/directory_tests.rs
+++ b/src/config/agents/directory_tests.rs
@@ -390,11 +390,11 @@ fn test_directory_provider_id_mismatch_warn() {
     );
 }
 
-/// `config.json` with `id` set to an empty string `""` must fail to
-/// load — the agent is rejected with `MissingId` because the empty id
-/// does not satisfy the required-field constraint.
+/// `config.json` with `id` set to an empty string `""` must cause
+/// provider construction to fail — the empty id does not satisfy the
+/// required-field constraint, so `new()` returns an error.
 #[test]
-fn test_directory_provider_id_empty_string_skips_agent() {
+fn test_directory_provider_empty_string_id_fails_construction() {
     let user = TempDir::new().unwrap();
     let agent_dir = user.path().join("empty-id");
     std::fs::create_dir_all(&agent_dir).unwrap();

--- a/src/config/agents/directory_tests.rs
+++ b/src/config/agents/directory_tests.rs
@@ -290,8 +290,8 @@ fn test_action_permission_round_trip() {
 // WARN-on-mismatch behaviour.
 // =====================================================================
 
-/// `config.json` without an `id` field must have its id backfilled from
-/// the directory name (the registry id).
+/// `config.json` without an `id` field must fail to load — the agent
+/// is skipped (deserialization of the required `id` field fails).
 #[test]
 fn test_directory_provider_id_from_dirname() {
     let user = TempDir::new().unwrap();
@@ -303,16 +303,22 @@ fn test_directory_provider_id_from_dirname() {
     )
     .unwrap();
 
-    let provider =
-        AgentDirectoryProvider::new(vec!["foo".to_string()], user.path().to_path_buf(), None)
-            .unwrap();
+    // Create a valid agent to ensure loading continues after the skip.
+    write_config(user.path(), "bar", "Bar Agent");
 
-    let entry = provider.get("foo").expect("foo should be loaded");
-    // Id backfilled from the directory name.
-    assert_eq!(entry.id, "foo");
-    // Name from the config file is preserved.
-    assert_eq!(entry.name, "Foo Agent");
-    assert_eq!(entry.source, ConfigSource::User);
+    let provider = AgentDirectoryProvider::new(
+        vec!["foo".to_string(), "bar".to_string()],
+        user.path().to_path_buf(),
+        None,
+    )
+    .unwrap();
+
+    // foo has no `id` → deserialization fails → agent is skipped.
+    assert!(provider.get("foo").is_none());
+    // bar is still loaded normally.
+    let entry = provider.get("bar").expect("bar should be loaded");
+    assert_eq!(entry.id, "bar");
+    assert_eq!(entry.name, "Bar Agent");
 }
 
 /// A `config.json` `id` that disagrees with the directory name must
@@ -381,6 +387,38 @@ fn test_directory_provider_id_mismatch_warn() {
         output.contains("does not match directory name"),
         "expected WARN log, got: {}",
         output
+    );
+}
+
+/// `config.json` with `id` set to an empty string `""` must fail to
+/// load — the agent is rejected with `MissingId` because the empty id
+/// does not satisfy the required-field constraint.
+#[test]
+fn test_directory_provider_id_empty_string_skips_agent() {
+    let user = TempDir::new().unwrap();
+    let agent_dir = user.path().join("empty-id");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("config.json"),
+        r#"{ "id": "", "name": "Empty ID Agent" }"#,
+    )
+    .unwrap();
+
+    let result = AgentDirectoryProvider::new(
+        vec!["empty-id".to_string()],
+        user.path().to_path_buf(),
+        None,
+    );
+
+    assert!(
+        result.is_err(),
+        "empty-string id should cause provider to fail"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Missing required agent id"),
+        "error should mention missing id, got: {}",
+        err_msg
     );
 }
 


### PR DESCRIPTION
Make `AgentConfig.id` a required field during deserialization to align with the design doc.

The design doc specifies `id` as a required config field, but the code used `#[serde(default)]` with silent backfill from directory name when `id` was omitted. This change enforces the required semantics: missing `id` now fails deserialization immediately.

Changes:
- Remove `#[serde(default)]` from `AgentConfig.id` to enforce required deserialization
- Remove the empty-string backfill branch in `inject_dirname_id` (dead code now)
- Update existing test to expect failure on missing `id` instead of silent backfill
- Add test for empty-string `id` failing deserialization
- Rename test to accurately reflect behavior (provider failure, not skip)

Source: design-doc
Type: fix
