### PR TITLE
fix: remove erroneous depth rejection in compute_effective_max_depth

### DIFF
--- a/src/agent/spawn.rs
+++ b/src/agent/spawn.rs
@@ -46,7 +46,6 @@ pub struct SpawnController {
 
 /// Internal result from resolving parent depth and max spawn budget.
 struct ResolvedParentDepth {
-    parent_depth: u32,
     parent_effective_budget: u32,
 }
 
@@ -129,11 +128,8 @@ impl SpawnController {
             .await?;
 
         // ⑧ Compute effective_max_spawn_depth and validate child depth.
-        let effective_max = self.compute_effective_max_depth(
-            parent.parent_depth,
-            parent.parent_effective_budget,
-            Some(&config),
-        )?;
+        let effective_max =
+            self.compute_effective_max_depth(parent.parent_effective_budget, Some(&config))?;
 
         Ok(SpawnValidationResult {
             config,
@@ -142,11 +138,8 @@ impl SpawnController {
     }
 
     /// Compute the effective maximum spawn depth for a child session.
-    ///
-    /// Returns `Err(DepthExceeded)` if the child would exceed the budget.
     fn compute_effective_max_depth(
         &self,
-        parent_depth: u32,
         parent_effective_budget: u32,
         target_config: Option<&ResolvedAgentConfig>,
     ) -> Result<u32, SpawnError> {
@@ -154,13 +147,6 @@ impl SpawnController {
             .map(|c| c.subagents.max_spawn_depth)
             .unwrap_or(1);
         let effective_max = child_max_depth.min(parent_effective_budget.saturating_sub(1));
-        let child_depth = parent_depth + 1;
-        if child_depth > effective_max {
-            return Err(SpawnError::DepthExceeded {
-                current: child_depth,
-                max: effective_max,
-            });
-        }
         Ok(effective_max)
     }
 
@@ -249,12 +235,6 @@ impl SpawnController {
         parent_session_id: &str,
         parent_agent_id: &str,
     ) -> Result<ResolvedParentDepth, SpawnError> {
-        let parent_depth = self
-            .session_manager
-            .get_session_depth(parent_session_id)
-            .await
-            .unwrap_or(0);
-
         let parent_max_spawn_depth = {
             let agents = self
                 .config_manager
@@ -274,14 +254,10 @@ impl SpawnController {
             .unwrap_or(parent_max_spawn_depth);
 
         if parent_effective_budget == 0 {
-            return Err(SpawnError::DepthExceeded {
-                current: parent_depth + 1,
-                max: 0,
-            });
+            return Err(SpawnError::DepthExceeded { current: 1, max: 0 });
         }
 
         Ok(ResolvedParentDepth {
-            parent_depth,
             parent_effective_budget,
         })
     }

--- a/src/agent/spawn_budget_tests.rs
+++ b/src/agent/spawn_budget_tests.rs
@@ -107,11 +107,9 @@ async fn save_checkpoint_with_budget(
 // Step 1.5: Depth budget propagation tests
 // ══════════════════════════════════════════════════════════════════════
 
-/// Multi-level depth budget propagation:
-/// root(maxSpawnDepth=3) → child1(maxSpawnDepth=5, effective=2)
-/// → child2 rejected (child_depth=2 > effective_max=1)
+/// Verify effective budget read from checkpoint vs config fallback.
 #[tokio::test]
-async fn test_depth_budget_propagation_multilevel() {
+async fn test_depth_budget_checkpoint_vs_config_fallback() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
     let controller = SpawnController::new(
@@ -127,67 +125,35 @@ async fn test_depth_budget_propagation_multilevel() {
     root_sub.max_spawn_depth = 3;
     let root = make_agent("root", root_sub);
     let root_id = setup_parent_session(&sm, "root").await;
-    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(3), None).await;
+    // NO checkpoint saved → config fallback (3) is used
 
-    // child1: maxSpawnDepth=5 — effective = min(5, 3-1) = 2
-    let mut child1_sub = SubagentsConfig::default();
-    child1_sub.max_spawn_depth = 5;
-    let child1 = make_agent("child1", child1_sub);
-    inject_agents(&cm, vec![("root", root), ("child1", child1)]);
+    let mut child_sub = SubagentsConfig::default();
+    child_sub.max_spawn_depth = 1;
+    let child = make_agent("child", child_sub);
+    inject_agents(&cm, vec![("root", root), ("child", child)]);
 
-    let result1 = controller
-        .validate(&root_id, Some("child1"))
+    // Fallback: effective = min(1, 3-1) = 1
+    let result = controller
+        .validate(&root_id, Some("child"))
         .await
-        .expect("should pass: effective=2, child_depth=1");
-    assert_eq!(result1.effective_max_spawn_depth, 2);
+        .expect("should pass with config fallback");
+    assert_eq!(result.effective_max_spawn_depth, 1);
 
-    // Simulate child1 created with effective budget = 2
-    let child1_session_id = "child1-session-id";
-    sm.sessions.write().await.insert(
-        child1_session_id.to_string(),
-        crate::gateway::Session {
-            id: child1_session_id.to_string(),
-            agent_id: "child1".to_string(),
-            channel: "test".to_string(),
-            created_at: 0,
-            depth: 1,
-        },
-    );
-    sm.register_child(
-        &root_id,
-        ChildSessionInfo {
-            session_id: child1_session_id.to_string(),
-            parent_session_id: root_id.to_string(),
-            agent_id: "child1".to_string(),
-            depth: 1,
-            mode: SpawnMode::Session,
-        },
-    )
-    .await;
-    save_checkpoint_with_budget(&mem_storage, child1_session_id, 1, Some(2), Some(&root_id)).await;
+    // Now save a checkpoint with effective budget = 1
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(1), None).await;
 
-    // child2: maxSpawnDepth=5 — effective = min(5, 2-1) = 1
-    // child_depth=2 > effective_max=1 → DepthExceeded (correct behavior)
-    let mut child2_sub = SubagentsConfig::default();
-    child2_sub.max_spawn_depth = 5;
-    let child2 = make_agent("child2", child2_sub);
-    inject_agents(&cm, vec![("child2", child2)]);
-
-    let err = controller
-        .validate(child1_session_id, Some("child2"))
+    // effective = min(1, 1-1) = 0, parent budget=1 > 0 → can create
+    // Per design doc: effective=0 means child exists but cannot spawn further.
+    let result2 = controller
+        .validate(&root_id, Some("child"))
         .await
-        .expect_err("should reject: child_depth=2 > effective_max=1");
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 2);
-            assert_eq!(max, 1);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+        .expect("should pass: parent budget > 0, child created with effective=0");
+    assert_eq!(result2.effective_max_spawn_depth, 0);
 }
 
-/// Spawn rejected when effective budget ≤ 0.
-/// root(maxSpawnDepth=3) → child1(effective=1) → child2(effective=0) rejected
+/// Spawn allowed when parent effective budget > 0 (child effective budget
+/// may be 0). Root(maxSpawnDepth=3) → child1(effective=1) →
+/// child2(effective=0, exists but cannot spawn further).
 #[tokio::test]
 async fn test_depth_budget_rejected_when_effective_zero() {
     let cm = Arc::new(make_config_manager());
@@ -244,24 +210,19 @@ async fn test_depth_budget_rejected_when_effective_zero() {
     .await;
     save_checkpoint_with_budget(&mem_storage, child1_session_id, 1, Some(1), Some(&root_id)).await;
 
-    // child2 attempt: effective = min(1, 1-1) = 0, child_depth=2 > 0 → reject
+    // child2 attempt: effective = min(1, 1-1) = 0
+    // Per design doc: child with effective=0 can be created (exists in tree)
+    // but cannot spawn further children.
     let mut child2_sub = SubagentsConfig::default();
     child2_sub.max_spawn_depth = 1;
     let child2 = make_agent("child2", child2_sub);
     inject_agents(&cm, vec![("child2", child2)]);
 
-    let err = controller
+    let result2 = controller
         .validate(child1_session_id, Some("child2"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=2 > 0");
-
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 2);
-            assert_eq!(max, 0);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+        .expect("should pass: parent budget > 0, child created with effective=0");
+    assert_eq!(result2.effective_max_spawn_depth, 0);
 }
 
 /// Child maxSpawnDepth narrows via min: parent has large budget but
@@ -323,28 +284,23 @@ async fn test_depth_budget_child_narrows_via_min() {
     save_checkpoint_with_budget(&mem_storage, child_session_id, 1, Some(2), Some(&root_id)).await;
 
     // grandchild: maxSpawnDepth=5 — effective = min(5, 2-1) = 1
-    // child_depth=2 > effective_max=1 → DepthExceeded (budget exhausted)
+    // Per design doc: child with effective=1 can be created and exists in tree.
     let mut grandchild_sub = SubagentsConfig::default();
     grandchild_sub.max_spawn_depth = 5;
     let grandchild = make_agent("grandchild", grandchild_sub);
     inject_agents(&cm, vec![("grandchild", grandchild)]);
 
-    let err = controller
+    let result2 = controller
         .validate(child_session_id, Some("grandchild"))
         .await
-        .expect_err("should reject: child_depth=2 > effective_max=1");
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 2);
-            assert_eq!(max, 1);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+        .expect("should pass: parent budget > 0, child created with effective=1");
+    assert_eq!(result2.effective_max_spawn_depth, 1);
 }
 
-/// Verify effective budget read from checkpoint vs config fallback.
+/// Full multi-level spawn tree from design doc:
+/// root(3) → child1(5,eff=2) → child2(5,eff=1) → child3(1,eff=0)
 #[tokio::test]
-async fn test_depth_budget_checkpoint_vs_config_fallback() {
+async fn test_depth_budget_full_multilevel_tree() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
     let controller = SpawnController::new(
@@ -355,34 +311,135 @@ async fn test_depth_budget_checkpoint_vs_config_fallback() {
         )),
     );
 
-    // Root: maxSpawnDepth=3
+    // root: maxSpawnDepth=3
     let mut root_sub = SubagentsConfig::default();
     root_sub.max_spawn_depth = 3;
     let root = make_agent("root", root_sub);
     let root_id = setup_parent_session(&sm, "root").await;
-    // NO checkpoint saved → config fallback (3) is used
+    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(3), None).await;
 
-    let mut child_sub = SubagentsConfig::default();
-    child_sub.max_spawn_depth = 1;
-    let child = make_agent("child", child_sub);
-    inject_agents(&cm, vec![("root", root), ("child", child)]);
+    // child1: maxSpawnDepth=5 — effective = min(5, 3-1) = 2
+    let mut child1_sub = SubagentsConfig::default();
+    child1_sub.max_spawn_depth = 5;
+    let child1 = make_agent("child1", child1_sub);
+    inject_agents(&cm, vec![("root", root), ("child1", child1)]);
 
-    // Fallback: effective = min(1, 3-1) = 1
-    let result = controller
-        .validate(&root_id, Some("child"))
+    let result1 = controller
+        .validate(&root_id, Some("child1"))
         .await
-        .expect("should pass with config fallback");
-    assert_eq!(result.effective_max_spawn_depth, 1);
+        .expect("root → child1: should pass, effective=2");
+    assert_eq!(result1.effective_max_spawn_depth, 2);
 
-    // Now save a checkpoint with effective budget = 1
-    save_checkpoint_with_budget(&mem_storage, &root_id, 0, Some(1), None).await;
+    // Simulate child1 created with effective budget = 2
+    let child1_sid = "tree-child1";
+    sm.sessions.write().await.insert(
+        child1_sid.to_string(),
+        crate::gateway::Session {
+            id: child1_sid.to_string(),
+            agent_id: "child1".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 1,
+        },
+    );
+    sm.register_child(
+        &root_id,
+        ChildSessionInfo {
+            session_id: child1_sid.to_string(),
+            parent_session_id: root_id.to_string(),
+            agent_id: "child1".to_string(),
+            depth: 1,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child1_sid, 1, Some(2), Some(&root_id)).await;
 
-    // effective = min(1, 1-1) = 0, child_depth=1 > 0 → DepthExceeded
+    // child2: maxSpawnDepth=5 — effective = min(5, 2-1) = 1
+    let mut child2_sub = SubagentsConfig::default();
+    child2_sub.max_spawn_depth = 5;
+    let child2 = make_agent("child2", child2_sub);
+    inject_agents(&cm, vec![("child2", child2)]);
+
+    let result2 = controller
+        .validate(child1_sid, Some("child2"))
+        .await
+        .expect("child1 → child2: should pass, effective=1");
+    assert_eq!(result2.effective_max_spawn_depth, 1);
+
+    // Simulate child2 created with effective budget = 1
+    let child2_sid = "tree-child2";
+    sm.sessions.write().await.insert(
+        child2_sid.to_string(),
+        crate::gateway::Session {
+            id: child2_sid.to_string(),
+            agent_id: "child2".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 2,
+        },
+    );
+    sm.register_child(
+        child1_sid,
+        ChildSessionInfo {
+            session_id: child2_sid.to_string(),
+            parent_session_id: child1_sid.to_string(),
+            agent_id: "child2".to_string(),
+            depth: 2,
+            mode: SpawnMode::Session,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child2_sid, 2, Some(1), Some(child1_sid)).await;
+
+    // child3: maxSpawnDepth=1 — effective = min(1, 1-1) = 0
+    // Per design doc: child3 exists in tree but cannot spawn further.
+    let mut child3_sub = SubagentsConfig::default();
+    child3_sub.max_spawn_depth = 1;
+    let child3 = make_agent("child3", child3_sub);
+    inject_agents(&cm, vec![("child3", child3)]);
+
+    let result3 = controller
+        .validate(child2_sid, Some("child3"))
+        .await
+        .expect("child2 → child3: should pass, effective=0 (leaf node)");
+    assert_eq!(result3.effective_max_spawn_depth, 0);
+
+    // Simulate child3 created with effective budget = 0
+    let child3_sid = "tree-child3";
+    sm.sessions.write().await.insert(
+        child3_sid.to_string(),
+        crate::gateway::Session {
+            id: child3_sid.to_string(),
+            agent_id: "child3".to_string(),
+            channel: "test".to_string(),
+            created_at: 0,
+            depth: 3,
+        },
+    );
+    sm.register_child(
+        child2_sid,
+        ChildSessionInfo {
+            session_id: child3_sid.to_string(),
+            parent_session_id: child2_sid.to_string(),
+            agent_id: "child3".to_string(),
+            depth: 3,
+            mode: SpawnMode::Run,
+        },
+    )
+    .await;
+    save_checkpoint_with_budget(&mem_storage, child3_sid, 3, Some(0), Some(child2_sid)).await;
+
+    // child3 has effective budget = 0 → cannot spawn further
+    let mut child4_sub = SubagentsConfig::default();
+    child4_sub.max_spawn_depth = 5;
+    let child4 = make_agent("child4", child4_sub);
+    inject_agents(&cm, vec![("child4", child4)]);
+
     let err = controller
-        .validate(&root_id, Some("child"))
+        .validate(child3_sid, Some("child4"))
         .await
-        .expect_err("should reject: checkpoint budget=1, effective=0");
-
+        .expect_err("child3 → child4: should reject, parent effective budget = 0");
     match err {
         SpawnError::DepthExceeded { current, max } => {
             assert_eq!(current, 1);

--- a/src/agent/spawn_budget_tests.rs
+++ b/src/agent/spawn_budget_tests.rs
@@ -155,7 +155,7 @@ async fn test_depth_budget_checkpoint_vs_config_fallback() {
 /// may be 0). Root(maxSpawnDepth=3) → child1(effective=1) →
 /// child2(effective=0, exists but cannot spawn further).
 #[tokio::test]
-async fn test_depth_budget_rejected_when_effective_zero() {
+async fn test_depth_budget_allowed_when_effective_zero() {
     let cm = Arc::new(make_config_manager());
     let (sm, mem_storage) = make_session_manager_with_memory_storage();
     let controller = SpawnController::new(

--- a/src/agent/spawn_tests.rs
+++ b/src/agent/spawn_tests.rs
@@ -356,7 +356,7 @@ async fn test_validate_wildcard_allow() {
 
 /// Parent maxSpawnDepth=1, child maxSpawnDepth=2
 /// → effective_max = min(2, 1-1) = 0
-/// → child_depth=1 > 0 → DepthExceeded.
+/// → child exists with effective_budget=0 (cannot spawn further).
 #[tokio::test]
 async fn test_validate_cascade_parent_depth1_child_depth2() {
     let cm = Arc::new(make_config_manager());
@@ -375,18 +375,12 @@ async fn test_validate_cascade_parent_depth1_child_depth2() {
 
     let parent_id = setup_parent_session(&sm, "parent").await;
 
-    let err = controller
+    let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+        .expect("should allow: effective_max=0, child exists but cannot spawn further");
 
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+    assert_eq!(result.effective_max_spawn_depth, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -589,7 +583,7 @@ async fn test_validate_cascade_parent_depth0_child_depth5() {
 /// Target agent not configured (default max_spawn_depth=1)
 /// with parent max_spawn_depth=1
 /// → effective_max = min(1, 1-1) = 0
-/// → child_depth=1 > 0 → DepthExceeded.
+/// → child exists with effective_budget=0 (cannot spawn further).
 /// Verifies that unconfigured targets use the default max_spawn_depth=1.
 #[tokio::test]
 async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
@@ -607,18 +601,12 @@ async fn test_validate_cascade_unconfigured_child_depth1_parent1() {
 
     let parent_id = setup_parent_session(&sm, "parent").await;
 
-    let err = controller
+    let result = controller
         .validate(&parent_id, Some("child"))
         .await
-        .expect_err("should reject: effective_max=0, child_depth=1 > 0");
+        .expect("should allow: effective_max=0, child exists but cannot spawn further");
 
-    match err {
-        SpawnError::DepthExceeded { current, max } => {
-            assert_eq!(current, 1);
-            assert_eq!(max, 0);
-        }
-        other => panic!("expected DepthExceeded, got {:?}", other),
-    }
+    assert_eq!(result.effective_max_spawn_depth, 0);
 }
 
 // ── Step 1.1: depth-before-agentId order verification ────────────────────


### PR DESCRIPTION
Remove erroneous depth rejection in `compute_effective_max_depth`.

The function had an extra `child_depth > effective_max` check that contradicted the documented spawn depth model (agent-spawn.md). Per the doc, an agent with effective_budget=0 should still be creatable — it just cannot spawn further children. That enforcement already exists in `resolve_parent_depth` (parent_effective_budget == 0 check).

Changes:
- Remove `child_depth > effective_max` rejection and `parent_depth` parameter from `compute_effective_max_depth`
- Update 4 spawn_budget_tests assertions to expect successful creation with effective_budget=0
- Rename `test_depth_budget_rejected_when_effective_zero` → `test_depth_budget_allowed_when_effective_zero`
- Fix 2 remaining spawn_tests assertions (effective_budget=0 creates successfully)
- Add new tests for effective_budget=0 creation and full 4-level spawn tree

Source: user
Type: fix
