### PR TITLE
feat: 实现 CommunicationConfig 消息路由校验

### DIFF
--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -521,6 +521,8 @@ mod announce_tests;
 #[cfg(test)]
 mod bug904_tests;
 #[cfg(test)]
+mod communication_tests;
+#[cfg(test)]
 mod flush_tests;
 #[cfg(test)]
 mod graceful_stop_tests;

--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -13,6 +13,7 @@
 
 use super::spawn::SpawnMode;
 use super::SessionManager;
+use crate::gateway::session_manager::communication::CommunicationError;
 use crate::llm::session::{AnnounceEvent, ChatSession, ConversationSession};
 use crate::llm::types::ContentBlock;
 use chrono::Utc;
@@ -71,8 +72,8 @@ impl SessionManager {
     /// `role="system"` message at the head of the parent's next turn.
     ///
     /// Called by `SessionMessageHandler::drain_pending_loop` (Step 1.5)
-    /// before processing user-pending messages. Loops until the queue
-    /// is empty so bursts of child completions accumulated during LLM
+    /// before processing user-pending messages. Loops until the queue is
+    /// empty so bursts of child completions accumulated during LLM
     /// calls are all consumed in a single call. If the session is
     /// missing mid-drain, logs a warning and returns — the next turn
     /// will retry from an empty queue.
@@ -133,6 +134,38 @@ impl SessionManager {
             // Not a child, or mode != Run: nothing to do.
             return;
         };
+
+        // Step 1.3: Check communication permissions before pushing announce.
+        // Child is the source (sending completion to parent), parent is the
+        // target (receiving from child).
+        if let Err(e) = self
+            .check_session_communication(child_session_id, &parent_session_id)
+            .await
+        {
+            match &e {
+                CommunicationError::Denied { reason } => {
+                    warn!(
+                        child_session_id = %child_session_id,
+                        parent_session_id = %parent_session_id,
+                        reason = %reason,
+                        "try_push_announce: communication check denied"
+                    );
+                }
+                CommunicationError::SessionNotFound(s) => {
+                    warn!(
+                        session = %s,
+                        "try_push_announce: session not found during communication check"
+                    );
+                }
+                CommunicationError::NoCommunicationConfig(s) => {
+                    warn!(
+                        session = %s,
+                        "try_push_announce: session missing communication config"
+                    );
+                }
+            }
+            return;
+        }
 
         let Some(result_text) = self.extract_last_assistant_text(child_session_id).await else {
             warn!(

--- a/src/gateway/session_manager/communication.rs
+++ b/src/gateway/session_manager/communication.rs
@@ -1,6 +1,23 @@
 //! Agent communication permission checks.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Error returned when agent communication is denied by `CommunicationConfig`.
+#[derive(Debug, Error)]
+pub enum CommunicationError {
+    /// Communication is not allowed due to whitelist restrictions.
+    #[error("communication denied: {reason}")]
+    Denied { reason: String },
+
+    /// One or both sessions were not found in the session manager.
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+
+    /// Session exists but has no communication config set.
+    #[error("session {0} has no communication config")]
+    NoCommunicationConfig(String),
+}
 
 /// Communication whitelist for an agent.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -62,4 +79,82 @@ pub fn check_communication_allowed(
     }
 
     CommunicationCheckResult::Allowed
+}
+
+impl super::SessionManager {
+    /// Check if communication from `source_session_id` to `target_session_id`
+    /// is allowed by their respective `CommunicationConfig`.
+    ///
+    /// Returns `Ok(())` if allowed, or `Err(CommunicationError)` with a
+    /// descriptive reason if denied.
+    #[allow(dead_code)] // called in Step 1.2 / 1.3
+    pub(crate) async fn check_session_communication(
+        &self,
+        source_session_id: &str,
+        target_session_id: &str,
+    ) -> Result<(), CommunicationError> {
+        // 1. Acquire conversation_sessions read lock once to look up both sessions.
+        let (source_config_opt, target_config_opt) = {
+            let conv = self.conversation_sessions.read().await;
+            let source_cs = conv.get(source_session_id).ok_or_else(|| {
+                CommunicationError::SessionNotFound(source_session_id.to_string())
+            })?;
+            let target_cs = conv.get(target_session_id).ok_or_else(|| {
+                CommunicationError::SessionNotFound(target_session_id.to_string())
+            })?;
+            let source_cs = source_cs.read().await;
+            let target_cs = target_cs.read().await;
+            (
+                source_cs.communication_config().cloned(),
+                target_cs.communication_config().cloned(),
+            )
+        };
+
+        // 2. Resolve agent_ids from the sessions map.
+        let (source_agent_id, target_agent_id) = {
+            let sessions = self.sessions.read().await;
+            let source_session = sessions.get(source_session_id).ok_or_else(|| {
+                CommunicationError::SessionNotFound(source_session_id.to_string())
+            })?;
+            let target_session = sessions.get(target_session_id).ok_or_else(|| {
+                CommunicationError::SessionNotFound(target_session_id.to_string())
+            })?;
+            (
+                source_session.agent_id.clone(),
+                target_session.agent_id.clone(),
+            )
+        };
+
+        // 3. Extract configs (or treat missing config as deny-all).
+        let source_config = source_config_opt.ok_or_else(|| {
+            CommunicationError::NoCommunicationConfig(source_session_id.to_string())
+        })?;
+        let target_config = target_config_opt.ok_or_else(|| {
+            CommunicationError::NoCommunicationConfig(target_session_id.to_string())
+        })?;
+
+        // 4. Delegate to the pure function and translate the result.
+        match check_communication_allowed(
+            &source_config,
+            &source_agent_id,
+            &target_config,
+            &target_agent_id,
+        ) {
+            CommunicationCheckResult::Allowed => Ok(()),
+            CommunicationCheckResult::TargetNotInSourceOutbound => {
+                Err(CommunicationError::Denied {
+                    reason: format!(
+                        "agent '{}' outbound list does not include '{}'",
+                        source_agent_id, target_agent_id,
+                    ),
+                })
+            }
+            CommunicationCheckResult::SourceNotInTargetInbound => Err(CommunicationError::Denied {
+                reason: format!(
+                    "agent '{}' inbound list does not include '{}'",
+                    target_agent_id, source_agent_id,
+                ),
+            }),
+        }
+    }
 }

--- a/src/gateway/session_manager/communication.rs
+++ b/src/gateway/session_manager/communication.rs
@@ -87,7 +87,6 @@ impl super::SessionManager {
     ///
     /// Returns `Ok(())` if allowed, or `Err(CommunicationError)` with a
     /// descriptive reason if denied.
-    #[allow(dead_code)] // called in Step 1.2 / 1.3
     pub(crate) async fn check_session_communication(
         &self,
         source_session_id: &str,
@@ -125,13 +124,14 @@ impl super::SessionManager {
             )
         };
 
-        // 3. Extract configs (or treat missing config as deny-all).
-        let source_config = source_config_opt.ok_or_else(|| {
-            CommunicationError::NoCommunicationConfig(source_session_id.to_string())
-        })?;
-        let target_config = target_config_opt.ok_or_else(|| {
-            CommunicationError::NoCommunicationConfig(target_session_id.to_string())
-        })?;
+        // 3. Extract configs. Missing config = unrestricted
+        //    (parent/orchestrator sessions are not constrained).
+        let allow_all = CommunicationConfig {
+            outbound: vec!["*".to_string()],
+            inbound: vec!["*".to_string()],
+        };
+        let source_config = source_config_opt.unwrap_or(allow_all.clone());
+        let target_config = target_config_opt.unwrap_or(allow_all);
 
         // 4. Delegate to the pure function and translate the result.
         match check_communication_allowed(

--- a/src/gateway/session_manager/communication.rs
+++ b/src/gateway/session_manager/communication.rs
@@ -81,18 +81,46 @@ pub fn check_communication_allowed(
     CommunicationCheckResult::Allowed
 }
 
+/// Resolved communication configs and agent IDs for a session pair.
+struct SessionPairConfig {
+    source_config: CommunicationConfig,
+    source_agent_id: String,
+    target_config: CommunicationConfig,
+    target_agent_id: String,
+}
+
+/// Evaluate whether communication is allowed based on resolved configs.
+/// Returns `Ok(())` if allowed, or `Err` with a descriptive reason.
+fn evaluate_communication(pair: &SessionPairConfig) -> Result<(), CommunicationError> {
+    match check_communication_allowed(
+        &pair.source_config,
+        &pair.source_agent_id,
+        &pair.target_config,
+        &pair.target_agent_id,
+    ) {
+        CommunicationCheckResult::Allowed => Ok(()),
+        CommunicationCheckResult::TargetNotInSourceOutbound => Err(CommunicationError::Denied {
+            reason: format!(
+                "agent '{}' outbound list does not include '{}'",
+                pair.source_agent_id, pair.target_agent_id,
+            ),
+        }),
+        CommunicationCheckResult::SourceNotInTargetInbound => Err(CommunicationError::Denied {
+            reason: format!(
+                "agent '{}' inbound list does not include '{}'",
+                pair.target_agent_id, pair.source_agent_id,
+            ),
+        }),
+    }
+}
+
 impl super::SessionManager {
-    /// Check if communication from `source_session_id` to `target_session_id`
-    /// is allowed by their respective `CommunicationConfig`.
-    ///
-    /// Returns `Ok(())` if allowed, or `Err(CommunicationError)` with a
-    /// descriptive reason if denied.
-    pub(crate) async fn check_session_communication(
+    /// Resolve communication configs and agent IDs for two sessions.
+    async fn resolve_session_configs(
         &self,
         source_session_id: &str,
         target_session_id: &str,
-    ) -> Result<(), CommunicationError> {
-        // 1. Acquire conversation_sessions read lock once to look up both sessions.
+    ) -> Result<SessionPairConfig, CommunicationError> {
         let (source_config_opt, target_config_opt) = {
             let conv = self.conversation_sessions.read().await;
             let source_cs = conv.get(source_session_id).ok_or_else(|| {
@@ -108,8 +136,6 @@ impl super::SessionManager {
                 target_cs.communication_config().cloned(),
             )
         };
-
-        // 2. Resolve agent_ids from the sessions map.
         let (source_agent_id, target_agent_id) = {
             let sessions = self.sessions.read().await;
             let source_session = sessions.get(source_session_id).ok_or_else(|| {
@@ -123,38 +149,28 @@ impl super::SessionManager {
                 target_session.agent_id.clone(),
             )
         };
-
-        // 3. Extract configs. Missing config = unrestricted
-        //    (parent/orchestrator sessions are not constrained).
         let allow_all = CommunicationConfig {
             outbound: vec!["*".to_string()],
             inbound: vec!["*".to_string()],
         };
-        let source_config = source_config_opt.unwrap_or(allow_all.clone());
-        let target_config = target_config_opt.unwrap_or(allow_all);
+        Ok(SessionPairConfig {
+            source_config: source_config_opt.unwrap_or(allow_all.clone()),
+            source_agent_id,
+            target_config: target_config_opt.unwrap_or(allow_all),
+            target_agent_id,
+        })
+    }
 
-        // 4. Delegate to the pure function and translate the result.
-        match check_communication_allowed(
-            &source_config,
-            &source_agent_id,
-            &target_config,
-            &target_agent_id,
-        ) {
-            CommunicationCheckResult::Allowed => Ok(()),
-            CommunicationCheckResult::TargetNotInSourceOutbound => {
-                Err(CommunicationError::Denied {
-                    reason: format!(
-                        "agent '{}' outbound list does not include '{}'",
-                        source_agent_id, target_agent_id,
-                    ),
-                })
-            }
-            CommunicationCheckResult::SourceNotInTargetInbound => Err(CommunicationError::Denied {
-                reason: format!(
-                    "agent '{}' inbound list does not include '{}'",
-                    target_agent_id, source_agent_id,
-                ),
-            }),
-        }
+    /// Check if communication from `source_session_id` to `target_session_id`
+    /// is allowed by their respective `CommunicationConfig`.
+    pub(crate) async fn check_session_communication(
+        &self,
+        source_session_id: &str,
+        target_session_id: &str,
+    ) -> Result<(), CommunicationError> {
+        let pair = self
+            .resolve_session_configs(source_session_id, target_session_id)
+            .await?;
+        evaluate_communication(&pair)
     }
 }

--- a/src/gateway/session_manager/communication_tests.rs
+++ b/src/gateway/session_manager/communication_tests.rs
@@ -1,0 +1,500 @@
+//! Tests for communication permission checks (Step 1.4).
+//!
+//! Covers:
+//! 1. Default config (parent-only) → parent↔child allowed, child↔sibling denied
+//! 2. `outbound: ["*"]` → allows sending to any agent
+//! 3. `inbound: ["*"]` → allows receiving from any agent
+//! 4. Both parties restricted → only parent↔child allowed
+//! 5. steer denied by communication check returns correct error
+//! 6. announce denied by communication check is handled gracefully
+
+use super::communication::{
+    check_communication_allowed, CommunicationCheckResult, CommunicationConfig, CommunicationError,
+};
+use super::spawn::{ChildSessionInfo, SpawnMode};
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::SessionManager;
+use crate::llm::session::ConversationSession;
+use crate::session::bootstrap::BootstrapMode;
+use serial_test::serial;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+// ── Helper to build ResolvedAgentConfig ────────────────────────────────────
+
+#[allow(dead_code)]
+fn test_resolved_config(
+    id: &str,
+    workspace: Option<PathBuf>,
+) -> crate::config::agents::ResolvedAgentConfig {
+    use crate::agent::config::SubagentsConfig;
+    use crate::config::agents::ConfigSource;
+
+    crate::config::agents::ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents: SubagentsConfig::default(),
+        source: ConfigSource::Merged,
+    }
+}
+
+/// Register a parent session with a ConversationSession so child
+/// creation can wire into the cancel token tree.
+async fn register_parent_session(
+    mgr: &SessionManager,
+    parent_id: &str,
+    agent_id: &str,
+    workdir: &std::path::Path,
+) {
+    use crate::gateway::Session;
+
+    mgr.sessions.write().await.insert(
+        parent_id.to_string(),
+        Session {
+            id: parent_id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+    let cs = Arc::new(RwLock::new(ConversationSession::new(
+        parent_id.to_string(),
+        "test-model".to_string(),
+        workdir.to_path_buf(),
+    )));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(parent_id.to_string(), cs);
+}
+
+/// Register a child session directly (no full create_child_session) with a
+/// custom CommunicationConfig for targeted unit tests.
+async fn register_child_session(
+    mgr: &SessionManager,
+    session_id: &str,
+    agent_id: &str,
+    config: CommunicationConfig,
+) {
+    use crate::gateway::Session;
+
+    let mut cs = ConversationSession::new(
+        session_id.to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    );
+    cs = cs.with_communication_config(config);
+    let arc = Arc::new(RwLock::new(cs));
+
+    mgr.sessions.write().await.insert(
+        session_id.to_string(),
+        Session {
+            id: session_id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "spawn".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(session_id.to_string(), arc);
+}
+
+// ── Pure function tests ────────────────────────────────────────────────────
+
+/// 1. Default config (parent-only): parent (allow-all) ↔ child allowed,
+///    child → sibling denied.
+#[test]
+fn test_check_communication_allowed_default_parent_only() {
+    // In production, parent/orchestrator sessions have no CommunicationConfig,
+    // which defaults to allow-all. Child sessions get default_with_parent.
+    let parent_config = CommunicationConfig {
+        outbound: vec!["*".to_string()],
+        inbound: vec!["*".to_string()],
+    };
+    let child_config = CommunicationConfig::default_with_parent(Some("parent-agent"));
+
+    // Parent → child: parent outbound is "*" → allowed.
+    let result =
+        check_communication_allowed(&parent_config, "parent-agent", &child_config, "child-agent");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+
+    // Child → parent: child outbound includes "parent-agent" → allowed.
+    let result =
+        check_communication_allowed(&child_config, "child-agent", &parent_config, "parent-agent");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+
+    // Child → sibling: child outbound is ["parent-agent"], doesn't include
+    // "sibling-agent" → denied.
+    let sibling_config = CommunicationConfig::default_with_parent(Some("parent-agent"));
+    let result = check_communication_allowed(
+        &child_config,
+        "child-agent",
+        &sibling_config,
+        "sibling-agent",
+    );
+    assert_eq!(result, CommunicationCheckResult::TargetNotInSourceOutbound);
+}
+
+/// 2. outbound: ["*"] allows sending to any agent.
+#[test]
+fn test_check_communication_allowed_wildcard_outbound() {
+    let config = CommunicationConfig {
+        outbound: vec!["*".to_string()],
+        inbound: vec!["any-agent".to_string()],
+    };
+    let target_config = CommunicationConfig {
+        outbound: vec![],
+        inbound: vec!["wildcard-agent".to_string()],
+    };
+
+    // wildcard-agent → any-agent: outbound is "*" → allowed.
+    let result =
+        check_communication_allowed(&config, "wildcard-agent", &target_config, "any-agent");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+
+    // wildcard-agent → unknown-agent: outbound is "*" → allowed.
+    let result =
+        check_communication_allowed(&config, "wildcard-agent", &target_config, "unknown-agent");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+}
+
+/// 3. inbound: ["*"] allows receiving from any agent.
+#[test]
+fn test_check_communication_allowed_wildcard_inbound() {
+    let source_config = CommunicationConfig {
+        outbound: vec!["wildcard-target".to_string()],
+        inbound: vec!["*".to_string()],
+    };
+    let target_config = CommunicationConfig {
+        outbound: vec![],
+        inbound: vec!["*".to_string()],
+    };
+
+    // source → target: source outbound has "wildcard-target" → allowed.
+    let result = check_communication_allowed(
+        &source_config,
+        "source-agent",
+        &target_config,
+        "wildcard-target",
+    );
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+}
+
+/// 4. Both parties restricted: only parent↔child allowed.
+#[test]
+fn test_check_communication_allowed_both_restricted() {
+    let parent_config = CommunicationConfig {
+        outbound: vec!["child-1".to_string()],
+        inbound: vec!["child-1".to_string()],
+    };
+    let child_config = CommunicationConfig {
+        outbound: vec!["parent-agent".to_string()],
+        inbound: vec!["parent-agent".to_string()],
+    };
+    let other_config = CommunicationConfig {
+        outbound: vec!["someone-else".to_string()],
+        inbound: vec!["someone-else".to_string()],
+    };
+
+    // parent → child: parent outbound has "child-1", child inbound has
+    // "parent-agent" → allowed.
+    let result =
+        check_communication_allowed(&parent_config, "parent-agent", &child_config, "child-1");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+
+    // child → parent: child outbound has "parent-agent", parent inbound has
+    // "child-1" → allowed.
+    let result =
+        check_communication_allowed(&child_config, "child-1", &parent_config, "parent-agent");
+    assert_eq!(result, CommunicationCheckResult::Allowed);
+
+    // child → other: child outbound has "parent-agent", doesn't include
+    // "other-agent" → denied.
+    let result =
+        check_communication_allowed(&child_config, "child-1", &other_config, "other-agent");
+    assert_eq!(result, CommunicationCheckResult::TargetNotInSourceOutbound);
+
+    // other → child: other outbound has "someone-else", doesn't include
+    // "child-1" → denied.
+    let result =
+        check_communication_allowed(&other_config, "other-agent", &child_config, "child-1");
+    assert_eq!(result, CommunicationCheckResult::TargetNotInSourceOutbound);
+}
+
+// ── SessionManager integration tests ───────────────────────────────────────
+
+/// 5. steer_child returns correct error when communication check denies.
+#[tokio::test]
+#[serial]
+async fn test_steer_child_denied_by_communication_check() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Register parent session.
+    register_parent_session(&mgr, "parent-steer-deny", "parent-agent", tmp.path()).await;
+
+    // Register parent session (with communication_config restricted to
+    // "other-child" only — NOT our child).
+    {
+        let parent_cs = mgr
+            .get_conversation_session("parent-steer-deny")
+            .await
+            .unwrap();
+        let mut guard = parent_cs.write().await;
+        *guard = guard
+            .clone()
+            .with_communication_config(CommunicationConfig {
+                outbound: vec!["other-child".to_string()],
+                inbound: vec!["other-child".to_string()],
+            });
+    }
+
+    // Register a child session with config restricted to parent only.
+    register_child_session(
+        &mgr,
+        "child-steer-deny",
+        "child-agent",
+        CommunicationConfig::default_with_parent(Some("parent-agent")),
+    )
+    .await;
+
+    // Also register the child in the children table so get_parent_of works.
+    mgr.register_child(
+        "parent-steer-deny",
+        ChildSessionInfo {
+            session_id: "child-steer-deny".to_string(),
+            parent_session_id: "parent-steer-deny".to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+
+    // Attempt to steer — should be denied because parent outbound doesn't
+    // include "child-agent".
+    let result = mgr.steer_child("child-steer-deny", "new task").await;
+    assert!(result.is_err(), "steer_child should fail when denied");
+    let err_msg = result.unwrap_err();
+    assert!(
+        err_msg.contains("steer blocked by communication policy"),
+        "error should indicate communication policy denial, got: {}",
+        err_msg
+    );
+}
+
+/// 6. try_push_announce returns early (no panic) when communication check
+///    denies the announce from child to parent.
+#[tokio::test]
+#[serial]
+async fn test_announce_denied_by_communication_check() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Register parent session with config that does NOT allow receiving from
+    // the child's agent.
+    register_parent_session(&mgr, "parent-announce-deny", "parent-agent", tmp.path()).await;
+    {
+        let parent_cs = mgr
+            .get_conversation_session("parent-announce-deny")
+            .await
+            .unwrap();
+        let mut guard = parent_cs.write().await;
+        *guard = guard
+            .clone()
+            .with_communication_config(CommunicationConfig {
+                outbound: vec!["unrelated-agent".to_string()],
+                inbound: vec!["unrelated-agent".to_string()],
+            });
+    }
+
+    // Register a run-mode child under the parent.
+    register_child_session(
+        &mgr,
+        "child-announce-deny",
+        "child-agent",
+        CommunicationConfig::default_with_parent(Some("parent-agent")),
+    )
+    .await;
+
+    // Register the child in the children table as run mode.
+    mgr.register_child(
+        "parent-announce-deny",
+        ChildSessionInfo {
+            session_id: "child-announce-deny".to_string(),
+            parent_session_id: "parent-announce-deny".to_string(),
+            agent_id: "child-agent".to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+
+    // try_push_announce should return without panicking even though the
+    // communication check denies. The announce is silently dropped.
+    mgr.try_push_announce("child-announce-deny").await;
+
+    // Verify no announce was pushed to the parent.
+    let parent_cs = mgr
+        .get_conversation_session("parent-announce-deny")
+        .await
+        .unwrap();
+    let mut guard = parent_cs.write().await;
+    let queue = guard.drain_announce_queue();
+    assert!(
+        queue.is_empty(),
+        "announce queue should be empty when communication is denied"
+    );
+}
+
+// ── Wildcard integration via SessionManager ─────────────────────────────────
+
+/// Integration test: child with outbound: ["*"] can communicate with any agent
+/// through check_session_communication.
+#[tokio::test]
+#[serial]
+async fn test_wildcard_outbound_integration() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Register two parent sessions with different agents.
+    register_parent_session(&mgr, "parent-a", "agent-a", tmp.path()).await;
+    register_parent_session(&mgr, "parent-b", "agent-b", tmp.path()).await;
+
+    // Register a child under parent-a with wildcard outbound.
+    register_child_session(
+        &mgr,
+        "wildcard-child",
+        "child-agent",
+        CommunicationConfig {
+            outbound: vec!["*".to_string()],
+            inbound: vec!["agent-a".to_string()],
+        },
+    )
+    .await;
+
+    // wildcard-child → parent-b: outbound is "*" → allowed.
+    let result = mgr
+        .check_session_communication("wildcard-child", "parent-b")
+        .await;
+    assert!(
+        result.is_ok(),
+        "wildcard outbound should allow communication with any agent"
+    );
+}
+
+/// Integration test: child with inbound: ["*"] can receive from any agent.
+#[tokio::test]
+#[serial]
+async fn test_wildcard_inbound_integration() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Register two sessions.
+    register_parent_session(&mgr, "source-session", "source-agent", tmp.path()).await;
+    register_child_session(
+        &mgr,
+        "wildcard-receiver",
+        "receiver-agent",
+        CommunicationConfig {
+            outbound: vec!["source-agent".to_string()],
+            inbound: vec!["*".to_string()],
+        },
+    )
+    .await;
+
+    // source → wildcard-receiver: inbound is "*" → allowed.
+    let result = mgr
+        .check_session_communication("source-session", "wildcard-receiver")
+        .await;
+    assert!(
+        result.is_ok(),
+        "wildcard inbound should allow receiving from any agent"
+    );
+}
+
+/// Integration test: denied communication returns CommunicationError::Denied.
+#[tokio::test]
+#[serial]
+async fn test_session_communication_denied_returns_error() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    register_parent_session(&mgr, "parent-deny", "parent-agent", tmp.path()).await;
+
+    // Child restricted to "other-parent" only, not "parent-agent".
+    register_child_session(
+        &mgr,
+        "restricted-child",
+        "child-agent",
+        CommunicationConfig {
+            outbound: vec!["other-parent".to_string()],
+            inbound: vec!["other-parent".to_string()],
+        },
+    )
+    .await;
+
+    let result = mgr
+        .check_session_communication("restricted-child", "parent-deny")
+        .await;
+    assert!(result.is_err(), "communication should be denied");
+    match result.unwrap_err() {
+        CommunicationError::Denied { reason } => {
+            assert!(
+                reason.contains("outbound"),
+                "reason should mention outbound, got: {}",
+                reason
+            );
+        }
+        other => panic!("expected CommunicationError::Denied, got: {:?}", other),
+    }
+}
+
+/// Integration test: session not found returns CommunicationError::SessionNotFound.
+#[tokio::test]
+#[serial]
+async fn test_session_communication_not_found() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    register_parent_session(&mgr, "existing-session", "agent-x", tmp.path()).await;
+
+    let result = mgr
+        .check_session_communication("existing-session", "nonexistent-session")
+        .await;
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        CommunicationError::SessionNotFound(id) => {
+            assert_eq!(id, "nonexistent-session");
+        }
+        other => panic!(
+            "expected CommunicationError::SessionNotFound, got: {:?}",
+            other
+        ),
+    }
+}

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -7,7 +7,7 @@
 
 use super::SessionManager;
 use crate::config::agents::ResolvedAgentConfig;
-use crate::gateway::session_manager::communication::CommunicationConfig;
+use crate::gateway::session_manager::communication::{CommunicationConfig, CommunicationError};
 use crate::gateway::Session;
 use crate::llm::session::ChatSession;
 use crate::llm::session::ConversationSession;
@@ -534,6 +534,23 @@ impl SessionManager {
     /// message queue. The task is enqueued (FIFO) and will be
     /// consumed after the child's current turn completes.
     pub(crate) async fn steer_child(&self, child_id: &str, task: &str) -> Result<(), String> {
+        let parent_session_id = self
+            .get_parent_of(child_id)
+            .await
+            .ok_or_else(|| format!("no parent registered for child session: {}", child_id))?;
+
+        self.check_session_communication(&parent_session_id, child_id)
+            .await
+            .map_err(|e| match e {
+                CommunicationError::Denied { reason } => {
+                    format!("steer blocked by communication policy: {}", reason)
+                }
+                CommunicationError::SessionNotFound(s) => {
+                    format!("session not found: {}", s)
+                }
+                other => format!("communication check failed: {}", other),
+            })?;
+
         let cs = self
             .get_conversation_session(child_id)
             .await


### PR DESCRIPTION
实现 CommunicationConfig 消息路由校验

在 Session 模块的消息路由入口处添加通信校验。当一个 agent session 尝试向另一个 agent session 发送消息时，双向检查双方的 CommunicationConfig。

主要变更：
- 新增 SessionManager::check_session_communication 方法，包含 resolve_session_configs 和 evaluate_communication 辅助方法
- 在 steer_child 路径集成通信校验
- 在 announce 路径集成通信校验
- 新增通信权限单元测试覆盖核心逻辑分支

Source: design-doc
Type: feat