### PR TITLE
docs(design): narrow ContentNormalizer to 3-step text normalization

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,7 +13,7 @@
 | [mode](mode/README.md) | Session 运行模式管理：Plan Mode（规划/执行分离、双路径、审批栅栏）和 Auto Mode（连续自主执行），通过工具过滤和权限边界约束 agent 行为 |
 | [permission](permission/README.md) | 系统级身份型访问控制：交集模型、七类权限维度、审批工作流与配置管理 |
 | [platform](platform/README.md) | 操作系统抽象层：进程管理、信号处理、配置目录、终端 I/O 的平台差异封装 |
-| [processor_chain](processor_chain/README.md) | 统一出入站消息处理：入站纯变换链（审计日志、session_key 计算、内容清洗标准化）、出站 DSL 解析、ContentBlock[] 传递 |
+| [processor_chain](processor_chain/README.md) | 统一出入站消息处理：入站纯变换链（审计日志、session_key 计算、文本标准化）、出站 DSL 解析、ContentBlock[] 传递 |
 | [im_adapter](im_adapter/README.md) | IM 平台插件化适配框架：IMPlugin trait 统一接口，每个平台一个插件（含 Adapter + Renderer），通用代码渲染和流式渲染能力 |
 | [session](session/README.md) | Agent 会话生命周期管理：session_key 路由映射与解析、持久化（创建、压缩、归档、清理）、执行层（三维执行状态、级联停止、后台结果注入） |
 | [slash](slash/README.md) | 斜杠指令系统：Gateway 层拦截、统一分派、Handler 执行，不进入 LLM 对话流程 |

