### PR TITLE
refactor: align agent spawn implementation with design doc

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -87,16 +87,16 @@ impl SpawnController {
             .resolve_parent_depth(parent_session_id, &parent_agent_id)
             .await?;
 
-        // ② AgentId fallback + target config resolution.
-        let resolved = self
-            .resolve_target_config(&parent_agent_id, target_agent_id)
-            .await?;
-
-        // ③ Read parent config for concurrency/whitelist/requireAgentId.
+        // ② Read parent config for concurrency/whitelist/requireAgentId.
         let parent_cfg = self.read_parent_config(&parent_agent_id).await?;
 
-        // ④ Concurrency check.
+        // ③ Concurrency check.
         self.check_concurrency(parent_session_id, parent_cfg.max_children)
+            .await?;
+
+        // ④ AgentId fallback + target config resolution.
+        let resolved = self
+            .resolve_target_config(&parent_agent_id, target_agent_id)
             .await?;
 
         // ⑤ Whitelist check (on resolved target_id, after fallback).

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -60,7 +60,7 @@ pub struct SessionManager {
     /// Priority prompt overrides (checked at request time, not session creation).
     prompt_overrides: RwLock<Option<PromptOverrides>>,
     /// Children tracking table: parent_session_id → list of child sessions.
-    children: RwLock<HashMap<String, Vec<ChildSessionInfo>>>,
+    children: RwLock<spawn::SpawnTree>,
     /// Channel → active session_id mapping.
     /// Updated by `force_new_for_channel` so subsequent `find_or_create`
     /// calls route to the latest session for a channel.
@@ -110,7 +110,7 @@ impl SessionManager {
             skill_registry: RwLock::new(None),
             default_reasoning_level,
             prompt_overrides: RwLock::new(None),
-            children: RwLock::new(HashMap::new()),
+            children: RwLock::new(spawn::SpawnTree::new()),
             channel_active_sessions: RwLock::new(HashMap::new()),
             key_registry: RwLock::new(HashMap::new()),
             config_manager: RwLock::new(None),

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -539,6 +539,8 @@ mod spawn_gap_tests;
 #[cfg(test)]
 mod spawn_tests;
 #[cfg(test)]
+mod spawn_tree_tests;
+#[cfg(test)]
 mod test_helpers;
 #[cfg(test)]
 mod tests;

--- a/src/gateway/session_manager/announce.rs
+++ b/src/gateway/session_manager/announce.rs
@@ -211,15 +211,10 @@ impl SessionManager {
     /// helper — we never hold it while touching any session lock.
     async fn find_run_mode_parent(&self, child_session_id: &str) -> Option<(String, String)> {
         let children = self.children.read().await;
-        for infos in children.values() {
-            if let Some(info) = infos
-                .iter()
-                .find(|i| i.session_id == child_session_id && i.mode == SpawnMode::Run)
-            {
-                return Some((info.parent_session_id.clone(), info.agent_id.clone()));
-            }
-        }
-        None
+        children
+            .find_child(child_session_id)
+            .filter(|i| i.mode == SpawnMode::Run)
+            .map(|info| (info.parent_session_id.clone(), info.agent_id.clone()))
     }
 
     /// Extract the concatenated `Text` blocks from the child's last

--- a/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
+++ b/src/gateway/session_manager/rebuild_spawn_tree_tests.rs
@@ -78,7 +78,8 @@ async fn test_rebuild_spawn_tree_basic() {
     assert_eq!(count, 1, "parent-1 should have exactly 1 child");
 
     let children = mgr.children.read().await;
-    let list = children.get("parent-1").unwrap();
+    let list = children.list_children("parent-1");
+    assert_eq!(list.len(), 1);
     assert_eq!(list[0].session_id, "child-1");
     assert_eq!(list[0].parent_session_id, "parent-1");
     assert_eq!(list[0].agent_id, "child-agent");

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -18,7 +18,7 @@ use crate::session::persistence::{
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::ToolContext;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use tracing::warn;
 use uuid::Uuid;
@@ -40,6 +40,128 @@ pub enum SpawnMode {
     Run,
     /// Persistent: child stays alive for subsequent steering.
     Session,
+}
+
+/// Spawn tree: maintains parent-child relationships between sessions.
+///
+/// Wraps the `children` lookup table (parent_session_id → child list)
+/// and exposes the three query interfaces described in the design doc:
+/// `list_children`, `list_descendants`, `get_parent`.
+pub(crate) struct SpawnTree {
+    inner: HashMap<String, Vec<ChildSessionInfo>>,
+}
+
+impl SpawnTree {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    // ── Design doc query interfaces ────────────────────────────────
+
+    /// List all direct children of a session.
+    #[allow(dead_code)] // Used in tests; will be used by SessionManager in Step 1.3
+    pub(crate) fn list_children(&self, session_id: &str) -> Vec<&ChildSessionInfo> {
+        self.inner
+            .get(session_id)
+            .map(|v| v.iter().collect())
+            .unwrap_or_default()
+    }
+
+    /// List all descendants of a session (recursive BFS).
+    ///
+    /// Returns session IDs in reverse BFS order (deepest first,
+    /// shallowest last) so callers can process leaves before parents.
+    pub(crate) fn list_descendants(&self, session_id: &str) -> Vec<String> {
+        let mut result = Vec::new();
+        let mut queue = VecDeque::new();
+        if let Some(list) = self.inner.get(session_id) {
+            for info in list {
+                queue.push_back(info.session_id.clone());
+            }
+        }
+        while let Some(current) = queue.pop_front() {
+            result.push(current.clone());
+            if let Some(list) = self.inner.get(&current) {
+                for info in list {
+                    queue.push_back(info.session_id.clone());
+                }
+            }
+        }
+        result.reverse();
+        result
+    }
+
+    /// Get the parent session ID of a given session.
+    pub(crate) fn get_parent(&self, session_id: &str) -> Option<String> {
+        self.inner
+            .values()
+            .flatten()
+            .find(|info| info.session_id == session_id)
+            .map(|info| info.parent_session_id.clone())
+    }
+
+    // ── Internal accessors ─────────────────────────────────────────
+
+    /// Get the children list for a parent session.
+    pub(crate) fn get(&self, parent_id: &str) -> Option<&Vec<ChildSessionInfo>> {
+        self.inner.get(parent_id)
+    }
+
+    /// Check if the tree is empty.
+    #[allow(dead_code)] // Used in tests
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Find a child session info by its session ID.
+    pub(crate) fn find_child(&self, session_id: &str) -> Option<&ChildSessionInfo> {
+        self.inner
+            .values()
+            .flatten()
+            .find(|info| info.session_id == session_id)
+    }
+
+    /// Register a child session under its parent.
+    pub(crate) fn register_child(&mut self, parent_id: &str, info: ChildSessionInfo) {
+        self.inner
+            .entry(parent_id.to_string())
+            .or_default()
+            .push(info);
+    }
+
+    /// Iterate all parent → children entries.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &Vec<ChildSessionInfo>)> {
+        self.inner.iter()
+    }
+
+    /// Remove a direct child from its parent's list. Removes the
+    /// parent entry entirely if the list becomes empty.
+    pub(crate) fn remove_child(&mut self, parent_id: &str, child_id: &str) {
+        if let Some(list) = self.inner.get_mut(parent_id) {
+            list.retain(|info| info.session_id != child_id);
+            if list.is_empty() {
+                self.inner.remove(parent_id);
+            }
+        }
+    }
+
+    /// Remove entries for descendant sessions from the tree.
+    /// For each descendant, removes it from its parent's list and
+    /// removes any sub-entries where it is itself a parent.
+    pub(crate) fn remove_descendant_entries(&mut self, descendant_ids: &[String]) {
+        for id in descendant_ids {
+            let parent = self
+                .inner
+                .values_mut()
+                .find(|list| list.iter().any(|info| info.session_id == *id));
+            if let Some(list) = parent {
+                list.retain(|info| info.session_id != *id);
+            }
+            self.inner.remove(id);
+        }
+    }
 }
 
 impl SessionManager {
@@ -68,11 +190,7 @@ impl SessionManager {
     /// Returns `None` if the child is unknown or has no registered parent.
     pub async fn get_parent_of(&self, child_id: &str) -> Option<String> {
         let children = self.children.read().await;
-        children
-            .values()
-            .flatten()
-            .find(|info| info.session_id == child_id)
-            .map(|info| info.parent_session_id.clone())
+        children.get_parent(child_id)
     }
 
     /// Count active (non-completed) child sessions for a parent.
@@ -119,10 +237,7 @@ impl SessionManager {
     /// Register a child session under its parent. Called after child session creation.
     pub(crate) async fn register_child(&self, parent_id: &str, info: ChildSessionInfo) {
         let mut children = self.children.write().await;
-        children
-            .entry(parent_id.to_string())
-            .or_default()
-            .push(info);
+        children.register_child(parent_id, info);
     }
 
     /// Create a child session for a spawned sub-agent.
@@ -571,7 +686,10 @@ impl SessionManager {
     /// IDs before any removals, preventing lock-ordering issues.
     pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
         // 1. Collect all descendant session IDs via BFS.
-        let descendant_ids = self.collect_descendant_ids(child_id).await;
+        let descendant_ids = {
+            let children = self.children.read().await;
+            children.list_descendants(child_id)
+        };
 
         // 2. Stop active sessions. Completed/terminated sessions
         //    skip the stop step but still get cleaned up from the
@@ -612,8 +730,11 @@ impl SessionManager {
         }
 
         // 6. Remove child + descendants from children table.
-        self.remove_children_entries(parent_id, child_id, &descendant_ids)
-            .await;
+        {
+            let mut children = self.children.write().await;
+            children.remove_child(parent_id, child_id);
+            children.remove_descendant_entries(&descendant_ids);
+        }
 
         Ok(())
     }
@@ -643,76 +764,6 @@ impl SessionManager {
                 );
             }
         }
-    }
-
-    /// Remove a direct child and all its descendants from the
-    /// `children` tracking table.
-    ///
-    /// Handles: (a) removing the direct child from `parent_id`'s
-    /// list, (b) removing each descendant from its own parent's
-    /// list, and (c) removing any entries where a descendant is
-    /// itself a parent of further descendants.
-    async fn remove_children_entries(
-        &self,
-        parent_id: &str,
-        child_id: &str,
-        descendant_ids: &[String],
-    ) {
-        let mut children = self.children.write().await;
-
-        // Remove the direct child from parent's children list.
-        if let Some(list) = children.get_mut(parent_id) {
-            list.retain(|info| info.session_id != child_id);
-            if list.is_empty() {
-                children.remove(parent_id);
-            }
-        }
-
-        // Remove each descendant from its own parent's list
-        // and clean up any sub-entries.
-        for id in descendant_ids {
-            let parent = children
-                .values_mut()
-                .find(|list| list.iter().any(|info| info.session_id == *id));
-            if let Some(list) = parent {
-                list.retain(|info| info.session_id != *id);
-            }
-            children.remove(id);
-        }
-    }
-
-    /// Collect all descendant session IDs of a given session via BFS
-    /// on the `children` table.
-    ///
-    /// Returns session IDs in reverse BFS order (deepest first,
-    /// shallowest last) so that the caller removes leaves before
-    /// their parents — matching the design doc requirement to
-    /// "terminate from deepest to shallowest".
-    async fn collect_descendant_ids(&self, session_id: &str) -> Vec<String> {
-        let children = self.children.read().await;
-        let mut result = Vec::new();
-        let mut queue = std::collections::VecDeque::new();
-
-        // Seed the queue with the direct children of session_id.
-        if let Some(list) = children.get(session_id) {
-            for info in list {
-                queue.push_back(info.session_id.clone());
-            }
-        }
-
-        while let Some(current) = queue.pop_front() {
-            result.push(current.clone());
-            // Enqueue this session's own children (grandchildren).
-            if let Some(list) = children.get(&current) {
-                for info in list {
-                    queue.push_back(info.session_id.clone());
-                }
-            }
-        }
-
-        // Reverse so deepest descendants come first.
-        result.reverse();
-        result
     }
 
     /// Rebuild the spawn tree (children table) from persisted checkpoints.

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -61,7 +61,6 @@ impl SpawnTree {
     // ── Design doc query interfaces ────────────────────────────────
 
     /// List all direct children of a session.
-    #[allow(dead_code)] // Used in tests; will be used by SessionManager in Step 1.3
     pub(crate) fn list_children(&self, session_id: &str) -> Vec<&ChildSessionInfo> {
         self.inner
             .get(session_id)
@@ -100,13 +99,6 @@ impl SpawnTree {
             .flatten()
             .find(|info| info.session_id == session_id)
             .map(|info| info.parent_session_id.clone())
-    }
-
-    // ── Internal accessors ─────────────────────────────────────────
-
-    /// Get the children list for a parent session.
-    pub(crate) fn get(&self, parent_id: &str) -> Option<&Vec<ChildSessionInfo>> {
-        self.inner.get(parent_id)
     }
 
     /// Check if the tree is empty.
@@ -207,9 +199,10 @@ impl SessionManager {
         let child_ids: Vec<String> = {
             let children = self.children.read().await;
             children
-                .get(parent_id)
-                .map(|list| list.iter().map(|i| i.session_id.clone()).collect())
-                .unwrap_or_default()
+                .list_children(parent_id)
+                .into_iter()
+                .map(|info| info.session_id.clone())
+                .collect()
         };
         if child_ids.is_empty() {
             return 0;
@@ -229,9 +222,10 @@ impl SessionManager {
     pub(crate) async fn list_active_child_ids(&self, parent_id: &str) -> Vec<String> {
         let children = self.children.read().await;
         children
-            .get(parent_id)
-            .map(|list| list.iter().map(|info| info.session_id.clone()).collect())
-            .unwrap_or_default()
+            .list_children(parent_id)
+            .into_iter()
+            .map(|info| info.session_id.clone())
+            .collect()
     }
 
     /// Register a child session under its parent. Called after child session creation.
@@ -640,8 +634,9 @@ impl SessionManager {
     ) -> Option<ChildSessionInfo> {
         let children = self.children.read().await;
         children
-            .get(parent_id)
-            .and_then(|list| list.iter().find(|info| info.session_id == child_id))
+            .list_children(parent_id)
+            .into_iter()
+            .find(|info| info.session_id == child_id)
             .cloned()
     }
 
@@ -750,9 +745,10 @@ impl SessionManager {
         let child_ids: Vec<String> = {
             let children = self.children.read().await;
             children
-                .get(parent_id)
-                .map(|list| list.iter().map(|i| i.session_id.clone()).collect())
-                .unwrap_or_default()
+                .list_children(parent_id)
+                .into_iter()
+                .map(|info| info.session_id.clone())
+                .collect()
         };
         for child_id in child_ids {
             if let Err(e) = self.kill_child(parent_id, &child_id).await {

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -217,9 +217,8 @@ async fn test_create_child_session_registers_child_info() {
 
     // Direct lookup via children table
     let children = mgr.children.read().await;
-    let list = children
-        .get("parent-7")
-        .expect("parent-7 should have a children entry");
+    let list = children.list_children("parent-7");
+    assert!(!list.is_empty(), "parent-7 should have a children entry");
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].session_id, child_id);
     assert_eq!(list[0].parent_session_id, "parent-7");
@@ -341,7 +340,7 @@ async fn test_kill_child_removes_from_all_tables() {
     );
     let children = mgr.children.read().await;
     assert!(
-        children.get("parent-kill").is_none(),
+        children.list_children("parent-kill").is_empty(),
         "parent entry should be removed from children table when list is empty"
     );
 }

--- a/src/gateway/session_manager/spawn_tree_tests.rs
+++ b/src/gateway/session_manager/spawn_tree_tests.rs
@@ -1,0 +1,191 @@
+//! Unit tests for `SpawnTree` query interfaces.
+//!
+//! Tests cover the three design-doc query APIs:
+//! - `list_children`: with children / without children / empty session_id
+//! - `list_descendants`: multi-level nesting / single level / no descendants
+//! - `get_parent`: has parent / root node (no parent)
+
+use super::spawn::{ChildSessionInfo, SpawnMode, SpawnTree};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn info(session_id: &str, parent_session_id: &str, depth: u32) -> ChildSessionInfo {
+    ChildSessionInfo {
+        session_id: session_id.to_string(),
+        parent_session_id: parent_session_id.to_string(),
+        agent_id: "test-agent".to_string(),
+        depth,
+        mode: SpawnMode::Run,
+    }
+}
+
+// ── list_children ────────────────────────────────────────────────────────
+
+#[test]
+fn test_list_children_with_children() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("child-a", "root", 1));
+    tree.register_child("root", info("child-b", "root", 1));
+
+    let children = tree.list_children("root");
+    assert_eq!(children.len(), 2);
+    let ids: Vec<&str> = children.iter().map(|c| c.session_id.as_str()).collect();
+    assert!(ids.contains(&"child-a"));
+    assert!(ids.contains(&"child-b"));
+}
+
+#[test]
+fn test_list_children_without_children() {
+    let tree = SpawnTree::new();
+    let children = tree.list_children("nonexistent");
+    assert!(children.is_empty());
+}
+
+#[test]
+fn test_list_children_empty_session_id() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("child-a", "root", 1));
+
+    let children = tree.list_children("");
+    assert!(children.is_empty());
+}
+
+#[test]
+fn test_list_children_returns_empty_vec_for_unknown_parent() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("parent-a", info("child-x", "parent-a", 1));
+
+    let children = tree.list_children("parent-b");
+    assert!(children.is_empty());
+}
+
+// ── list_descendants ─────────────────────────────────────────────────────
+
+#[test]
+fn test_list_descendants_no_descendants() {
+    let tree = SpawnTree::new();
+    let descendants = tree.list_descendants("root");
+    assert!(descendants.is_empty());
+}
+
+#[test]
+fn test_list_descendants_single_level() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+    tree.register_child("root", info("b", "root", 1));
+
+    let descendants = tree.list_descendants("root");
+    // BFS reversed → deepest first, but all at depth 1 so order is
+    // reversed insertion: b, a
+    assert_eq!(descendants, vec!["b".to_string(), "a".to_string()]);
+}
+
+#[test]
+fn test_list_descendants_multi_level() {
+    // root → a, b
+    // a → a1, a2
+    // a1 → a1a
+    //
+    // BFS order: a, b, a1, a2, a1a
+    // Reversed (deepest first): a1a, a2, a1, b, a
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+    tree.register_child("root", info("b", "root", 1));
+    tree.register_child("a", info("a1", "a", 2));
+    tree.register_child("a", info("a2", "a", 2));
+    tree.register_child("a1", info("a1a", "a1", 3));
+
+    let descendants = tree.list_descendants("root");
+    assert_eq!(
+        descendants,
+        vec![
+            "a1a".to_string(),
+            "a2".to_string(),
+            "a1".to_string(),
+            "b".to_string(),
+            "a".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn test_list_descendants_unknown_session_returns_empty() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+
+    let descendants = tree.list_descendants("nonexistent");
+    assert!(descendants.is_empty());
+}
+
+#[test]
+fn test_list_descendants_empty_session_id() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+
+    let descendants = tree.list_descendants("");
+    assert!(descendants.is_empty());
+}
+
+#[test]
+fn test_list_descendants_middle_node() {
+    // root → a → a1 → a1a
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+    tree.register_child("a", info("a1", "a", 2));
+    tree.register_child("a1", info("a1a", "a1", 3));
+
+    let descendants = tree.list_descendants("a");
+    // BFS from "a": a1, a1a → reversed: a1a, a1
+    assert_eq!(descendants, vec!["a1a".to_string(), "a1".to_string()]);
+}
+
+// ── get_parent ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_parent_has_parent() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("child-a", "root", 1));
+
+    let parent = tree.get_parent("child-a");
+    assert_eq!(parent.as_deref(), Some("root"));
+}
+
+#[test]
+fn test_get_parent_root_node_no_parent() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("child-a", "root", 1));
+
+    // "root" is a top-level session — not registered as a child of
+    // anything, so get_parent should return None.
+    let parent = tree.get_parent("root");
+    assert_eq!(parent, None);
+}
+
+#[test]
+fn test_get_parent_unknown_session() {
+    let tree = SpawnTree::new();
+    let parent = tree.get_parent("nonexistent");
+    assert_eq!(parent, None);
+}
+
+#[test]
+fn test_get_parent_empty_session_id() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("child-a", "root", 1));
+
+    let parent = tree.get_parent("");
+    assert_eq!(parent, None);
+}
+
+#[test]
+fn test_get_parent_multi_level() {
+    let mut tree = SpawnTree::new();
+    tree.register_child("root", info("a", "root", 1));
+    tree.register_child("a", info("a1", "a", 2));
+    tree.register_child("a1", info("a1a", "a1", 3));
+
+    assert_eq!(tree.get_parent("a").as_deref(), Some("root"));
+    assert_eq!(tree.get_parent("a1").as_deref(), Some("a"));
+    assert_eq!(tree.get_parent("a1a").as_deref(), Some("a1"));
+    assert_eq!(tree.get_parent("root"), None);
+}

--- a/src/gateway/session_manager/stop.rs
+++ b/src/gateway/session_manager/stop.rs
@@ -196,7 +196,7 @@ impl SessionManager {
 
         // Collect all child IDs that have a parent in the tree.
         let mut all_child_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for child_infos in children.values() {
+        for child_infos in children.iter().map(|(_, v)| v) {
             for info in child_infos {
                 if sessions.contains_key(&info.session_id) {
                     all_child_ids.insert(info.session_id.clone());


### PR DESCRIPTION
重构 agent spawn 实现，对齐 docs/design/agent/agent-spawn.md 设计文档，消除两处 must_fix 差异：

1. **重构 validate() 步骤顺序**：将 parent config 读取和并发检查移到 agentId 解析之前，执行顺序从 `①depth→②agentId→③parent config→④concurrency→...` 改为 `①depth→②parent config→③concurrency→④agentId→...`，匹配文档描述
2. **提取 SpawnTree 统一抽象**：从 SessionManager 的 children 字段提取独立的 SpawnTree 结构体，提供 `list_children`、`list_descendants`、`get_parent` 三类查询接口
3. **迁移所有方法到 SpawnTree 接口**：将 `count_active_children`、`list_active_child_ids`、`validate_child_ownership`、`cascade_kill_all_children` 等方法迁移到使用 SpawnTree 查询接口，消除重复的 children 访问逻辑

Source: docs/design/agent/agent-spawn.md
Type: refactor
