### PR TITLE
fix: agent spawn 设计文档对齐修复

### DIFF
--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -104,12 +104,26 @@ fn inject_agents(cm: &ConfigManager, agents: Vec<(&str, ResolvedAgentConfig)>) {
 
 /// Register N child sessions under a given parent in the SessionManager
 /// (used to simulate concurrency pressure for the max_children test).
+///
+/// Also inserts each child into `conversation_sessions` so
+/// `count_active_children` (which checks session liveness) counts
+/// them correctly.
 async fn fill_children(mgr: &SessionManager, parent_id: &str, count: usize) {
     for i in 0..count {
+        let child_id = format!("child-{}", i);
+        let cs = crate::llm::session::ConversationSession::new(
+            child_id.clone(),
+            "test-model".to_string(),
+            std::path::PathBuf::from("/tmp"),
+        );
+        mgr.conversation_sessions.write().await.insert(
+            child_id.clone(),
+            std::sync::Arc::new(tokio::sync::RwLock::new(cs)),
+        );
         mgr.register_child(
             parent_id,
             ChildSessionInfo {
-                session_id: format!("child-{}", i),
+                session_id: child_id,
                 parent_session_id: parent_id.to_string(),
                 agent_id: "child".to_string(),
                 depth: 1,

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -533,6 +533,8 @@ mod rebuild_tests;
 #[cfg(test)]
 mod resolve_tests;
 #[cfg(test)]
+mod spawn_gap_tests;
+#[cfg(test)]
 mod spawn_tests;
 #[cfg(test)]
 mod test_helpers;

--- a/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
+++ b/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
@@ -61,6 +61,18 @@ async fn test_rebuild_spawn_tree_basic() {
     let mgr = make_mgr_with_storage(storage);
     mgr.rebuild_spawn_tree().await.unwrap();
 
+    // Register child-1 in conversation_sessions so count_active_children
+    // (which checks session liveness) counts it correctly.
+    let child_cs = crate::llm::session::ConversationSession::new(
+        "child-1".to_string(),
+        "test-model".to_string(),
+        std::path::PathBuf::from("/tmp"),
+    );
+    mgr.conversation_sessions.write().await.insert(
+        "child-1".to_string(),
+        std::sync::Arc::new(tokio::sync::RwLock::new(child_cs)),
+    );
+
     // children table should have one entry under parent-1.
     let count = mgr.count_active_children("parent-1").await;
     assert_eq!(count, 1, "parent-1 should have exactly 1 child");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -63,6 +63,18 @@ impl SessionManager {
         }
     }
 
+    /// Get the parent session ID of a given child session.
+    ///
+    /// Returns `None` if the child is unknown or has no registered parent.
+    pub async fn get_parent_of(&self, child_id: &str) -> Option<String> {
+        let children = self.children.read().await;
+        children
+            .values()
+            .flatten()
+            .find(|info| info.session_id == child_id)
+            .map(|info| info.parent_session_id.clone())
+    }
+
     /// Count active (non-completed) child sessions for a parent.
     pub async fn count_active_children(&self, parent_id: &str) -> usize {
         let children = self.children.read().await;

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -553,16 +553,19 @@ impl SessionManager {
     /// table is traversed via BFS to discover all descendant session
     /// IDs before any removals, preventing lock-ordering issues.
     pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
-        // 1. Recursively collect all descendant session IDs via
-        //    BFS on the `children` table.
+        // 1. Collect all descendant session IDs via BFS.
         let descendant_ids = self.collect_descendant_ids(child_id).await;
 
-        // 2. Get the child's conversation session, verify it exists,
-        //    and cascade-stop its token tree.
+        // 2. Stop active sessions. Completed/terminated sessions
+        //    skip the stop step but still get cleaned up from the
+        //    spawn tree (design doc §级联 Kill).
         if let Some(cs) = self.get_conversation_session(child_id).await {
             cs.read().await.stop(true).await;
-        } else {
-            return Err(format!("child session not found: {}", child_id));
+        }
+        for id in &descendant_ids {
+            if let Some(cs) = self.get_conversation_session(id).await {
+                cs.read().await.stop(true).await;
+            }
         }
 
         // 3. Remove child + descendants from conversation_sessions.

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -151,6 +151,19 @@ impl SessionManager {
         };
         let config = &config;
 
+        // Tool-level spawn prevention (design doc §两层防护):
+        // When the effective max_spawn_depth budget is 0, strip
+        // sessions_spawn from the child's tool whitelist so the LLM
+        // cannot even see the tool.
+        let config = if max_spawn_depth == 0 {
+            let mut filtered = config.clone();
+            filtered.tools.retain(|t| t != "sessions_spawn");
+            filtered
+        } else {
+            config.clone()
+        };
+        let config = &config;
+
         // 1. Generate child session_id
         let child_session_id = Uuid::new_v4().to_string();
 

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -76,9 +76,31 @@ impl SessionManager {
     }
 
     /// Count active (non-completed) child sessions for a parent.
+    ///
+    /// A child is considered "active" if its session still exists in
+    /// `conversation_sessions`. Run-mode sessions that have completed
+    /// and been cleaned up are excluded from the count, so the
+    /// concurrency limit is not consumed by finished children.
+    ///
+    /// Lock order: `children` read lock (collect IDs) then
+    /// `conversation_sessions` read lock (check existence), held
+    /// separately to avoid deadlocks.
     pub async fn count_active_children(&self, parent_id: &str) -> usize {
-        let children = self.children.read().await;
-        children.get(parent_id).map(|v| v.len()).unwrap_or(0)
+        let child_ids: Vec<String> = {
+            let children = self.children.read().await;
+            children
+                .get(parent_id)
+                .map(|list| list.iter().map(|i| i.session_id.clone()).collect())
+                .unwrap_or_default()
+        };
+        if child_ids.is_empty() {
+            return 0;
+        }
+        let conv = self.conversation_sessions.read().await;
+        child_ids
+            .iter()
+            .filter(|id| conv.contains_key(id.as_str()))
+            .count()
     }
 
     /// List all active child session IDs for a parent.

--- a/src/gateway/session_manager/spawn_gap_tests.rs
+++ b/src/gateway/session_manager/spawn_gap_tests.rs
@@ -1,0 +1,566 @@
+//! Step 1.5 unit tests for gaps 1–4 in agent spawn.
+//!
+//! Covers tool-level interception (Gap 1), `SpawnTree::get_parent`
+//! (Gap 2), `count_active_children` semantics (Gap 3), and
+//! `kill_child` for completed sessions (Gap 4).
+
+use super::spawn::SpawnMode;
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::SessionManager;
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::llm::session::ChatSession;
+use crate::session::recovery::SpawnTree;
+
+use serial_test::serial;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn test_resolved_config(id: &str) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: crate::session::bootstrap::BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: crate::agent::config::SubagentsConfig::default(),
+        source: ConfigSource::Merged,
+    }
+}
+
+/// Register a parent `ConversationSession` so child creation can
+/// derive the cancel token from the parent's token tree.
+async fn register_parent(mgr: &SessionManager, parent_id: &str, workdir: PathBuf) {
+    use crate::llm::session::ConversationSession;
+    use tokio::sync::RwLock;
+
+    let cs = ConversationSession::new(parent_id.to_string(), "test-model".to_string(), workdir);
+    let arc = Arc::new(RwLock::new(cs));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), arc);
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        crate::gateway::Session {
+            id: parent_id.to_string(),
+            agent_id: "parent-agent".to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+}
+
+// ── Mock tool for tool-level interception test ────────────────────────────
+
+struct MockSpawnTool;
+
+impl crate::tools::Tool for MockSpawnTool {
+    fn name(&self) -> &str {
+        "sessions_spawn"
+    }
+    fn group(&self) -> &str {
+        "sessions"
+    }
+    fn summary(&self) -> String {
+        "Spawn a sub-agent for a sub-task".into()
+    }
+    fn detail(&self) -> String {
+        "Create a child session for a spawned sub-agent.".into()
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object", "properties": {} })
+    }
+    fn flags(&self) -> crate::tools::ToolFlags {
+        crate::tools::ToolFlags::default()
+    }
+}
+
+/// Create a `SessionManager` with a `ToolRegistry` containing a mock
+/// `sessions_spawn` tool so the system prompt renders tool definitions.
+async fn make_mgr_with_spawn_tool(workspace: Option<&std::path::Path>) -> SessionManager {
+    use crate::tools::ToolRegistry;
+
+    let mgr = make_test_mgr(workspace);
+    let registry = Arc::new(ToolRegistry::new());
+    registry.register(MockSpawnTool).await.unwrap();
+    mgr.set_tool_registry(registry).await;
+    mgr
+}
+
+// ── Gap 1 tests ─────────────────────────────────────────────────────────
+
+/// Verify that `max_spawn_depth == 0` strips `sessions_spawn` from the
+/// child's tool whitelist so the LLM cannot call it.
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_removes_spawn_tool_when_budget_zero() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_mgr_with_spawn_tool(Some(tmp.path())).await;
+    // Config must list sessions_spawn in tools so whitelist filtering
+    // is active (empty list = wildcard = no filtering).  Include other
+    // tools so the filtered list is non-empty (proper whitelist).
+    let config = ResolvedAgentConfig {
+        tools: vec!["sessions_spawn".to_string(), "read".to_string()],
+        ..test_resolved_config("child-agent")
+    };
+
+    register_parent(&mgr, "parent-budget-0", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-budget-0",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            0, // max_spawn_depth == 0
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child session should exist");
+    let guard = cs.read().await;
+    let prompt = guard.system_prompt().expect("system prompt should be set");
+
+    // The tool definition for sessions_spawn must NOT appear when the
+    // budget is zero.
+    assert!(
+        !prompt.contains("**sessions_spawn**"),
+        "system prompt must NOT contain sessions_spawn tool definition \
+         when max_spawn_depth == 0, but found it in: {:?}",
+        prompt
+    );
+}
+
+/// Verify that `max_spawn_depth > 0` keeps `sessions_spawn` in the
+/// child's tool whitelist.
+#[tokio::test]
+#[serial]
+async fn test_create_child_session_keeps_spawn_tool_when_budget_positive() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_mgr_with_spawn_tool(Some(tmp.path())).await;
+    let config = ResolvedAgentConfig {
+        tools: vec!["sessions_spawn".to_string(), "read".to_string()],
+        ..test_resolved_config("child-agent")
+    };
+
+    register_parent(&mgr, "parent-budget-pos", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-budget-pos",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3, // max_spawn_depth > 0
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    let cs = mgr
+        .get_conversation_session(&child_id)
+        .await
+        .expect("child session should exist");
+    let guard = cs.read().await;
+    let prompt = guard.system_prompt().expect("system prompt should be set");
+
+    // The tool definition for sessions_spawn must appear when the
+    // budget is positive.
+    assert!(
+        prompt.contains("**sessions_spawn**"),
+        "system prompt must contain sessions_spawn tool definition \
+         when max_spawn_depth > 0, but it was missing in: {:?}",
+        prompt
+    );
+}
+
+// ── Gap 2 tests (SpawnTree::get_parent) ─────────────────────────────────
+
+/// Verify that `get_parent` returns `None` for a root session.
+#[test]
+fn test_spawn_tree_get_parent_root() {
+    let tree = SpawnTree {
+        roots: vec!["root-1".to_string(), "root-2".to_string()],
+        children: HashMap::new(),
+    };
+    assert_eq!(tree.get_parent("root-1"), None);
+    assert_eq!(tree.get_parent("root-2"), None);
+}
+
+/// Verify that `get_parent` returns the correct parent for a child.
+#[test]
+fn test_spawn_tree_get_parent_child() {
+    let mut children = HashMap::new();
+    children.insert(
+        "parent-1".to_string(),
+        vec!["child-a".to_string(), "child-b".to_string()],
+    );
+    let tree = SpawnTree {
+        roots: vec!["parent-1".to_string()],
+        children,
+    };
+    assert_eq!(
+        tree.get_parent("child-a").map(|s| s.as_str()),
+        Some("parent-1")
+    );
+    assert_eq!(
+        tree.get_parent("child-b").map(|s| s.as_str()),
+        Some("parent-1")
+    );
+    // Unknown session returns None.
+    assert_eq!(tree.get_parent("unknown-id"), None);
+}
+
+// ── Gap 3 tests (count_active_children) ──────────────────────────────────
+
+/// Verify that completed run-mode children are excluded from the
+/// active count.
+#[tokio::test]
+#[serial]
+async fn test_count_active_children_excludes_completed() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("worker");
+
+    register_parent(&mgr, "parent-count", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-count",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Initially active.
+    assert_eq!(mgr.count_active_children("parent-count").await, 1);
+
+    // Simulate completion: remove from conversation_sessions.
+    mgr.conversation_sessions.write().await.remove(&child_id);
+
+    // Completed child must NOT be counted.
+    assert_eq!(
+        mgr.count_active_children("parent-count").await,
+        0,
+        "completed run-mode child should not be counted"
+    );
+}
+
+/// Verify that active session-mode children are correctly counted.
+#[tokio::test]
+#[serial]
+async fn test_count_active_children_includes_active() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("worker");
+
+    register_parent(&mgr, "parent-active", tmp.path().to_path_buf()).await;
+
+    // Spawn 2 active session-mode children.
+    let id1 = mgr
+        .create_child_session(
+            &config,
+            "parent-active",
+            1,
+            "task1",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+    let id2 = mgr
+        .create_child_session(
+            &config,
+            "parent-active",
+            1,
+            "task2",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(mgr.count_active_children("parent-active").await, 2);
+
+    // Complete one child, verify count drops.
+    mgr.conversation_sessions.write().await.remove(&id1);
+    assert_eq!(
+        mgr.count_active_children("parent-active").await,
+        1,
+        "only one active child should remain"
+    );
+
+    // Complete the other, count should be 0.
+    mgr.conversation_sessions.write().await.remove(&id2);
+    assert_eq!(
+        mgr.count_active_children("parent-active").await,
+        0,
+        "no active children should remain"
+    );
+}
+
+// ── Gap 4 tests (kill completed child) ───────────────────────────────────
+
+/// Verify that `kill_child` succeeds for a completed child — it must
+/// skip the stop step but still clean up from the children table.
+#[tokio::test]
+#[serial]
+async fn test_kill_completed_child_succeeds() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("worker");
+
+    register_parent(&mgr, "parent-kill-completed", tmp.path().to_path_buf()).await;
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-kill-completed",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    // Simulate completion: remove from conversation_sessions.
+    mgr.conversation_sessions.write().await.remove(&child_id);
+
+    // Kill must NOT error on a completed child.
+    let result = mgr.kill_child("parent-kill-completed", &child_id).await;
+    assert!(
+        result.is_ok(),
+        "kill_child should succeed for completed child, got: {:?}",
+        result
+    );
+
+    // Child must be removed from children table.
+    assert_eq!(
+        mgr.count_active_children("parent-kill-completed").await,
+        0,
+        "completed child should be removed from children table"
+    );
+}
+
+/// Verify that `kill_child` on an active child stops and cleans up
+/// correctly, including cascading to descendants.
+#[tokio::test]
+#[serial]
+async fn test_kill_active_child_cascades() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config_child = test_resolved_config("child");
+    let config_grandchild = test_resolved_config("grandchild");
+
+    register_parent(&mgr, "parent-kill-active", tmp.path().to_path_buf()).await;
+
+    // Spawn child.
+    let child_id = mgr
+        .create_child_session(
+            &config_child,
+            "parent-kill-active",
+            1,
+            "child task",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    // Spawn grandchild under child.
+    let grandchild_id = mgr
+        .create_child_session(
+            &config_grandchild,
+            &child_id,
+            2,
+            "grandchild task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    // Both active.
+    assert!(mgr.has_session(&child_id).await);
+    assert!(mgr.has_session(&grandchild_id).await);
+
+    // Kill the child — should cascade to grandchild.
+    mgr.kill_child("parent-kill-active", &child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(!mgr.has_session(&child_id).await);
+    assert!(!mgr.has_session(&grandchild_id).await);
+    assert_eq!(mgr.count_active_children("parent-kill-active").await, 0);
+}
+
+/// Verify cascade kill handles a mix of active and completed children
+/// at different levels of the spawn tree.
+#[tokio::test]
+#[serial]
+async fn test_cascade_kill_mixed_active_completed() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config_child = test_resolved_config("child");
+    let config_active = test_resolved_config("active");
+    let config_completed = test_resolved_config("completed");
+
+    register_parent(&mgr, "parent-mixed", tmp.path().to_path_buf()).await;
+
+    // Spawn child (active, session-mode).
+    let child_id = mgr
+        .create_child_session(
+            &config_child,
+            "parent-mixed",
+            1,
+            "child task",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    // Spawn active grandchild under child.
+    let active_gc = mgr
+        .create_child_session(
+            &config_active,
+            &child_id,
+            2,
+            "active grandchild",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+
+    // Spawn completed grandchild under child, then simulate completion.
+    let completed_gc = mgr
+        .create_child_session(
+            &config_completed,
+            &child_id,
+            2,
+            "completed grandchild",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .unwrap();
+    mgr.conversation_sessions
+        .write()
+        .await
+        .remove(&completed_gc);
+
+    // Child has 2 descendants: 1 active, 1 completed.
+    assert!(mgr.has_session(&child_id).await);
+    assert!(mgr.has_session(&active_gc).await);
+    assert_eq!(
+        mgr.count_active_children(&child_id).await,
+        1,
+        "child should have exactly 1 active descendant"
+    );
+
+    // Kill the child — must handle both active and completed descendants.
+    mgr.kill_child("parent-mixed", &child_id)
+        .await
+        .expect("kill_child should succeed with mixed descendants");
+
+    assert!(!mgr.has_session(&child_id).await);
+    assert!(!mgr.has_session(&active_gc).await);
+    assert_eq!(mgr.count_active_children("parent-mixed").await, 0);
+}

--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -384,6 +384,19 @@ impl SpawnTree {
     pub fn root_ids(&self) -> &[String] {
         &self.roots
     }
+
+    /// Get the parent session ID of a given session.
+    ///
+    /// Returns `None` for root nodes or unknown sessions.
+    pub fn get_parent(&self, session_id: &str) -> Option<&String> {
+        if self.is_root(session_id) {
+            return None;
+        }
+        self.children
+            .iter()
+            .find(|(_, children)| children.iter().any(|id| id == session_id))
+            .map(|(parent, _)| parent)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Agent Spawn 设计文档对齐修复

修复代码与 `docs/design/agent/agent-spawn.md` 之间的 4 处 must_fix 差异：

1. **工具层拦截**：`max_spawn_depth == 0` 时从子 agent 工具白名单移除 `sessions_spawn`，实现两层防护
2. **get_parent 查询接口**：为 `SpawnTree` 和 `SessionManager` 添加 `get_parent` / `get_parent_of` 方法
3. **count_active_children 语义**：仅统计仍存在于 `conversation_sessions` 中的活跃子 session，排除已完成的 run-mode session
4. **kill_child 清理**：已完成的子 session 跳过终止步骤但仍从 spawn_tree 移除，级联 kill 同样适用

新增 9 个单元测试覆盖所有新增逻辑分支。

Source: CI
Type: fix