### PR TITLE
fix: replace clone with slice::from_ref for clippy lint

### DIFF
--- a/src/gateway/session_manager/spawn.rs
+++ b/src/gateway/session_manager/spawn.rs
@@ -711,7 +711,7 @@ impl SessionManager {
             self.children
                 .write()
                 .await
-                .remove_descendant_entries(&[id.clone()]);
+                .remove_descendant_entries(std::slice::from_ref(id));
         }
 
         if let Some(cs) = self.get_conversation_session(child_id).await {


### PR DESCRIPTION
Fix clippy lint `clipped::cloned-ref-to-slice-refs` in spawn.rs.

Replace `&[id.clone()]` with `std::slice::from_ref(id)` to avoid unnecessary clone. Single line change, no logic modification.

Source: CI
Type: fix