--- a/docs/design/cli/chat.md
+++ b/docs/design/cli/chat.md
@@ -58,7 +58,7 @@ TerminalAdapter 封装 NormalizedMessage { platform: "terminal", sender_id, peer
 Processor Chain 入站
   ├── RawLog：记录原始输入到日志
   ├── SessionRouter：根据平台、用户和端点计算 session key
-  └── ContentNormalizer：清洗 stdin 残留控制字符 + 标准化格式
+  └── ContentNormalizer：文本标准化（去控制字符、压缩空行、去尾空格）
   ↓
 ProcessedMessage → Gateway 路由
   ├── / 开头 → SlashDispatcher（与飞书等渠道共享同一套）

--- a/docs/design/gateway/inbound-flow.md
+++ b/docs/design/gateway/inbound-flow.md
@@ -19,7 +19,7 @@ webhook
                     → hash 由 platform:sender_id:peer_id:account_id:timestamp_ms 计算
                     → 写入 metadata，不创建 session
     ↓
-  ContentNormalizer(30) → 清洗平台残留 → 标准化 markdown 格式
+  ContentNormalizer(30) → 文本标准化（去控制字符、压缩空行、去尾空格）
   ↓
 ProcessedMessage { content, metadata { session_key } }
   ↓
@@ -72,9 +72,9 @@ NormalizedMessage 进入入站 Processor Chain。链按 priority 升序依次执
 - 输出：将 `session_key` 写入 metadata
 - SessionRouter 不创建 session、不查 SessionManager——仅计算 session key
 
-**ContentNormalizer（priority 30）**：对消息内容做平台无关的文本标准化。去除控制字符和 ANSI 转义序列，压缩连续空行，去行尾空格，为裸 URL 补全 `https://` 前缀，为无语言标签的代码块添加 `text` 标注。不负责平台格式转换——富文本到 markdown 的转换由各 IM 插件在解析阶段完成。
+**ContentNormalizer（priority 30）**：对消息内容做平台无关的文本标准化。去除控制字符和 ANSI 转义序列，压缩连续空行，去行尾空格。不负责 Markdown 格式处理——URL 补全、代码块语言标签、富文本展开等均由各 IM 插件在解析阶段完成。
 
-链输出入站 `ProcessedMessage`（`content` 清洗后文本 + `metadata` 含 `session_key`）。ContentNormalizer 保留 metadata 不变，下游 Gateway 从 metadata 取出 session_key。
+链输出入站 `ProcessedMessage`（`content` 标准化后文本 + `metadata` 含 `session_key`）。ContentNormalizer 保留 metadata 不变，下游 Gateway 从 metadata 取出 session_key。
 
 ### 第三步：Gateway 路由
 

--- a/docs/design/im_adapter/README.md
+++ b/docs/design/im_adapter/README.md
@@ -10,7 +10,7 @@ IM Adapter 模块提供跨消息渠道的插件化适配框架。每个消息渠
 
 IM Adapter 模块不包含业务逻辑，由三层组成：
 
-- **插件接口层**：定义 IMPlugin trait，统一插件契约。每个消息渠道实现此 trait，提供入站解析、格式渲染、消息发送、生命周期管理、平台清洗五组方法。terminal 渠道的实现位于 [CLI 模块](../cli/README.md)，不在此目录。
+- **插件接口层**：定义 IMPlugin trait，统一插件契约。每个消息渠道实现此 trait，提供入站解析、格式渲染、消息发送、生命周期管理四组方法。terminal 渠道的实现位于 [CLI 模块](../cli/README.md)，不在此目录。
 - **通用渲染能力**：代码块语法高亮和流式增量渲染是跨平台通用机制，作为 IMPlugin trait 的默认实现提供。各平台插件自动继承，按需覆盖平台差异化部分。
 - **平台插件**：每个消息渠道的数据和渲染实现。IM 渠道（飞书、Discord 等）的插件放在 `platforms/` 子目录下。terminal 渠道的实现位于 CLI 模块。
 
@@ -28,7 +28,7 @@ platforms/<平台名>/
 │                  — 出站：API 调用发送消息
 │                  — token 管理与刷新
 ├── renderer.rs    — ContentBlock[] + DSL → 平台原生格式
-├── cleaner.rs     — 平台消息清洗（@ 语法、mention 等），实现 clean_content() 回调
+
 └── tools/         — 平台工具注册
     ├── mod.rs     — register_tools() 入口
     └── ...        — 各工具分组文件
@@ -54,8 +54,6 @@ im_adapter/
 每个消息渠道插件实现统一接口，包含以下方法分组：
 
 **入站**：解析 webhook payload 为 NormalizedMessage。消息过滤（空内容、非文本消息）在解析阶段完成——Adapter 对不支持的消息类型不产 NormalizedMessage。
-
-**清洗**：`clean_content(raw: &str) -> String`，接收平台原生文本，移除平台专属标记（飞书 @ 语法、Discord mention 等），产出清洗后的纯文本。由 Processor Chain 的 ContentNormalizer 调用。各平台按需实现，不需要的平台空实现透传。
 
 **渲染**：接收 ContentBlock[] 和 DSL 解析结果，按平台能力选择输出格式（纯文本或富格式）。渲染是纯数据转换，无副作用。
 

--- a/docs/design/im_adapter/platforms/feishu.md
+++ b/docs/design/im_adapter/platforms/feishu.md
@@ -86,10 +86,7 @@ platforms/feishu/
 │                  — markdown → 飞书元素映射（标题/粗体/代码块/列表/引用/链接/分割线）
 │                  — header 提取 + body 渲染
 │                  — DSL 按钮注入
-├── cleaner.rs     — 飞书平台消息清洗，实现 clean_content()
-│                  — 移除 @ 提及语法
-│                  — 移除 `<at>xxx</at>` 等飞书专属标记
-│                  — ContentNormalizer 调用此回调完成平台残留清洗
+
 └── tools/         — 飞书工具注册
     ├── mod.rs     — register_tools() 入口，注册所有飞书工具分组
     └── ...        — 各工具分组实现文件（im/calendar/task/bitable/doc/drive/sheet）

--- a/docs/design/processor_chain/README.md
+++ b/docs/design/processor_chain/README.md
@@ -22,7 +22,7 @@ IM Adapter（入站）
 Processor 链（入站，按 priority 顺序执行，纯变换）
   ├── RawLogProcessor（priority 10）→ 原始消息写入日志
   ├── SessionRouter（priority 20）   → 计算 session_key，写入 metadata
-  └── ContentNormalizer（priority 30）→ 清洗 + 标准化 markdown 格式
+  └── ContentNormalizer（priority 30）→ 文本标准化（去控制字符、压缩空行、去尾空格）
   ↓
 Gateway
   → 从 metadata 取 session_key → SessionManager.resolve(key) 获得 session_id
@@ -59,7 +59,7 @@ IM webhook → IM Adapter 解析 → NormalizedMessage（platform, sender_id, pe
 
 NormalizedMessage 是平台无关的中间结构，承载消息的通用字段（发送者、内容、会话标识等）。IM Adapter 的入站部分负责将自己平台的格式转为此结构，content 为清洗后的消息文本。内容块（ContentBlock[]）概念仅在出站方向使用——LLM 输出 UnifiedResponse 时引入，经出站链处理后由 Renderer 渲染。
 
-Processor 链在入站方向按 priority 升序执行，全链路操作 NormalizedMessage 的 content 字段（纯文本）。SessionRouter 计算 session_key 后写入 metadata。ContentNormalizer 对文本做清洗和标准化。链输出 ProcessedMessage（content + metadata），由 Gateway 消费。
+Processor 链在入站方向按 priority 升序执行，全链路操作 NormalizedMessage 的 content 字段（纯文本）。SessionRouter 计算 session_key 后写入 metadata。ContentNormalizer 对文本做平台无关的标准化——去除控制字符和 ANSI 转义序列、压缩连续空行、去行尾空格。平台格式转换和清洗由 IM Adapter 在解析阶段完成。链输出 ProcessedMessage（content + metadata），由 Gateway 消费。
 
 ### 出站路径
 

--- a/docs/design/processor_chain/inbound-chain.md
+++ b/docs/design/processor_chain/inbound-chain.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-入站 Processor 链在所有 IM 平台的归一化之后运行。各 IM Adapter 的入站部分先将平台特定格式转为 NormalizedMessage，链再统一处理日志、会话路由计算和内容清洗。
+入站 Processor 链在所有 IM 平台的归一化之后运行。各 IM Adapter 的入站部分先将平台特定格式转为 NormalizedMessage，链再统一处理日志、会话路由计算和文本标准化。
 
 Processor 链是纯变换链——只做内容计算和 metadata 填充，不管理 session 生命周期、不做路由决策。链路不感知平台差异，平台特有的解析和适配逻辑由 IM Adapter 负责。
 
@@ -34,9 +34,7 @@ Processor 链（按 priority 升序执行，纯变换）
   │     → 不创建 session、不查 SessionManager
   │
   └── ContentNormalizer（priority 30）
-        → 平台清洗：调用 IMPlugin.clean_content()，委托对应平台插件移除专属标记
-        → 富文本展开为标准 markdown
-        → 标准化格式：压缩连续空行、去行尾空格、裸 URL 补全 https:// 前缀
+        → 文本标准化：去除控制字符和 ANSI 转义序列、压缩连续空行、去行尾空格
   ↓
 ProcessedMessage → Gateway 路由
 ```
@@ -73,7 +71,7 @@ SessionRouter 不区分私聊和群聊。会话粒度由 Adapter 通过 peer_id 
 IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, account_id, content }
   → RawLogProcessor：记录原始内容到日志 → 透传
     → SessionRouter：计算 session_key = hash(platform, sender_id, peer_id, account_id, agent_id) → 写入 metadata.session_key
-      → ContentNormalizer：清洗平台残留 → 标准化 markdown 格式
+      → ContentNormalizer：文本标准化（去控制字符、压缩空行、去尾空格）
         → ProcessedMessage { content, metadata { session_key } }
           → Gateway
             → 调用 SessionManager.resolve(session_key) 获得 session_id
@@ -85,7 +83,7 @@ IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, 
 - ContentNormalizer 异常时内容不变（丢回原文），消息继续流转
 - 所有异常均记录日志，用于后续问题定位和改进
 
-**平台清洗委托**：ContentNormalizer 的"平台残留清洗"不包含任何平台专属逻辑。清洗行为委托给 IMPlugin trait 的 `clean_content()` 回调——ContentNormalizer 调用消息来源平台的插件方法，各平台插件实现自己的清洗逻辑（飞书处理 @ 语法，Discord 处理 mention，不支持的平台空实现透传）。ContentNormalizer 自身只执行平台无关的标准化（富文本展开、空行压缩、去尾空格、URL 补全）。
+
 
 ## 模块关系
 
@@ -94,5 +92,5 @@ IM Adapter 产出 NormalizedMessage { platform, sender_id, peer_id, thread_id?, 
 - **链内**：
   - RawLogProcessor — 审计日志（副作用），不改内容
   - SessionRouter — 计算 session_key（纯哈希计算），写 metadata
-  - ContentNormalizer — 格式标准化（平台无关）+ 委托 IMPlugin 清洗平台残留
+  - ContentNormalizer — 文本标准化（去控制字符、压缩空行、去尾空格）
 - **无关**：出站 Processor 链（独立链路，与入站互不干扰）

--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -99,10 +99,10 @@
   },
   {
     "path": "docs/design/gateway/inbound-flow.md",
-    "commit": "",
-    "commit_time": "",
-    "confirmed_time": "2026-06-24T04:03:00+08:00",
-    "comment": "blocked: F2b doc_problem + must_fix"
+    "commit": "b4770d160d417335ea2ce5d75e57320b065e36fc",
+    "commit_time": "2026-06-25T02:31:02+08:00",
+    "confirmed_time": "2026-06-25T02:31:02+08:00",
+    "comment": "cleared: #1197 — ContentNormalizer 职责缩减为3项纯文本标准化(去控制字符/压缩空行/去尾空格)。URL补全和代码块标签归属IM插件。clean_content()从IMPlugin trait移除,平台清洗由Adapter解析阶段完成。RawLogProcessor disabled时中断链为代码bug(返回None→应返回pass-through),另开issue修。"
   },
   {
     "path": "docs/design/im_adapter/code-render.md",


### PR DESCRIPTION
设计文档：gateway/inbound-flow.md（矛盾修复）+ processor_chain/inbound-chain.md（同步修正）+ 4 份跨模块同步

## 修改内容

ContentNormalizer 职责从「5 项处理 + 委托 IMPlugin 清洗平台残留」缩减为「3 项纯文本标准化」：
- 保留：去控制字符和 ANSI 转义序列、压缩连续空行、去行尾空格
- 移除：URL 补全、代码块语言标签 → 归属 IM 插件在解析阶段处理
- 移除：`clean_content()` → 从 IMPlugin trait 中删除，平台清洗归入 Adapter 解析阶段

## 修改文件
- `docs/design/gateway/inbound-flow.md` — 架构图标签 + 详细描述
- `docs/design/processor_chain/inbound-chain.md` — 架构图 + 详细描述 + 删除平台清洗委托段落
- `docs/design/processor_chain/README.md` — 架构图 + 数据流描述
- `docs/design/im_adapter/README.md` — IMPlugin trait 方法组（5→4）+ 删除 clean_content()
- `docs/design/im_adapter/platforms/feishu.md` — 删除 cleaner.rs 引用
- `docs/design/cli/chat.md` — 数据流描述
- `docs/design/README.md` — processor_chain 索引条目

## 附带修改
- `scripts/design-doc-tracker/records.json` — 清除 gateway/inbound-flow.md blocked 标记

## 代码对照发现
3 条代码差异（详细见 CODE-GAPS.md）：
1. ContentNormalizer 代码仍执行 5 步处理，需缩减为 3 步
2. IMPlugin trait 代码仍有 clean_content()，需移除
3. RawLogProcessor disabled 时返回 None 中断链（#1197 Problem 2，另开 issue）

Source: user
Type: docs
