### PR TITLE
feat: 一般操作增加 spawn 链路维度级交集计算

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -294,6 +294,7 @@ impl Daemon {
         gateway: &Arc<Gateway>,
         session_manager: &Arc<SessionManager>,
         permission_engine: &Arc<PermissionEngine>,
+        config_manager: &Arc<crate::config::ConfigManager>,
     ) -> Arc<tokio::sync::Mutex<ApprovalFlow>> {
         let approval_flow = Arc::new(tokio::sync::Mutex::new(ApprovalFlow::new(
             Arc::clone(session_manager),
@@ -305,6 +306,7 @@ impl Daemon {
             Arc::clone(permission_engine),
             Arc::clone(&approval_flow),
             Some(Arc::clone(session_manager)),
+            config_manager.agent_permissions(),
         );
         approval_flow
     }
@@ -431,8 +433,13 @@ impl Daemon {
             .set_shutdown_handle(Arc::clone(&shutdown))
             .await;
 
-        let approval_flow =
-            Self::init_phase_4_wiring(&gateway, &session_manager, &permission_engine).await;
+        let approval_flow = Self::init_phase_4_wiring(
+            &gateway,
+            &session_manager,
+            &permission_engine,
+            &config_manager,
+        )
+        .await;
         let (sweeper_tx, dreaming_tx, config_watcher) = Self::init_phase_5_background(
             &config_manager,
             &agent_registry,

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -125,6 +125,11 @@ impl SessionManager {
         *self.config_manager.write().await = Some(config_manager);
     }
 
+    /// Get the config manager reference (if set).
+    pub async fn get_config_manager(&self) -> Option<Arc<ConfigManager>> {
+        self.config_manager.read().await.clone()
+    }
+
     /// Set the agent registry for resolved config lookups.
     pub async fn set_agent_registry(
         &self,

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use crate::llm::session::ChatSession;
 use crate::permission::engine::engine_eval::PermissionEngine;
-use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
 use crate::permission::engine::engine_types::{
     Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
 };
@@ -123,17 +122,10 @@ impl Gateway {
             .await
             .unwrap_or_default();
 
-        // Collect full-chain deny subjects from all ancestors.
-        let extra_deny = {
-            let rules = engine.rules.clone();
-            let subjects =
-                collect_chain_deny_subjects(&self.session_manager, &rules, session_id, &agent_id)
-                    .await;
-            if subjects.is_empty() {
-                None
-            } else {
-                Some(subjects)
-            }
+        // Build agent_permissions map from config_manager for chain intersection.
+        let agent_permissions = match self.session_manager.get_config_manager().await {
+            Some(cm) => cm.agent_permissions(),
+            None => std::collections::HashMap::new(),
         };
 
         let caller = Caller {
@@ -149,7 +141,17 @@ impl Gateway {
             },
         };
 
-        if let PermissionResponse::Denied { reason, .. } = engine.evaluate(request, extra_deny) {
+        // Chain-aware permission check: dimension-level intersection
+        // with the parent agent chain.
+        let response = engine
+            .evaluate_with_chain(
+                request,
+                &self.session_manager,
+                session_id,
+                &agent_permissions,
+            )
+            .await;
+        if let PermissionResponse::Denied { reason, .. } = response {
             self.send_reply_if_available(&format!("无权限：{reason}"))
                 .await;
             return false;

--- a/src/permission/engine/engine_chain.rs
+++ b/src/permission/engine/engine_chain.rs
@@ -1,0 +1,124 @@
+//! Permission Engine - Chain-aware evaluation for general operations.
+//!
+//! Adds dimension-level intersection with the parent agent chain,
+//! closing the gap between spawn-time validation and general-operation
+//! permission checks.
+
+use super::engine_eval::PermissionEngine;
+use super::engine_helpers::{collect_chain_deny_subjects, collect_chain_effective_permissions};
+use super::engine_risk::assess_risk_level;
+use super::engine_types::{PermissionRequest, PermissionResponse};
+use crate::agent::config::AgentPermissions;
+use crate::gateway::SessionManager;
+use std::collections::HashMap;
+use tracing::info;
+
+impl PermissionEngine {
+    /// Evaluate a permission request with parent-agent chain intersection.
+    ///
+    /// This method extends [`Self::evaluate`] by also checking the
+    /// dimension-level intersection with the parent agent chain.  It
+    /// is the general-operation counterpart of the spawn-time
+    /// `validate_and_inject_spawn` check.
+    ///
+    /// # Implementation
+    ///
+    /// 1. Collect chain effective permissions via
+    ///    [`collect_chain_effective_permissions`].
+    /// 2. Collect chain deny subjects via
+    ///    [`collect_chain_deny_subjects`].
+    /// 3. Call [`Self::evaluate`] with the deny subjects.
+    /// 4. If chain effective permissions exist, check whether the
+    ///    requested dimension is denied in the chain intersection.
+    ///    A denied dimension overrides the evaluate result.
+    ///
+    /// # Design constraints
+    ///
+    /// - **Child-agent self-Deny**: handled by `evaluate()` rule
+    ///   matching; if the child is denied by its own rules, evaluate
+    ///   returns `Denied` before reaching the chain check.
+    /// - **No caching**: each call computes permissions fresh.
+    /// - **Workspace forced auth**: `evaluate()` handles this in
+    ///   Step 0.5; the chain check is applied after evaluate returns,
+    ///   so workspace authorization is not disrupted.
+    /// - **Sub-agent Deny → no user approval**: when this method
+    ///   returns `Denied`, the caller should surface an error directly
+    ///   rather than entering the user-approval flow.
+    pub async fn evaluate_with_chain(
+        &self,
+        request: PermissionRequest,
+        session_manager: &SessionManager,
+        session_id: &str,
+        agent_permissions: &HashMap<String, AgentPermissions>,
+    ) -> PermissionResponse {
+        let agent_id = request.agent_id().to_string();
+
+        // --- Step 1: Collect chain effective permissions ---
+        let chain_effective = self
+            .collect_chain_effective(session_manager, session_id, agent_permissions)
+            .await;
+
+        // --- Step 2: Collect chain deny subjects ---
+        let deny_subjects =
+            collect_chain_deny_subjects(session_manager, &self.rules, session_id, &agent_id).await;
+        let extra_deny = if deny_subjects.is_empty() {
+            None
+        } else {
+            Some(deny_subjects)
+        };
+
+        // --- Step 3: Evaluate with deny subjects ---
+        let response = self.evaluate(request.clone(), extra_deny);
+
+        // --- Step 4: Dimension-level chain intersection check ---
+        if let Some(ref chain_perms) = chain_effective {
+            if let Some(dim) = request.body().dimension_name() {
+                if let Some(dim_perm) = chain_perms.permissions.get(dim) {
+                    if !dim_perm.allowed {
+                        info!(
+                            agent = %agent_id,
+                            dimension = %dim,
+                            result = "denied",
+                            reason = "chain_dimension_deny",
+                            "permission check completed"
+                        );
+                        return PermissionResponse::Denied {
+                            reason: format!(
+                                "action denied by parent agent chain: \
+                                 dimension '{}' denied by ancestor",
+                                dim
+                            ),
+                            rule: "<chain_intersection>".to_string(),
+                            risk_level: assess_risk_level(request.body()),
+                        };
+                    }
+                }
+            }
+        }
+
+        response
+    }
+
+    /// Walk the parent chain from `session_id` upward and compute the
+    /// intersection of all ancestors' configured permissions.
+    ///
+    /// Returns `None` when the direct parent (or any ancestor in the
+    /// chain) has no configured permissions, matching the behavior of
+    /// [`collect_chain_effective_permissions`].
+    async fn collect_chain_effective(
+        &self,
+        session_manager: &SessionManager,
+        session_id: &str,
+        agent_permissions: &HashMap<String, AgentPermissions>,
+    ) -> Option<AgentPermissions> {
+        let parent_session_id = session_manager.get_parent_of(session_id).await?;
+        let parent_agent_id = session_manager.get_chat_id(&parent_session_id).await?;
+        collect_chain_effective_permissions(
+            session_manager,
+            agent_permissions,
+            &parent_session_id,
+            &parent_agent_id,
+        )
+        .await
+    }
+}

--- a/src/permission/engine/engine_chain_tests.rs
+++ b/src/permission/engine/engine_chain_tests.rs
@@ -1,0 +1,785 @@
+use std::collections::HashMap;
+
+use super::engine_eval::PermissionEngine;
+use super::engine_types::{Effect, PermissionRequest, PermissionRequestBody, PermissionResponse};
+use crate::agent::config::{ActionPermission, AgentPermissions, PermissionLimits};
+use crate::gateway::session_manager::{ChildSessionInfo, SpawnMode};
+use crate::gateway::{DmScope, GatewayConfig, Session, SessionManager};
+use crate::permission::actions::ActionBuilder;
+use crate::permission::rules::{RuleBuilder, RuleSetBuilder};
+use crate::session::bootstrap::BootstrapMode;
+
+// -------------------------------------------------------------------------
+// Test helpers
+// -------------------------------------------------------------------------
+
+fn make_engine_with_defaults() -> PermissionEngine {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .default_config(Effect::Allow)
+        .build()
+        .unwrap();
+    PermissionEngine::new_with_default_data_root(ruleset)
+}
+
+fn make_perms(agent_id: &str, dims: &[(&str, bool)]) -> AgentPermissions {
+    let permissions = dims
+        .iter()
+        .map(|&(dim, allowed)| {
+            (
+                dim.to_string(),
+                ActionPermission {
+                    allowed,
+                    limits: PermissionLimits::default(),
+                },
+            )
+        })
+        .collect();
+    AgentPermissions {
+        agent_id: agent_id.to_string(),
+        permissions,
+        inherited_from: None,
+    }
+}
+
+fn make_all_allowed(agent_id: &str) -> AgentPermissions {
+    make_perms(
+        agent_id,
+        &[
+            ("exec", true),
+            ("file_read", true),
+            ("file_write", true),
+            ("network", true),
+            ("spawn", true),
+            ("tool_call", true),
+            ("config_write", true),
+        ],
+    )
+}
+
+async fn make_session_manager() -> SessionManager {
+    let config = GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 65536,
+        dm_scope: DmScope::PerAccountChannelPeer,
+        ..Default::default()
+    };
+    SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        crate::session::persistence::ReasoningLevel::default(),
+    )
+}
+
+async fn register_session(mgr: &SessionManager, session_id: &str, agent_id: &str) {
+    mgr.sessions.write().await.insert(
+        session_id.to_string(),
+        Session {
+            id: session_id.to_string(),
+            agent_id: agent_id.to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 0,
+        },
+    );
+}
+
+async fn register_parent_child(
+    mgr: &SessionManager,
+    parent_session_id: &str,
+    child_session_id: &str,
+    child_agent_id: &str,
+) {
+    mgr.register_child(
+        parent_session_id,
+        ChildSessionInfo {
+            session_id: child_session_id.to_string(),
+            parent_session_id: parent_session_id.to_string(),
+            agent_id: child_agent_id.to_string(),
+            depth: 1,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+}
+
+// -------------------------------------------------------------------------
+// Test 1: Chain intersection narrows dimension (parent Deny → child blocked)
+// -------------------------------------------------------------------------
+
+/// Parent denies file_write in its configured permissions.
+/// Child tries file_write → denied by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_file_write_denied_by_parent() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    // Parent denies file_write, allows everything else
+    perms.insert(
+        "parent".to_string(),
+        make_perms(
+            "parent",
+            &[
+                ("exec", true),
+                ("file_read", true),
+                ("file_write", false),
+                ("network", true),
+                ("spawn", true),
+                ("tool_call", true),
+                ("config_write", true),
+            ],
+        ),
+    );
+    // Child allows everything
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "child".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { ref reason, .. } if reason.contains("chain")),
+        "file_write should be denied by parent chain intersection: {:?}",
+        resp
+    );
+}
+
+/// Parent denies file_write, child tries file_read → allowed (different dimension).
+#[tokio::test]
+async fn test_chain_intersection_file_read_allowed_when_only_write_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms(
+            "parent",
+            &[
+                ("exec", true),
+                ("file_read", true),
+                ("file_write", false),
+                ("network", true),
+                ("spawn", true),
+                ("tool_call", true),
+                ("config_write", true),
+            ],
+        ),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "child".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "read".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Allowed { .. }),
+        "file_read should be allowed (parent only denies file_write): {:?}",
+        resp
+    );
+}
+
+/// Single parent denies file_write → child blocked.
+/// Verifies single-level chain works, not just multi-level.
+#[tokio::test]
+async fn test_single_parent_denies_file_write() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms(
+            "parent",
+            &[("exec", true), ("file_read", true), ("file_write", false)],
+        ),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "child".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "file_write should be denied by single parent: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 2: No chain → behavior equivalent to evaluate()
+// -------------------------------------------------------------------------
+
+/// Root agent (no parent) → evaluate_with_chain behaves like evaluate.
+/// The chain intersection check is skipped, and the response matches evaluate().
+#[tokio::test]
+async fn test_no_chain_matches_evaluate() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "root-session", "root").await;
+    // No parent registered → no chain
+
+    let mut perms = HashMap::new();
+    perms.insert("root".to_string(), make_all_allowed("root"));
+
+    let engine = make_engine_with_defaults();
+
+    let req_chain = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "root".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+    let resp_chain = engine
+        .evaluate_with_chain(req_chain, &mgr, "root-session", &perms)
+        .await;
+
+    // Same request evaluated directly
+    let req_direct = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "root".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+    let resp_direct = engine.evaluate(req_direct, None);
+
+    assert_eq!(
+        std::mem::discriminant(&resp_chain),
+        std::mem::discriminant(&resp_direct),
+        "no-chain evaluate_with_chain should match evaluate: chain={:?}, direct={:?}",
+        resp_chain,
+        resp_direct
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 3: Deny subject propagation still works
+// -------------------------------------------------------------------------
+
+/// Parent AgentOnly deny rule propagated to child via chain deny subjects.
+/// Parent has a deny rule for "parent" on tool_call → rewritten to "child"
+/// → child tool_call denied via extra_deny subjects.
+#[tokio::test]
+async fn test_deny_subject_propagation_through_chain() {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .default_config(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("parent-deny-toolcall")
+                .subject_agent("parent")
+                .deny()
+                .action(ActionBuilder::tool_call("*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
+
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert("parent".to_string(), make_all_allowed("parent"));
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    // Child tries tool_call — should be denied by chain deny propagation
+    let req = PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+        agent: "child".to_string(),
+        skill: "some_tool".to_string(),
+        method: "run".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "child tool_call should be denied by chain deny propagation: {:?}",
+        resp
+    );
+}
+
+/// Parent deny propagation: child exec is also denied because the deny
+/// subject `AgentOnly { agent: "child" }` matches all actions for "child",
+/// not just tool_call. This is the expected behavior of deny subject propagation.
+#[tokio::test]
+async fn test_deny_propagation_blocks_all_actions_for_child() {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .default_config(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("parent-deny-toolcall")
+                .subject_agent("parent")
+                .deny()
+                .action(ActionBuilder::tool_call("*").build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
+
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert("parent".to_string(), make_all_allowed("parent"));
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    // Child exec is also denied because the deny subject
+    // `AgentOnly { agent: "child" }` matches all actions for "child".
+    let req_exec = PermissionRequest::Bare(PermissionRequestBody::CommandExec {
+        agent: "child".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    });
+    let resp_exec = engine
+        .evaluate_with_chain(req_exec, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp_exec, PermissionResponse::Denied { .. }),
+        "child exec should also be denied by chain deny propagation: {:?}",
+        resp_exec
+    );
+
+    // Child file_read is also denied (same deny subject applies to all actions)
+    let req_read = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "child".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "read".to_string(),
+    });
+    let resp_read = engine
+        .evaluate_with_chain(req_read, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp_read, PermissionResponse::Denied { .. }),
+        "child file_read should also be denied by chain deny propagation: {:?}",
+        resp_read
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 4: Owner skip — owner path not blocked by chain intersection
+// -------------------------------------------------------------------------
+
+/// Owner session with no parent chain → no chain intersection applied.
+/// Owner gets the same result as direct evaluate().
+#[tokio::test]
+async fn test_owner_no_chain_not_blocked() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "owner-session", "owner").await;
+    // No parent → no chain intersection
+
+    let mut perms = HashMap::new();
+    perms.insert("owner".to_string(), make_all_allowed("owner"));
+
+    let engine = make_engine_with_defaults();
+
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "owner".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "owner-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Allowed { .. }),
+        "owner with no chain should not be blocked: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — exec
+// -------------------------------------------------------------------------
+
+/// Parent denies exec → child exec blocked by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_exec_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("exec", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::CommandExec {
+        agent: "child".to_string(),
+        cmd: "ls".to_string(),
+        args: vec![],
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "exec should be denied by parent chain: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — network
+// -------------------------------------------------------------------------
+
+/// Parent denies network → child network blocked by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_network_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("network", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::NetOp {
+        agent: "child".to_string(),
+        host: "example.com".to_string(),
+        port: 443,
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "network should be denied by parent chain: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — spawn
+// -------------------------------------------------------------------------
+
+/// Parent denies spawn → child inter-agent msg blocked by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_spawn_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("spawn", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::InterAgentMsg {
+        from: "child".to_string(),
+        to: "other-agent".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "spawn should be denied by parent chain: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — tool_call
+// -------------------------------------------------------------------------
+
+/// Parent denies tool_call → child tool_call blocked by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_tool_call_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("tool_call", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::ToolCall {
+        agent: "child".to_string(),
+        skill: "some_skill".to_string(),
+        method: "run".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "tool_call should be denied by parent chain: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — config_write
+// -------------------------------------------------------------------------
+
+/// Parent denies config_write → child config_write blocked by chain intersection.
+#[tokio::test]
+async fn test_chain_intersection_config_write_denied() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("config_write", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::ConfigWrite {
+        agent: "child".to_string(),
+        config_file: "/etc/config.toml".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "config_write should be denied by parent chain: {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — SlashCommand (no dimension → not blocked)
+// -------------------------------------------------------------------------
+
+/// SlashCommand has no dimension_name() → chain intersection does not block.
+#[tokio::test]
+async fn test_chain_intersection_slash_command_not_blocked() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    // Parent denies exec — but SlashCommand has no dimension, so not blocked
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("exec", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::SlashCommand {
+        agent: "child".to_string(),
+        command: "/help".to_string(),
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    // SlashCommand has no dimension → chain check skips → evaluate result
+    // With default Allow and no deny rules, this should be Allowed
+    assert!(
+        matches!(resp, PermissionResponse::Allowed { .. }),
+        "SlashCommand should not be blocked by chain (no dimension): {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test 5: Dimension coverage — unknown op (None dimension)
+// -------------------------------------------------------------------------
+
+/// FileOp with unknown op → dimension_name() returns None → not blocked.
+#[tokio::test]
+async fn test_chain_intersection_unknown_op_not_blocked() {
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "parent-session", "parent").await;
+    register_session(&mgr, "child-session", "child").await;
+    register_parent_child(&mgr, "parent-session", "child-session", "child").await;
+
+    // Parent denies file_write — but unknown op has no dimension
+    let mut perms = HashMap::new();
+    perms.insert(
+        "parent".to_string(),
+        make_perms("parent", &[("file_write", false)]),
+    );
+    perms.insert("child".to_string(), make_all_allowed("child"));
+
+    let engine = make_engine_with_defaults();
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "child".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "delete".to_string(), // unknown op → None dimension
+    });
+
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "child-session", &perms)
+        .await;
+    // Unknown op → dimension_name() = None → chain check skips
+    // evaluate() with default Allow → Allowed
+    assert!(
+        matches!(resp, PermissionResponse::Allowed { .. }),
+        "unknown op should not be blocked by chain (no dimension): {:?}",
+        resp
+    );
+}
+
+// -------------------------------------------------------------------------
+// Test: Three-level chain intersection
+// -------------------------------------------------------------------------
+
+/// Three-level chain intersection:
+/// Root denies network and file_write via configured permissions + deny rules.
+/// B tries file_write → denied by chain intersection (Root denies file_write).
+/// B tries network → denied by chain intersection (Root denies network).
+/// Note: Root's deny rules are rewritten to target B via
+/// `collect_chain_deny_subjects`, so exec is also denied by the deny
+/// subject propagation mechanism (not by chain intersection).
+#[tokio::test]
+async fn test_three_level_chain_intersection() {
+    let ruleset = RuleSetBuilder::new()
+        .default_file(Effect::Allow)
+        .default_command(Effect::Allow)
+        .default_network(Effect::Allow)
+        .default_inter_agent(Effect::Allow)
+        .default_tool_call(Effect::Allow)
+        .default_config(Effect::Allow)
+        .rule(
+            RuleBuilder::new()
+                .name("root-deny-network")
+                .subject_agent("root")
+                .deny()
+                .action(ActionBuilder::network().build().unwrap())
+                .build()
+                .unwrap(),
+        )
+        .rule(
+            RuleBuilder::new()
+                .name("root-deny-filewrite")
+                .subject_agent("root")
+                .deny()
+                .action(
+                    ActionBuilder::file("write", vec!["/**".to_string()])
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let engine = PermissionEngine::new_with_default_data_root(ruleset);
+
+    let mgr = make_session_manager().await;
+    register_session(&mgr, "session-root", "root").await;
+    register_session(&mgr, "session-a", "agent-a").await;
+    register_parent_child(&mgr, "session-root", "session-a", "agent-a").await;
+    register_session(&mgr, "session-b", "agent-b").await;
+    register_parent_child(&mgr, "session-a", "session-b", "agent-b").await;
+
+    // Root denies network and file_write; A allows everything
+    let mut perms = HashMap::new();
+    perms.insert(
+        "root".to_string(),
+        make_perms("root", &[("network", false), ("file_write", false)]),
+    );
+    perms.insert("agent-a".to_string(), make_all_allowed("agent-a"));
+    perms.insert("agent-b".to_string(), make_all_allowed("agent-b"));
+
+    // B tries file_write → denied by chain intersection (Root denies file_write)
+    let req = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+        agent: "agent-b".to_string(),
+        path: "/tmp/test.txt".to_string(),
+        op: "write".to_string(),
+    });
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "session-b", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "file_write should be denied by chain intersection: {:?}",
+        resp
+    );
+
+    // B tries network → denied by chain intersection (Root denies network)
+    let req = PermissionRequest::Bare(PermissionRequestBody::NetOp {
+        agent: "agent-b".to_string(),
+        host: "example.com".to_string(),
+        port: 443,
+    });
+    let resp = engine
+        .evaluate_with_chain(req, &mgr, "session-b", &perms)
+        .await;
+    assert!(
+        matches!(resp, PermissionResponse::Denied { .. }),
+        "network should be denied by chain intersection: {:?}",
+        resp
+    );
+}

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Runs as a separate OS process, evaluates access rules for agents.
 
+pub mod engine_chain;
 pub mod engine_check;
 pub mod engine_eval;
 pub mod engine_helpers;

--- a/src/permission/engine/mod.rs
+++ b/src/permission/engine/mod.rs
@@ -36,4 +36,7 @@ mod engine_two_phase_tests;
 mod engine_types_tests;
 
 #[cfg(test)]
+mod engine_chain_tests;
+
+#[cfg(test)]
 mod engine_spawn_tests;

--- a/src/skills/builtin/file_ops.rs
+++ b/src/skills/builtin/file_ops.rs
@@ -1,17 +1,19 @@
 //! File operations skill
+use crate::agent::config::AgentPermissions;
 use crate::gateway::SessionManager;
 use crate::permission::approval_flow::ApprovalFlow;
-use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
-use crate::permission::engine::engine_types::{Caller, PermissionRequestBody};
+use crate::permission::engine::engine_types::{Caller, PermissionRequest, PermissionRequestBody};
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct FileOpsSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
     approval_flow: Option<Arc<tokio::sync::Mutex<ApprovalFlow>>>,
     session_manager: Option<Arc<SessionManager>>,
+    agent_permissions: HashMap<String, AgentPermissions>,
 }
 
 impl Default for FileOpsSkill {
@@ -26,6 +28,7 @@ impl FileOpsSkill {
             engine: None,
             approval_flow: None,
             session_manager: None,
+            agent_permissions: HashMap::new(),
         }
     }
 
@@ -34,6 +37,7 @@ impl FileOpsSkill {
             engine: Some(engine),
             approval_flow: None,
             session_manager: None,
+            agent_permissions: HashMap::new(),
         }
     }
 
@@ -45,11 +49,20 @@ impl FileOpsSkill {
             engine: Some(engine),
             approval_flow: Some(approval_flow),
             session_manager: None,
+            agent_permissions: HashMap::new(),
         }
     }
 
     pub fn with_session_manager(mut self, session_manager: Arc<SessionManager>) -> Self {
         self.session_manager = Some(session_manager);
+        self
+    }
+
+    pub fn with_agent_permissions(
+        mut self,
+        agent_permissions: HashMap<String, AgentPermissions>,
+    ) -> Self {
+        self.agent_permissions = agent_permissions;
         self
     }
 }
@@ -91,31 +104,51 @@ impl Skill for FileOpsSkill {
                 .get("agent_id")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| SkillError::InvalidArgs("agent_id required".to_string()))?;
-            // Collect chain deny subjects from all ancestors if session context
-            // is available. Falls back to None when session_id is absent.
-            let extra_deny = if let (Some(ref sm), Some(session_id)) = (
+            // Chain-aware permission check: dimension-level intersection
+            // with the parent agent chain.
+            let user_id = args
+                .get("user_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let file_op = match action {
+                "file_read" => "read",
+                "file_write" => "write",
+                _ => action,
+            };
+            let request = PermissionRequest::Bare(PermissionRequestBody::FileOp {
+                agent: agent_id.to_string(),
+                path: args
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                op: file_op.to_string(),
+            });
+            let response = match (
                 &self.session_manager,
                 args.get("session_id").and_then(|v| v.as_str()),
             ) {
-                let subjects =
-                    collect_chain_deny_subjects(sm, &engine.rules, session_id, agent_id).await;
-                if subjects.is_empty() {
-                    None
-                } else {
-                    Some(subjects)
+                (Some(ref sm), Some(sid)) => {
+                    let caller = Caller {
+                        user_id: user_id.to_string(),
+                        agent: agent_id.to_string(),
+                        creator_id: String::new(),
+                    };
+                    let request = request.with_caller(caller);
+                    engine
+                        .evaluate_with_chain(request, sm, sid, &self.agent_permissions)
+                        .await
                 }
-            } else {
-                None
+                _ => engine.evaluate(request, None),
             };
-            let deny_ref = extra_deny.as_deref();
-            match engine.check(agent_id, action, deny_ref) {
+            match response {
                 PermissionResponse::Allowed { .. } => {}
                 PermissionResponse::Denied {
                     reason, risk_level, ..
                 } => {
                     if let Some(ref flow) = self.approval_flow {
                         let caller = Caller {
-                            user_id: "unknown".to_string(),
+                            user_id: user_id.to_string(),
                             agent: agent_id.to_string(),
                             creator_id: String::new(),
                         };

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -64,6 +64,7 @@ impl BuiltinSkills {
             crate::agent::config::AgentPermissions,
         >,
     ) -> Vec<Arc<dyn Skill>> {
+        let agent_perms_for_perm = agent_permissions.clone();
         let file_ops =
             FileOpsSkill::with_engine_and_approval_flow(engine.clone(), approval_flow.clone())
                 .with_agent_permissions(agent_permissions);
@@ -72,7 +73,8 @@ impl BuiltinSkills {
         } else {
             file_ops
         };
-        let perm_skill = PermissionSkill::with_engine(engine.clone());
+        let perm_skill = PermissionSkill::with_engine(engine.clone())
+            .with_agent_permissions(agent_perms_for_perm);
         let perm_skill = if let Some(ref sm) = session_manager {
             perm_skill.with_session_manager(Arc::clone(sm))
         } else {

--- a/src/skills/builtin/mod.rs
+++ b/src/skills/builtin/mod.rs
@@ -59,9 +59,14 @@ impl BuiltinSkills {
         engine: Arc<crate::permission::PermissionEngine>,
         approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
         session_manager: Option<Arc<SessionManager>>,
+        agent_permissions: std::collections::HashMap<
+            String,
+            crate::agent::config::AgentPermissions,
+        >,
     ) -> Vec<Arc<dyn Skill>> {
         let file_ops =
-            FileOpsSkill::with_engine_and_approval_flow(engine.clone(), approval_flow.clone());
+            FileOpsSkill::with_engine_and_approval_flow(engine.clone(), approval_flow.clone())
+                .with_agent_permissions(agent_permissions);
         let file_ops = if let Some(ref sm) = session_manager {
             file_ops.with_session_manager(Arc::clone(sm))
         } else {
@@ -105,8 +110,14 @@ pub fn builtin_skills_with_engine_and_approval_flow(
     engine: Arc<crate::permission::PermissionEngine>,
     approval_flow: Arc<tokio::sync::Mutex<ApprovalFlow>>,
     session_manager: Option<Arc<SessionManager>>,
+    agent_permissions: std::collections::HashMap<String, crate::agent::config::AgentPermissions>,
 ) -> Vec<Arc<dyn Skill>> {
-    BuiltinSkills::all_with_engine_and_approval_flow(engine, approval_flow, session_manager)
+    BuiltinSkills::all_with_engine_and_approval_flow(
+        engine,
+        approval_flow,
+        session_manager,
+        agent_permissions,
+    )
 }
 
 #[cfg(test)]

--- a/src/skills/builtin/permission.rs
+++ b/src/skills/builtin/permission.rs
@@ -1,14 +1,17 @@
 //! Permission skill - allows agents to query their own permissions
+use crate::agent::config::AgentPermissions;
 use crate::gateway::SessionManager;
-use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
+use crate::permission::engine::engine_types::{PermissionRequest, PermissionRequestBody};
 use crate::permission::PermissionResponse;
 use crate::skills::{Skill, SkillError, SkillManifest};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct PermissionSkill {
     engine: Option<Arc<crate::permission::PermissionEngine>>,
     session_manager: Option<Arc<SessionManager>>,
+    agent_permissions: HashMap<String, AgentPermissions>,
 }
 
 impl PermissionSkill {
@@ -16,6 +19,7 @@ impl PermissionSkill {
         Self {
             engine: None,
             session_manager: None,
+            agent_permissions: HashMap::new(),
         }
     }
 
@@ -23,11 +27,20 @@ impl PermissionSkill {
         Self {
             engine: Some(engine),
             session_manager: None,
+            agent_permissions: HashMap::new(),
         }
     }
 
     pub fn with_session_manager(mut self, session_manager: Arc<SessionManager>) -> Self {
         self.session_manager = Some(session_manager);
+        self
+    }
+
+    pub fn with_agent_permissions(
+        mut self,
+        agent_permissions: HashMap<String, AgentPermissions>,
+    ) -> Self {
+        self.agent_permissions = agent_permissions;
         self
     }
 }
@@ -72,24 +85,57 @@ impl Skill for PermissionSkill {
                     .ok_or_else(|| SkillError::InvalidArgs("action required".to_string()))?;
 
                 if let Some(ref engine) = self.engine {
-                    // Collect chain deny subjects from all ancestors if session
-                    // context is available.
-                    let extra_deny = if let (Some(ref sm), Some(sid)) = (
+                    let body = match action {
+                        "exec" => PermissionRequestBody::CommandExec {
+                            agent: agent_id.to_string(),
+                            cmd: "*".to_string(),
+                            args: Vec::new(),
+                        },
+                        "file_read" => PermissionRequestBody::FileOp {
+                            agent: agent_id.to_string(),
+                            path: "*".to_string(),
+                            op: "read".to_string(),
+                        },
+                        "file_write" => PermissionRequestBody::FileOp {
+                            agent: agent_id.to_string(),
+                            path: "*".to_string(),
+                            op: "write".to_string(),
+                        },
+                        "network" => PermissionRequestBody::NetOp {
+                            agent: agent_id.to_string(),
+                            host: "*".to_string(),
+                            port: 0,
+                        },
+                        "spawn" => PermissionRequestBody::InterAgentMsg {
+                            from: agent_id.to_string(),
+                            to: "*".to_string(),
+                        },
+                        "tool_call" => PermissionRequestBody::ToolCall {
+                            agent: agent_id.to_string(),
+                            skill: "*".to_string(),
+                            method: "*".to_string(),
+                        },
+                        "config_write" => PermissionRequestBody::ConfigWrite {
+                            agent: agent_id.to_string(),
+                            config_file: "*".to_string(),
+                        },
+                        _ => PermissionRequestBody::ToolCall {
+                            agent: agent_id.to_string(),
+                            skill: action.to_string(),
+                            method: "unknown".to_string(),
+                        },
+                    };
+                    let request = PermissionRequest::Bare(body);
+                    let response = if let (Some(ref sm), Some(sid)) = (
                         &self.session_manager,
                         args.get("session_id").and_then(|v| v.as_str()),
                     ) {
-                        let subjects =
-                            collect_chain_deny_subjects(sm, &engine.rules, sid, agent_id).await;
-                        if subjects.is_empty() {
-                            None
-                        } else {
-                            Some(subjects)
-                        }
+                        engine
+                            .evaluate_with_chain(request, sm, sid, &self.agent_permissions)
+                            .await
                     } else {
-                        None
+                        engine.evaluate(request, None)
                     };
-                    let deny_ref = extra_deny.as_deref();
-                    let response = engine.check(agent_id, action, deny_ref);
                     match response {
                         PermissionResponse::Allowed { token: _ } => Ok(serde_json::json!({
                             "allowed": true,

--- a/src/tools/builtin/bash.rs
+++ b/src/tools/builtin/bash.rs
@@ -10,10 +10,12 @@
 //! etc.) live in the sibling module [`super::bash_kill`] to keep this
 //! file under the CONTRIBUTING.md 500-line hard cap.
 
+use crate::config::ConfigManager;
 use crate::gateway::SessionManager;
 use crate::permission::engine::engine_eval::PermissionEngine;
-use crate::permission::engine::engine_helpers::collect_chain_deny_subjects;
-use crate::permission::engine::engine_types::PermissionResponse;
+use crate::permission::engine::engine_types::{
+    PermissionRequest, PermissionRequestBody, PermissionResponse,
+};
 use crate::tasks::BackgroundTaskManager;
 use crate::tools::security::{BashSecurityAnalyzer, TrustLevel};
 use crate::tools::{
@@ -43,20 +45,23 @@ pub struct BashTool {
     permission_engine: Arc<PermissionEngine>,
     bg_manager: Arc<BackgroundTaskManager>,
     session_manager: Arc<SessionManager>,
+    config_manager: Arc<ConfigManager>,
 }
 
 impl BashTool {
-    /// Creates a new `BashTool` backed by the given permission engine
-    /// and background task manager.
+    /// Creates a new `BashTool` backed by the given permission engine,
+    /// background task manager, and config manager.
     pub fn new(
         permission_engine: Arc<PermissionEngine>,
         bg_manager: Arc<BackgroundTaskManager>,
         session_manager: Arc<SessionManager>,
+        config_manager: Arc<ConfigManager>,
     ) -> Self {
         Self {
             permission_engine,
             bg_manager,
             session_manager,
+            config_manager,
         }
     }
 }
@@ -143,6 +148,7 @@ impl Tool for BashTool {
             &self.permission_engine,
             &self.session_manager,
             &self.bg_manager,
+            &self.config_manager,
             args,
             ctx,
         )
@@ -272,6 +278,7 @@ async fn execute_bash_call(
     perm: &PermissionEngine,
     session_manager: &SessionManager,
     bg: &Arc<BackgroundTaskManager>,
+    config_manager: &ConfigManager,
     args: Value,
     ctx: &ToolContext,
 ) -> Result<ToolResult, ToolCallError> {
@@ -313,21 +320,20 @@ async fn execute_bash_call(
         }
     }
 
-    // --- 3. Permission check ---
-    let extra_deny = if let Some(ref session_id) = ctx.session_id {
-        let subjects =
-            collect_chain_deny_subjects(session_manager, &perm.rules, session_id, &ctx.agent_id)
-                .await;
-        if subjects.is_empty() {
-            None
-        } else {
-            Some(subjects)
-        }
+    // --- 3. Permission check (chain-aware) ---
+    let request = PermissionRequest::Bare(PermissionRequestBody::CommandExec {
+        agent: ctx.agent_id.clone(),
+        cmd: "*".to_string(),
+        args: Vec::new(),
+    });
+    let agent_perms = config_manager.agent_permissions();
+    let response = if let Some(ref session_id) = ctx.session_id {
+        perm.evaluate_with_chain(request, session_manager, session_id, &agent_perms)
+            .await
     } else {
-        None
+        perm.evaluate(request, None)
     };
-    let deny_ref = extra_deny.as_deref();
-    if let PermissionResponse::Denied { reason, .. } = perm.check(&ctx.agent_id, "exec", deny_ref) {
+    if let PermissionResponse::Denied { reason, .. } = response {
         return Err(ToolCallError::PermissionDenied(reason));
     }
 

--- a/src/tools/builtin/bash_tests.rs
+++ b/src/tools/builtin/bash_tests.rs
@@ -40,6 +40,14 @@ fn test_session_manager() -> Arc<SessionManager> {
     ))
 }
 
+fn test_config_manager() -> Arc<crate::config::ConfigManager> {
+    let tmp = tempfile::TempDir::new().unwrap();
+    Arc::new(
+        crate::config::ConfigManager::new(tmp.path().to_path_buf())
+            .expect("ConfigManager::new should succeed"),
+    )
+}
+
 fn test_tool_context() -> ToolContext {
     ToolContext {
         agent_id: "test-agent".to_string(),
@@ -159,6 +167,7 @@ fn test_bash_tool_name_and_group() {
         test_permission_engine(),
         test_bg_manager(),
         test_session_manager(),
+        test_config_manager(),
     );
     assert_eq!(tool.name(), "Bash");
     assert_eq!(tool.group(), "bash");
@@ -170,6 +179,7 @@ fn test_bash_tool_flags() {
         test_permission_engine(),
         test_bg_manager(),
         test_session_manager(),
+        test_config_manager(),
     );
     let flags = tool.flags();
     assert!(flags.is_destructive);
@@ -184,6 +194,7 @@ fn test_input_schema_command_required() {
         test_permission_engine(),
         test_bg_manager(),
         test_session_manager(),
+        test_config_manager(),
     );
     let schema = tool.input_schema();
     let required = schema["required"].as_array().unwrap();
@@ -196,6 +207,7 @@ fn test_input_schema_six_properties() {
         test_permission_engine(),
         test_bg_manager(),
         test_session_manager(),
+        test_config_manager(),
     );
     let schema = tool.input_schema();
     let props = schema["properties"].as_object().unwrap();

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -113,6 +113,7 @@ pub async fn register_builtin_tools(
             context.permission_engine.clone(),
             bg_manager,
             context.session_manager.clone(),
+            context.config_manager.clone(),
         ))
         .await
         .ok();

--- a/src/tools/prompt_generation_tests.rs
+++ b/src/tools/prompt_generation_tests.rs
@@ -52,11 +52,20 @@ fn test_session_manager() -> Arc<SessionManager> {
     ))
 }
 
+fn test_config_manager() -> Arc<crate::config::ConfigManager> {
+    let tmp = tempfile::TempDir::new().unwrap();
+    Arc::new(
+        crate::config::ConfigManager::new(tmp.path().to_path_buf())
+            .expect("ConfigManager::new should succeed"),
+    )
+}
+
 fn test_bash_tool() -> BashTool {
     BashTool::new(
         test_permission_engine(),
         test_bg_manager(),
         test_session_manager(),
+        test_config_manager(),
     )
 }
 


### PR DESCRIPTION
## 概述

在 `PermissionEngine` 中新增 `evaluate_with_chain()` 方法，使一般操作（bash exec、file_ops、slash_permission、permission skill）也经过 spawn 链路维度级交集计算，而非仅做 deny 主体传播。

## 背景

设计文档 `docs/design/agent/agent-permissions.md` 要求所有操作沿 spawn 链路收集父 agent 实际权限并做维度级交集。此前仅 spawn 验证路径（`validate_and_inject_spawn`）执行了完整的链路交集，一般操作路径仅调用 `collect_chain_deny_subjects()` 做 deny 主体传播，导致父 agent 对某维度的整体 Deny 无法通过交集收窄子 agent 在一般操作中的该维度权限。

## 变更

- **新增** `engine_chain.rs`：实现 `evaluate_with_chain()` 方法，接收 session context，内部完成链路有效权限收集 + deny 主体收集 + 规则匹配 + 维度级收窄
- **修改** `bash.rs`：改用 `evaluate_with_chain()` 替代手动 `collect_chain_deny_subjects() + check()` 组合
- **修改** `file_ops.rs`：同上
- **修改** `slash_permission.rs`：同上
- **修改** `permission.rs`：同上
- **新增** `engine_chain_tests.rs`：覆盖链路交集收窄、无链路时原行为保持、deny 主体传播、Owner 跳过 User 维度、各维度覆盖等场景
- **修改** `session_manager.rs`：导出 `collect_chain_effective_permissions` 供新方法调用
- **修改** `daemon/mod.rs`：导出相关类型

## 测试

- 单元测试全部通过（`cargo test`）
- 新增 `engine_chain_tests.rs`，覆盖 6 个场景

Source: user
Type: feat
