### PR TITLE
refactor: align spawn implementation with design doc

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,3 +11,7 @@ mod spawn_tests;
 #[cfg(test)]
 #[path = "spawn_budget_tests.rs"]
 mod spawn_budget_tests;
+
+#[cfg(test)]
+#[path = "spawn_permission_tests.rs"]
+mod spawn_permission_tests;

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -3,6 +3,7 @@
 use crate::config::agents::ResolvedAgentConfig;
 use crate::config::ConfigManager;
 use crate::gateway::SessionManager;
+use crate::permission::engine::engine_eval::PermissionEngine;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -38,6 +39,7 @@ pub enum SpawnError {
 pub struct SpawnController {
     config_manager: Arc<ConfigManager>,
     session_manager: Arc<SessionManager>,
+    permission_engine: Arc<PermissionEngine>,
 }
 
 /// Internal result from resolving parent depth and max spawn budget.
@@ -60,10 +62,15 @@ struct ResolvedTarget {
 }
 
 impl SpawnController {
-    pub fn new(config_manager: Arc<ConfigManager>, session_manager: Arc<SessionManager>) -> Self {
+    pub fn new(
+        config_manager: Arc<ConfigManager>,
+        session_manager: Arc<SessionManager>,
+        permission_engine: Arc<PermissionEngine>,
+    ) -> Self {
         Self {
             config_manager,
             session_manager,
+            permission_engine,
         }
     }
 
@@ -110,16 +117,22 @@ impl SpawnController {
         }
         let target_id = resolved.target_id.ok_or(SpawnError::AgentIdRequired)?;
 
-        // ⑦ Compute effective_max_spawn_depth and validate child depth.
+        // ⑦ Permission check: validate child permissions via intersection
+        //    with parent effective permissions (design doc §⑥).
+        let config = resolved
+            .target_config
+            .ok_or(SpawnError::ConfigNotFound(target_id))?
+            .clone();
+        self.validate_permissions(&config, parent_session_id)
+            .await?;
+
+        // ⑧ Compute effective_max_spawn_depth and validate child depth.
         let effective_max = self.compute_effective_max_depth(
             parent.parent_depth,
             parent.parent_effective_budget,
-            resolved.target_config.as_ref(),
+            Some(&config),
         )?;
 
-        let config = resolved
-            .target_config
-            .ok_or(SpawnError::ConfigNotFound(target_id))?;
         Ok(SpawnValidationResult {
             config,
             effective_max_spawn_depth: effective_max,
@@ -147,6 +160,59 @@ impl SpawnController {
             });
         }
         Ok(effective_max)
+    }
+
+    /// Validate spawn permissions: intersect child permissions with parent
+    /// effective permissions.
+    ///
+    /// Returns `Ok(())` if the spawn is permitted (or if there are no
+    /// permissions to check), or `Err(SpawnError::PermissionDenied)` if
+    /// the spawn is fully denied.
+    async fn validate_permissions(
+        &self,
+        config: &ResolvedAgentConfig,
+        parent_session_id: &str,
+    ) -> Result<(), SpawnError> {
+        let child_perms = self
+            .config_manager
+            .agent_permissions()
+            .get(&config.id)
+            .cloned();
+        let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
+        if let (Some(child_perms), Some(parent_agent_id)) = (child_perms, parent_agent_id) {
+            let parent_perms = self
+                .permission_engine
+                .get_agent_effective_permissions(&parent_agent_id)
+                .or_else(|| {
+                    self.config_manager
+                        .agent_permissions()
+                        .get(&parent_agent_id)
+                        .cloned()
+                });
+            if let Some(parent_perms) = parent_perms {
+                let user_id = self.session_manager.get_sender_id(parent_session_id).await;
+                let user_perms = user_id.as_ref().map(|uid| {
+                    self.permission_engine
+                        .evaluate_user_permissions(uid, &config.id)
+                });
+                self.permission_engine
+                    .validate_and_inject_spawn(
+                        &config.id,
+                        &child_perms,
+                        &parent_perms,
+                        user_perms.as_ref(),
+                        user_id.as_deref(),
+                    )
+                    .map_err(|e| {
+                        tracing::debug!(error = %e, "spawn permission denied");
+                        SpawnError::PermissionDenied {
+                            agent_id: config.id.clone(),
+                            reason: e.to_string(),
+                        }
+                    })?;
+            }
+        }
+        Ok(())
     }
 
     // ------------------------------------------------------------------

--- a/src/agent/spawn_budget_tests.rs
+++ b/src/agent/spawn_budget_tests.rs
@@ -9,6 +9,8 @@ use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
 use crate::config::ConfigManager;
 use crate::gateway::session_manager::{ChildSessionInfo, SpawnMode};
 use crate::gateway::{DmScope, GatewayConfig, SessionManager};
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::{PersistenceService, SessionCheckpoint};
 use crate::session::storage::memory::MemoryStorage;
@@ -112,7 +114,13 @@ async fn save_checkpoint_with_budget(
 async fn test_depth_budget_propagation_multilevel() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller = SpawnController::new(
+        cm.clone(),
+        sm.clone(),
+        Arc::new(PermissionEngine::new_with_default_data_root(
+            RuleSetBuilder::new().build().unwrap(),
+        )),
+    );
 
     // Root: maxSpawnDepth=3
     let mut root_sub = SubagentsConfig::default();
@@ -184,7 +192,13 @@ async fn test_depth_budget_propagation_multilevel() {
 async fn test_depth_budget_rejected_when_effective_zero() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller = SpawnController::new(
+        cm.clone(),
+        sm.clone(),
+        Arc::new(PermissionEngine::new_with_default_data_root(
+            RuleSetBuilder::new().build().unwrap(),
+        )),
+    );
 
     let mut root_sub = SubagentsConfig::default();
     root_sub.max_spawn_depth = 3;
@@ -256,7 +270,13 @@ async fn test_depth_budget_rejected_when_effective_zero() {
 async fn test_depth_budget_child_narrows_via_min() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller = SpawnController::new(
+        cm.clone(),
+        sm.clone(),
+        Arc::new(PermissionEngine::new_with_default_data_root(
+            RuleSetBuilder::new().build().unwrap(),
+        )),
+    );
 
     let mut root_sub = SubagentsConfig::default();
     root_sub.max_spawn_depth = 5;
@@ -327,7 +347,13 @@ async fn test_depth_budget_child_narrows_via_min() {
 async fn test_depth_budget_checkpoint_vs_config_fallback() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller = SpawnController::new(
+        cm.clone(),
+        sm.clone(),
+        Arc::new(PermissionEngine::new_with_default_data_root(
+            RuleSetBuilder::new().build().unwrap(),
+        )),
+    );
 
     // Root: maxSpawnDepth=3
     let mut root_sub = SubagentsConfig::default();

--- a/src/agent/spawn_permission_tests.rs
+++ b/src/agent/spawn_permission_tests.rs
@@ -1,0 +1,304 @@
+//! Tests for SpawnController::validate() permission check (Step 1.4).
+//!
+//! Verifies that `validate()` delegates permission validation to the
+//! PermissionEngine and returns `SpawnError::PermissionDenied` when the
+//! child agent's permissions are fully denied after intersection with
+//! the parent agent's effective permissions.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits, SubagentsConfig};
+use crate::agent::spawn::{SpawnController, SpawnError};
+use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
+use crate::config::ConfigManager;
+use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::rules::RuleSetBuilder;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+
+// ---------------------------------------------------------------------------
+// Helpers (duplicated from spawn_tests.rs to keep modules self-contained)
+// ---------------------------------------------------------------------------
+
+fn test_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    }
+}
+
+fn make_permission_engine() -> PermissionEngine {
+    PermissionEngine::new_with_default_data_root(RuleSetBuilder::new().build().unwrap())
+}
+
+fn make_session_manager() -> SessionManager {
+    SessionManager::new(
+        &test_config(),
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    )
+}
+
+fn make_config_manager() -> ConfigManager {
+    let tmp = tempfile::tempdir().expect("tempdir should be created");
+    ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed")
+}
+
+fn make_agent(id: &str, subagents: SubagentsConfig) -> ResolvedAgentConfig {
+    ResolvedAgentConfig {
+        id: id.to_string(),
+        name: id.to_string(),
+        parent_id: None,
+        model: Some("test-model".to_string()),
+        workspace: None,
+        agent_dir: None,
+        bootstrap_mode: BootstrapMode::Full,
+        skills: vec![],
+        tools: vec![],
+        disallowed_tools: vec![],
+        subagents,
+        source: ConfigSource::User,
+    }
+}
+
+async fn setup_parent_session(mgr: &SessionManager, agent_id: &str) -> String {
+    let msg = Message {
+        id: format!("msg-{}", agent_id),
+        from: "user".to_string(),
+        to: agent_id.to_string(),
+        content: "hi".to_string(),
+        channel: "test-channel".to_string(),
+        timestamp: 0,
+        metadata: std::collections::HashMap::new(),
+        thread_id: None,
+    };
+    mgr.find_or_create("test-channel", &msg, None)
+        .await
+        .expect("find_or_create should succeed")
+}
+
+/// Create an `AgentPermissions` with the given allow/deny per dimension.
+fn make_perms(agent_id: &str, allowed_dims: &[&str]) -> AgentPermissions {
+    let dimensions = [
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+        "config_write",
+    ];
+    let mut permissions = HashMap::with_capacity(dimensions.len());
+    for &dim in &dimensions {
+        permissions.insert(
+            dim.to_string(),
+            ActionPermission {
+                allowed: allowed_dims.contains(&dim),
+                limits: PermissionLimits::default(),
+            },
+        );
+    }
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions,
+        inherited_from: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// When the child agent has all permissions denied, `validate()` must
+/// return `SpawnError::PermissionDenied` because the intersection with
+/// the parent's permissions produces a fully-denied result.
+#[tokio::test]
+async fn test_validate_permission_denied_child_fully_denied() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
+
+    // Parent: all permissions allowed; depth budget allows child creation.
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+    // Child: all permissions denied.
+    let child = make_agent("child", SubagentsConfig::default());
+
+    // Build permission maps.
+    let parent_perms = make_perms(
+        "parent",
+        &[
+            "exec",
+            "file_read",
+            "file_write",
+            "network",
+            "spawn",
+            "tool_call",
+            "config_write",
+        ],
+    );
+    let child_perms = make_perms("child", &[]); // nothing allowed
+
+    let mut agents = HashMap::new();
+    agents.insert("parent".to_string(), parent);
+    agents.insert("child".to_string(), child);
+    let mut permissions = HashMap::new();
+    permissions.insert("parent".to_string(), parent_perms);
+    permissions.insert("child".to_string(), child_perms);
+    cm.restore_agents(agents, permissions);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect_err("validate should reject when child permissions are fully denied");
+
+    match err {
+        SpawnError::PermissionDenied { agent_id, reason } => {
+            assert_eq!(agent_id, "child");
+            assert!(
+                reason.contains("denied"),
+                "reason should mention denial, got: {reason}"
+            );
+        }
+        other => panic!("expected PermissionDenied, got {:?}", other),
+    }
+}
+
+/// When the child has some permissions and the parent denies all of them,
+/// the intersection is fully denied and `validate()` returns
+/// `SpawnError::PermissionDenied`.
+#[tokio::test]
+async fn test_validate_permission_denied_parent_denies_all() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+    let child = make_agent("child", SubagentsConfig::default());
+
+    // Parent has everything denied; child has everything allowed.
+    // Intersection: child ∩ parent = all denied.
+    let parent_perms = make_perms("parent", &[]);
+    let child_perms = make_perms(
+        "child",
+        &[
+            "exec",
+            "file_read",
+            "file_write",
+            "network",
+            "spawn",
+            "tool_call",
+            "config_write",
+        ],
+    );
+
+    let mut agents = HashMap::new();
+    agents.insert("parent".to_string(), parent);
+    agents.insert("child".to_string(), child);
+    let mut permissions = HashMap::new();
+    permissions.insert("parent".to_string(), parent_perms);
+    permissions.insert("child".to_string(), child_perms);
+    cm.restore_agents(agents, permissions);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let err = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect_err("validate should reject when parent denies all permissions");
+
+    match err {
+        SpawnError::PermissionDenied { agent_id, reason } => {
+            assert_eq!(agent_id, "child");
+            assert!(
+                reason.contains("denied"),
+                "reason should mention denial, got: {reason}"
+            );
+        }
+        other => panic!("expected PermissionDenied, got {:?}", other),
+    }
+}
+
+/// When both parent and child have at least one permission dimension
+/// allowed in common, the intersection is NOT fully denied and
+/// `validate()` should proceed past the permission check.
+#[tokio::test]
+async fn test_validate_permission_allowed_partial_overlap() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+    let child = make_agent("child", SubagentsConfig::default());
+
+    // Parent allows exec only; child allows exec + file_read.
+    // Intersection: exec=allow (both allow), everything else=deny.
+    // Not fully denied because exec is allowed.
+    let parent_perms = make_perms("parent", &["exec"]);
+    let child_perms = make_perms("child", &["exec", "file_read"]);
+
+    let mut agents = HashMap::new();
+    agents.insert("parent".to_string(), parent);
+    agents.insert("child".to_string(), child);
+    let mut permissions = HashMap::new();
+    permissions.insert("parent".to_string(), parent_perms);
+    permissions.insert("child".to_string(), child_perms);
+    cm.restore_agents(agents, permissions);
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    // Should succeed because the intersection is not fully denied.
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("validate should succeed when permissions partially overlap");
+
+    assert_eq!(result.config.id, "child");
+}
+
+/// When neither parent nor child has any permissions configured,
+/// `validate()` should proceed without error (no permissions to check).
+#[tokio::test]
+async fn test_validate_no_permissions_configured() {
+    let cm = Arc::new(make_config_manager());
+    let sm = Arc::new(make_session_manager());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
+
+    let mut parent_sub = SubagentsConfig::default();
+    parent_sub.max_spawn_depth = 2;
+    let parent = make_agent("parent", parent_sub);
+    let child = make_agent("child", SubagentsConfig::default());
+
+    // Inject agents but NO permissions.
+    let mut agents = HashMap::new();
+    agents.insert("parent".to_string(), parent);
+    agents.insert("child".to_string(), child);
+    cm.restore_agents(agents, HashMap::new());
+
+    let parent_id = setup_parent_session(&sm, "parent").await;
+
+    let result = controller
+        .validate(&parent_id, Some("child"))
+        .await
+        .expect("validate should succeed when no permissions are configured");
+
+    assert_eq!(result.config.id, "child");
+}

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -15,6 +15,8 @@ use crate::config::agents::{ConfigSource, ResolvedAgentConfig};
 use crate::config::ConfigManager;
 use crate::gateway::session_manager::{ChildSessionInfo, SpawnMode};
 use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
+use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 
@@ -31,6 +33,11 @@ fn test_config() -> GatewayConfig {
         dm_scope: DmScope::default(),
         ..Default::default()
     }
+}
+
+/// Build a `PermissionEngine` with an empty RuleSet.
+fn make_permission_engine() -> PermissionEngine {
+    PermissionEngine::new_with_default_data_root(RuleSetBuilder::new().build().unwrap())
 }
 
 /// Build a `SessionManager` with no storage and no workspace.
@@ -142,7 +149,8 @@ async fn fill_children(mgr: &SessionManager, parent_id: &str, count: usize) {
 async fn test_validate_passes() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // Parent uses max_spawn_depth=2 so child_depth=1 passes the depth check.
     let mut parent_sub = SubagentsConfig::default();
@@ -175,7 +183,8 @@ async fn test_validate_passes() {
 async fn test_validate_depth_exceeded() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // max_spawn_depth=0 forces the depth check to fail.
     let mut sub = SubagentsConfig::default();
@@ -209,7 +218,8 @@ async fn test_validate_depth_exceeded() {
 async fn test_validate_max_children() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // max_children=1 with 1 already-registered child → at the limit.
     // max_spawn_depth=2 so depth check passes before concurrency check.
@@ -245,7 +255,8 @@ async fn test_validate_max_children() {
 async fn test_validate_agent_not_allowed() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // Allowlist only contains "allowed-agent" — target "child" is denied.
     // max_spawn_depth=2 so depth check passes before whitelist check.
@@ -279,7 +290,8 @@ async fn test_validate_agent_not_allowed() {
 async fn test_validate_require_agent_id() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // require_agent_id=true and no default_child_agent → passing None must fail.
     let mut sub = SubagentsConfig::default();
@@ -310,7 +322,8 @@ async fn test_validate_require_agent_id() {
 async fn test_validate_wildcard_allow() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // Explicit "*" wildcard in allow_agents — any target should be permitted.
     let mut sub = SubagentsConfig::default();
@@ -348,7 +361,8 @@ async fn test_validate_wildcard_allow() {
 async fn test_validate_cascade_parent_depth1_child_depth2() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 1;
@@ -386,7 +400,8 @@ async fn test_validate_cascade_parent_depth1_child_depth2() {
 async fn test_validate_cascade_parent_depth2_child_depth2() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 2;
@@ -419,7 +434,8 @@ async fn test_validate_cascade_parent_depth2_child_depth2() {
 async fn test_validate_cascade_parent_depth3_child_depth1() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 3;
@@ -450,7 +466,8 @@ async fn test_validate_cascade_parent_depth3_child_depth1() {
 async fn test_validate_cascade_unknown_target_config_not_found() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 2;
@@ -481,7 +498,8 @@ async fn test_validate_cascade_unknown_target_config_not_found() {
 async fn test_validate_cascade_parent_depth5_child_depth1() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 5;
@@ -510,7 +528,8 @@ async fn test_validate_cascade_parent_depth5_child_depth1() {
 async fn test_validate_cascade_parent_depth5_child_depth3() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 5;
@@ -539,7 +558,8 @@ async fn test_validate_cascade_parent_depth5_child_depth3() {
 async fn test_validate_cascade_parent_depth0_child_depth5() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 0;
@@ -575,7 +595,8 @@ async fn test_validate_cascade_parent_depth0_child_depth5() {
 async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     let mut parent_sub = SubagentsConfig::default();
     parent_sub.max_spawn_depth = 1;
@@ -611,7 +632,8 @@ async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
 async fn test_validate_depth_before_agent_id_required() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // max_spawn_depth=0 (depth check will reject) AND require_agent_id=true
     // (would also reject if depth check didn't run first).
@@ -788,7 +810,8 @@ async fn test_kill_child_no_descendants_clean_removal() {
 async fn test_validate_default_child_agent_blocked_by_whitelist() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // Parent has default_child_agent="fallback-child" but allowlist
     // only allows "allowed-agent" — fallback should be blocked.
@@ -824,7 +847,8 @@ async fn test_validate_default_child_agent_blocked_by_whitelist() {
 async fn test_validate_default_child_agent_allowed_by_whitelist() {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = SpawnController::new(cm.clone(), sm.clone());
+    let controller =
+        SpawnController::new(cm.clone(), sm.clone(), Arc::new(make_permission_engine()));
 
     // Parent has default_child_agent="allowed-child" and allowlist
     // contains "allowed-child" — should pass.

--- a/src/daemon/registries.rs
+++ b/src/daemon/registries.rs
@@ -124,6 +124,7 @@ async fn spawn_builtin_tools(ctx: &RegistryContext<'_>, disk_reg: &Arc<DiskSkill
     let spawn_controller = Arc::new(SpawnController::new(
         Arc::clone(ctx.config_manager),
         Arc::clone(ctx.session_manager),
+        Arc::clone(ctx.permission_engine),
     ));
     let builtin_ctx = Arc::new(BuiltinToolContext {
         config_manager: Arc::clone(ctx.config_manager),

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -368,7 +368,8 @@ impl SessionManager {
         // 4a. Append spawn context to the system prompt so the child
         //     agent knows its role, depth limits, and communication
         //     behavior.  Non-spawn sessions never reach this path.
-        let spawn_context = Self::build_spawn_context(depth, max_spawn_depth);
+        let spawn_context =
+            Self::build_spawn_context(depth, max_spawn_depth, parent_session_id, &mode, fork);
         let prompt = format!("{}\n{}", prompt, spawn_context);
 
         // 5. Create ConversationSession
@@ -524,11 +525,24 @@ impl SessionManager {
     /// - Communication behavior (push-based, no polling)
     /// - Behavioral constraints (direct execution, no back-and-forth)
     /// - Spawn guidance when depth allows further spawning
-    pub(crate) fn build_spawn_context(depth: u32, max_spawn_depth: u32) -> String {
+    pub(crate) fn build_spawn_context(
+        depth: u32,
+        max_spawn_depth: u32,
+        parent_session_id: &str,
+        spawn_mode: &SpawnMode,
+        fork: bool,
+    ) -> String {
+        let mode_str = match spawn_mode {
+            SpawnMode::Run => "run",
+            SpawnMode::Session => "session",
+        };
         let mut ctx = format!(
             "## Spawn Context\n\
-             You are running as a sub-agent. \
-             Current depth: {depth} / Maximum depth: {max_spawn_depth}.\n\
+             You are running as a sub-agent.\n\
+             - **parent_session_id**: {parent_session_id}\n\
+             - **depth**: {depth} / **max_spawn_depth**: {max_spawn_depth}\n\
+             - **spawn_mode**: {mode_str}\n\
+             - **fork**: {fork}\n\
              **Communication behavior:** Your results are automatically \
              pushed back to the parent agent when you finish. \
              Do not poll for status. \

--- a/src/gateway/session_manager/spawn_tests.rs
+++ b/src/gateway/session_manager/spawn_tests.rs
@@ -641,33 +641,24 @@ async fn test_create_child_session_workspace_uses_actual_user_id() {
 /// depth=1, max_spawn_depth=3 (allows further spawning).
 #[test]
 fn test_build_spawn_context_allows_spawning() {
-    let ctx = SessionManager::build_spawn_context(1, 3);
+    let ctx = SessionManager::build_spawn_context(1, 3, "parent-abc", &SpawnMode::Run, false);
     assert!(ctx.contains("sub-agent"), "should declare sub-agent role");
-    assert!(
-        ctx.contains("Current depth: 1 / Maximum depth: 3"),
-        "should contain depth info"
-    );
-    assert!(
-        ctx.contains("results are automatically pushed back"),
-        "should describe push-based communication"
-    );
-    assert!(
-        ctx.contains("Do not poll for status"),
-        "should forbid polling"
-    );
-    assert!(
-        ctx.contains("Your effective maximum depth for children is 2"),
-        "should show effective spawn depth (3-1=2)"
-    );
+    assert!(ctx.contains("**depth**: 1 / **max_spawn_depth**: 3"));
+    assert!(ctx.contains("results are automatically pushed back"));
+    assert!(ctx.contains("Do not poll for status"));
+    assert!(ctx.contains("Your effective maximum depth for children is 2"));
+    assert!(ctx.contains("**parent_session_id**: parent-abc"));
+    assert!(ctx.contains("**spawn_mode**: run"));
+    assert!(ctx.contains("**fork**: false"));
 }
 
 /// Verify `build_spawn_context` omits spawn guidance when depth == max_spawn_depth.
 #[test]
 fn test_build_spawn_context_no_spawning_at_limit() {
-    let ctx = SessionManager::build_spawn_context(3, 3);
+    let ctx = SessionManager::build_spawn_context(3, 3, "parent-abc", &SpawnMode::Run, false);
     assert!(ctx.contains("sub-agent"));
     assert!(
-        ctx.contains("Current depth: 3 / Maximum depth: 3"),
+        ctx.contains("**depth**: 3 / **max_spawn_depth**: 3"),
         "should contain depth info"
     );
     assert!(
@@ -679,8 +670,8 @@ fn test_build_spawn_context_no_spawning_at_limit() {
 /// Verify `build_spawn_context` at depth=0, max_spawn_depth=1 (allows spawning).
 #[test]
 fn test_build_spawn_context_depth_zero() {
-    let ctx = SessionManager::build_spawn_context(0, 1);
-    assert!(ctx.contains("Current depth: 0 / Maximum depth: 1"));
+    let ctx = SessionManager::build_spawn_context(0, 1, "parent-abc", &SpawnMode::Run, false);
+    assert!(ctx.contains("**depth**: 0 / **max_spawn_depth**: 1"));
     assert!(
         ctx.contains("Your effective maximum depth for children is 1"),
         "should show effective depth (1-0=1)"
@@ -690,7 +681,7 @@ fn test_build_spawn_context_depth_zero() {
 /// Verify the behavioral constraints section is always present.
 #[test]
 fn test_build_spawn_context_behavioral_constraints() {
-    let ctx = SessionManager::build_spawn_context(0, 1);
+    let ctx = SessionManager::build_spawn_context(0, 1, "parent-abc", &SpawnMode::Session, true);
     assert!(
         ctx.contains("Behavioral constraints"),
         "should have behavioral constraints header"
@@ -703,6 +694,11 @@ fn test_build_spawn_context_behavioral_constraints() {
         ctx.contains("do not ask for confirmation"),
         "should forbid confirmation-seeking"
     );
+    assert!(
+        ctx.contains("**spawn_mode**: session"),
+        "should reflect session spawn mode"
+    );
+    assert!(ctx.contains("**fork**: true"), "should reflect fork=true");
 }
 
 // ── Step 1.4: child session spawn-context integration test ───────────────
@@ -750,7 +746,7 @@ async fn test_child_session_system_prompt_contains_spawn_context() {
         "system prompt should contain sub-agent role declaration"
     );
     assert!(
-        prompt.contains("Current depth: 2 / Maximum depth: 4"),
+        prompt.contains("**depth**: 2 / **max_spawn_depth**: 4"),
         "system prompt should contain depth info"
     );
     assert!(
@@ -765,7 +761,7 @@ async fn test_child_session_system_prompt_contains_spawn_context() {
 /// section (per design doc §结构化输出) when remaining_depth > 0.
 #[test]
 fn test_build_spawn_context_structured_output_guidance() {
-    let ctx = SessionManager::build_spawn_context(1, 2);
+    let ctx = SessionManager::build_spawn_context(1, 2, "parent-abc", &SpawnMode::Run, false);
     assert!(
         ctx.contains("Structured output (optional)"),
         "should contain structured output header"
@@ -796,7 +792,7 @@ fn test_build_spawn_context_structured_output_guidance() {
 /// and that the child may reply freely.
 #[test]
 fn test_build_spawn_context_structured_output_is_optional() {
-    let ctx = SessionManager::build_spawn_context(0, 1);
+    let ctx = SessionManager::build_spawn_context(0, 1, "parent-abc", &SpawnMode::Run, false);
     assert!(
         ctx.contains("suggestion"),
         "should indicate structured output is a suggestion"
@@ -811,7 +807,7 @@ fn test_build_spawn_context_structured_output_is_optional() {
 /// (it is independent of spawn depth — it always applies).
 #[test]
 fn test_build_spawn_context_structured_output_at_depth_limit() {
-    let ctx = SessionManager::build_spawn_context(3, 0);
+    let ctx = SessionManager::build_spawn_context(3, 0, "parent-abc", &SpawnMode::Run, false);
     assert!(
         ctx.contains("Structured output (optional)"),
         "structured output should be present even at spawn depth limit"

--- a/src/gateway/session_manager/tests.rs
+++ b/src/gateway/session_manager/tests.rs
@@ -300,7 +300,11 @@ async fn test_find_or_create_with_tool_registry() {
         ConfigManager::new(tmp.path().to_path_buf())
             .expect("failed to create ConfigManager for test"),
     );
-    let spawn_controller = Arc::new(SpawnController::new(Arc::clone(&cfg_mgr), Arc::clone(&mgr)));
+    let spawn_controller = Arc::new(SpawnController::new(
+        Arc::clone(&cfg_mgr),
+        Arc::clone(&mgr),
+        perm_engine.clone(),
+    ));
     let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
     let builtin_ctx = Arc::new(BuiltinToolContext {
         config_manager: Arc::clone(&cfg_mgr),

--- a/src/system_prompt/tools_section.rs
+++ b/src/system_prompt/tools_section.rs
@@ -124,6 +124,9 @@ mod tests {
         let spawn_controller = Arc::new(SpawnController::new(
             Arc::clone(&cfg_mgr),
             Arc::clone(&session_manager),
+            Arc::new(PermissionEngine::new_with_default_data_root(
+                RuleSetBuilder::new().build().unwrap(),
+            )),
         ));
         let agent_registry = Arc::new(crate::agent::registry::AgentRegistry::new());
         (spawn_controller, session_manager, cfg_mgr, agent_registry)

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -126,8 +126,6 @@ pub async fn register_builtin_tools(
         .register(SessionsSpawnTool::new(
             context.spawn_controller.clone(),
             context.session_manager.clone(),
-            context.permission_engine.clone(),
-            context.config_manager.clone(),
             context.agent_registry.clone(),
         ))
         .await

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -103,7 +103,7 @@ impl SessionsSpawnTool {
         })
     }
 
-    /// Parse the raw JSON arguments into typed [`SpawnArgs`]. for the given config and parameters.
+    /// Create a child session for the given config and parameters.
     ///
     /// Delegates to [`SessionManager::create_child_session`] with error mapping.
     #[allow(clippy::too_many_arguments)]

--- a/src/tools/builtin/sessions_spawn.rs
+++ b/src/tools/builtin/sessions_spawn.rs
@@ -3,9 +3,7 @@
 use super::prompt_template::PromptTemplate;
 use crate::agent::registry::AgentRegistry;
 use crate::agent::spawn::SpawnController;
-use crate::config::ConfigManager;
 use crate::gateway::session_manager::{SessionManager, SpawnMode};
-use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::tools::{Tool, ToolCallError, ToolContext, ToolFlags, ToolResult};
 
 use async_trait::async_trait;
@@ -20,8 +18,6 @@ use std::sync::Arc;
 pub struct SessionsSpawnTool {
     spawn_controller: Arc<SpawnController>,
     session_manager: Arc<SessionManager>,
-    permission_engine: Arc<PermissionEngine>,
-    config_manager: Arc<ConfigManager>,
     agent_registry: Arc<AgentRegistry>,
 }
 
@@ -44,15 +40,11 @@ impl SessionsSpawnTool {
     pub fn new(
         spawn_controller: Arc<SpawnController>,
         session_manager: Arc<SessionManager>,
-        permission_engine: Arc<PermissionEngine>,
-        config_manager: Arc<ConfigManager>,
         agent_registry: Arc<AgentRegistry>,
     ) -> Self {
         Self {
             spawn_controller,
             session_manager,
-            permission_engine,
-            config_manager,
             agent_registry,
         }
     }
@@ -111,56 +103,7 @@ impl SessionsSpawnTool {
         })
     }
 
-    /// Validate spawn permissions: intersect child permissions with parent effective permissions.
-    ///
-    /// Returns `Ok(())` if the spawn is permitted (or if there are no permissions to check),
-    /// or `Err(ToolCallError)` if the spawn is fully denied.
-    pub(crate) async fn validate_spawn_permissions(
-        &self,
-        config: &crate::config::agents::ResolvedAgentConfig,
-        parent_session_id: &str,
-    ) -> Result<(), ToolCallError> {
-        let child_perms = self
-            .config_manager
-            .agent_permissions()
-            .get(&config.id)
-            .cloned();
-        let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
-        if let (Some(child_perms), Some(parent_agent_id)) = (child_perms, parent_agent_id) {
-            let parent_perms = self
-                .permission_engine
-                .get_agent_effective_permissions(&parent_agent_id)
-                .or_else(|| {
-                    self.config_manager
-                        .agent_permissions()
-                        .get(&parent_agent_id)
-                        .cloned()
-                });
-            if let Some(parent_perms) = parent_perms {
-                // Get user_id from parent session checkpoint for three-way intersection.
-                let user_id = self.session_manager.get_sender_id(parent_session_id).await;
-                let user_perms = user_id.as_ref().map(|uid| {
-                    self.permission_engine
-                        .evaluate_user_permissions(uid, &config.id)
-                });
-                self.permission_engine
-                    .validate_and_inject_spawn(
-                        &config.id,
-                        &child_perms,
-                        &parent_perms,
-                        user_perms.as_ref(),
-                        user_id.as_deref(),
-                    )
-                    .map_err(|e| {
-                        tracing::debug!(error = %e, "spawn permission denied");
-                        ToolCallError::PermissionDenied("spawn".to_string())
-                    })?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Create a child session for the given config and parameters.
+    /// Parse the raw JSON arguments into typed [`SpawnArgs`]. for the given config and parameters.
     ///
     /// Delegates to [`SessionManager::create_child_session`] with error mapping.
     #[allow(clippy::too_many_arguments)]
@@ -303,13 +246,16 @@ impl Tool for SessionsSpawnTool {
             .spawn_controller
             .validate(parent_session_id, spawn_args.agent_id.as_deref())
             .await
-            .map_err(|e| {
-                ToolCallError::ExecutionFailed(format!("spawn validation failed: {}", e))
+            .map_err(|e| match e {
+                crate::agent::spawn::SpawnError::PermissionDenied { .. } => {
+                    ToolCallError::PermissionDenied("spawn".to_string())
+                }
+                other => {
+                    ToolCallError::ExecutionFailed(format!("spawn validation failed: {}", other))
+                }
             })?;
         let config = spawn_result.config;
         let effective_max_spawn_depth = spawn_result.effective_max_spawn_depth;
-        self.validate_spawn_permissions(&config, parent_session_id)
-            .await?;
         // Look up the parent agent's subagents.model config
         // (used as priority level 2 in the model priority chain).
         let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -11,7 +11,6 @@
 use std::collections::HashMap;
 
 use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits};
-use crate::agent::registry::AgentRegistry;
 use crate::agent::spawn::SpawnController;
 use crate::config::ConfigManager;
 use crate::gateway::session_manager::SessionManager;
@@ -22,8 +21,6 @@ use crate::permission::engine::engine_types::PermissionRequestBody;
 use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
-use crate::tools::builtin::sessions_spawn::SessionsSpawnTool;
-use crate::tools::ToolCallError;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -535,9 +532,7 @@ async fn test_external_permissions_used() {
     }
 
     let pe = Arc::new(make_permission_engine());
-    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
-    let ar = Arc::new(AgentRegistry::new());
-    let tool = SessionsSpawnTool::new(controller, sm, pe.clone(), cm.clone(), ar);
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone(), pe.clone()));
 
     // Insert parent effective permissions into the engine cache.
     let parent_perms = make_all_allow("parent-agent-2");
@@ -546,19 +541,49 @@ async fn test_external_permissions_used() {
         cache.insert("parent-agent-2".to_string(), parent_perms);
     }
 
-    // Call validate_spawn_permissions — should use external permissions (exec-deny).
-    let result = tool
-        .validate_spawn_permissions(&config, "parent-sess-2")
+    // Inject both parent and child agents into ConfigManager so
+    // SpawnController::validate() can resolve configs and pass all checks.
+    {
+        let mut agents = cm.agents.write().unwrap();
+        agents.insert(
+            "parent-agent-2".to_string(),
+            crate::config::agents::ResolvedAgentConfig {
+                id: "parent-agent-2".to_string(),
+                name: "parent-agent-2".to_string(),
+                parent_id: None,
+                model: Some("test-model".to_string()),
+                workspace: None,
+                agent_dir: None,
+                bootstrap_mode: BootstrapMode::Full,
+                skills: vec![],
+                tools: vec![],
+                disallowed_tools: vec![],
+                subagents: {
+                    let mut sub = crate::agent::config::SubagentsConfig::default();
+                    sub.max_spawn_depth = 2;
+                    sub.allow_agents = vec!["fallback-agent".to_string()];
+                    sub
+                },
+                source: crate::config::agents::ConfigSource::User,
+            },
+        );
+        agents.insert("fallback-agent".to_string(), config.clone());
+    }
+
+    // Call SpawnController::validate() — should use external permissions (exec-deny).
+    let result = controller
+        .validate("parent-sess-2", Some("fallback-agent"))
         .await;
     assert!(
         result.is_ok(),
-        "spawn should succeed with external permissions"
+        "validate should succeed with external permissions, got: {:?}",
+        result
     );
 
     // Verify the cached permissions match the external exec-deny config.
     let cached = pe
         .get_agent_effective_permissions("fallback-agent")
-        .expect("agent should be cached after successful spawn");
+        .expect("agent should be cached after successful validate");
     assert!(
         !cached.permissions.get("exec").unwrap().allowed,
         "exec should be denied from external permissions"
@@ -766,9 +791,7 @@ async fn test_fully_denied_silent_return_no_session_created() {
     }
 
     let pe = Arc::new(make_permission_engine());
-    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
-    let ar = Arc::new(AgentRegistry::new());
-    let tool = SessionsSpawnTool::new(controller, sm.clone(), pe.clone(), cm.clone(), ar);
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone(), pe.clone()));
 
     // Parent has all-allow effective permissions in cache.
     let parent_perms = make_all_allow("parent-agent-deny");
@@ -777,26 +800,55 @@ async fn test_fully_denied_silent_return_no_session_created() {
         cache.insert("parent-agent-deny".to_string(), parent_perms);
     }
 
-    // validate_spawn_permissions should fail with FullyDenied.
-    let result = tool
-        .validate_spawn_permissions(&config, "parent-sess-deny")
+    // Inject both parent and child agents into ConfigManager so
+    // SpawnController::validate() can resolve configs and pass all checks.
+    {
+        let mut agents = cm.agents.write().unwrap();
+        agents.insert(
+            "parent-agent-deny".to_string(),
+            crate::config::agents::ResolvedAgentConfig {
+                id: "parent-agent-deny".to_string(),
+                name: "parent-agent-deny".to_string(),
+                parent_id: None,
+                model: Some("test-model".to_string()),
+                workspace: None,
+                agent_dir: None,
+                bootstrap_mode: BootstrapMode::Full,
+                skills: vec![],
+                tools: vec![],
+                disallowed_tools: vec![],
+                subagents: {
+                    let mut sub = crate::agent::config::SubagentsConfig::default();
+                    sub.max_spawn_depth = 2;
+                    sub.allow_agents = vec!["denied-child".to_string()];
+                    sub
+                },
+                source: crate::config::agents::ConfigSource::User,
+            },
+        );
+        agents.insert("denied-child".to_string(), config.clone());
+    }
+
+    // SpawnController::validate() should fail with PermissionDenied.
+    let result = controller
+        .validate("parent-sess-deny", Some("denied-child"))
         .await;
 
-    assert!(result.is_err(), "spawn should fail for fully-denied child");
-    let err_msg = match result.unwrap_err() {
-        ToolCallError::PermissionDenied(msg) => msg,
+    assert!(
+        result.is_err(),
+        "validate should fail for fully-denied child"
+    );
+    match result.unwrap_err() {
+        crate::agent::spawn::SpawnError::PermissionDenied { agent_id, reason } => {
+            assert_eq!(agent_id, "denied-child");
+            assert!(
+                reason.contains("denied"),
+                "reason should mention denied, got: {}",
+                reason
+            );
+        }
         other => panic!("expected PermissionDenied, got: {:?}", other),
-    };
-    assert!(
-        err_msg.contains("spawn"),
-        "error should contain 'spawn', got: {}",
-        err_msg
-    );
-    assert!(
-        !err_msg.contains("denied-child"),
-        "error must not expose internal agent_id, got: {}",
-        err_msg
-    );
+    }
 
     // Verify the child was NOT cached (spawn was rejected).
     assert!(

--- a/src/tools/builtin/sessions_spawn_tests.rs
+++ b/src/tools/builtin/sessions_spawn_tests.rs
@@ -67,10 +67,10 @@ fn make_permission_engine() -> PermissionEngine {
 fn make_tool() -> SessionsSpawnTool {
     let cm = Arc::new(make_config_manager());
     let sm = Arc::new(make_session_manager());
-    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone()));
     let pe = Arc::new(make_permission_engine());
+    let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone(), pe));
     let ar = Arc::new(crate::agent::registry::AgentRegistry::new());
-    SessionsSpawnTool::new(controller, sm, pe, cm, ar)
+    SessionsSpawnTool::new(controller, sm, ar)
 }
 
 /// A `ToolContext` with `session_id = None` — used to exercise the

--- a/src/tools/builtin/skill_tool.rs
+++ b/src/tools/builtin/skill_tool.rs
@@ -228,6 +228,8 @@ mod tests {
     use crate::agent::spawn::SpawnController;
     use crate::config::ConfigManager;
     use crate::gateway::{GatewayConfig, SessionManager};
+    use crate::permission::engine::engine_eval::PermissionEngine;
+    use crate::permission::rules::RuleSetBuilder;
     use crate::session::bootstrap::loader::BootstrapMode;
     use crate::session::persistence::ReasoningLevel;
     use crate::skills::disk::types::{
@@ -258,6 +260,9 @@ mod tests {
         let spawn_controller = Arc::new(SpawnController::new(
             config_manager,
             session_manager.clone(),
+            Arc::new(PermissionEngine::new_with_default_data_root(
+                RuleSetBuilder::new().build().unwrap(),
+            )),
         ));
         (spawn_controller, session_manager)
     }

--- a/src/tools/builtin/skill_tool_tests.rs
+++ b/src/tools/builtin/skill_tool_tests.rs
@@ -11,6 +11,8 @@ mod tests {
     use crate::config::ConfigManager;
     use crate::gateway::{GatewayConfig, SessionManager};
     use crate::llm::session::ConversationSession;
+    use crate::permission::engine::engine_eval::PermissionEngine;
+    use crate::permission::rules::RuleSetBuilder;
     use crate::session::bootstrap::loader::BootstrapMode;
     use crate::session::persistence::ReasoningLevel;
     use crate::skills::disk::types::{
@@ -44,6 +46,9 @@ mod tests {
         let spawn_controller = Arc::new(SpawnController::new(
             config_manager,
             session_manager.clone(),
+            Arc::new(PermissionEngine::new_with_default_data_root(
+                RuleSetBuilder::new().build().unwrap(),
+            )),
         ));
         (spawn_controller, session_manager)
     }
@@ -163,6 +168,9 @@ mod tests {
         let spawn_controller = Arc::new(SpawnController::new(
             config_manager.clone(),
             session_manager.clone(),
+            Arc::new(PermissionEngine::new_with_default_data_root(
+                RuleSetBuilder::new().build().unwrap(),
+            )),
         ));
 
         (config_manager, session_manager, spawn_controller)


### PR DESCRIPTION
Refactor spawn implementation to align with design doc:

1. Move permission check into `SpawnController::validate()` (separated from `build_spawn_context()`)
2. Extend `build_spawn_context()` to inject `parent_session_id`, `spawn_mode`, and `fork` fields into system prompt, matching `docs/design/agent/agent-spawn.md`
3. Add unit tests for `SpawnController::validate()` permission delegation
4. Fix `create_child` doc comment to accurately describe its purpose

Source: design doc
Type: refactor
