### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -102,7 +102,7 @@
     "commit": "b4770d160d417335ea2ce5d75e57320b065e36fc",
     "commit_time": "2026-06-25T02:31:02+08:00",
     "confirmed_time": "2026-06-25T02:31:02+08:00",
-    "comment": "cleared: #1197 — ContentNormalizer 职责缩减为3项纯文本标准化(去控制字符/压缩空行/去尾空格)。URL补全和代码块标签归属IM插件。clean_content()从IMPlugin trait移除,平台清洗由Adapter解析阶段完成。RawLogProcessor disabled时中断链为代码bug(返回None→应返回pass-through),另开issue修。"
+    "comment": "blocked: hash-includes-timestamp_ms contradicts session-reuse-via-resolve"
   },
   {
     "path": "docs/design/im_adapter/code-render.md",


### PR DESCRIPTION
操作文档：docs/design/gateway/inbound-flow.md
操作类型：blocked
原因简述：SessionRouter session_key hash 计算存在文档内部矛盾——文档要求 hash 包含 timestamp_ms 但同时描述了 session 复用机制，两者不可兼得。