### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -8,9 +8,9 @@
   },
   {
     "path": "docs/design/agent/agent-config.md",
-    "commit": "7264e812f9244b352780b446205b670e1732ec6d",
-    "commit_time": "2026-06-19T21:50:32+08:00",
-    "confirmed_time": "2026-06-19T21:58:08.208839+08:00",
+    "commit": "84bbf35c650355d1264180f2d6754b3e84945d5e",
+    "commit_time": "2026-06-25T04:19:02+08:00",
+    "confirmed_time": "2026-06-25T04:27:37.984448+08:00",
     "comment": ""
   },
   {


### PR DESCRIPTION
## DDT Records Update

- **Doc path**: `docs/design/agent/agent-config.md`
- **Operation**: `finished`
- **Reason**: Mark agent-config design doc as finished

> Auto-generated by design-doc-tracker.