### PR TITLE
fix(permission): align Permission Engine with design doc (4 must_fix items)

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -188,7 +188,8 @@ impl SpawnController {
                 .cloned();
             if let Some(parent_perms) = parent_perms {
                 let user_id = self.session_manager.get_sender_id(parent_session_id).await;
-                // Owner skips User dimension — design doc: "Owner（User ID = 'owner'）→ 跳过 User 维度，仅评估 Agent 维度"
+                // Owner skips User dimension — design doc:
+                // "Owner(User ID = 'owner') → skip User dim, only Agent"
                 let user_perms = if user_id.as_deref() == Some("owner") {
                     None
                 } else {

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -187,10 +187,15 @@ impl SpawnController {
                 .cloned();
             if let Some(parent_perms) = parent_perms {
                 let user_id = self.session_manager.get_sender_id(parent_session_id).await;
-                let user_perms = user_id.as_ref().map(|uid| {
-                    self.permission_engine
-                        .evaluate_user_permissions(uid, &config.id)
-                });
+                // Owner skips User dimension — design doc: "Owner（User ID = 'owner'）→ 跳过 User 维度，仅评估 Agent 维度"
+                let user_perms = if user_id.as_deref() == Some("owner") {
+                    None
+                } else {
+                    user_id.as_ref().map(|uid| {
+                        self.permission_engine
+                            .evaluate_user_permissions(uid, &config.id)
+                    })
+                };
                 self.permission_engine
                     .validate_and_inject_spawn(
                         &config.id,

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -4,6 +4,7 @@ use crate::config::agents::ResolvedAgentConfig;
 use crate::config::ConfigManager;
 use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -196,6 +197,21 @@ impl SpawnController {
                             .evaluate_user_permissions(uid, &config.id)
                     })
                 };
+                // Collect full-chain deny subjects from all ancestors.
+                let rules = self.permission_engine.rules.clone();
+                let chain_deny_subjects = collect_chain_deny_subjects(
+                    &self.session_manager,
+                    &rules,
+                    parent_session_id,
+                    &config.id,
+                )
+                .await;
+                let extra_deny = if chain_deny_subjects.is_empty() {
+                    None
+                } else {
+                    Some(chain_deny_subjects.as_slice())
+                };
+
                 self.permission_engine
                     .validate_and_inject_spawn(
                         &config.id,
@@ -203,6 +219,7 @@ impl SpawnController {
                         &parent_perms,
                         user_perms.as_ref(),
                         user_id.as_deref(),
+                        extra_deny,
                     )
                     .map_err(|e| {
                         tracing::debug!(error = %e, "spawn permission denied");

--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -181,14 +181,10 @@ impl SpawnController {
         let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
         if let (Some(child_perms), Some(parent_agent_id)) = (child_perms, parent_agent_id) {
             let parent_perms = self
-                .permission_engine
-                .get_agent_effective_permissions(&parent_agent_id)
-                .or_else(|| {
-                    self.config_manager
-                        .agent_permissions()
-                        .get(&parent_agent_id)
-                        .cloned()
-                });
+                .config_manager
+                .agent_permissions()
+                .get(&parent_agent_id)
+                .cloned();
             if let Some(parent_perms) = parent_perms {
                 let user_id = self.session_manager.get_sender_id(parent_session_id).await;
                 let user_perms = user_id.as_ref().map(|uid| {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -304,6 +304,7 @@ impl Daemon {
         let _builtin_skills = builtin_skills_with_engine_and_approval_flow(
             Arc::clone(permission_engine),
             Arc::clone(&approval_flow),
+            Some(Arc::clone(session_manager)),
         );
         approval_flow
     }

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -538,6 +538,9 @@ mod resolve_tests;
 mod spawn_gap_tests;
 #[cfg(test)]
 mod spawn_tests;
+
+#[cfg(test)]
+mod spawn_cascade_tests;
 #[cfg(test)]
 mod spawn_tree_tests;
 #[cfg(test)]

--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -684,67 +684,48 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Force-terminate a child session: cancel its token tree,
-    /// remove it from `conversation_sessions`, `sessions`, and
-    /// the parent's `children` tracking table. The archive is
-    /// preserved (no purge).
+    /// Force-terminate a child session and all its descendants.
     ///
-    /// All descendants are also cleaned up recursively (per design
-    /// doc §级联 Kill — from deepest to shallowest). The `children`
-    /// table is traversed via BFS to discover all descendant session
-    /// IDs before any removals, preventing lock-ordering issues.
+    /// Per design doc §级联 Kill: processes deepest descendants
+    /// first, then the target child itself. For each session:
+    /// stop → clean conversation_sessions → unregister handle →
+    /// clean sessions → clean children table.
     pub(crate) async fn kill_child(&self, parent_id: &str, child_id: &str) -> Result<(), String> {
-        // 1. Collect all descendant session IDs via BFS.
         let descendant_ids = {
             let children = self.children.read().await;
             children.list_descendants(child_id)
         };
 
-        // 2. Stop active sessions. Completed/terminated sessions
-        //    skip the stop step but still get cleaned up from the
-        //    spawn tree (design doc §级联 Kill).
-        if let Some(cs) = self.get_conversation_session(child_id).await {
-            cs.read().await.stop(true).await;
-        }
         for id in &descendant_ids {
             if let Some(cs) = self.get_conversation_session(id).await {
                 cs.read().await.stop(true).await;
             }
-        }
-
-        // 3. Remove child + descendants from conversation_sessions.
-        {
-            let mut cs = self.conversation_sessions.write().await;
-            cs.remove(child_id);
-            for id in &descendant_ids {
-                cs.remove(id);
+            self.conversation_sessions.write().await.remove(id);
+            if let Some(info) = self.children.read().await.find_child(id) {
+                let pid = info.parent_session_id.clone();
+                if let Some(pcs) = self.conversation_sessions.read().await.get(&pid) {
+                    pcs.read().await.unregister_child_handle(id);
+                }
             }
+            self.sessions.write().await.remove(id);
+            self.children
+                .write()
+                .await
+                .remove_descendant_entries(&[id.clone()]);
         }
 
-        // 4. Unregister child handle from parent.
-        {
-            let cs = self.conversation_sessions.read().await;
-            if let Some(parent_cs) = cs.get(parent_id) {
-                parent_cs.read().await.unregister_child_handle(child_id);
-            }
+        if let Some(cs) = self.get_conversation_session(child_id).await {
+            cs.read().await.stop(true).await;
         }
-
-        // 5. Remove child + descendants from sessions.
-        {
-            let mut sessions = self.sessions.write().await;
-            sessions.remove(child_id);
-            for id in &descendant_ids {
-                sessions.remove(id);
-            }
+        self.conversation_sessions.write().await.remove(child_id);
+        if let Some(pcs) = self.conversation_sessions.read().await.get(parent_id) {
+            pcs.read().await.unregister_child_handle(child_id);
         }
-
-        // 6. Remove child + descendants from children table.
-        {
-            let mut children = self.children.write().await;
-            children.remove_child(parent_id, child_id);
-            children.remove_descendant_entries(&descendant_ids);
-        }
-
+        self.sessions.write().await.remove(child_id);
+        self.children
+            .write()
+            .await
+            .remove_child(parent_id, child_id);
         Ok(())
     }
 

--- a/src/gateway/session_manager/spawn_cascade_tests.rs
+++ b/src/gateway/session_manager/spawn_cascade_tests.rs
@@ -1,0 +1,328 @@
+//! Tests for `SessionManager::kill_child` cascade behavior.
+//!
+//! Validates the design doc §级联 Kill ordering: deepest descendants
+//! are removed first, completed/terminated sessions skip cancel but
+//! are still cleaned up, and single-child scenarios work correctly.
+
+use super::spawn::{ChildSessionInfo, SpawnMode};
+use super::test_helpers::test_resolved_config;
+use super::tests::{clear_global_prompt_state, make_test_mgr};
+use super::SessionManager;
+use crate::llm::session::ConversationSession;
+use serial_test::serial;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Helper: register a `ConversationSession` in the manager's
+/// `conversation_sessions` map and in `sessions`.
+async fn register_session(mgr: &SessionManager, id: &str, agent_id: &str, depth: u32) {
+    let cs = ConversationSession::new(id.to_string(), "test-model".into(), PathBuf::from("/tmp"));
+    mgr.conversation_sessions
+        .write()
+        .await
+        .insert(id.to_string(), Arc::new(RwLock::new(cs)));
+    mgr.sessions.write().await.insert(
+        id.to_string(),
+        crate::gateway::Session {
+            id: id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "spawn".into(),
+            created_at: 0,
+            depth,
+        },
+    );
+}
+
+/// Helper: register a parent-child entry in the `children` table.
+async fn register_tree_entry(
+    mgr: &SessionManager,
+    parent_id: &str,
+    child_id: &str,
+    agent_id: &str,
+    depth: u32,
+) {
+    mgr.register_child(
+        parent_id,
+        ChildSessionInfo {
+            session_id: child_id.to_string(),
+            parent_session_id: parent_id.to_string(),
+            agent_id: agent_id.to_string(),
+            depth,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+}
+
+/// Verify `kill_child` removes descendants deepest-first when
+/// the tree has 3+ layers.
+///
+/// Tree:
+/// ```text
+///   parent (root, not killed)
+///     └─ child (killed)
+///          └─ grandchild
+///               ├─ great_grandchild (deepest leaf)
+///               └─ great_grandchild2 (deepest leaf)
+/// ```
+///
+/// `list_descendants` returns deepest-first (reversed BFS), so
+/// `kill_child` should clean up in order:
+/// great_grandchild, great_grandchild2, grandchild, then child.
+#[tokio::test]
+#[serial]
+async fn test_kill_child_deep_nesting_removes_leaves_first() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+
+    // Register parent with a ConversationSession.
+    {
+        let cs = ConversationSession::new(
+            "parent".into(),
+            "test-model".into(),
+            tmp.path().to_path_buf(),
+        );
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert("parent".into(), Arc::new(RwLock::new(cs)));
+        mgr.sessions.write().await.insert(
+            "parent".into(),
+            crate::gateway::Session {
+                id: "parent".into(),
+                agent_id: "root-agent".into(),
+                channel: "spawn".into(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    // Register all descendant sessions.
+    register_session(&mgr, "child", "child-agent", 1).await;
+    register_session(&mgr, "grandchild", "gc-agent", 2).await;
+    register_session(&mgr, "great_grandchild", "ggc-agent", 3).await;
+    register_session(&mgr, "great_grandchild2", "ggc2-agent", 3).await;
+
+    // Build the spawn tree: parent→child→grandchild→{great, great2}.
+    register_tree_entry(&mgr, "parent", "child", "child-agent", 1).await;
+    register_tree_entry(&mgr, "child", "grandchild", "gc-agent", 2).await;
+    register_tree_entry(&mgr, "grandchild", "great_grandchild", "ggc-agent", 3).await;
+    register_tree_entry(&mgr, "grandchild", "great_grandchild2", "ggc2-agent", 3).await;
+
+    // Confirm pre-conditions: all sessions exist.
+    assert!(mgr.has_session("child").await);
+    assert!(mgr.has_session("grandchild").await);
+    assert!(mgr.has_session("great_grandchild").await);
+    assert!(mgr.has_session("great_grandchild2").await);
+
+    // Kill the child and all its descendants.
+    mgr.kill_child("parent", "child")
+        .await
+        .expect("kill_child should succeed");
+
+    // All descendants and the child itself should be removed.
+    assert!(!mgr.has_session("child").await, "child should be removed");
+    assert!(
+        !mgr.has_session("grandchild").await,
+        "grandchild should be removed"
+    );
+    assert!(
+        !mgr.has_session("great_grandchild").await,
+        "great_grandchild should be removed"
+    );
+    assert!(
+        !mgr.has_session("great_grandchild2").await,
+        "great_grandchild2 should be removed"
+    );
+
+    // conversation_sessions entries are gone.
+    assert!(mgr.get_conversation_session("child").await.is_none());
+    assert!(mgr.get_conversation_session("grandchild").await.is_none());
+    assert!(mgr
+        .get_conversation_session("great_grandchild")
+        .await
+        .is_none());
+    assert!(mgr
+        .get_conversation_session("great_grandchild2")
+        .await
+        .is_none());
+
+    // children table is empty for the killed subtree.
+    assert_eq!(mgr.count_active_children("child").await, 0);
+    assert_eq!(mgr.count_active_children("grandchild").await, 0);
+}
+
+/// Verify that a session which is already stopped (completed /
+/// terminated) skips the `stop()` call but is still removed from
+/// `conversation_sessions`, `sessions`, and the `children` table.
+///
+/// Simulates the scenario where a run-mode child completed its turn
+/// before the parent calls `kill_child`.
+#[tokio::test]
+#[serial]
+async fn test_kill_child_completed_session_skips_stop() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("done-child", None);
+
+    // Register parent with a ConversationSession.
+    {
+        let cs = ConversationSession::new(
+            "parent-done".into(),
+            "test-model".into(),
+            tmp.path().to_path_buf(),
+        );
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert("parent-done".into(), Arc::new(RwLock::new(cs)));
+        mgr.sessions.write().await.insert(
+            "parent-done".into(),
+            crate::gateway::Session {
+                id: "parent-done".into(),
+                agent_id: "root-agent".into(),
+                channel: "spawn".into(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-done",
+            1,
+            "task",
+            false,
+            None,
+            SpawnMode::Run,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    // Simulate the child having completed (stop already called).
+    {
+        let cs = mgr
+            .get_conversation_session(&child_id)
+            .await
+            .expect("conversation session should exist");
+        cs.read().await.stop(true).await; // mark as stopped
+    }
+    // Verify the stopped flag is now set.
+    {
+        let cs = mgr.get_conversation_session(&child_id).await.unwrap();
+        assert!(cs.read().await.is_stopped(), "session should be stopped");
+    }
+
+    // Kill should succeed and remove from all tables.
+    mgr.kill_child("parent-done", &child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(
+        !mgr.has_session(&child_id).await,
+        "session should be removed from sessions"
+    );
+    assert!(
+        mgr.get_conversation_session(&child_id).await.is_none(),
+        "session should be removed from conversation_sessions"
+    );
+    assert_eq!(
+        mgr.count_active_children("parent-done").await,
+        0,
+        "children table should be empty"
+    );
+}
+
+/// Verify `kill_child` works correctly with a single child node
+/// (no deeper descendants).
+#[tokio::test]
+#[serial]
+async fn test_kill_child_single_child() {
+    clear_global_prompt_state();
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mgr = make_test_mgr(Some(tmp.path()));
+    let config = test_resolved_config("only-child", None);
+
+    // Register parent with a ConversationSession.
+    {
+        let cs = ConversationSession::new(
+            "parent-single".into(),
+            "test-model".into(),
+            tmp.path().to_path_buf(),
+        );
+        mgr.conversation_sessions
+            .write()
+            .await
+            .insert("parent-single".into(), Arc::new(RwLock::new(cs)));
+        mgr.sessions.write().await.insert(
+            "parent-single".into(),
+            crate::gateway::Session {
+                id: "parent-single".into(),
+                agent_id: "root-agent".into(),
+                channel: "spawn".into(),
+                created_at: 0,
+                depth: 0,
+            },
+        );
+    }
+
+    let child_id = mgr
+        .create_child_session(
+            &config,
+            "parent-single",
+            1,
+            "lone task",
+            false,
+            None,
+            SpawnMode::Session,
+            false,
+            None,
+            None,
+            None,
+            3,
+        )
+        .await
+        .expect("create_child_session should succeed");
+
+    assert!(mgr.has_session(&child_id).await);
+    assert!(mgr.get_conversation_session(&child_id).await.is_some());
+    assert_eq!(mgr.count_active_children("parent-single").await, 1);
+
+    // Kill the single child.
+    mgr.kill_child("parent-single", &child_id)
+        .await
+        .expect("kill_child should succeed");
+
+    assert!(
+        !mgr.has_session(&child_id).await,
+        "child removed from sessions"
+    );
+    assert!(
+        mgr.get_conversation_session(&child_id).await.is_none(),
+        "child removed from conversation_sessions"
+    );
+    assert_eq!(
+        mgr.count_active_children("parent-single").await,
+        0,
+        "children table should be empty"
+    );
+    let children = mgr.children.read().await;
+    assert!(
+        children.list_children("parent-single").is_empty(),
+        "parent entry should be removed when child list is empty"
+    );
+}

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::llm::session::ChatSession;
 use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use crate::permission::engine::engine_types::{
     Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
 };
@@ -121,6 +122,20 @@ impl Gateway {
             .get_chat_id(session_id)
             .await
             .unwrap_or_default();
+
+        // Collect full-chain deny subjects from all ancestors.
+        let extra_deny = {
+            let rules = engine.rules.clone();
+            let subjects =
+                collect_chain_deny_subjects(&self.session_manager, &rules, session_id, &agent_id)
+                    .await;
+            if subjects.is_empty() {
+                None
+            } else {
+                Some(subjects)
+            }
+        };
+
         let caller = Caller {
             user_id: sender_id.unwrap_or("").to_owned(),
             agent: agent_id.clone(),
@@ -134,7 +149,7 @@ impl Gateway {
             },
         };
 
-        if let PermissionResponse::Denied { reason, .. } = engine.evaluate(request, None) {
+        if let PermissionResponse::Denied { reason, .. } = engine.evaluate(request, extra_deny) {
             self.send_reply_if_available(&format!("无权限：{reason}"))
                 .await;
             return false;

--- a/src/permission/engine/engine_check.rs
+++ b/src/permission/engine/engine_check.rs
@@ -2,12 +2,17 @@
 
 use super::engine_eval::PermissionEngine;
 use super::engine_risk::assess_risk_level;
-use super::engine_types::{PermissionRequest, PermissionRequestBody, PermissionResponse};
+use super::engine_types::{PermissionRequest, PermissionRequestBody, PermissionResponse, Subject};
 
 impl PermissionEngine {
     /// Simplified permission check — evaluates if `agent_id` may
     /// perform `action`.
-    pub fn check(&self, agent_id: &str, action: &str) -> PermissionResponse {
+    pub fn check(
+        &self,
+        agent_id: &str,
+        action: &str,
+        extra_deny_subjects: Option<&[Subject]>,
+    ) -> PermissionResponse {
         let body = match action {
             "exec" => PermissionRequestBody::CommandExec {
                 agent: agent_id.to_string(),
@@ -56,6 +61,9 @@ impl PermissionEngine {
             }
         };
 
-        self.evaluate(PermissionRequest::Bare(body), None)
+        self.evaluate(
+            PermissionRequest::Bare(body),
+            extra_deny_subjects.map(|s| s.to_vec()),
+        )
     }
 }

--- a/src/permission/engine/engine_eval.rs
+++ b/src/permission/engine/engine_eval.rs
@@ -11,6 +11,8 @@ use super::engine_workspace;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::info;
+// NOTE: Cache fields (agent_permissions, user_effective_permissions) removed per
+// design doc: "权限评估每次新鲜计算，不缓存评估结果"
 
 /// Permission Engine - evaluates access requests against rules
 pub struct PermissionEngine {
@@ -24,12 +26,6 @@ pub struct PermissionEngine {
     templates: HashMap<String, crate::permission::templates::Template>,
     /// Data root directory for workspace path resolution
     data_root: PathBuf,
-    /// Per-agent effective permissions cache (populated by spawn validation)
-    pub(crate) agent_permissions:
-        std::sync::RwLock<HashMap<String, crate::agent::config::AgentPermissions>>,
-    /// Per-user effective permissions cache (populated by spawn validation)
-    pub(crate) user_effective_permissions:
-        std::sync::RwLock<HashMap<String, crate::agent::config::AgentPermissions>>,
 }
 
 // --- Construction & index management ---
@@ -43,8 +39,6 @@ impl PermissionEngine {
             user_agent_rule_index: HashMap::new(),
             templates: HashMap::new(),
             data_root,
-            agent_permissions: std::sync::RwLock::new(HashMap::new()),
-            user_effective_permissions: std::sync::RwLock::new(HashMap::new()),
         };
         engine.rebuild_indices_with_rules(&rules);
         engine
@@ -134,20 +128,6 @@ impl PermissionEngine {
         );
 
         let is_owner = caller.user_id == "owner";
-
-        // Step 0.7: Agent effective permissions pre-check
-        if let Some(response) = self.check_agent_effective_permissions(&agent_id, request.body()) {
-            return response;
-        }
-
-        // Step 0.8: User effective permissions pre-check
-        if !is_owner {
-            if let Some(response) =
-                self.check_user_effective_permissions(&caller.user_id, request.body())
-            {
-                return response;
-            }
-        }
 
         // Step 0: Creator rule (highest priority)
         if let Some(response) = self.check_creator_rule(&caller, &agent_id) {

--- a/src/permission/engine/engine_helpers.rs
+++ b/src/permission/engine/engine_helpers.rs
@@ -1,6 +1,7 @@
 //! Permission Engine - Helper utilities.
 
 use super::engine_types::{Action, Effect, Subject};
+use crate::gateway::SessionManager;
 use crate::permission::engine::engine_types::RuleSet;
 use std::collections::HashMap;
 
@@ -34,6 +35,54 @@ pub fn get_agent_deny_subjects(
             Subject::UserAndAgent { .. } => unreachable!(),
         })
         .collect()
+}
+
+/// Collect AgentOnly Deny subjects from all ancestor agents in the parent
+/// session chain. Traverses upward via `SessionManager::get_parent_of`,
+/// collecting each ancestor's AgentOnly Deny rules from the RuleSet and
+/// replacing their agent field with `child_agent_id`. Deduplicates results
+/// by `(agent, match_type)`.
+///
+/// This implements the design doc requirement: "沿 spawn 链每增加一级深度，
+/// Deny 约束集只增不减".
+pub async fn collect_chain_deny_subjects(
+    session_manager: &SessionManager,
+    rules: &RuleSet,
+    parent_session_id: &str,
+    child_agent_id: &str,
+) -> Vec<Subject> {
+    let mut all_subjects: Vec<Subject> = Vec::new();
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    let mut current_session = parent_session_id.to_string();
+
+    loop {
+        let parent_agent_id = match session_manager.get_chat_id(&current_session).await {
+            Some(id) => id,
+            None => break,
+        };
+
+        let subjects = get_agent_deny_subjects(rules, &parent_agent_id, child_agent_id);
+        for subject in subjects {
+            match &subject {
+                Subject::AgentOnly { agent, match_type } => {
+                    let key = (agent.clone(), format!("{:?}", match_type));
+                    if seen.insert(key) {
+                        all_subjects.push(subject);
+                    }
+                }
+                _ => {
+                    all_subjects.push(subject);
+                }
+            }
+        }
+
+        match session_manager.get_parent_of(&current_session).await {
+            Some(parent_id) => current_session = parent_id,
+            None => break,
+        }
+    }
+
+    all_subjects
 }
 
 /// Resolve template actions with overrides applied.

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -1,6 +1,6 @@
-//! Permission Engine - Agent spawn permission validation and caching.
+//! Permission Engine - Agent spawn permission validation.
 
-use super::engine_types::{PermissionRequestBody, PermissionResponse};
+use super::engine_types::PermissionRequestBody;
 use crate::agent::config::AgentPermissions;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -26,29 +26,13 @@ pub enum SpawnPermissionError {
 }
 
 impl super::engine_eval::PermissionEngine {
-    /// Get the effective permissions for a given agent from the cache.
-    ///
-    /// Returns `Some(AgentPermissions)` if the agent has been previously validated
-    /// and injected into the cache, `None` if not found.
-    pub fn get_agent_effective_permissions(&self, agent_id: &str) -> Option<AgentPermissions> {
-        let cache = self
-            .agent_permissions
-            .read()
-            .expect("agent_permissions lock poisoned");
-        cache.get(agent_id).cloned()
-    }
-
     /// Validate that a child agent's permissions after intersection with parent
-    /// are not fully denied, then inject the result into the cache.
+    /// are not fully denied.
     ///
-    /// - Computes `child_perms.intersect(parent_perms)` (owner path, `user_perms` is `None`)
-    ///   or `child_perms.intersect(parent_perms).intersect(user_perms)` (non-owner path)
-    /// - If fully denied → returns `Err(SpawnPermissionError::FullyDenied)` or
-    ///   `Err(SpawnPermissionError::FullyDeniedWithUser)` if user context is present
-    /// - Otherwise → injects into `self.agent_permissions` cache (agent effective permissions)
-    ///   and, when `user_perms` is provided, also injects the intersection result into
-    ///   `self.user_effective_permissions` cache (user effective permissions for eval pre-check)
-    /// - Idempotent: if already cached, returns `Ok(())` immediately
+    /// Computes `child_perms.intersect(parent_perms)` (owner path, `user_perms` is `None`)
+    /// or `child_perms.intersect(parent_perms).intersect(user_perms)` (non-owner path).
+    /// If fully denied → returns `Err(SpawnPermissionError::FullyDenied)` or
+    /// `Err(SpawnPermissionError::FullyDeniedWithUser)` if user context is present.
     pub fn validate_and_inject_spawn(
         &self,
         child_agent_id: &str,
@@ -57,16 +41,6 @@ impl super::engine_eval::PermissionEngine {
         user_perms: Option<&AgentPermissions>,
         user_id: Option<&str>,
     ) -> Result<(), SpawnPermissionError> {
-        let mut agent_cache = self
-            .agent_permissions
-            .write()
-            .expect("agent_permissions lock poisoned");
-
-        // Idempotent: already cached
-        if agent_cache.contains_key(child_agent_id) {
-            return Ok(());
-        }
-
         // Step 1: child ∩ parent
         let effective = child_perms.intersect(parent_perms);
 
@@ -90,110 +64,8 @@ impl super::engine_eval::PermissionEngine {
             });
         }
 
-        agent_cache.insert(child_agent_id.to_string(), final_effective.clone());
-
-        // Inject user effective permissions for eval pre-check (non-owner path only)
-        if let Some(uid) = user_id {
-            let mut user_cache = self
-                .user_effective_permissions
-                .write()
-                .expect("user_effective_permissions lock poisoned");
-            user_cache.insert(uid.to_string(), final_effective);
-        }
-
+        // No caching — evaluate() computes permissions fresh each time
         Ok(())
-    }
-
-    /// Check the agent effective permissions cache for a given request body.
-    ///
-    /// Returns:
-    /// - `None` if dimension is unknown (e.g., SlashCommand) or cache miss
-    /// - `Some(Denied)` if the dimension is denied
-    /// - `None` if the dimension is allowed (continue with normal evaluate)
-    pub fn check_agent_effective_permissions(
-        &self,
-        agent_id: &str,
-        body: &PermissionRequestBody,
-    ) -> Option<PermissionResponse> {
-        let dim = body.dimension_name()?;
-
-        let cache = self
-            .agent_permissions
-            .read()
-            .expect("agent_permissions lock poisoned");
-
-        match cache.get(agent_id) {
-            None => None, // cache miss → continue with normal evaluate
-            Some(perms) => {
-                let allowed = perms
-                    .permissions
-                    .get(dim)
-                    .map(|p| p.allowed)
-                    .unwrap_or(false);
-
-                if allowed {
-                    None // allowed → continue with normal evaluate
-                } else {
-                    Some(PermissionResponse::Denied {
-                        reason: format!("agent effective permission denied for dimension '{dim}'"),
-                        rule: "<agent_effective_permissions>".to_string(),
-                        risk_level: super::engine_risk::assess_risk_level(body),
-                    })
-                }
-            }
-        }
-    }
-
-    /// Get the effective permissions for a given user from the cache.
-    ///
-    /// Returns `Some(AgentPermissions)` if the user has been previously validated
-    /// and injected into the cache, `None` if not found.
-    pub fn get_user_effective_permissions(&self, user_id: &str) -> Option<AgentPermissions> {
-        let cache = self
-            .user_effective_permissions
-            .read()
-            .expect("user_effective_permissions lock poisoned");
-        cache.get(user_id).cloned()
-    }
-
-    /// Check the user effective permissions cache for a given request body.
-    ///
-    /// Returns:
-    /// - `None` if dimension is unknown (e.g., SlashCommand) or cache miss
-    /// - `Some(Denied)` if the dimension is denied
-    /// - `None` if the dimension is allowed (continue with normal evaluate)
-    pub fn check_user_effective_permissions(
-        &self,
-        user_id: &str,
-        body: &PermissionRequestBody,
-    ) -> Option<PermissionResponse> {
-        let dim = body.dimension_name()?;
-
-        let cache = self
-            .user_effective_permissions
-            .read()
-            .expect("user_effective_permissions lock poisoned");
-
-        match cache.get(user_id) {
-            None => None, // cache miss → continue with normal evaluate
-            Some(perms) => {
-                let allowed = perms
-                    .permissions
-                    .get(dim)
-                    .map(|p| p.allowed)
-                    .unwrap_or(false);
-
-                if allowed {
-                    None // allowed → continue with normal evaluate
-                } else {
-                    Some(PermissionResponse::Denied {
-                        reason: format!("user effective permission denied for dimension '{}'", dim),
-                        rule: "<user_effective_permissions>".to_string(),
-                        risk_level: super::engine_risk::assess_risk_level(body),
-                    })
-                }
-            }
-        }
     }
 }
 

--- a/src/permission/engine/engine_spawn.rs
+++ b/src/permission/engine/engine_spawn.rs
@@ -1,6 +1,6 @@
 //! Permission Engine - Agent spawn permission validation.
 
-use super::engine_types::PermissionRequestBody;
+use super::engine_types::{PermissionRequestBody, Subject};
 use crate::agent::config::AgentPermissions;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -40,7 +40,25 @@ impl super::engine_eval::PermissionEngine {
         parent_perms: &AgentPermissions,
         user_perms: Option<&AgentPermissions>,
         user_id: Option<&str>,
+        extra_deny_subjects: Option<&[Subject]>,
     ) -> Result<(), SpawnPermissionError> {
+        // Step 0: Extra deny — chain deny subjects override all other checks.
+        if let Some(subjects) = extra_deny_subjects {
+            let caller = super::engine_types::Caller {
+                user_id: user_id.unwrap_or_default().to_string(),
+                agent: child_agent_id.to_string(),
+                creator_id: String::new(),
+            };
+            for subject in subjects {
+                if subject.matches(&caller) {
+                    return Err(SpawnPermissionError::FullyDenied {
+                        child_agent_id: child_agent_id.to_string(),
+                        parent_agent_id: parent_perms.agent_id.clone(),
+                    });
+                }
+            }
+        }
+
         // Step 1: child ∩ parent
         let effective = child_perms.intersect(parent_perms);
 

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -64,7 +64,7 @@ fn test_validate_and_inject_spawn_success() {
     let child = make_allowed_perms("child");
     let parent = make_allowed_perms("parent");
 
-    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None, None);
     assert!(result.is_ok());
 }
 
@@ -74,7 +74,7 @@ fn test_validate_and_inject_spawn_fully_denied() {
     let child = make_fully_denied_perms("child");
     let parent = make_allowed_perms("parent");
 
-    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None, None);
     assert!(result.is_err());
     match result.unwrap_err() {
         SpawnPermissionError::FullyDenied {
@@ -99,8 +99,14 @@ fn test_validate_and_inject_spawn_user_deny_overrides() {
     let parent = make_allowed_perms("parent");
     let user = make_fully_denied_perms("user-1");
 
-    let result =
-        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-1"));
+    let result = engine.validate_and_inject_spawn(
+        "child",
+        &child,
+        &parent,
+        Some(&user),
+        Some("user-1"),
+        None,
+    );
     assert!(result.is_err());
     match result.unwrap_err() {
         SpawnPermissionError::FullyDeniedWithUser {
@@ -147,8 +153,14 @@ fn test_validate_and_inject_spawn_user_partial_deny() {
         inherited_from: None,
     };
 
-    let result =
-        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-2"));
+    let result = engine.validate_and_inject_spawn(
+        "child",
+        &child,
+        &parent,
+        Some(&user),
+        Some("user-2"),
+        None,
+    );
     assert!(result.is_ok());
 }
 
@@ -159,8 +171,14 @@ fn test_validate_and_inject_spawn_user_allow_full() {
     let parent = make_allowed_perms("parent");
     let user = make_allowed_perms("user-3");
 
-    let result =
-        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-3"));
+    let result = engine.validate_and_inject_spawn(
+        "child",
+        &child,
+        &parent,
+        Some(&user),
+        Some("user-3"),
+        None,
+    );
     assert!(result.is_ok());
 }
 
@@ -190,6 +208,7 @@ fn test_concurrent_spawn_and_evaluate() {
                 &format!("child-{}", i),
                 &child,
                 &parent,
+                None,
                 None,
                 None,
             );

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -1,6 +1,6 @@
 use super::engine_eval::PermissionEngine;
 use super::engine_spawn::SpawnPermissionError;
-use super::engine_types::{Effect, PermissionRequest, PermissionRequestBody, PermissionResponse};
+use super::engine_types::Effect;
 use crate::agent::config::AgentPermissions;
 use crate::permission::rules::RuleSetBuilder;
 use std::collections::HashMap;
@@ -55,7 +55,7 @@ fn make_fully_denied_perms(agent_id: &str) -> AgentPermissions {
 }
 
 // -------------------------------------------------------------------------
-// validate_and_inject_spawn tests
+// validate_and_inject_spawn tests (no caching)
 // -------------------------------------------------------------------------
 
 #[test]
@@ -66,10 +66,6 @@ fn test_validate_and_inject_spawn_success() {
 
     let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
     assert!(result.is_ok());
-
-    // Verify cache was populated
-    let cache = engine.agent_permissions.read().unwrap();
-    assert!(cache.contains_key("child"));
 }
 
 #[test]
@@ -90,25 +86,6 @@ fn test_validate_and_inject_spawn_fully_denied() {
         }
         other => panic!("expected FullyDenied, got {:?}", other),
     }
-
-    // Verify cache was NOT populated
-    let cache = engine.agent_permissions.read().unwrap();
-    assert!(!cache.contains_key("child"));
-}
-
-#[test]
-fn test_validate_and_inject_spawn_idempotent() {
-    let engine = make_engine();
-    let child = make_allowed_perms("child");
-    let parent = make_allowed_perms("parent");
-
-    // First call succeeds
-    engine
-        .validate_and_inject_spawn("child", &child, &parent, None, None)
-        .unwrap();
-    // Second call succeeds (idempotent)
-    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
-    assert!(result.is_ok());
 }
 
 // -------------------------------------------------------------------------
@@ -173,14 +150,6 @@ fn test_validate_and_inject_spawn_user_partial_deny() {
     let result =
         engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-2"));
     assert!(result.is_ok());
-
-    // Verify cached agent perms: exec should be denied (user denied it)
-    let cache = engine.agent_permissions.read().unwrap();
-    let cached = cache.get("child").unwrap();
-    assert!(!cached.permissions.get("exec").unwrap().allowed);
-    // Other dims should be allowed
-    assert!(cached.permissions.get("file_read").unwrap().allowed);
-    assert!(cached.permissions.get("spawn").unwrap().allowed);
 }
 
 #[test]
@@ -193,181 +162,18 @@ fn test_validate_and_inject_spawn_user_allow_full() {
     let result =
         engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-3"));
     assert!(result.is_ok());
-
-    // Verify cached agent perms: all allowed
-    let cache = engine.agent_permissions.read().unwrap();
-    let cached = cache.get("child").unwrap();
-    for dim in &[
-        "exec",
-        "file_read",
-        "file_write",
-        "network",
-        "spawn",
-        "tool_call",
-        "config_write",
-    ] {
-        assert!(
-            cached.permissions.get(*dim).unwrap().allowed,
-            "{} should be allowed",
-            dim
-        );
-    }
-}
-
-#[test]
-fn test_validate_and_inject_spawn_user_cache_injection() {
-    let engine = make_engine();
-    let child = make_allowed_perms("child");
-    let parent = make_allowed_perms("parent");
-    let user = make_allowed_perms("user-4");
-
-    let result =
-        engine.validate_and_inject_spawn("child", &child, &parent, Some(&user), Some("user-4"));
-    assert!(result.is_ok());
-
-    // Verify user_effective_permissions cache was populated
-    let user_cache = engine.user_effective_permissions.read().unwrap();
-    assert!(user_cache.contains_key("user-4"));
-}
-
-#[test]
-fn test_validate_and_inject_spawn_no_user_no_cache() {
-    let engine = make_engine();
-    let child = make_allowed_perms("child");
-    let parent = make_allowed_perms("parent");
-
-    // No user → user cache should NOT be populated
-    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None);
-    assert!(result.is_ok());
-
-    let user_cache = engine.user_effective_permissions.read().unwrap();
-    assert!(user_cache.is_empty());
 }
 
 // -------------------------------------------------------------------------
-// check_agent_effective_permissions tests
-// -------------------------------------------------------------------------
-
-#[test]
-fn test_check_agent_effective_permissions_cache_miss() {
-    let engine = make_engine();
-    let body = PermissionRequestBody::CommandExec {
-        agent: "unknown-agent".to_string(),
-        cmd: "ls".to_string(),
-        args: vec![],
-    };
-
-    let result = engine.check_agent_effective_permissions("unknown-agent", &body);
-    assert!(result.is_none());
-}
-
-#[test]
-fn test_check_agent_effective_permissions_deny() {
-    let engine = make_engine();
-    // Inject a fully denied agent into cache
-    // Force inject by directly manipulating cache
-    {
-        let mut cache = engine.agent_permissions.write().unwrap();
-        cache.insert(
-            "denied-agent".to_string(),
-            AgentPermissions {
-                agent_id: "denied-agent".to_string(),
-                permissions: HashMap::from([(
-                    "exec".to_string(),
-                    crate::agent::config::ActionPermission {
-                        allowed: false,
-                        limits: crate::agent::config::PermissionLimits::default(),
-                    },
-                )]),
-                inherited_from: Some("parent".to_string()),
-            },
-        );
-    }
-
-    let body = PermissionRequestBody::CommandExec {
-        agent: "denied-agent".to_string(),
-        cmd: "ls".to_string(),
-        args: vec![],
-    };
-    let result = engine.check_agent_effective_permissions("denied-agent", &body);
-    assert!(result.is_some());
-    match result.unwrap() {
-        PermissionResponse::Denied { reason, .. } => {
-            assert!(reason.contains("agent effective permission denied"));
-        }
-        other => panic!("expected Denied, got {:?}", other),
-    }
-}
-
-#[test]
-fn test_check_agent_effective_permissions_allow() {
-    let engine = make_engine();
-    // Inject an allowed agent into cache
-    {
-        let mut cache = engine.agent_permissions.write().unwrap();
-        cache.insert(
-            "allowed-agent".to_string(),
-            AgentPermissions {
-                agent_id: "allowed-agent".to_string(),
-                permissions: HashMap::from([(
-                    "exec".to_string(),
-                    crate::agent::config::ActionPermission {
-                        allowed: true,
-                        limits: crate::agent::config::PermissionLimits::default(),
-                    },
-                )]),
-                inherited_from: None,
-            },
-        );
-    }
-
-    let body = PermissionRequestBody::CommandExec {
-        agent: "allowed-agent".to_string(),
-        cmd: "ls".to_string(),
-        args: vec![],
-    };
-    let result = engine.check_agent_effective_permissions("allowed-agent", &body);
-    assert!(result.is_none());
-}
-
-#[test]
-fn test_check_agent_effective_permissions_slash_command() {
-    let engine = make_engine();
-    // Even with agent in cache, SlashCommand → None (dimension_name returns None)
-    {
-        let mut cache = engine.agent_permissions.write().unwrap();
-        cache.insert(
-            "cached-agent".to_string(),
-            AgentPermissions {
-                agent_id: "cached-agent".to_string(),
-                permissions: HashMap::from([(
-                    "exec".to_string(),
-                    crate::agent::config::ActionPermission {
-                        allowed: false,
-                        limits: crate::agent::config::PermissionLimits::default(),
-                    },
-                )]),
-                inherited_from: None,
-            },
-        );
-    }
-
-    let body = PermissionRequestBody::SlashCommand {
-        agent: "cached-agent".to_string(),
-        command: "/status".to_string(),
-    };
-    let result = engine.check_agent_effective_permissions("cached-agent", &body);
-    assert!(result.is_none());
-}
-
-// -------------------------------------------------------------------------
-// Concurrent test (E)
+// Concurrent test
 // -------------------------------------------------------------------------
 
 #[test]
 fn test_concurrent_spawn_and_evaluate() {
     use std::sync::Arc;
     use std::thread;
+
+    use super::engine_types::{PermissionRequest, PermissionRequestBody};
 
     let engine = Arc::new(make_engine());
     let parent = Arc::new(make_allowed_perms("parent"));

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -1,7 +1,11 @@
 use super::engine_eval::PermissionEngine;
 use super::engine_spawn::SpawnPermissionError;
-use super::engine_types::Effect;
+use super::engine_types::{
+    Effect, MatchType, PermissionRequest, PermissionRequestBody, PermissionResponse, Subject,
+};
 use crate::agent::config::AgentPermissions;
+use crate::permission::actions::ActionBuilder;
+use crate::permission::rules::RuleBuilder;
 use crate::permission::rules::RuleSetBuilder;
 use std::collections::HashMap;
 
@@ -233,4 +237,376 @@ fn test_concurrent_spawn_and_evaluate() {
     for h in handles {
         h.join().unwrap();
     }
+}
+
+// -------------------------------------------------------------------------
+// Owner spawn: verify User dimension is skipped
+// -------------------------------------------------------------------------
+
+/// Owner spawn skips User dimension — child ∩ parent only, user_perms ignored.
+/// When user_perms is None (owner path), user deny cannot block the spawn.
+#[test]
+fn test_owner_spawn_skips_user_dimension() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    // user_perms is None (simulates owner path in spawn.rs)
+    let result = engine.validate_and_inject_spawn("child", &child, &parent, None, None, None);
+    assert!(result.is_ok());
+}
+
+/// Non-owner spawn: user deny blocks the spawn when all dims denied.
+#[test]
+fn test_non_owner_spawn_user_deny_blocks() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    let user = make_fully_denied_perms("user-1");
+    let result = engine.validate_and_inject_spawn(
+        "child",
+        &child,
+        &parent,
+        Some(&user),
+        Some("user-1"),
+        None,
+    );
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDeniedWithUser { user_id, .. } => {
+            assert_eq!(user_id, "user-1");
+        }
+        other => panic!("expected FullyDeniedWithUser, got {:?}", other),
+    }
+}
+
+/// Owner spawn: user deny is ignored, even if user_perms would block all dims.
+#[test]
+fn test_owner_spawn_ignores_user_deny() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    // Even though user would block everything, owner path passes None for user_perms
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, None, Some("owner"), None);
+    assert!(result.is_ok());
+}
+
+/// Owner spawn + extra_deny: extra deny still blocks even for owner.
+#[test]
+fn test_owner_spawn_extra_deny_still_blocks() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    let extra = vec![Subject::AgentOnly {
+        agent: "child".to_string(),
+        match_type: MatchType::Exact,
+    }];
+    let result = engine.validate_and_inject_spawn(
+        "child",
+        &child,
+        &parent,
+        None,
+        Some("owner"),
+        Some(&extra),
+    );
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDenied {
+            child_agent_id,
+            parent_agent_id,
+        } => {
+            assert_eq!(child_agent_id, "child");
+            assert_eq!(parent_agent_id, "parent");
+        }
+        other => panic!("expected FullyDenied, got {:?}", other),
+    }
+}
+
+// -------------------------------------------------------------------------
+// Chain deny: root → A → B propagation
+// -------------------------------------------------------------------------
+
+/// Three-level chain deny: root's Deny rule propagates to B via extra_deny_subjects.
+/// Root has AgentOnly Deny for tool_call on "root-agent".
+/// When evaluating B (child-agent) with extra_deny_subjects containing
+/// the rewritten deny subject, B is denied.
+#[test]
+fn test_chain_deny_root_to_b_propagation() {
+    let rules = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_config(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("root-deny-toolcall")
+                .subject_agent("root-agent")
+                .deny()
+                .action(ActionBuilder::tool_call("*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(rules);
+
+    // Simulate collect_chain_deny_subjects traversing root → A → B:
+    // Root's deny rule on "root-agent" gets rewritten to "child-agent" (B).
+    let chain_deny_subjects = vec![Subject::AgentOnly {
+        agent: "child-agent".to_string(),
+        match_type: MatchType::Exact,
+    }];
+
+    // B tries to execute tool_call — normally allowed by default
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "child-agent".to_string(),
+            skill: "some_tool".to_string(),
+            method: "run".to_string(),
+        }),
+        Some(chain_deny_subjects),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref rule, .. } if rule == "<extra_deny>"),
+        "B should be denied by chain deny from root: {:?}",
+        resp
+    );
+}
+
+/// Chain deny: root deny propagates to B, but A (intermediate) allows the same action.
+/// The chain deny subjects accumulate — root's deny for B takes precedence.
+#[test]
+fn test_chain_deny_accumulates_across_levels() {
+    let rules = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_config(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("root-deny-toolcall")
+                .subject_agent("root-agent")
+                .deny()
+                .action(ActionBuilder::tool_call("*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(rules);
+
+    // Simulate chain deny subjects from root → A → B:
+    // Root's deny for A (rewritten to child-agent) + Root's deny for B (rewritten to child-agent)
+    // Both target child-agent, deduplication keeps one.
+    let chain_deny_subjects = vec![Subject::AgentOnly {
+        agent: "child-agent".to_string(),
+        match_type: MatchType::Exact,
+    }];
+
+    // B tries tool_call — denied by chain deny from root
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "child-agent".to_string(),
+            skill: "any".to_string(),
+            method: "any".to_string(),
+        }),
+        Some(chain_deny_subjects),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref rule, .. } if rule == "<extra_deny>"),
+        "B should be denied: chain deny accumulates: {:?}",
+        resp
+    );
+}
+
+/// Chain deny with glob match: root deny uses glob pattern "root-*",
+/// rewritten to "child-*", matching "child-agent".
+#[test]
+fn test_chain_deny_glob_match() {
+    let rules = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_config(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("root-deny-toolcall-glob")
+                .subject_agent("root-*")
+                .deny()
+                .action(ActionBuilder::tool_call("*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(rules);
+
+    // Simulate glob deny rewrite: root-* → child-*
+    let chain_deny_subjects = vec![Subject::AgentOnly {
+        agent: "child-*".to_string(),
+        match_type: MatchType::Glob,
+    }];
+
+    // child-agent matches child-* glob → denied
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "child-agent".to_string(),
+            skill: "web".to_string(),
+            method: "search".to_string(),
+        }),
+        Some(chain_deny_subjects.clone()),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref rule, .. } if rule == "<extra_deny>"),
+        "child-agent should be denied by glob chain deny: {:?}",
+        resp
+    );
+
+    // other-agent does NOT match child-* → allowed
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "other-agent".to_string(),
+            skill: "web".to_string(),
+            method: "search".to_string(),
+        }),
+        Some(chain_deny_subjects),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Allowed { .. }),
+        "other-agent should NOT be affected by child-* glob deny: {:?}",
+        resp
+    );
+}
+
+/// Chain deny: extra_deny subjects with multiple deny rules from different ancestors.
+/// Root denies tool_call, A denies network — both propagate to B.
+#[test]
+fn test_chain_deny_multiple_ancestors() {
+    let rules = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_config(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(rules);
+
+    // Simulate chain deny from two ancestors:
+    // Root denies tool_call for B, A denies network for B
+    let chain_deny_subjects = vec![
+        Subject::AgentOnly {
+            agent: "child-agent".to_string(),
+            match_type: MatchType::Exact,
+        },
+        Subject::AgentOnly {
+            agent: "child-agent".to_string(),
+            match_type: MatchType::Exact,
+        }, // duplicate — deduplication keeps one
+    ];
+
+    // tool_call denied
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+            agent: "child-agent".to_string(),
+            skill: "any".to_string(),
+            method: "any".to_string(),
+        }),
+        Some(chain_deny_subjects.clone()),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref rule, .. } if rule == "<extra_deny>"),
+        "tool_call should be denied: {:?}",
+        resp
+    );
+
+    // network also denied (same subject matches any action)
+    let resp = engine.evaluate(
+        PermissionRequest::Bare(PermissionRequestBody::NetOp {
+            agent: "child-agent".to_string(),
+            host: "example.com".to_string(),
+            port: 443,
+        }),
+        Some(chain_deny_subjects),
+    );
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref rule, .. } if rule == "<extra_deny>"),
+        "network should also be denied: {:?}",
+        resp
+    );
+}
+
+/// Chain deny with validate_and_inject_spawn: extra deny blocks spawn of child
+/// that has full permissions — simulates root deny propagating to grandchild.
+#[test]
+fn test_chain_deny_blocks_spawn() {
+    let engine = make_engine();
+    let child = make_allowed_perms("child");
+    let parent = make_allowed_perms("parent");
+    // Simulate root's deny rule rewritten to target child
+    let extra = vec![Subject::AgentOnly {
+        agent: "child".to_string(),
+        match_type: MatchType::Exact,
+    }];
+    let result =
+        engine.validate_and_inject_spawn("child", &child, &parent, None, None, Some(&extra));
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDenied {
+            child_agent_id,
+            parent_agent_id,
+        } => {
+            assert_eq!(child_agent_id, "child");
+            assert_eq!(parent_agent_id, "parent");
+        }
+        other => panic!("expected FullyDenied, got {:?}", other),
+    }
+}
+
+/// Chain deny: extra deny with glob pattern blocks spawn via validate_and_inject_spawn.
+#[test]
+fn test_chain_deny_glob_blocks_spawn() {
+    let engine = make_engine();
+    let child = make_allowed_perms("dev-child");
+    let parent = make_allowed_perms("parent");
+    let extra = vec![Subject::AgentOnly {
+        agent: "dev-*".to_string(),
+        match_type: MatchType::Glob,
+    }];
+    let result =
+        engine.validate_and_inject_spawn("dev-child", &child, &parent, None, None, Some(&extra));
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpawnPermissionError::FullyDenied {
+            child_agent_id,
+            parent_agent_id,
+        } => {
+            assert_eq!(child_agent_id, "dev-child");
+            assert_eq!(parent_agent_id, "parent");
+        }
+        other => panic!("expected FullyDenied, got {:?}", other),
+    }
+}
+
+/// Chain deny: glob deny pattern does NOT block non-matching child spawn.
+#[test]
+fn test_chain_deny_glob_no_match_allows_spawn() {
+    let engine = make_engine();
+    let child = make_allowed_perms("prod-child");
+    let parent = make_allowed_perms("parent");
+    // deny pattern is dev-* — prod-child should not match
+    let extra = vec![Subject::AgentOnly {
+        agent: "dev-*".to_string(),
+        match_type: MatchType::Glob,
+    }];
+    let result =
+        engine.validate_and_inject_spawn("prod-child", &child, &parent, None, None, Some(&extra));
+    assert!(result.is_ok());
 }

--- a/src/permission/engine/engine_tests.rs
+++ b/src/permission/engine/engine_tests.rs
@@ -91,7 +91,7 @@ fn make_engine() -> PermissionEngine {
 #[test]
 fn test_engine_allow_read() {
     let engine = make_engine();
-    let resp = engine.check("test-agent", "file_read");
+    let resp = engine.check("test-agent", "file_read", None);
     matches!(resp, PermissionResponse::Allowed { .. });
 }
 
@@ -106,7 +106,7 @@ fn test_engine_default_deny() {
         .build()
         .unwrap();
     let engine = PermissionEngine::new_with_default_data_root(ruleset);
-    let resp = engine.check("unknown-agent", "file_read");
+    let resp = engine.check("unknown-agent", "file_read", None);
     matches!(resp, PermissionResponse::Denied { .. });
 }
 
@@ -377,6 +377,6 @@ fn test_tool_call_default_allow() {
         .build()
         .unwrap();
     let engine = PermissionEngine::new_with_default_data_root(ruleset);
-    let resp = engine.check("unknown-agent", "tool_call");
+    let resp = engine.check("unknown-agent", "tool_call", None);
     matches!(resp, PermissionResponse::Allowed { .. });
 }

--- a/src/permission/sandbox/ipc.rs
+++ b/src/permission/sandbox/ipc.rs
@@ -33,7 +33,11 @@ pub const IPC_TIMEOUT_MS: u64 = 3000;
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SandboxRequest {
     /// Ask the engine to evaluate a permission request.
-    Evaluate { request: PermissionRequest },
+    Evaluate {
+        request: PermissionRequest,
+        #[serde(default)]
+        extra_deny_subjects: Option<Vec<crate::permission::engine::engine_types::Subject>>,
+    },
     /// Ask the engine to reload its ruleset.
     ReloadRules { rules: RuleSet },
     /// Ping — returns Pong.
@@ -177,9 +181,12 @@ async fn handle_connection(
 
         // Process request
         let response = match &request {
-            SandboxRequest::Evaluate { request } => {
-                SandboxResponse::PermissionResponse(engine.evaluate(request.clone(), None))
-            }
+            SandboxRequest::Evaluate {
+                request,
+                extra_deny_subjects,
+            } => SandboxResponse::PermissionResponse(
+                engine.evaluate(request.clone(), extra_deny_subjects.clone()),
+            ),
             SandboxRequest::ReloadRules { rules: _ } => {
                 // The engine is recreated externally; we just acknowledge.
                 SandboxResponse::RulesReloaded
@@ -255,6 +262,7 @@ mod tests {
                     op: "read".to_string(),
                 },
             ),
+            extra_deny_subjects: None,
         };
         let json = serde_json::to_vec(&req).unwrap();
         let deserialized: SandboxRequest = serde_json::from_slice(&json).unwrap();

--- a/src/permission/sandbox/mod.rs
+++ b/src/permission/sandbox/mod.rs
@@ -214,6 +214,7 @@ impl Sandbox {
     pub async fn evaluate(
         &self,
         request: PermissionRequest,
+        extra_deny_subjects: Option<Vec<crate::permission::engine::engine_types::Subject>>,
     ) -> Result<PermissionResponse, SandboxError> {
         let state = *self.state.read().await;
         if state != SandboxState::Running {
@@ -222,7 +223,10 @@ impl Sandbox {
 
         let resp = timeout(
             Duration::from_millis(IPC_TIMEOUT_MS),
-            self.channel.call(&SandboxRequest::Evaluate { request }),
+            self.channel.call(&SandboxRequest::Evaluate {
+                request,
+                extra_deny_subjects,
+            }),
         )
         .await
         .map_err(|_| SandboxError::IpcTimeout)?

--- a/src/permission/sandbox/tests.rs
+++ b/src/permission/sandbox/tests.rs
@@ -101,7 +101,7 @@ async fn test_sandbox_evaluate_invalid_state_unstarted() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("sandbox.sock");
     let sandbox = Sandbox::new(&path);
-    let result = sandbox.evaluate(dummy_request()).await;
+    let result = sandbox.evaluate(dummy_request(), None).await;
     let err = result.unwrap_err();
     match err {
         SandboxError::InvalidState { state } => {
@@ -142,7 +142,7 @@ async fn test_sandbox_evaluate_invalid_state_shutdown() {
     let mut sandbox = Sandbox::new(&path);
     sandbox.shutdown().await;
     assert_eq!(sandbox.state().await, SandboxState::Shutdown);
-    let result = sandbox.evaluate(dummy_request()).await;
+    let result = sandbox.evaluate(dummy_request(), None).await;
     let err = result.unwrap_err();
     match err {
         SandboxError::InvalidState { state } => {

--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -1,15 +1,23 @@
 //! File operations skill
+use crate::gateway::SessionManager;
 use crate::permission::approval_flow::ApprovalFlow;
+use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-#[derive(Default)]
 pub struct FileOpsSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
     approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
+    session_manager: Option<Arc<SessionManager>>,
+}
+
+impl Default for FileOpsSkill {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FileOpsSkill {
@@ -17,6 +25,7 @@ impl FileOpsSkill {
         Self {
             engine: None,
             approval_flow: None,
+            session_manager: None,
         }
     }
 
@@ -24,6 +33,7 @@ impl FileOpsSkill {
         Self {
             engine: Some(engine),
             approval_flow: None,
+            session_manager: None,
         }
     }
 
@@ -34,7 +44,13 @@ impl FileOpsSkill {
         Self {
             engine: Some(engine),
             approval_flow: Some(approval_flow),
+            session_manager: None,
         }
+    }
+
+    pub fn with_session_manager(mut self, session_manager: Arc<SessionManager>) -> Self {
+        self.session_manager = Some(session_manager);
+        self
     }
 }
 
@@ -75,7 +91,24 @@ impl Skill for FileOpsSkill {
                 .get("agent_id")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| SkillError::InvalidArgs("agent_id required".to_string()))?;
-            match engine.check(agent_id, action) {
+            // Collect chain deny subjects from all ancestors if session context
+            // is available. Falls back to None when session_id is absent.
+            let extra_deny = if let (Some(ref sm), Some(session_id)) = (
+                &self.session_manager,
+                args.get("session_id").and_then(|v| v.as_str()),
+            ) {
+                let subjects =
+                    collect_chain_deny_subjects(sm, &engine.rules, session_id, agent_id).await;
+                if subjects.is_empty() {
+                    None
+                } else {
+                    Some(subjects)
+                }
+            } else {
+                None
+            };
+            let deny_ref = extra_deny.as_deref();
+            match engine.check(agent_id, action, deny_ref) {
                 PermissionResponse::Allowed { .. } => {}
                 PermissionResponse::Denied {
                     reason, risk_level, ..

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -16,6 +16,7 @@ pub use git_ops::GitOpsSkill;
 pub use permission::PermissionSkill;
 pub use search::SearchSkill;
 
+use crate::gateway::SessionManager;
 use crate::permission::approval_flow::ApprovalFlow;
 use crate::skills::Skill;
 use std::sync::Arc;
@@ -57,15 +58,26 @@ impl BuiltinSkills {
     pub fn all_with_engine_and_approval_flow(
         engine: Arc<crate::permission::PermissionEngine>,
         approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+        session_manager: Option<Arc<SessionManager>>,
     ) -> Vec<Arc<dyn Skill>> {
+        let file_ops =
+            FileOpsSkill::with_engine_and_approval_flow(engine.clone(), approval_flow.clone());
+        let file_ops = if let Some(ref sm) = session_manager {
+            file_ops.with_session_manager(Arc::clone(sm))
+        } else {
+            file_ops
+        };
+        let perm_skill = PermissionSkill::with_engine(engine.clone());
+        let perm_skill = if let Some(ref sm) = session_manager {
+            perm_skill.with_session_manager(Arc::clone(sm))
+        } else {
+            perm_skill
+        };
         vec![
-            Arc::new(FileOpsSkill::with_engine_and_approval_flow(
-                engine.clone(),
-                approval_flow.clone(),
-            )) as Arc<dyn Skill>,
+            Arc::new(file_ops) as Arc<dyn Skill>,
             Arc::new(GitOpsSkill::new()),
             Arc::new(SearchSkill::new()),
-            Arc::new(PermissionSkill::with_engine(engine.clone())),
+            Arc::new(perm_skill),
             Arc::new(SkillDiscoverySkill::with_engine_and_approval_flow(
                 engine,
                 approval_flow,
@@ -92,8 +104,9 @@ pub fn builtin_skills_with_engine(
 pub fn builtin_skills_with_engine_and_approval_flow(
     engine: Arc<crate::permission::PermissionEngine>,
     approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
+    session_manager: Option<Arc<SessionManager>>,
 ) -> Vec<Arc<dyn Skill>> {
-    BuiltinSkills::all_with_engine_and_approval_flow(engine, approval_flow)
+    BuiltinSkills::all_with_engine_and_approval_flow(engine, approval_flow, session_manager)
 }
 
 #[cfg(test)]

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -1,4 +1,6 @@
 //! Permission skill - allows agents to query their own permissions
+use crate::gateway::SessionManager;
+use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
@@ -6,17 +8,27 @@ use std::sync::Arc;
 
 pub struct PermissionSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
+    session_manager: Option<Arc<SessionManager>>,
 }
 
 impl PermissionSkill {
     pub fn new() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            session_manager: None,
+        }
     }
 
     pub fn with_engine(engine: Arc<crate::permission::PermissionEngine>) -> Self {
         Self {
             engine: Some(engine),
+            session_manager: None,
         }
+    }
+
+    pub fn with_session_manager(mut self, session_manager: Arc<SessionManager>) -> Self {
+        self.session_manager = Some(session_manager);
+        self
     }
 }
 
@@ -60,7 +72,24 @@ impl Skill for PermissionSkill {
                     .ok_or_else(|| SkillError::InvalidArgs("action required".to_string()))?;
 
                 if let Some(ref engine) = self.engine {
-                    let response = engine.check(agent_id, action);
+                    // Collect chain deny subjects from all ancestors if session
+                    // context is available.
+                    let extra_deny = if let (Some(ref sm), Some(sid)) = (
+                        &self.session_manager,
+                        args.get("session_id").and_then(|v| v.as_str()),
+                    ) {
+                        let subjects =
+                            collect_chain_deny_subjects(sm, &engine.rules, sid, agent_id).await;
+                        if subjects.is_empty() {
+                            None
+                        } else {
+                            Some(subjects)
+                        }
+                    } else {
+                        None
+                    };
+                    let deny_ref = extra_deny.as_deref();
+                    let response = engine.check(agent_id, action, deny_ref);
                     match response {
                         PermissionResponse::Allowed { token: _ } => Ok(serde_json::json!({
                             "allowed": true,

--- a/src/tools/builtin/bash.rs
+++ b/src/tools/builtin/bash.rs
@@ -10,7 +10,9 @@
 //! etc.) live in the sibling module [`super::bash_kill`] to keep this
 //! file under the CONTRIBUTING.md 500-line hard cap.
 
+use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
+use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use crate::permission::engine::engine_types::PermissionResponse;
 use crate::tasks::BackgroundTaskManager;
 use crate::tools::security::{BashSecurityAnalyzer, TrustLevel};
@@ -40,6 +42,7 @@ const AUTO_BG_TIMEOUT_MS: u64 = 15_000;
 pub struct BashTool {
     permission_engine: Arc<PermissionEngine>,
     bg_manager: Arc<BackgroundTaskManager>,
+    session_manager: Arc<SessionManager>,
 }
 
 impl BashTool {
@@ -48,10 +51,12 @@ impl BashTool {
     pub fn new(
         permission_engine: Arc<PermissionEngine>,
         bg_manager: Arc<BackgroundTaskManager>,
+        session_manager: Arc<SessionManager>,
     ) -> Self {
         Self {
             permission_engine,
             bg_manager,
+            session_manager,
         }
     }
 }
@@ -134,7 +139,14 @@ impl Tool for BashTool {
     }
 
     async fn call(&self, args: Value, ctx: &ToolContext) -> Result<ToolResult, ToolCallError> {
-        execute_bash_call(&self.permission_engine, &self.bg_manager, args, ctx).await
+        execute_bash_call(
+            &self.permission_engine,
+            &self.session_manager,
+            &self.bg_manager,
+            args,
+            ctx,
+        )
+        .await
     }
 }
 
@@ -258,6 +270,7 @@ async fn handle_foreground_result(
 /// Execute the BashTool call: parse args, check permissions, run command.
 async fn execute_bash_call(
     perm: &PermissionEngine,
+    session_manager: &SessionManager,
     bg: &Arc<BackgroundTaskManager>,
     args: Value,
     ctx: &ToolContext,
@@ -301,7 +314,20 @@ async fn execute_bash_call(
     }
 
     // --- 3. Permission check ---
-    if let PermissionResponse::Denied { reason, .. } = perm.check(&ctx.agent_id, "exec") {
+    let extra_deny = if let Some(ref session_id) = ctx.session_id {
+        let subjects =
+            collect_chain_deny_subjects(session_manager, &perm.rules, session_id, &ctx.agent_id)
+                .await;
+        if subjects.is_empty() {
+            None
+        } else {
+            Some(subjects)
+        }
+    } else {
+        None
+    };
+    let deny_ref = extra_deny.as_deref();
+    if let PermissionResponse::Denied { reason, .. } = perm.check(&ctx.agent_id, "exec", deny_ref) {
         return Err(ToolCallError::PermissionDenied(reason));
     }
 

--- a/src/tools/builtin/bash_tests.rs
+++ b/src/tools/builtin/bash_tests.rs
@@ -20,6 +20,26 @@ fn test_bg_manager() -> Arc<BackgroundTaskManager> {
     Arc::new(BackgroundTaskManager::new())
 }
 
+fn test_session_manager() -> Arc<SessionManager> {
+    use crate::gateway::GatewayConfig;
+    use crate::gateway::SessionManager;
+    use crate::session::bootstrap::BootstrapMode;
+    use crate::session::persistence::ReasoningLevel;
+    Arc::new(SessionManager::new(
+        &GatewayConfig {
+            name: "test".to_string(),
+            rate_limit_per_minute: 100,
+            max_message_size: 1024,
+            dm_scope: crate::gateway::DmScope::default(),
+            ..Default::default()
+        },
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
 fn test_tool_context() -> ToolContext {
     ToolContext {
         agent_id: "test-agent".to_string(),
@@ -135,14 +155,22 @@ fn test_resolve_cwd_with_cwd_arg() {
 
 #[test]
 fn test_bash_tool_name_and_group() {
-    let tool = BashTool::new(test_permission_engine(), test_bg_manager());
+    let tool = BashTool::new(
+        test_permission_engine(),
+        test_bg_manager(),
+        test_session_manager(),
+    );
     assert_eq!(tool.name(), "Bash");
     assert_eq!(tool.group(), "bash");
 }
 
 #[test]
 fn test_bash_tool_flags() {
-    let tool = BashTool::new(test_permission_engine(), test_bg_manager());
+    let tool = BashTool::new(
+        test_permission_engine(),
+        test_bg_manager(),
+        test_session_manager(),
+    );
     let flags = tool.flags();
     assert!(flags.is_destructive);
     assert!(flags.is_expensive);
@@ -152,7 +180,11 @@ fn test_bash_tool_flags() {
 
 #[test]
 fn test_input_schema_command_required() {
-    let tool = BashTool::new(test_permission_engine(), test_bg_manager());
+    let tool = BashTool::new(
+        test_permission_engine(),
+        test_bg_manager(),
+        test_session_manager(),
+    );
     let schema = tool.input_schema();
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&json!("command")));
@@ -160,7 +192,11 @@ fn test_input_schema_command_required() {
 
 #[test]
 fn test_input_schema_six_properties() {
-    let tool = BashTool::new(test_permission_engine(), test_bg_manager());
+    let tool = BashTool::new(
+        test_permission_engine(),
+        test_bg_manager(),
+        test_session_manager(),
+    );
     let schema = tool.input_schema();
     let props = schema["properties"].as_object().unwrap();
     assert_eq!(props.len(), 6);

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -109,7 +109,11 @@ pub async fn register_builtin_tools(
     // bash
     let bg_manager = Arc::new(crate::tasks::BackgroundTaskManager::new());
     registry
-        .register(BashTool::new(context.permission_engine.clone(), bg_manager))
+        .register(BashTool::new(
+            context.permission_engine.clone(),
+            bg_manager,
+            context.session_manager.clone(),
+        ))
         .await
         .ok();
     // skills

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -85,7 +85,8 @@ async fn test_child_all_deny_spawn_returns_permission_denied() {
     let child = make_all_deny("child-all-deny");
     let parent = make_all_allow("parent-agent");
 
-    let result = engine.validate_and_inject_spawn("child-all-deny", &child, &parent, None, None);
+    let result =
+        engine.validate_and_inject_spawn("child-all-deny", &child, &parent, None, None, None);
 
     match result {
         Err(SpawnPermissionError::FullyDenied {
@@ -112,7 +113,8 @@ async fn test_child_partial_deny_spawn_success() {
     let child = make_partial_deny("child-partial", &["exec", "file_write"]);
     let parent = make_all_allow("parent-agent");
 
-    let result = engine.validate_and_inject_spawn("child-partial", &child, &parent, None, None);
+    let result =
+        engine.validate_and_inject_spawn("child-partial", &child, &parent, None, None, None);
     assert!(
         result.is_ok(),
         "spawn should succeed for partial-deny child"
@@ -158,7 +160,7 @@ fn test_multi_generation_spawn_chain() {
 
     // Spawn child under root.
     engine
-        .validate_and_inject_spawn("child-agent", &child, &root, None, None)
+        .validate_and_inject_spawn("child-agent", &child, &root, None, None, None)
         .expect("spawn of child under root should succeed");
 
     // Compute child's effective permissions (no cache — compute manually)
@@ -185,6 +187,7 @@ fn test_multi_generation_spawn_chain() {
             "grandchild-agent",
             &grandchild,
             &child_effective,
+            None,
             None,
             None,
         )
@@ -329,7 +332,7 @@ fn test_recursive_permission_intersection_three_layers() {
 
     // Spawn child under root: effective = child ∩ root.
     engine
-        .validate_and_inject_spawn("child-agent", &child, &root, None, None)
+        .validate_and_inject_spawn("child-agent", &child, &root, None, None, None)
         .expect("spawn of child-agent should succeed");
 
     let child_effective = child.intersect(&root);
@@ -378,6 +381,7 @@ fn test_recursive_permission_intersection_three_layers() {
             "grandchild-agent",
             &grandchild,
             &child_effective,
+            None,
             None,
             None,
         )

--- a/src/tools/builtin/sessions_spawn_permission_tests.rs
+++ b/src/tools/builtin/sessions_spawn_permission_tests.rs
@@ -2,11 +2,10 @@
 //!
 //! Covers:
 //! 1. Child agent all-deny → spawn returns PermissionDenied
-//! 2. Child agent partial deny → spawn succeeds, effective permissions cached
-//! 3. Parent effective permissions from cache hit (spawn chain simulation)
+//! 2. Child agent partial deny → spawn succeeds
+//! 3. Parent effective permissions (no cache — config_manager provides base perms)
 //! 4. SpawnError::PermissionDenied includes agent_id and reason
-//! 5. Runtime permission enforcement via check_agent_effective_permissions
-//! 6. Multi-generation spawn chain (depth=2)
+//! 5. Multi-generation spawn chain (depth=2)
 
 use std::collections::HashMap;
 
@@ -17,7 +16,6 @@ use crate::gateway::session_manager::SessionManager;
 use crate::gateway::{DmScope, GatewayConfig, Session};
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_spawn::SpawnPermissionError;
-use crate::permission::engine::engine_types::PermissionRequestBody;
 use crate::permission::rules::RuleSetBuilder;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
@@ -81,19 +79,12 @@ fn make_all_allow(agent_id: &str) -> AgentPermissions {
 // ===========================================================================
 
 /// Test 1: Child agent all seven dimensions denied → spawn returns PermissionDenied.
-///
-/// When the intersection of child and parent permissions is fully denied,
-/// `validate_and_inject_spawn` returns `Err(SpawnPermissionError::FullyDenied)`,
-/// and `sessions_spawn` surfaces this as `ToolCallError::ExecutionFailed` with
-/// "permission denied" in the message.
 #[tokio::test]
 async fn test_child_all_deny_spawn_returns_permission_denied() {
     let engine = make_permission_engine();
     let child = make_all_deny("child-all-deny");
     let parent = make_all_allow("parent-agent");
 
-    // Simulate the permission validation that sessions_spawn performs.
-    // Child all-deny × parent all-allow = fully denied.
     let result = engine.validate_and_inject_spawn("child-all-deny", &child, &parent, None, None);
 
     match result {
@@ -112,160 +103,23 @@ async fn test_child_all_deny_spawn_returns_permission_denied() {
             other
         ),
     }
-
-    // Verify the cache does NOT contain the child (was rejected).
-    assert!(
-        engine
-            .get_agent_effective_permissions("child-all-deny")
-            .is_none(),
-        "all-deny child should not be cached after rejection"
-    );
 }
 
-/// Test 2: Child agent partial deny → spawn succeeds, effective permissions
-/// injected into cache.
-///
-/// Child denies exec + file_write, allows the rest. Parent is all-allow.
-/// After successful spawn, the permission cache should contain the child
-/// with exec=deny, file_write=deny, file_read=allow.
+/// Test 2: Child agent partial deny → spawn succeeds.
 #[tokio::test]
-async fn test_child_partial_deny_spawn_success_injects_cache() {
+async fn test_child_partial_deny_spawn_success() {
     let engine = make_permission_engine();
     let child = make_partial_deny("child-partial", &["exec", "file_write"]);
     let parent = make_all_allow("parent-agent");
 
-    // Spawn should succeed (child is not fully denied).
     let result = engine.validate_and_inject_spawn("child-partial", &child, &parent, None, None);
     assert!(
         result.is_ok(),
         "spawn should succeed for partial-deny child"
     );
-
-    // Verify the cache contains the child.
-    let cached = engine
-        .get_agent_effective_permissions("child-partial")
-        .expect("child should be in cache after successful spawn");
-
-    // Verify exec = deny.
-    let exec_perm = cached
-        .permissions
-        .get("exec")
-        .expect("exec dimension should exist");
-    assert!(
-        !exec_perm.allowed,
-        "exec should be denied in cached effective permissions"
-    );
-
-    // Verify file_write = deny.
-    let fw_perm = cached
-        .permissions
-        .get("file_write")
-        .expect("file_write dimension should exist");
-    assert!(
-        !fw_perm.allowed,
-        "file_write should be denied in cached effective permissions"
-    );
-
-    // Verify file_read = allow.
-    let fr_perm = cached
-        .permissions
-        .get("file_read")
-        .expect("file_read dimension should exist");
-    assert!(
-        fr_perm.allowed,
-        "file_read should be allowed in cached effective permissions"
-    );
-
-    // Verify other allowed dimensions.
-    for dim in &["network", "spawn", "tool_call", "config_write"] {
-        let perm = cached
-            .permissions
-            .get(*dim)
-            .unwrap_or_else(|| panic!("{dim} dimension should exist"));
-        assert!(
-            perm.allowed,
-            "{dim} should be allowed in cached effective permissions"
-        );
-    }
 }
 
-/// Test 3: Parent effective permissions from cache hit (spawn chain simulation).
-///
-/// First spawn child A (injects A's effective permissions into cache).
-/// Then use A's effective permissions as parent to spawn grandchild B.
-/// Verify B's cached permissions = B original ∩ A effective.
-#[tokio::test]
-async fn test_parent_effective_permissions_from_cache() {
-    let engine = make_permission_engine();
-
-    // Parent: all-allow.
-    let grandparent = make_all_allow("grandparent");
-
-    // Child A: deny exec, allow rest.
-    let child_a = make_partial_deny("child-a", &["exec"]);
-
-    // Spawn A under grandparent.
-    engine
-        .validate_and_inject_spawn("child-a", &child_a, &grandparent, None, None)
-        .expect("spawn of child-a should succeed");
-
-    // Verify A's effective permissions are in cache.
-    let a_effective = engine
-        .get_agent_effective_permissions("child-a")
-        .expect("child-a should be in cache");
-    assert!(
-        !a_effective.permissions.get("exec").unwrap().allowed,
-        "child-a effective should have exec=deny"
-    );
-
-    // Grandchild B: deny file_write, allow rest.
-    let child_b = make_partial_deny("child-b", &["file_write"]);
-
-    // Spawn B under A (using A's effective permissions as parent).
-    engine
-        .validate_and_inject_spawn("child-b", &child_b, &a_effective, None, None)
-        .expect("spawn of child-b under child-a should succeed");
-
-    // Verify B's cached effective permissions.
-    let b_effective = engine
-        .get_agent_effective_permissions("child-b")
-        .expect("child-b should be in cache");
-
-    // B original ∩ A effective: exec=deny (from A), file_write=deny (from B),
-    // all others=allow.
-    assert!(
-        !b_effective.permissions.get("exec").unwrap().allowed,
-        "child-b effective should have exec=deny (inherited from child-a)"
-    );
-    assert!(
-        !b_effective.permissions.get("file_write").unwrap().allowed,
-        "child-b effective should have file_write=deny (own restriction)"
-    );
-    assert!(
-        b_effective.permissions.get("file_read").unwrap().allowed,
-        "child-b effective should have file_read=allow"
-    );
-    assert!(
-        b_effective.permissions.get("network").unwrap().allowed,
-        "child-b effective should have network=allow"
-    );
-    assert!(
-        b_effective.permissions.get("spawn").unwrap().allowed,
-        "child-b effective should have spawn=allow"
-    );
-    assert!(
-        b_effective.permissions.get("tool_call").unwrap().allowed,
-        "child-b effective should have tool_call=allow"
-    );
-    assert!(
-        b_effective.permissions.get("config_write").unwrap().allowed,
-        "child-b effective should have config_write=allow"
-    );
-}
-
-/// Test 4: SpawnError::PermissionDenied includes agent_id and reason.
-///
-/// Verify the error message format contains the denied agent_id.
+/// Test 3: SpawnError::PermissionDenied includes agent_id and reason.
 #[test]
 fn test_spawn_error_permission_denied_includes_agent_id() {
     let err = SpawnPermissionError::FullyDenied {
@@ -291,77 +145,9 @@ fn test_spawn_error_permission_denied_includes_agent_id() {
     );
 }
 
-/// Test 5: Runtime permission enforcement via check_agent_effective_permissions.
-///
-/// After spawning a child with exec=deny and file_read=allow:
-/// - Exec dimension check → Denied response
-/// - file_read dimension check → None (allowed, continue normal evaluate)
-#[tokio::test]
-async fn test_runtime_permission_enforcement() {
-    let engine = make_permission_engine();
-    let child = make_partial_deny("child-rt", &["exec"]);
-    let parent = make_all_allow("parent-agent");
-
-    // Spawn child (injects into cache).
-    engine
-        .validate_and_inject_spawn("child-rt", &child, &parent, None, None)
-        .expect("spawn should succeed");
-
-    // Simulate an exec operation for child-rt.
-    let exec_body = PermissionRequestBody::CommandExec {
-        agent: "child-rt".to_string(),
-        cmd: "ls".to_string(),
-        args: vec![],
-    };
-    let result = engine.check_agent_effective_permissions("child-rt", &exec_body);
-    assert!(
-        result.is_some(),
-        "exec dimension should be denied for child-rt"
-    );
-    match result.unwrap() {
-        crate::permission::engine::engine_types::PermissionResponse::Denied { reason, .. } => {
-            assert!(
-                reason.contains("exec"),
-                "denied reason should mention exec dimension, got: {}",
-                reason
-            );
-        }
-        other => panic!("expected Denied response, got: {:?}", other),
-    }
-
-    // Simulate a file_read operation for child-rt.
-    let tmp = TempDir::new().unwrap();
-    let read_body = PermissionRequestBody::FileOp {
-        agent: "child-rt".to_string(),
-        path: tmp.path().join("test.txt").to_string_lossy().to_string(),
-        op: "read".to_string(),
-    };
-    let result = engine.check_agent_effective_permissions("child-rt", &read_body);
-    assert!(
-        result.is_none(),
-        "file_read dimension should be allowed (None = continue) for child-rt"
-    );
-
-    // Simulate a network operation for child-rt (allowed dimension).
-    let net_body = PermissionRequestBody::NetOp {
-        agent: "child-rt".to_string(),
-        host: "example.com".to_string(),
-        port: 443,
-    };
-    let result = engine.check_agent_effective_permissions("child-rt", &net_body);
-    assert!(
-        result.is_none(),
-        "network dimension should be allowed for child-rt"
-    );
-}
-
-/// Test 6: Multi-generation spawn chain (depth=2).
-///
-/// Root agent disables exec. Child spawns successfully (effective: exec=deny).
-/// Grandchild spawns successfully, inherits exec=deny.
-/// Verify grandchild's check_agent_effective_permissions returns Denied for exec.
-#[tokio::test]
-async fn test_multi_generation_spawn_chain() {
+/// Test 4: Multi-generation spawn chain (depth=2) — intersection logic.
+#[test]
+fn test_multi_generation_spawn_chain() {
     let engine = make_permission_engine();
 
     // Root agent: deny exec, allow rest.
@@ -375,13 +161,11 @@ async fn test_multi_generation_spawn_chain() {
         .validate_and_inject_spawn("child-agent", &child, &root, None, None)
         .expect("spawn of child under root should succeed");
 
-    // Verify child's effective permissions: exec=deny (inherited from root).
-    let child_effective = engine
-        .get_agent_effective_permissions("child-agent")
-        .expect("child-agent should be in cache");
+    // Compute child's effective permissions (no cache — compute manually)
+    let child_effective = child.intersect(&root);
     assert!(
         !child_effective.permissions.get("exec").unwrap().allowed,
-        "child-agent effective should have exec=deny (inherited from root)"
+        "child effective should have exec=deny (inherited from root)"
     );
     assert!(
         child_effective
@@ -389,7 +173,7 @@ async fn test_multi_generation_spawn_chain() {
             .get("file_read")
             .unwrap()
             .allowed,
-        "child-agent effective should have file_read=allow"
+        "child effective should have file_read=allow"
     );
 
     // Grandchild agent: all-allow (inherits from child's effective).
@@ -406,17 +190,15 @@ async fn test_multi_generation_spawn_chain() {
         )
         .expect("spawn of grandchild under child should succeed");
 
-    // Verify grandchild's effective permissions: exec=deny (inherited chain).
-    let grandchild_effective = engine
-        .get_agent_effective_permissions("grandchild-agent")
-        .expect("grandchild-agent should be in cache");
+    // Compute grandchild's effective permissions
+    let grandchild_effective = grandchild.intersect(&child_effective);
     assert!(
         !grandchild_effective
             .permissions
             .get("exec")
             .unwrap()
             .allowed,
-        "grandchild-agent effective should have exec=deny (inherited chain root→child)"
+        "grandchild effective should have exec=deny (inherited chain root→child)"
     );
     assert!(
         grandchild_effective
@@ -424,49 +206,7 @@ async fn test_multi_generation_spawn_chain() {
             .get("file_read")
             .unwrap()
             .allowed,
-        "grandchild-agent effective should have file_read=allow"
-    );
-
-    // Verify runtime enforcement on grandchild.
-    let tmp = TempDir::new().unwrap();
-    let exec_body = PermissionRequestBody::CommandExec {
-        agent: "grandchild-agent".to_string(),
-        cmd: "rm".to_string(),
-        args: vec![
-            "-rf".to_string(),
-            tmp.path().join("test").to_string_lossy().to_string(),
-        ],
-    };
-    let result = engine.check_agent_effective_permissions("grandchild-agent", &exec_body);
-    assert!(
-        result.is_some(),
-        "exec should be denied at runtime for grandchild-agent"
-    );
-    match result.unwrap() {
-        crate::permission::engine::engine_types::PermissionResponse::Denied { reason, .. } => {
-            assert!(
-                reason.contains("exec"),
-                "denied reason should mention exec dimension, got: {}",
-                reason
-            );
-        }
-        other => panic!(
-            "expected Denied response for grandchild exec, got: {:?}",
-            other
-        ),
-    }
-
-    // Verify file_read is still allowed at runtime for grandchild.
-    let tmp2 = TempDir::new().unwrap();
-    let read_body = PermissionRequestBody::FileOp {
-        agent: "grandchild-agent".to_string(),
-        path: tmp2.path().join("data.txt").to_string_lossy().to_string(),
-        op: "read".to_string(),
-    };
-    let result = engine.check_agent_effective_permissions("grandchild-agent", &read_body);
-    assert!(
-        result.is_none(),
-        "file_read should be allowed at runtime for grandchild-agent"
+        "grandchild effective should have file_read=allow"
     );
 }
 
@@ -475,7 +215,6 @@ async fn test_multi_generation_spawn_chain() {
 async fn test_external_permissions_used() {
     let tmp = TempDir::new().unwrap();
 
-    // Create ConfigManager with external exec-deny permissions.
     let cm = Arc::new(
         ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed"),
     );
@@ -502,7 +241,6 @@ async fn test_external_permissions_used() {
         source: crate::config::agents::ConfigSource::Merged,
     };
 
-    // Build SessionManager with a parent session.
     let gw_config = GatewayConfig {
         name: "test".to_string(),
         rate_limit_per_minute: 100,
@@ -534,13 +272,6 @@ async fn test_external_permissions_used() {
     let pe = Arc::new(make_permission_engine());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone(), pe.clone()));
 
-    // Insert parent effective permissions into the engine cache.
-    let parent_perms = make_all_allow("parent-agent-2");
-    {
-        let mut cache = pe.agent_permissions.write().unwrap();
-        cache.insert("parent-agent-2".to_string(), parent_perms);
-    }
-
     // Inject both parent and child agents into ConfigManager so
     // SpawnController::validate() can resolve configs and pass all checks.
     {
@@ -570,7 +301,6 @@ async fn test_external_permissions_used() {
         agents.insert("fallback-agent".to_string(), config.clone());
     }
 
-    // Call SpawnController::validate() — should use external permissions (exec-deny).
     let result = controller
         .validate("parent-sess-2", Some("fallback-agent"))
         .await;
@@ -579,38 +309,14 @@ async fn test_external_permissions_used() {
         "validate should succeed with external permissions, got: {:?}",
         result
     );
-
-    // Verify the cached permissions match the external exec-deny config.
-    let cached = pe
-        .get_agent_effective_permissions("fallback-agent")
-        .expect("agent should be cached after successful validate");
-    assert!(
-        !cached.permissions.get("exec").unwrap().allowed,
-        "exec should be denied from external permissions"
-    );
-    assert!(
-        cached.permissions.get("file_read").unwrap().allowed,
-        "file_read should be allowed from external permissions"
-    );
 }
 
 // ===========================================================================
-// Multi-layer recursive permission intersection (Step 1.4)
+// Multi-layer recursive permission intersection
 // ===========================================================================
 
 /// Test: Three-layer spawn chain where each level introduces different
-/// permission restrictions. Verify the grandchild's effective permissions
-/// are the intersection of all restrictions along the full chain.
-///
-/// Chain:
-///   depth=0 (root-agent):  deny exec, deny file_write
-///   depth=1 (child-agent): deny network, deny file_read
-///   depth=2 (grandchild):  deny spawn
-///
-/// Expected grandchild effective:
-///   exec=deny (root), file_read=deny (child), file_write=deny (root),
-///   network=deny (child), spawn=deny (grandchild),
-///   tool_call=allow, config_write=allow
+/// permission restrictions.
 #[test]
 fn test_recursive_permission_intersection_three_layers() {
     let engine = make_permission_engine();
@@ -626,9 +332,7 @@ fn test_recursive_permission_intersection_three_layers() {
         .validate_and_inject_spawn("child-agent", &child, &root, None, None)
         .expect("spawn of child-agent should succeed");
 
-    let child_effective = engine
-        .get_agent_effective_permissions("child-agent")
-        .expect("child-agent should be in cache");
+    let child_effective = child.intersect(&root);
 
     // Child effective: exec=deny (root), file_read=deny (child),
     // file_write=deny (root), network=deny (child),
@@ -679,9 +383,7 @@ fn test_recursive_permission_intersection_three_layers() {
         )
         .expect("spawn of grandchild-agent should succeed");
 
-    let gc_effective = engine
-        .get_agent_effective_permissions("grandchild-agent")
-        .expect("grandchild-agent should be in cache");
+    let gc_effective = grandchild.intersect(&child_effective);
 
     // Grandchild effective: all denied dims from every level accumulate.
     assert!(
@@ -716,24 +418,14 @@ fn test_recursive_permission_intersection_three_layers() {
             .allowed,
         "config_write should be allowed (no restriction in chain)"
     );
-
-    // Verify inherited_from chain is correct.
-    assert_eq!(gc_effective.inherited_from, Some("child-agent".to_string()));
-    assert_eq!(
-        child_effective.inherited_from,
-        Some("root-agent".to_string())
-    );
 }
 
 // ===========================================================================
-// FullyDenied silent return through SessionsSpawnTool (Step 1.4)
+// FullyDenied silent return through SessionsSpawnTool
 // ===========================================================================
 
-/// Test: When a child agent is fully denied, `validate_spawn_permissions`
-/// returns `ToolCallError::PermissionDenied("spawn")`.
-/// The child session is NOT created — the error short-circuits the spawn
-/// pipeline before `create_child` is reached.
-/// The error message is generic and does not expose internal agent_id details.
+/// Test: When a child agent is fully denied, validate_spawn_permissions
+/// returns SpawnError::PermissionDenied.
 #[tokio::test]
 async fn test_fully_denied_silent_return_no_session_created() {
     let tmp = TempDir::new().unwrap();
@@ -741,11 +433,14 @@ async fn test_fully_denied_silent_return_no_session_created() {
     let cm = Arc::new(
         ConfigManager::new(tmp.path().to_path_buf()).expect("ConfigManager::new should succeed"),
     );
-    // External permissions: child has all-deny.
     cm.agent_permissions
         .write()
         .unwrap()
         .insert("denied-child".to_string(), make_all_deny("denied-child"));
+    cm.agent_permissions.write().unwrap().insert(
+        "parent-agent-deny".to_string(),
+        make_all_allow("parent-agent-deny"),
+    );
 
     let config = crate::config::agents::ResolvedAgentConfig {
         id: "denied-child".to_string(),
@@ -793,15 +488,7 @@ async fn test_fully_denied_silent_return_no_session_created() {
     let pe = Arc::new(make_permission_engine());
     let controller = Arc::new(SpawnController::new(cm.clone(), sm.clone(), pe.clone()));
 
-    // Parent has all-allow effective permissions in cache.
-    let parent_perms = make_all_allow("parent-agent-deny");
-    {
-        let mut cache = pe.agent_permissions.write().unwrap();
-        cache.insert("parent-agent-deny".to_string(), parent_perms);
-    }
-
-    // Inject both parent and child agents into ConfigManager so
-    // SpawnController::validate() can resolve configs and pass all checks.
+    // Inject both parent and child agents into ConfigManager.
     {
         let mut agents = cm.agents.write().unwrap();
         agents.insert(
@@ -829,7 +516,6 @@ async fn test_fully_denied_silent_return_no_session_created() {
         agents.insert("denied-child".to_string(), config.clone());
     }
 
-    // SpawnController::validate() should fail with PermissionDenied.
     let result = controller
         .validate("parent-sess-deny", Some("denied-child"))
         .await;
@@ -849,10 +535,4 @@ async fn test_fully_denied_silent_return_no_session_created() {
         }
         other => panic!("expected PermissionDenied, got: {:?}", other),
     }
-
-    // Verify the child was NOT cached (spawn was rejected).
-    assert!(
-        pe.get_agent_effective_permissions("denied-child").is_none(),
-        "fully-denied child should NOT be in permission cache after rejection"
-    );
 }

--- a/src/tools/prompt_generation_tests.rs
+++ b/src/tools/prompt_generation_tests.rs
@@ -12,8 +12,12 @@
 
 use std::sync::Arc;
 
+use crate::gateway::GatewayConfig;
+use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::rules::RuleSetBuilder;
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
 use crate::system_prompt::WorkdirContext;
 use crate::tasks::BackgroundTaskManager;
 use crate::tools::builtin::BashTool;
@@ -32,8 +36,28 @@ fn test_bg_manager() -> Arc<BackgroundTaskManager> {
     Arc::new(BackgroundTaskManager::new())
 }
 
+fn test_session_manager() -> Arc<SessionManager> {
+    Arc::new(SessionManager::new(
+        &GatewayConfig {
+            name: "test".to_string(),
+            rate_limit_per_minute: 100,
+            max_message_size: 1024,
+            dm_scope: crate::gateway::DmScope::default(),
+            ..Default::default()
+        },
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ))
+}
+
 fn test_bash_tool() -> BashTool {
-    BashTool::new(test_permission_engine(), test_bg_manager())
+    BashTool::new(
+        test_permission_engine(),
+        test_bg_manager(),
+        test_session_manager(),
+    )
 }
 
 // --- generate_prompt: workdir-aware behavior ---

--- a/tests/sandbox_integration_test.rs
+++ b/tests/sandbox_integration_test.rs
@@ -176,6 +176,7 @@ async fn test_ipc_channel_protocol_evaluate_request_serde() {
                 args: vec![".".to_string()],
             },
         },
+        extra_deny_subjects: None,
     };
 
     let json = serde_json::to_vec(&request).unwrap();
@@ -183,7 +184,10 @@ async fn test_ipc_channel_protocol_evaluate_request_serde() {
 
     let parsed: SandboxRequest = serde_json::from_slice(&json).unwrap();
     match parsed {
-        SandboxRequest::Evaluate { request: _ } => {}
+        SandboxRequest::Evaluate {
+            request: _,
+            extra_deny_subjects: _,
+        } => {}
         other => panic!("expected Evaluate, got {:?}", other),
     }
 }
@@ -320,7 +324,7 @@ async fn test_sandbox_ping_after_spawn() {
             cmd: "echo".to_string(),
             args: vec![],
         });
-        let eval_result = sandbox.evaluate(dummy_request).await;
+        let eval_result = sandbox.evaluate(dummy_request, None).await;
         assert!(
             eval_result.is_ok(),
             "evaluate should succeed after spawn (sandbox is alive)"
@@ -364,7 +368,7 @@ async fn test_sandbox_evaluate_permission_request() {
             },
         };
 
-        let eval_result = sandbox.evaluate(request).await;
+        let eval_result = sandbox.evaluate(request, None).await;
         assert!(
             eval_result.is_ok(),
             "evaluate should succeed with permissive rules"
@@ -409,7 +413,7 @@ async fn test_sandbox_restart_after_shutdown() {
             cmd: "echo".to_string(),
             args: vec![],
         });
-        assert!(sandbox.evaluate(dummy).await.is_ok());
+        assert!(sandbox.evaluate(dummy, None).await.is_ok());
 
         sandbox.shutdown().await;
 
@@ -433,7 +437,7 @@ async fn test_sandbox_restart_after_shutdown() {
             args: vec![],
         });
         assert!(
-            sandbox.evaluate(dummy2).await.is_ok(),
+            sandbox.evaluate(dummy2, None).await.is_ok(),
             "evaluate should succeed after restart"
         );
 
@@ -455,7 +459,7 @@ async fn test_sandbox_cannot_operate_when_not_spawned() {
         cmd: "echo".to_string(),
         args: vec![],
     });
-    let eval_result = sandbox.evaluate(dummy_request).await;
+    let eval_result = sandbox.evaluate(dummy_request, None).await;
     assert!(eval_result.is_err(), "evaluate without spawn should fail");
 
     // _tmpdir auto-cleans on drop


### PR DESCRIPTION
## Summary

Align Permission Engine implementation with design doc `docs/design/agent/agent-permissions.md` (4 must_fix items from F2b deep diff).

### Changes

1. **Remove permission cache** (`PermissionEngine`): deleted `agent_permissions` / `user_effective_permissions` cache fields and pre-check methods; `evaluate()` now always performs full rule matching (compliance with "no cached evaluation results")

2. **Owner spawn skips User dimension**: when `user_id == "owner"`, `validate_permissions` no longer calls `evaluate_user_permissions` — child agent effective permissions are solely child ∩ parent, unaffected by User dimension

3. **Full-chain Deny propagation**: added `collect_chain_deny_subjects` that walks up the `parent_session_id` chain collecting all ancestors' AgentOnly Deny rules; ensures Deny constraints only grow (never shrink) along the spawn depth

4. **extra_deny passed to all `evaluate()` call sites**: all callers now receive deny subjects from the session chain, not just `discovery.rs`

5. **Unit tests** covering Owner spawn, cache removal, full-chain Deny propagation, and extra_deny in non-spawn paths

### Files

- `src/permission/engine/engine_eval.rs` — cache removal + evaluate adjustments
- `src/permission/engine/engine_spawn.rs` — `validate_and_inject_spawn` simplified (no cache write)
- `src/permission/engine/engine_helpers.rs` — new `collect_chain_deny_subjects`
- `src/permission/engine/engine_check.rs` — deny subjects passed to evaluate
- `src/agent/spawn.rs` — Owner skip logic + chain deny integration
- `src/tools/builtin/sessions_spawn.rs` — deny subjects at call site
- Test files: `engine_spawn_tests.rs`, `engine_tests.rs`, `sessions_spawn_permission_tests.rs`

Source: user
Type: fix
