### PR TITLE
fix: use chain effective permissions in spawn validation

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -5,6 +5,7 @@ use crate::config::ConfigManager;
 use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
+use crate::permission::engine::engine_helpers::collect_chain_effective_permissions;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -181,11 +182,13 @@ impl SpawnController {
             .cloned();
         let parent_agent_id = self.session_manager.get_chat_id(parent_session_id).await;
         if let (Some(child_perms), Some(parent_agent_id)) = (child_perms, parent_agent_id) {
-            let parent_perms = self
-                .config_manager
-                .agent_permissions()
-                .get(&parent_agent_id)
-                .cloned();
+            let parent_perms = collect_chain_effective_permissions(
+                &self.session_manager,
+                &self.config_manager.agent_permissions(),
+                parent_session_id,
+                &parent_agent_id,
+            )
+            .await;
             if let Some(parent_perms) = parent_perms {
                 let user_id = self.session_manager.get_sender_id(parent_session_id).await;
                 // Owner skips User dimension — design doc:

--- a/src/permission/engine/engine_helpers.rs
+++ b/src/permission/engine/engine_helpers.rs
@@ -1,6 +1,7 @@
 //! Permission Engine - Helper utilities.
 
 use super::engine_types::{Action, Effect, Subject};
+use crate::agent::config::AgentPermissions;
 use crate::gateway::SessionManager;
 use crate::permission::engine::engine_types::RuleSet;
 use std::collections::HashMap;
@@ -83,6 +84,46 @@ pub async fn collect_chain_deny_subjects(
     }
 
     all_subjects
+}
+
+/// Compute the effective permissions for a child agent by intersecting
+/// configured permissions of every ancestor in the spawn chain.
+///
+/// Traverses upward from the direct parent via `SessionManager::get_parent_of`.
+/// At each level the ancestor's configured permissions (from
+/// `agent_permissions`) are intersected with the accumulated result.
+/// Ancestors without configured permissions are skipped.
+///
+/// Returns `None` if the direct parent has no configured permissions
+/// (caller should treat as no restriction, matching prior behavior).
+pub async fn collect_chain_effective_permissions(
+    session_manager: &SessionManager,
+    agent_permissions: &HashMap<String, AgentPermissions>,
+    parent_session_id: &str,
+    parent_agent_id: &str,
+) -> Option<AgentPermissions> {
+    let mut result = agent_permissions.get(parent_agent_id)?.clone();
+    let mut current_session = parent_session_id.to_string();
+
+    loop {
+        let ancestor_session = match session_manager.get_parent_of(&current_session).await {
+            Some(id) => id,
+            None => break,
+        };
+
+        let ancestor_agent_id = match session_manager.get_chat_id(&ancestor_session).await {
+            Some(id) => id,
+            None => break,
+        };
+
+        if let Some(ancestor_perms) = agent_permissions.get(&ancestor_agent_id) {
+            result = result.intersect(ancestor_perms);
+        }
+
+        current_session = ancestor_session;
+    }
+
+    Some(result)
 }
 
 /// Resolve template actions with overrides applied.

--- a/src/permission/engine/engine_spawn_tests.rs
+++ b/src/permission/engine/engine_spawn_tests.rs
@@ -1,12 +1,16 @@
 use super::engine_eval::PermissionEngine;
+use super::engine_helpers::collect_chain_effective_permissions;
 use super::engine_spawn::SpawnPermissionError;
 use super::engine_types::{
     Effect, MatchType, PermissionRequest, PermissionRequestBody, PermissionResponse, Subject,
 };
-use crate::agent::config::AgentPermissions;
+use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits};
+use crate::gateway::session_manager::{ChildSessionInfo, SpawnMode};
+use crate::gateway::{DmScope, GatewayConfig, Session, SessionManager};
 use crate::permission::actions::ActionBuilder;
 use crate::permission::rules::RuleBuilder;
 use crate::permission::rules::RuleSetBuilder;
+use crate::session::bootstrap::BootstrapMode;
 use std::collections::HashMap;
 
 fn make_engine() -> PermissionEngine {
@@ -320,6 +324,217 @@ fn test_owner_spawn_extra_deny_still_blocks() {
         }
         other => panic!("expected FullyDenied, got {:?}", other),
     }
+}
+
+// -------------------------------------------------------------------------
+// collect_chain_effective_permissions tests
+// -------------------------------------------------------------------------
+
+fn make_gw_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 65536,
+        dm_scope: DmScope::PerAccountChannelPeer,
+        ..Default::default()
+    }
+}
+
+async fn make_session_manager() -> SessionManager {
+    SessionManager::new(
+        &make_gw_config(),
+        None,
+        None,
+        BootstrapMode::Full,
+        crate::session::persistence::ReasoningLevel::default(),
+    )
+}
+
+async fn register_session(mgr: &SessionManager, session_id: &str, agent_id: &str, depth: u32) {
+    mgr.sessions.write().await.insert(
+        session_id.to_string(),
+        Session {
+            id: session_id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth,
+        },
+    );
+}
+
+async fn register_parent_child(
+    mgr: &SessionManager,
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_agent_id: &str,
+    child_depth: u32,
+) {
+    mgr.register_child(
+        parent_session_id,
+        ChildSessionInfo {
+            session_id: child_session_id.to_string(),
+            parent_session_id: parent_session_id.to_string(),
+            agent_id: child_agent_id.to_string(),
+            depth: child_depth,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+}
+
+fn make_perms(agent_id: &str, dims: &[(&str, bool)]) -> AgentPermissions {
+    let permissions = dims
+        .iter()
+        .map(|&(dim, allowed)| {
+            (
+                dim.to_string(),
+                ActionPermission {
+                    allowed,
+                    limits: PermissionLimits::default(),
+                },
+            )
+        })
+        .collect();
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions,
+        inherited_from: None,
+    }
+}
+
+/// Three-level chain: Root -> A -> B.
+/// Root: {exec: allow, file_write: allow, network: deny}
+/// A:    {exec: allow, file_write: deny}
+/// B:    {exec: allow}
+/// B's effective perms should include network: deny (from Root via A)
+/// and file_write: deny (from A).
+#[tokio::test]
+async fn test_three_level_chain_effective_permissions() {
+    let mgr = make_session_manager().await;
+
+    register_session(&mgr, "session-root", "root", 0).await;
+    register_session(&mgr, "session-a", "agent-a", 1).await;
+    register_parent_child(&mgr, "session-root", "session-a", "agent-a", 1).await;
+    register_session(&mgr, "session-b", "agent-b", 2).await;
+    register_parent_child(&mgr, "session-a", "session-b", "agent-b", 2).await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "root".to_string(),
+        make_perms(
+            "root",
+            &[("exec", true), ("file_write", true), ("network", false)],
+        ),
+    );
+    perms.insert(
+        "agent-a".to_string(),
+        make_perms("agent-a", &[("exec", true), ("file_write", false)]),
+    );
+    perms.insert(
+        "agent-b".to_string(),
+        make_perms("agent-b", &[("exec", true)]),
+    );
+
+    let result = collect_chain_effective_permissions(&mgr, &perms, "session-a", "agent-a").await;
+    assert!(result.is_some(), "should return Some for parent with perms");
+    let effective = result.unwrap();
+
+    // Root intersects with A: exec=T∩T→T, file_write=T∩F→F,
+    // network=F∩absent→F
+    assert!(
+        effective.permissions["exec"].allowed,
+        "exec should be allowed"
+    );
+    assert!(
+        !effective.permissions["file_write"].allowed,
+        "file_write should be denied"
+    );
+    assert!(
+        !effective.permissions["network"].allowed,
+        "network denied from Root"
+    );
+}
+
+/// Single-level spawn: parent has no extra restrictions.
+#[tokio::test]
+async fn test_single_level_spawn_no_extra_restrictions() {
+    let mgr = make_session_manager().await;
+
+    register_session(&mgr, "session-parent", "parent", 0).await;
+    register_session(&mgr, "session-child", "child", 1).await;
+    register_parent_child(&mgr, "session-parent", "session-child", "child", 1).await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms(
+            "parent",
+            &[
+                ("exec", true),
+                ("file_read", true),
+                ("file_write", true),
+                ("network", true),
+                ("spawn", true),
+                ("tool_call", true),
+                ("config_write", true),
+            ],
+        ),
+    );
+
+    let result =
+        collect_chain_effective_permissions(&mgr, &perms, "session-parent", "parent").await;
+    assert!(result.is_some());
+    let effective = result.unwrap();
+
+    // No ancestors above parent -> parent's own perms returned
+    for dim in &[
+        "exec",
+        "file_read",
+        "file_write",
+        "network",
+        "spawn",
+        "tool_call",
+    ] {
+        assert!(
+            effective.permissions[*dim].allowed,
+            "{} should be allowed",
+            dim
+        );
+    }
+}
+
+/// Chain with a fully denied level: Root -> A (fully denied) -> B.
+/// A denies everything, so effective perms are fully denied.
+#[tokio::test]
+async fn test_chain_with_fully_denied_level() {
+    let mgr = make_session_manager().await;
+
+    register_session(&mgr, "session-root", "root", 0).await;
+    register_session(&mgr, "session-a", "agent-a", 1).await;
+    register_parent_child(&mgr, "session-root", "session-a", "agent-a", 1).await;
+    register_session(&mgr, "session-b", "agent-b", 2).await;
+    register_parent_child(&mgr, "session-a", "session-b", "agent-b", 2).await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "root".to_string(),
+        make_perms(
+            "root",
+            &[("exec", true), ("file_write", true), ("network", true)],
+        ),
+    );
+    // A is fully denied
+    perms.insert("agent-a".to_string(), make_fully_denied_perms("agent-a"));
+
+    let result = collect_chain_effective_permissions(&mgr, &perms, "session-a", "agent-a").await;
+    assert!(result.is_some());
+    let effective = result.unwrap();
+
+    assert!(
+        effective.is_fully_denied(),
+        "A is fully denied, so effective should be fully denied"
+    );
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Fix spawn chain effective permissions inheritance

Previously, `validate_permissions()` in `spawn.rs` used only the direct
parent agent's configured permissions when validating spawn requests.
This meant that in multi-level spawn chains (e.g., Root→A→B), the
grandfather agent's permission restrictions were not inherited by
grandchild agents.

Add `collect_chain_effective_permissions()` that traverses upward
through the spawn chain via `SessionManager::get_parent_of`,
intersecting each ancestor's configured permissions. Replace the
direct parent config lookup in `validate_permissions()` with this
chain-aware computation.

Includes unit tests for three-level chains, single-level spawns,
and fully-denied ancestor scenarios.

Source: user
Type: fix
