### PR TITLE
feat: implement active-searcher module for per-message entity search

### DIFF
--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -84,6 +84,9 @@ pub struct SessionMessageHandler {
     /// and decrement when complete. The shutdown drain waits for the
     /// count to reach zero before finalizing.
     pub(super) shutdown_handle: Option<Arc<ShutdownHandle>>,
+    /// Path to the SQLite database file used by the active-searcher.
+    /// When set, `dispatch_llm_call` spawns a background searcher task.
+    pub(super) memory_db_path: Option<std::path::PathBuf>,
 }
 
 // ── Construction ──
@@ -105,6 +108,7 @@ impl SessionMessageHandler {
             unified_fallback_client,
             gateway: None,
             shutdown_handle: None,
+            memory_db_path: None,
         }
     }
     /// Create a new handler without an output channel (used in tests).
@@ -123,6 +127,7 @@ impl SessionMessageHandler {
             unified_fallback_client,
             gateway: None,
             shutdown_handle: None,
+            memory_db_path: None,
         }
     }
     /// Attach a back-reference (weak) to the owning [`Gateway`].
@@ -142,6 +147,16 @@ impl SessionMessageHandler {
     /// waits for the count to reach zero before finalizing.
     pub fn with_shutdown_handle(mut self, handle: Arc<ShutdownHandle>) -> Self {
         self.shutdown_handle = Some(handle);
+        self
+    }
+
+    /// Set the SQLite database path for the active-searcher.
+    ///
+    /// When set, `dispatch_llm_call` spawns a background active-searcher
+    /// task that writes query results to the session's `memory_injection`
+    /// slot for the next turn to consume.
+    pub fn with_memory_db_path(mut self, path: std::path::PathBuf) -> Self {
+        self.memory_db_path = Some(path);
         self
     }
 }
@@ -299,10 +314,46 @@ impl SessionMessageHandler {
                 content: full_prompt,
             });
         }
-        messages.push(ChatMessage {
-            role: "user".to_string(),
-            content: content.to_string(),
-        });
+
+        // ── Consume memory_injection slot ──────────────────────────────────
+        // The active-searcher writes to this slot asynchronously; we consume
+        // and inject it here during message assembly.
+        let injection = if let Some(cs) = session_manager.get_conversation_session(session_id).await
+        {
+            cs.read().await.take_memory_injection()
+        } else {
+            None
+        };
+        if let Some(inj) = injection {
+            use crate::llm::session::InjectionPosition;
+            match inj.position_mode {
+                InjectionPosition::AfterCurrent => {
+                    messages.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                    });
+                    messages.push(ChatMessage {
+                        role: "tool".to_string(),
+                        content: inj.content,
+                    });
+                }
+                InjectionPosition::BeforeNext => {
+                    messages.push(ChatMessage {
+                        role: "tool".to_string(),
+                        content: inj.content,
+                    });
+                    messages.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                    });
+                }
+            }
+        } else {
+            messages.push(ChatMessage {
+                role: "user".to_string(),
+                content: content.to_string(),
+            });
+        }
 
         let internal_request = crate::llm::types::InternalRequest {
             model: String::new(),
@@ -349,6 +400,146 @@ impl SessionMessageHandler {
                 tracing::info!(session_id = %session_id, "LLM request cancelled");
                 Err(LLMError::Cancelled)
             }
+        }
+    }
+}
+// ── Active-searcher trigger ──
+impl SessionMessageHandler {
+    /// Spawn a background active-searcher task for the current message.
+    ///
+    /// Runs asynchronously and writes results to the session's
+    /// `memory_injection` slot. Skips if:
+    /// - `memory_db_path` is not set
+    /// - The agent_id is excluded (memory-miner, dreaming)
+    pub(super) fn maybe_spawn_active_searcher(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        content: &str,
+    ) {
+        use crate::memory::active_searcher::{ActiveSearcher, ActiveSearcherConfig};
+        use crate::memory::active_searcher_llm::should_trigger_role;
+
+        let Some(ref db_path) = self.memory_db_path else {
+            return;
+        };
+        if !should_trigger_role(agent_id) {
+            return;
+        }
+
+        let sm = Arc::clone(&self.session_manager);
+        let sid = session_id.to_string();
+        let aid = agent_id.to_string();
+        let content = content.to_string();
+        let db_path = db_path.clone();
+        let ufc = Arc::clone(&self.unified_fallback_client);
+        let model = ActiveSearcherConfig::default().model.clone();
+
+        tokio::spawn(async move {
+            // Build an LlmCaller wrapper around UnifiedFallbackClient.
+            let caller = FallbackLlmCaller { client: ufc, model };
+
+            let config = ActiveSearcherConfig::default();
+            let searcher = ActiveSearcher::new(&db_path, config);
+
+            // Gather context: last N messages from the session.
+            let context_messages = if let Some(cs) = sm.get_conversation_session(&sid).await {
+                let cs_read = cs.read().await;
+                let msgs = ChatSession::messages(&*cs_read);
+                let n = searcher.config().context_turns;
+                if msgs.len() > n {
+                    msgs[msgs.len() - n..].to_vec()
+                } else {
+                    msgs.to_vec()
+                }
+            } else {
+                Vec::new()
+            };
+
+            // Gather injected event IDs for dedup.
+            let injected_ids = if let Some(cs) = sm.get_conversation_session(&sid).await {
+                let cs_read = cs.read().await;
+                let slot = cs_read
+                    .memory_injection_arc()
+                    .lock()
+                    .expect("memory_injection lock poisoned");
+                slot.as_ref()
+                    .map(|inj| inj.injected_event_ids.clone())
+                    .unwrap_or_default()
+            } else {
+                std::collections::HashSet::new()
+            };
+
+            if let Some(injection) = searcher
+                .run(
+                    &aid,
+                    &aid,
+                    &content,
+                    &context_messages,
+                    &injected_ids,
+                    &caller,
+                )
+                .await
+            {
+                if let Some(cs) = sm.get_conversation_session(&sid).await {
+                    cs.read().await.set_memory_injection(injection);
+                }
+            }
+        });
+    }
+}
+
+/// LlmCaller adapter for `UnifiedFallbackClient`.
+///
+/// Wraps the unified fallback client so it can be used as a trait object
+/// by the active-searcher pipeline.
+struct FallbackLlmCaller {
+    client: Arc<UnifiedFallbackClient>,
+    model: String,
+}
+
+#[async_trait::async_trait]
+impl crate::memory::active_searcher_llm::LlmCaller for FallbackLlmCaller {
+    async fn complete(
+        &self,
+        prompt: &str,
+    ) -> Result<String, crate::memory::active_searcher::ActiveSearcherError> {
+        use crate::llm::types::InternalRequest;
+
+        let request = InternalRequest {
+            model: self.model.clone(),
+            messages: vec![crate::llm::types::InternalMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+            }],
+            temperature: 0.0,
+            max_tokens: None,
+            stream: false,
+            extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            session_id: None,
+            reasoning_level: crate::session::persistence::ReasoningLevel::default(),
+            turn_count: None,
+        };
+
+        match self.client.chat(request).await {
+            Ok(response) => {
+                let text = response
+                    .content_blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        crate::llm::types::ContentBlock::Text(t) => Some(t.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                Ok(text)
+            }
+            Err(e) => Err(crate::memory::active_searcher::ActiveSearcherError::Llm(
+                e.to_string(),
+            )),
         }
     }
 }

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -248,6 +248,58 @@ impl SessionMessageHandler {
         .await;
     }
 }
+
+/// Consume the `memory_injection` slot and push user + optional tool
+/// messages into `messages` according to the injection position mode.
+///
+/// When an injection is present:
+/// - `AfterCurrent` → `[user(content), tool(injection)]`
+/// - `BeforeNext`   → `[tool(injection), user(content)]`
+///
+/// When absent → `[user(content)]`.
+pub(super) async fn push_messages_with_injection(
+    messages: &mut Vec<ChatMessage>,
+    session_manager: &SessionManager,
+    session_id: &str,
+    content: &str,
+) {
+    let injection = match session_manager.get_conversation_session(session_id).await {
+        Some(cs) => cs.read().await.take_memory_injection(),
+        None => None,
+    };
+
+    if let Some(inj) = injection {
+        use crate::llm::session::InjectionPosition;
+        match inj.position_mode {
+            InjectionPosition::AfterCurrent => {
+                messages.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: content.to_string(),
+                });
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: inj.content,
+                });
+            }
+            InjectionPosition::BeforeNext => {
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: inj.content,
+                });
+                messages.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: content.to_string(),
+                });
+            }
+        }
+    } else {
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: content.to_string(),
+        });
+    }
+}
+
 // ── LLM calling ──
 impl SessionMessageHandler {
     /// Make a non-streaming LLM call with full system prompt injection.
@@ -316,44 +368,7 @@ impl SessionMessageHandler {
         }
 
         // ── Consume memory_injection slot ──────────────────────────────────
-        // The active-searcher writes to this slot asynchronously; we consume
-        // and inject it here during message assembly.
-        let injection = if let Some(cs) = session_manager.get_conversation_session(session_id).await
-        {
-            cs.read().await.take_memory_injection()
-        } else {
-            None
-        };
-        if let Some(inj) = injection {
-            use crate::llm::session::InjectionPosition;
-            match inj.position_mode {
-                InjectionPosition::AfterCurrent => {
-                    messages.push(ChatMessage {
-                        role: "user".to_string(),
-                        content: content.to_string(),
-                    });
-                    messages.push(ChatMessage {
-                        role: "tool".to_string(),
-                        content: inj.content,
-                    });
-                }
-                InjectionPosition::BeforeNext => {
-                    messages.push(ChatMessage {
-                        role: "tool".to_string(),
-                        content: inj.content,
-                    });
-                    messages.push(ChatMessage {
-                        role: "user".to_string(),
-                        content: content.to_string(),
-                    });
-                }
-            }
-        } else {
-            messages.push(ChatMessage {
-                role: "user".to_string(),
-                content: content.to_string(),
-            });
-        }
+        push_messages_with_injection(&mut messages, session_manager, session_id, content).await;
 
         let internal_request = crate::llm::types::InternalRequest {
             model: String::new(),

--- a/src/gateway/session_handler_dispatch.rs
+++ b/src/gateway/session_handler_dispatch.rs
@@ -58,6 +58,15 @@ impl SessionMessageHandler {
         plugin: Option<&Arc<dyn IMPlugin>>,
     ) -> HandleResult {
         self.set_busy(session_id, true).await;
+
+        // ── Trigger active-searcher (best-effort, non-blocking) ────────
+        // Look up the agent_id for role-based exclusion, then spawn a
+        // background searcher that writes results to the memory_injection
+        // slot for the next turn to consume.
+        if let Some(agent_id) = self.session_manager.get_chat_id(session_id).await {
+            self.maybe_spawn_active_searcher(session_id, &agent_id, &content);
+        }
+
         let session_id = session_id.to_string();
         let content_for_task = content;
         let sm = Arc::clone(&self.session_manager);

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -105,10 +105,44 @@ impl SessionMessageHandler {
                 content: full_prompt,
             });
         }
-        messages.push(ChatMessage {
-            role: "user".to_string(),
-            content: content.to_string(),
-        });
+
+        // ── Consume memory_injection slot ──────────────────────────────────
+        let injection = if let Some(cs) = session_manager.get_conversation_session(session_id).await
+        {
+            cs.read().await.take_memory_injection()
+        } else {
+            None
+        };
+        if let Some(inj) = injection {
+            use crate::llm::session::InjectionPosition;
+            match inj.position_mode {
+                InjectionPosition::AfterCurrent => {
+                    messages.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                    });
+                    messages.push(ChatMessage {
+                        role: "tool".to_string(),
+                        content: inj.content,
+                    });
+                }
+                InjectionPosition::BeforeNext => {
+                    messages.push(ChatMessage {
+                        role: "tool".to_string(),
+                        content: inj.content,
+                    });
+                    messages.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                    });
+                }
+            }
+        } else {
+            messages.push(ChatMessage {
+                role: "user".to_string(),
+                content: content.to_string(),
+            });
+        }
 
         let internal_request = crate::llm::types::InternalRequest {
             model: String::new(),

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -107,42 +107,13 @@ impl SessionMessageHandler {
         }
 
         // ── Consume memory_injection slot ──────────────────────────────────
-        let injection = if let Some(cs) = session_manager.get_conversation_session(session_id).await
-        {
-            cs.read().await.take_memory_injection()
-        } else {
-            None
-        };
-        if let Some(inj) = injection {
-            use crate::llm::session::InjectionPosition;
-            match inj.position_mode {
-                InjectionPosition::AfterCurrent => {
-                    messages.push(ChatMessage {
-                        role: "user".to_string(),
-                        content: content.to_string(),
-                    });
-                    messages.push(ChatMessage {
-                        role: "tool".to_string(),
-                        content: inj.content,
-                    });
-                }
-                InjectionPosition::BeforeNext => {
-                    messages.push(ChatMessage {
-                        role: "tool".to_string(),
-                        content: inj.content,
-                    });
-                    messages.push(ChatMessage {
-                        role: "user".to_string(),
-                        content: content.to_string(),
-                    });
-                }
-            }
-        } else {
-            messages.push(ChatMessage {
-                role: "user".to_string(),
-                content: content.to_string(),
-            });
-        }
+        super::session_handler::push_messages_with_injection(
+            &mut messages,
+            session_manager,
+            session_id,
+            content,
+        )
+        .await;
 
         let internal_request = crate::llm::types::InternalRequest {
             model: String::new(),

--- a/src/llm/session/memory_injection.rs
+++ b/src/llm/session/memory_injection.rs
@@ -1,0 +1,113 @@
+//! Memory injection slot for active-searcher results.
+//!
+//! Each [`ConversationSession`](super::ConversationSession) holds an
+//! `Arc<Mutex<Option<MemoryInjection>>>` so that the async active-searcher
+//! task can write results while the session owner reads / consumes them
+//! without a data race.
+
+use std::collections::HashSet;
+
+/// Where the memory-injection tool message should be placed
+/// relative to the current user message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InjectionPosition {
+    /// Insert the tool message immediately after the current
+    /// (most-recent) user message in the assembled list.
+    AfterCurrent,
+    /// Insert the tool message just before the next assistant
+    /// message would appear (i.e. at the end of the list).
+    BeforeNext,
+}
+
+/// A single memory-injection payload produced by the active-searcher.
+///
+/// Lifecycle per turn: **write** → **read/consume** → **clear**.
+/// The slot is *not* persisted across process restarts.
+#[derive(Debug, Clone)]
+pub struct MemoryInjection {
+    /// Summarised context text injected as a `role="tool"` message.
+    pub content: String,
+    /// Where to place the tool message in the assembled list.
+    pub position_mode: InjectionPosition,
+    /// Event IDs already injected this session — used for dedup
+    /// so the same event is never injected twice.
+    pub injected_event_ids: HashSet<i64>,
+}
+
+impl MemoryInjection {
+    /// Create a new injection with the given content and position.
+    /// The `injected_event_ids` set starts empty.
+    pub fn new(content: String, position_mode: InjectionPosition) -> Self {
+        Self {
+            content,
+            position_mode,
+            injected_event_ids: HashSet::new(),
+        }
+    }
+
+    /// Record that `event_id` has been injected so it won't appear
+    /// again in future active-searcher turns.
+    pub fn add_injected_event_id(&mut self, event_id: i64) {
+        self.injected_event_ids.insert(event_id);
+    }
+
+    /// Returns `true` if `event_id` was already injected.
+    pub fn is_event_injected(&self, event_id: i64) -> bool {
+        self.injected_event_ids.contains(&event_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_injection_new_fields() {
+        let inj = MemoryInjection::new("summary".into(), InjectionPosition::AfterCurrent);
+        assert_eq!(inj.content, "summary");
+        assert_eq!(inj.position_mode, InjectionPosition::AfterCurrent);
+        assert!(inj.injected_event_ids.is_empty());
+    }
+
+    #[test]
+    fn test_add_and_check_injected_event() {
+        let mut inj = MemoryInjection::new("s".into(), InjectionPosition::BeforeNext);
+        assert!(!inj.is_event_injected(42));
+        inj.add_injected_event_id(42);
+        assert!(inj.is_event_injected(42));
+        assert!(!inj.is_event_injected(99));
+    }
+
+    #[test]
+    fn test_add_injected_event_id_is_idempotent() {
+        let mut inj = MemoryInjection::new("s".into(), InjectionPosition::AfterCurrent);
+        inj.add_injected_event_id(1);
+        inj.add_injected_event_id(1);
+        inj.add_injected_event_id(1);
+        assert_eq!(inj.injected_event_ids.len(), 1);
+    }
+
+    #[test]
+    fn test_injection_clone_preserves_ids() {
+        let mut inj = MemoryInjection::new("text".into(), InjectionPosition::AfterCurrent);
+        inj.add_injected_event_id(10);
+        inj.add_injected_event_id(20);
+        let cloned = inj.clone();
+        assert_eq!(cloned.injected_event_ids.len(), 2);
+        assert!(cloned.is_event_injected(10));
+        assert!(cloned.is_event_injected(20));
+    }
+
+    #[test]
+    fn test_position_mode_equality() {
+        assert_eq!(
+            InjectionPosition::AfterCurrent,
+            InjectionPosition::AfterCurrent
+        );
+        assert_eq!(InjectionPosition::BeforeNext, InjectionPosition::BeforeNext);
+        assert_ne!(
+            InjectionPosition::AfterCurrent,
+            InjectionPosition::BeforeNext
+        );
+    }
+}

--- a/src/llm/session/mod.rs
+++ b/src/llm/session/mod.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::common::VerbosityLevel;
@@ -39,6 +39,9 @@ pub(crate) use crate::llm::session_handles::KillHandle;
 // `ChatSession` trait + `impl ChatSession for ConversationSession` live in
 // the sibling file `session_chat.rs`. Re-exported here so existing
 // `use crate::llm::session::ChatSession;` call sites keep working.
+mod memory_injection;
+pub use memory_injection::{InjectionPosition, MemoryInjection};
+
 mod session_chat;
 pub use session_chat::ChatSession;
 
@@ -117,6 +120,11 @@ pub struct ConversationSession {
     /// Communication configuration for spawned child sessions.
     /// When set, restricts which agents the child may communicate with.
     communication_config: Option<CommunicationConfig>,
+    /// Per-session memory-injection slot.
+    /// Written by the active-searcher async task, consumed and cleared
+    /// by the session owner when assembling the next message list.
+    /// Not persisted across process restarts.
+    memory_injection: Arc<Mutex<Option<MemoryInjection>>>,
     /// Last activity timestamp (Unix seconds) — updated on every message
     /// push or state mutation.  Used by the shutdown progress card to
     /// display accurate "elapsed since last activity" instead of session age.
@@ -161,6 +169,7 @@ impl ConversationSession {
             cancel_token: CancellationToken::new(),
             stopped: Arc::new(AtomicBool::new(false)),
             communication_config: None,
+            memory_injection: Arc::new(Mutex::new(None)),
             last_activity_at: Utc::now().timestamp(),
             shutdown_handle: None,
             verbosity_level: VerbosityLevel::default(),
@@ -254,6 +263,53 @@ impl ConversationSession {
     /// Overrides the verbosity level at runtime.
     pub fn set_verbosity_level(&mut self, level: VerbosityLevel) {
         self.verbosity_level = level;
+    }
+
+    /// Returns a reference to the memory-injection Arc.
+    pub fn memory_injection_arc(&self) -> &Arc<Mutex<Option<MemoryInjection>>> {
+        &self.memory_injection
+    }
+
+    /// Write a memory-injection payload into the slot.
+    pub fn set_memory_injection(&self, injection: MemoryInjection) {
+        let mut slot = self
+            .memory_injection
+            .lock()
+            .expect("memory_injection lock poisoned");
+        *slot = Some(injection);
+    }
+
+    /// Take the current memory-injection payload, replacing the slot
+    /// with `None`. Returns `None` if the slot was already empty.
+    pub fn take_memory_injection(&self) -> Option<MemoryInjection> {
+        let mut slot = self
+            .memory_injection
+            .lock()
+            .expect("memory_injection lock poisoned");
+        slot.take()
+    }
+
+    /// Record that `event_id` has been injected in the current session.
+    /// If no injection exists yet, this is a no-op.
+    pub fn add_injected_event_id(&self, event_id: i64) {
+        let mut slot = self
+            .memory_injection
+            .lock()
+            .expect("memory_injection lock poisoned");
+        if let Some(ref mut inj) = *slot {
+            inj.add_injected_event_id(event_id);
+        }
+    }
+
+    /// Returns `true` if `event_id` was already injected in this session.
+    pub fn is_event_injected(&self, event_id: i64) -> bool {
+        let slot = self
+            .memory_injection
+            .lock()
+            .expect("memory_injection lock poisoned");
+        slot.as_ref()
+            .map(|inj| inj.is_event_injected(event_id))
+            .unwrap_or(false)
     }
 
     /// Replace the system prompt on an existing session.
@@ -606,6 +662,13 @@ impl std::fmt::Debug for ConversationSession {
             .field("stopped", &self.stopped.load(Ordering::SeqCst))
             .field("communication_config", &self.communication_config)
             .field("verbosity_level", &self.verbosity_level)
+            .field(
+                "memory_injection",
+                &*self
+                    .memory_injection
+                    .lock()
+                    .expect("memory_injection lock poisoned"),
+            )
             .finish()
     }
 }

--- a/src/memory/active_searcher.rs
+++ b/src/memory/active_searcher.rs
@@ -281,7 +281,16 @@ impl ActiveSearcher {
             if out.len() + line.len() > max {
                 let remaining = max.saturating_sub(out.len());
                 if remaining > 0 {
-                    out.push_str(&line[..remaining.min(line.len())]);
+                    // UTF-8 safe truncation: accumulate chars until
+                    // the next char would exceed `remaining` bytes.
+                    let mut safe = String::new();
+                    for ch in line.chars() {
+                        if safe.len() + ch.len_utf8() > remaining {
+                            break;
+                        }
+                        safe.push(ch);
+                    }
+                    out.push_str(&safe);
                 }
                 break;
             }

--- a/src/memory/active_searcher.rs
+++ b/src/memory/active_searcher.rs
@@ -8,6 +8,12 @@ use rusqlite::{params, Connection};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+use tokio::time::timeout;
+
+use super::active_searcher_llm::{
+    extract_concepts_llm, should_trigger_role, summarize_events_llm, LlmCaller,
+};
+use crate::llm::session::{InjectionPosition, MemoryInjection};
 
 // ── Errors ───────────────────────────────────────────────────────────────
 
@@ -17,6 +23,9 @@ pub enum ActiveSearcherError {
     /// SQLite storage error.
     #[error("sqlite error: {0}")]
     Sqlite(String),
+    /// LLM caller error.
+    #[error("llm error: {0}")]
+    Llm(String),
 }
 
 // ── Configuration ────────────────────────────────────────────────────────
@@ -280,6 +289,92 @@ impl ActiveSearcher {
         }
 
         out
+    }
+
+    // ── Full pipeline ─────────────────────────────────────────────
+
+    /// Run the complete active-searcher pipeline.
+    ///
+    /// 1. Extract concepts via LLM
+    /// 2. Search entities in SQLite
+    /// 3. Find associated events
+    /// 4. Deduplicate against already-injected events
+    /// 5. Summarise via LLM
+    ///
+    /// Returns `None` if the pipeline times out or produces no results.
+    pub async fn run(
+        &self,
+        agent_id: &str,
+        session_role: &str,
+        current_message: &str,
+        context_messages: &[crate::llm::session::SessionMessage],
+        injected_event_ids: &HashSet<i64>,
+        llm: &dyn LlmCaller,
+    ) -> Option<MemoryInjection> {
+        if !should_trigger_role(session_role) {
+            return None;
+        }
+
+        let timeout_duration = std::time::Duration::from_millis(self.config.timeout_ms);
+
+        let result: Result<Result<Option<MemoryInjection>, ActiveSearcherError>, _> =
+            timeout(timeout_duration, async {
+                // 1. Extract concepts
+                let concepts = extract_concepts_llm(llm, context_messages, current_message).await?;
+                if concepts.is_empty() {
+                    return Ok(None);
+                }
+
+                // 2. Search entities
+                let entities = self.search_entities(agent_id, &concepts)?;
+                if entities.is_empty() {
+                    return Ok(None);
+                }
+
+                // 3. Find events
+                let entity_ids: Vec<i64> = entities.iter().map(|e| e.id).collect();
+                let events = self.find_events(&entity_ids)?;
+                if events.is_empty() {
+                    return Ok(None);
+                }
+
+                // 4. Deduplicate
+                let events = self.dedup_events(events, injected_event_ids);
+                if events.is_empty() {
+                    return Ok(None);
+                }
+
+                // 5. Summarise via LLM
+                let events_text = self.summarize_events(&events);
+                let summary =
+                    summarize_events_llm(llm, &events_text, self.config.max_summary_chars).await?;
+
+                // 6. Determine position mode based on session role
+                let position = if session_role == "user" {
+                    InjectionPosition::AfterCurrent
+                } else {
+                    InjectionPosition::BeforeNext
+                };
+
+                // 7. Build injection with event IDs for dedup
+                let mut injection = MemoryInjection::new(summary, position);
+                for ev in &events {
+                    injection.add_injected_event_id(ev.id);
+                }
+
+                Ok(Some(injection))
+            })
+            .await;
+
+        match result {
+            Ok(Ok(Some(injection))) => Some(injection),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if the given session role should trigger active-searcher.
+    pub fn should_trigger(session_role: &str) -> bool {
+        should_trigger_role(session_role)
     }
 
     // ── Internal ─────────────────────────────────────────────────────

--- a/src/memory/active_searcher.rs
+++ b/src/memory/active_searcher.rs
@@ -1,0 +1,291 @@
+//! Active Searcher — per-message entity search and memory injection.
+//!
+//! On every message, extracts query concepts via LLM, matches them against
+//! the SQLite `entities` table (agent-isolated), resolves associated events,
+//! deduplicates, and produces a text summary for the `memory_injection` slot.
+
+use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+// ── Errors ───────────────────────────────────────────────────────────────
+
+/// Errors specific to the active-searcher module.
+#[derive(Debug, Error)]
+pub enum ActiveSearcherError {
+    /// SQLite storage error.
+    #[error("sqlite error: {0}")]
+    Sqlite(String),
+}
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Search parameters for the active-searcher.
+///
+/// Typically loaded from the memory section of the agent config file.
+/// All fields have sensible defaults.
+#[derive(Debug, Clone)]
+pub struct ActiveSearcherConfig {
+    /// Timeout in milliseconds for the entire search pipeline.
+    pub timeout_ms: u64,
+    /// Maximum character count for the condensed summary text.
+    pub max_summary_chars: usize,
+    /// Minimum number of entity hits required to include an event.
+    pub min_entity_hits: u32,
+    /// Maximum number of events returned per search.
+    pub top_k_events: usize,
+    /// Number of recent conversation turns to include as context.
+    pub context_turns: usize,
+    /// LLM model used for concept extraction and summarisation.
+    pub model: String,
+}
+
+impl Default for ActiveSearcherConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: 5000,
+            max_summary_chars: 2000,
+            min_entity_hits: 1,
+            top_k_events: 10,
+            context_turns: 3,
+            model: "gpt-4o-mini".to_string(),
+        }
+    }
+}
+
+// ── Domain types ─────────────────────────────────────────────────────────
+
+/// A row from the `entities` table, enriched with the matching type weight.
+#[derive(Debug, Clone)]
+pub struct MatchedEntity {
+    /// Primary key of the matched entity.
+    pub id: i64,
+    /// Agent that owns this entity.
+    pub agent_id: String,
+    /// Entity type key (e.g. "person", "subject").
+    pub entity_type: String,
+    /// Human-readable entity name.
+    pub name: String,
+    /// Normalised name used for exact matching.
+    pub normalized_name: String,
+    /// Weight of the entity type (from `entity_types` table).
+    pub weight: f64,
+}
+
+/// A row from the `events` table.
+#[derive(Debug, Clone)]
+pub struct EventRecord {
+    /// Primary key.
+    pub id: i64,
+    /// Human-readable event content / summary.
+    pub content: String,
+    /// When the event was recorded (Unix timestamp).
+    pub timestamp: i64,
+    /// Source session that produced this event.
+    pub source_session_id: String,
+}
+
+// ── Core searcher ────────────────────────────────────────────────────────
+
+/// Stateless searcher that opens a fresh SQLite connection on each call.
+///
+/// Holding only a `PathBuf` and a config snapshot keeps the struct
+/// `Send + Sync` and avoids holding a long-lived connection open.
+#[derive(Debug, Clone)]
+pub struct ActiveSearcher {
+    /// Path to the SQLite database file.
+    db_path: PathBuf,
+    /// Search parameters.
+    config: ActiveSearcherConfig,
+}
+
+impl ActiveSearcher {
+    /// Create a new searcher with the given database path and config.
+    pub fn new(db_path: impl AsRef<Path>, config: ActiveSearcherConfig) -> Self {
+        Self {
+            db_path: db_path.as_ref().to_path_buf(),
+            config,
+        }
+    }
+
+    /// Returns a reference to the search configuration.
+    pub fn config(&self) -> &ActiveSearcherConfig {
+        &self.config
+    }
+
+    // ── Entity search ────────────────────────────────────────────────
+
+    /// Match a list of query concepts against the `entities` table.
+    ///
+    /// For each concept, performs:
+    /// - **Exact match**: `normalized_name = concept`
+    /// - **Fuzzy match**: `normalized_name LIKE '%concept%'`
+    ///
+    /// Results are de-duplicated by entity ID and sorted by entity type
+    /// weight descending (higher-weight types surface first).
+    pub fn search_entities(
+        &self,
+        agent_id: &str,
+        concepts: &[String],
+    ) -> Result<Vec<MatchedEntity>, ActiveSearcherError> {
+        let conn = self.open()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT e.id, e.agent_id, e.type, e.name, e.normalized_name,
+                        t.weight
+                 FROM entities e
+                 JOIN entity_types t ON e.type = t.type
+                 WHERE e.agent_id = ?1
+                   AND (e.normalized_name = ?2
+                        OR e.normalized_name LIKE '%' || ?2 || '%')
+                 ORDER BY t.weight DESC",
+            )
+            .map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))?;
+
+        let mut seen: HashSet<i64> = HashSet::new();
+        let mut results = Vec::new();
+
+        for concept in concepts {
+            let rows = stmt
+                .query_map(params![agent_id, concept], |row| {
+                    Ok(MatchedEntity {
+                        id: row.get(0)?,
+                        agent_id: row.get(1)?,
+                        entity_type: row.get(2)?,
+                        name: row.get(3)?,
+                        normalized_name: row.get(4)?,
+                        weight: row.get(5)?,
+                    })
+                })
+                .map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))?;
+
+            for row in rows {
+                let entity = row.map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))?;
+                if seen.insert(entity.id) {
+                    results.push(entity);
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    // ── Event resolution ─────────────────────────────────────────────
+
+    /// Resolve associated events for a set of entity IDs.
+    ///
+    /// Joins `event_entities` with `events`, counts distinct entity hits
+    /// per event, filters by `min_entity_hits`, and returns at most
+    /// `top_k_events` results ordered by hit count descending.
+    pub fn find_events(&self, entity_ids: &[i64]) -> Result<Vec<EventRecord>, ActiveSearcherError> {
+        if entity_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self.open()?;
+        let placeholders: Vec<String> = entity_ids.iter().map(|_| "?".to_string()).collect();
+        let in_clause = placeholders.join(", ");
+
+        let sql = format!(
+            "SELECT ev.id, ev.content, ev.timestamp, ev.source_session_id,
+                    COUNT(DISTINCT ee.entity_id) AS hit_count
+             FROM events ev
+             JOIN event_entities ee ON ev.id = ee.event_id
+             WHERE ee.entity_id IN ({in_clause})
+             GROUP BY ev.id
+             HAVING hit_count >= ?{param_idx}
+             ORDER BY hit_count DESC
+             LIMIT ?{limit_idx}",
+            in_clause = in_clause,
+            param_idx = entity_ids.len() + 1,
+            limit_idx = entity_ids.len() + 2,
+        );
+
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = entity_ids
+            .iter()
+            .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+            .collect();
+        param_values.push(Box::new(self.config.min_entity_hits));
+        param_values.push(Box::new(self.config.top_k_events as i64));
+
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))?;
+
+        let events = stmt
+            .query_map(params_refs.as_slice(), |row| {
+                Ok(EventRecord {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                    timestamp: row.get(2)?,
+                    source_session_id: row.get(3)?,
+                })
+            })
+            .map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(events)
+    }
+
+    // ── Dedup ────────────────────────────────────────────────────────
+
+    /// Exclude events whose IDs are already in `injected_event_ids`.
+    pub fn dedup_events(
+        &self,
+        events: Vec<EventRecord>,
+        injected_event_ids: &HashSet<i64>,
+    ) -> Vec<EventRecord> {
+        events
+            .into_iter()
+            .filter(|e| !injected_event_ids.contains(&e.id))
+            .collect()
+    }
+
+    // ── Summarise ────────────────────────────────────────────────────
+
+    /// Condense a list of events into a plain-text summary.
+    ///
+    /// Each event is rendered as `[timestamp] content` on its own line.
+    /// The result is truncated to `max_summary_chars` if necessary.
+    /// This is a pure-text implementation; LLM-based summarisation
+    /// will be added in a later iteration.
+    pub fn summarize_events(&self, events: &[EventRecord]) -> String {
+        if events.is_empty() {
+            return String::new();
+        }
+
+        let max = self.config.max_summary_chars;
+        let mut out = String::with_capacity(max.min(events.len() * 80));
+
+        for (i, ev) in events.iter().enumerate() {
+            let line = if i == 0 {
+                format!("[{}] {}", ev.timestamp, ev.content)
+            } else {
+                format!("\n[{}] {}", ev.timestamp, ev.content)
+            };
+
+            if out.len() + line.len() > max {
+                let remaining = max.saturating_sub(out.len());
+                if remaining > 0 {
+                    out.push_str(&line[..remaining.min(line.len())]);
+                }
+                break;
+            }
+            out.push_str(&line);
+        }
+
+        out
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────
+
+    /// Open a new SQLite connection to the database.
+    fn open(&self) -> Result<Connection, ActiveSearcherError> {
+        Connection::open(&self.db_path).map_err(|e| ActiveSearcherError::Sqlite(e.to_string()))
+    }
+}

--- a/src/memory/active_searcher_llm.rs
+++ b/src/memory/active_searcher_llm.rs
@@ -1,0 +1,153 @@
+//! LLM integration for the active-searcher.
+//!
+//! Provides concept extraction and LLM-based event summarisation
+//! via a mockable [`LlmCaller`] trait.
+
+use async_trait::async_trait;
+
+use crate::llm::session::SessionMessage;
+use crate::llm::types::ContentBlock;
+
+use super::active_searcher::ActiveSearcherError;
+
+// ── LLM caller trait ─────────────────────────────────────────────────────
+
+/// Abstract LLM caller for concept extraction and summarisation.
+///
+/// Implementors must be `Send + Sync` for use in async contexts.
+/// In production, wrap a real [`Provider`][crate::llm::Provider];
+/// in tests, provide a mock that returns fixed strings.
+#[async_trait]
+pub trait LlmCaller: Send + Sync {
+    /// Send a prompt to the LLM and return the text completion.
+    async fn complete(&self, prompt: &str) -> Result<String, ActiveSearcherError>;
+}
+
+// ── Prompt builders ──────────────────────────────────────────────────────
+
+/// Build the concept-extraction prompt.
+///
+/// Format:
+/// ```text
+/// System: Extract key concepts...
+/// Context: [recent turns]
+/// Message: [current message]
+/// ```
+pub(crate) fn build_concept_extraction_prompt(
+    messages: &[SessionMessage],
+    current_message: &str,
+) -> String {
+    let mut ctx = String::new();
+    for msg in messages {
+        let role = &msg.role;
+        let text: String = msg
+            .content_blocks
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text(t) => Some(t.as_str()),
+                ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !text.is_empty() {
+            ctx.push_str(&format!("{}: {}\n", role, text));
+        }
+    }
+
+    format!(
+        "You are a concept extraction assistant. \
+         Extract the key concepts from the conversation that would be useful \
+         for searching a memory database. Concepts should be specific entities, \
+         topics, or themes (not generic words like 'the', 'and', 'is').\n\n\
+         Context:\n{ctx}\n\
+         Current message: {current_message}\n\n\
+         Return a JSON array of concept strings. Example: [\"Alice\", \"project deadline\", \"meeting\"]\n\
+         Return ONLY the JSON array, nothing else."
+    )
+}
+
+/// Build the event-summarisation prompt.
+///
+/// The LLM receives the raw event text and must condense it into a
+/// concise summary within `max_chars` characters.
+pub(crate) fn build_summarization_prompt(event_text: &str, max_chars: usize) -> String {
+    format!(
+        "Condense the following memory events into a concise summary. \
+         Keep the most important information: who was involved, what happened, \
+         and key details. Maximum {max_chars} characters.\n\n\
+         Events:\n{event_text}"
+    )
+}
+
+// ── Response parsers ─────────────────────────────────────────────────────
+
+/// Parse the LLM response as a JSON array of concept strings.
+///
+/// Tolerant: extracts anything inside `[` and `]`, handling both
+/// `"concept"` and `"concept",` formats.
+pub(crate) fn parse_concepts(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+
+    // Try standard JSON parse first.
+    if let Ok(arr) = serde_json::from_str::<Vec<String>>(trimmed) {
+        return arr;
+    }
+
+    // Fallback: find the JSON array substring.
+    if let (Some(start), Some(end)) = (trimmed.find('['), trimmed.find(']')) {
+        let slice = &trimmed[start..=end];
+        if let Ok(arr) = serde_json::from_str::<Vec<String>>(slice) {
+            return arr;
+        }
+    }
+
+    Vec::new()
+}
+
+// ── LLM pipeline methods ────────────────────────────────────────────────
+
+/// Extract concepts via LLM from the current message and context.
+///
+/// Builds the prompt, calls the LLM, and parses the JSON array.
+pub(crate) async fn extract_concepts_llm(
+    caller: &dyn LlmCaller,
+    context_messages: &[SessionMessage],
+    current_message: &str,
+) -> Result<Vec<String>, ActiveSearcherError> {
+    let prompt = build_concept_extraction_prompt(context_messages, current_message);
+    let raw = caller.complete(&prompt).await?;
+    Ok(parse_concepts(&raw))
+}
+
+/// Summarise events via LLM.
+///
+/// Builds a prompt with the event text, calls the LLM, and returns
+/// the condensed summary (truncated to `max_chars` as a safety net).
+pub(crate) async fn summarize_events_llm(
+    caller: &dyn LlmCaller,
+    events_text: &str,
+    max_chars: usize,
+) -> Result<String, ActiveSearcherError> {
+    let prompt = build_summarization_prompt(events_text, max_chars);
+    let raw = caller.complete(&prompt).await?;
+    // Safety truncation — LLM should respect the limit, but guard against overflow.
+    if raw.len() > max_chars {
+        Ok(raw[..max_chars].to_string())
+    } else {
+        Ok(raw)
+    }
+}
+
+// ── Role exclusion ───────────────────────────────────────────────────────
+
+/// Session roles that should NOT trigger the active-searcher.
+const EXCLUDED_ROLES: &[&str] = &["memory-miner", "dreaming"];
+
+/// Returns `true` if the given session role should trigger active-searcher.
+///
+/// `memory-miner` and `dreaming` sessions are excluded to avoid
+/// circular memory writes.
+pub(crate) fn should_trigger_role(session_role: &str) -> bool {
+    !EXCLUDED_ROLES.contains(&session_role)
+}

--- a/src/memory/active_searcher_llm.rs
+++ b/src/memory/active_searcher_llm.rs
@@ -131,9 +131,18 @@ pub(crate) async fn summarize_events_llm(
 ) -> Result<String, ActiveSearcherError> {
     let prompt = build_summarization_prompt(events_text, max_chars);
     let raw = caller.complete(&prompt).await?;
-    // Safety truncation — LLM should respect the limit, but guard against overflow.
+    // Safety truncation — LLM should respect the limit, but guard
+    // against overflow. Use char-based truncation to avoid splitting
+    // multi-byte UTF-8 characters.
     if raw.len() > max_chars {
-        Ok(raw[..max_chars].to_string())
+        let mut end = 0;
+        for (idx, ch) in raw.char_indices() {
+            if idx + ch.len_utf8() > max_chars {
+                break;
+            }
+            end = idx + ch.len_utf8();
+        }
+        Ok(raw[..end].to_string())
     } else {
         Ok(raw)
     }

--- a/src/memory/active_searcher_tests.rs
+++ b/src/memory/active_searcher_tests.rs
@@ -1,0 +1,794 @@
+//! Unit tests for active-searcher module.
+//!
+//! Covers SQLite schema, search logic, event association, dedup,
+//! summarise, memory_injection slot, role exclusion, and timeout.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use rusqlite::{params, Connection};
+
+use crate::llm::session::{InjectionPosition, MemoryInjection};
+use crate::memory::active_searcher::{
+    ActiveSearcher, ActiveSearcherConfig, ActiveSearcherError, EventRecord,
+};
+use crate::memory::active_searcher_llm::{parse_concepts, should_trigger_role, LlmCaller};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Create a temporary SQLite database with the standard schema.
+fn create_test_db(dir: &Path) -> Connection {
+    let db_path = dir.join("test.db");
+    let conn = Connection::open(&db_path).unwrap();
+    init_test_schema(&conn);
+    conn
+}
+
+/// Initialize the test database with entity_types, entities, event_entities,
+/// and an events table (not part of init_schema yet).
+fn init_test_schema(conn: &Connection) {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS entity_types (
+            id INTEGER PRIMARY KEY,
+            type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            weight REAL NOT NULL DEFAULT 1.0,
+            similarity_threshold REAL NOT NULL DEFAULT 0.80,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            is_active INTEGER NOT NULL DEFAULT 1
+        );
+
+        INSERT OR IGNORE INTO entity_types (id, type, name, description, weight, similarity_threshold, is_default, is_active) VALUES
+            (1,  'time',         '时间',     '时间点', 1.0, 0.90, 0, 1),
+            (2,  'location',      '地点',     '地点',   1.0, 0.75, 0, 1),
+            (3,  'person',        '人物',     '人物',   1.2, 0.80, 0, 1),
+            (4,  'organization',  '组织',     '组织',   1.1, 0.80, 0, 1),
+            (5,  'subject',       '主题',     '主题',   1.5, 0.78, 1, 1),
+            (6,  'product',       '产品',     '产品',   1.1, 0.80, 0, 1),
+            (7,  'metric',        '指标',     '指标',   1.2, 0.85, 0, 1),
+            (8,  'action',        '动作',     '动作',   1.3, 0.78, 1, 1),
+            (9,  'work',          '作品',     '作品',   1.0, 0.80, 0, 1),
+            (10, 'group',         '群体',     '群体',   1.0, 0.78, 0, 1),
+            (11, 'tags',          '标签',     '标签',   0.5, 0.70, 1, 1);
+
+        CREATE TABLE IF NOT EXISTS entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            normalized_name TEXT NOT NULL,
+            description TEXT,
+            UNIQUE(agent_id, type, normalized_name)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_entities_agent_normalized
+            ON entities(agent_id, normalized_name);
+
+        CREATE TABLE IF NOT EXISTS event_entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id INTEGER NOT NULL,
+            entity_id INTEGER NOT NULL,
+            FOREIGN KEY (entity_id) REFERENCES entities(id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_event_entities_entity_id
+            ON event_entities(entity_id);
+
+        CREATE INDEX IF NOT EXISTS idx_event_entities_event_id
+            ON event_entities(event_id);
+
+        CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            source_session_id TEXT NOT NULL
+        );
+        "#,
+    )
+    .unwrap();
+}
+
+/// Insert an entity and return its ID.
+fn insert_entity(
+    conn: &Connection,
+    agent_id: &str,
+    entity_type: &str,
+    name: &str,
+    normalized_name: &str,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO entities (agent_id, type, name, normalized_name)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![agent_id, entity_type, name, normalized_name],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+/// Insert an event and return its ID.
+fn insert_event(conn: &Connection, content: &str, timestamp: i64, session_id: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO events (content, timestamp, source_session_id)
+         VALUES (?1, ?2, ?3)",
+        params![content, timestamp, session_id],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+/// Link an event to an entity.
+fn link_event_entity(conn: &Connection, event_id: i64, entity_id: i64) {
+    conn.execute(
+        "INSERT INTO event_entities (event_id, entity_id) VALUES (?1, ?2)",
+        params![event_id, entity_id],
+    )
+    .unwrap();
+}
+
+// ── SQLite schema tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_sqlite_schema_tables_created() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+
+    let tables: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table'")
+            .unwrap();
+        stmt.query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect()
+    };
+    assert!(tables.contains(&"entity_types".to_string()));
+    assert!(tables.contains(&"entities".to_string()));
+    assert!(tables.contains(&"event_entities".to_string()));
+}
+
+#[test]
+fn test_sqlite_schema_seed_data_integrity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM entity_types", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 11, "should have 11 seed entity types");
+
+    let types: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT type FROM entity_types ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect()
+    };
+    assert_eq!(types[0], "time");
+    assert_eq!(types[2], "person");
+    assert_eq!(types[4], "subject");
+}
+
+#[test]
+fn test_sqlite_schema_unique_constraint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+
+    insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let result = conn.execute(
+        "INSERT INTO entities (agent_id, type, name, normalized_name)
+         VALUES (?1, ?2, ?3, ?4)",
+        params!["agent-1", "person", "Alice Alt", "alice"],
+    );
+    assert!(
+        result.is_err(),
+        "UNIQUE constraint should prevent duplicate"
+    );
+}
+
+// ── Search logic tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_search_entities_exact_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let results = searcher
+        .search_entities("agent-1", &["alice".into()])
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "Alice");
+    assert_eq!(results[0].normalized_name, "alice");
+}
+
+#[test]
+fn test_search_entities_fuzzy_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    insert_entity(&conn, "agent-1", "person", "Alice Smith", "alice smith");
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let results = searcher
+        .search_entities("agent-1", &["alice".into()])
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].name, "Alice Smith");
+}
+
+#[test]
+fn test_search_entities_agent_id_isolation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    insert_entity(&conn, "agent-2", "person", "Bob", "bob");
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let r1 = searcher
+        .search_entities("agent-1", &["alice".into()])
+        .unwrap();
+    assert_eq!(r1.len(), 1);
+    assert_eq!(r1[0].agent_id, "agent-1");
+
+    let r1_all = searcher
+        .search_entities("agent-1", &["bob".into()])
+        .unwrap();
+    assert!(r1_all.is_empty(), "agent-1 should not see Bob");
+
+    let r2 = searcher
+        .search_entities("agent-2", &["bob".into()])
+        .unwrap();
+    assert_eq!(r2.len(), 1);
+    assert_eq!(r2[0].agent_id, "agent-2");
+}
+
+#[test]
+fn test_search_entities_type_weight_ordering() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    // "subject" has weight 1.5, "person" has weight 1.2, "tags" has weight 0.5
+    insert_entity(&conn, "agent-1", "tags", "alice", "alice");
+    insert_entity(&conn, "agent-1", "subject", "alice topic", "alice topic");
+    insert_entity(&conn, "agent-1", "person", "alice person", "alice person");
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let results = searcher
+        .search_entities("agent-1", &["alice".into()])
+        .unwrap();
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].entity_type, "subject");
+    assert_eq!(results[1].entity_type, "person");
+    assert_eq!(results[2].entity_type, "tags");
+}
+
+#[test]
+fn test_search_entities_no_data_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let results = searcher
+        .search_entities("agent-1", &["anything".into()])
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+// ── Event association tests ──────────────────────────────────────────────
+
+#[test]
+fn test_find_events_single_entity_multiple_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    let eid = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let ev1 = insert_event(&conn, "Alice did X", 1000, "sess-1");
+    let ev2 = insert_event(&conn, "Alice did Y", 2000, "sess-1");
+    link_event_entity(&conn, ev1, eid);
+    link_event_entity(&conn, ev2, eid);
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = searcher.find_events(&[eid]).unwrap();
+    assert_eq!(events.len(), 2);
+    let ids: HashSet<i64> = events.iter().map(|e| e.id).collect();
+    assert!(ids.contains(&ev1));
+    assert!(ids.contains(&ev2));
+}
+
+#[test]
+fn test_find_events_multiple_entities_dedup() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    let e1 = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let e2 = insert_entity(&conn, "agent-1", "person", "Bob", "bob");
+    let ev = insert_event(&conn, "Alice and Bob met", 1000, "sess-1");
+    link_event_entity(&conn, ev, e1);
+    link_event_entity(&conn, ev, e2);
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = searcher.find_events(&[e1, e2]).unwrap();
+    assert_eq!(events.len(), 1, "same event should appear once");
+    assert_eq!(events[0].id, ev);
+}
+
+#[test]
+fn test_find_events_min_entity_hits_filter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    let e1 = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let e2 = insert_entity(&conn, "agent-1", "person", "Bob", "bob");
+    let ev1 = insert_event(&conn, "Alice alone", 1000, "sess-1");
+    let ev2 = insert_event(&conn, "Alice and Bob", 2000, "sess-1");
+    link_event_entity(&conn, ev1, e1);
+    link_event_entity(&conn, ev2, e1);
+    link_event_entity(&conn, ev2, e2);
+
+    let config = ActiveSearcherConfig {
+        min_entity_hits: 2,
+        ..Default::default()
+    };
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), config);
+
+    let events = searcher.find_events(&[e1, e2]).unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].id, ev2);
+}
+
+#[test]
+fn test_find_events_top_k_truncation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+    let eid = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    for i in 0..5 {
+        let ev = insert_event(&conn, &format!("Event {i}"), i as i64 * 1000, "sess-1");
+        link_event_entity(&conn, ev, eid);
+    }
+
+    let config = ActiveSearcherConfig {
+        top_k_events: 3,
+        ..Default::default()
+    };
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), config);
+
+    let events = searcher.find_events(&[eid]).unwrap();
+    assert_eq!(events.len(), 3, "should be limited to top_k_events");
+}
+
+#[test]
+fn test_find_events_empty_entity_ids_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = searcher.find_events(&[]).unwrap();
+    assert!(events.is_empty());
+}
+
+// ── Dedup tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_dedup_events_first_time_inject_all() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = vec![
+        EventRecord {
+            id: 1,
+            content: "ev1".into(),
+            timestamp: 1000,
+            source_session_id: "s1".into(),
+        },
+        EventRecord {
+            id: 2,
+            content: "ev2".into(),
+            timestamp: 2000,
+            source_session_id: "s1".into(),
+        },
+    ];
+    let injected = HashSet::new();
+    let result = searcher.dedup_events(events.clone(), &injected);
+    assert_eq!(result.len(), 2);
+}
+
+#[test]
+fn test_dedup_events_already_injected_excluded() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = vec![
+        EventRecord {
+            id: 1,
+            content: "ev1".into(),
+            timestamp: 1000,
+            source_session_id: "s1".into(),
+        },
+        EventRecord {
+            id: 2,
+            content: "ev2".into(),
+            timestamp: 2000,
+            source_session_id: "s1".into(),
+        },
+        EventRecord {
+            id: 3,
+            content: "ev3".into(),
+            timestamp: 3000,
+            source_session_id: "s1".into(),
+        },
+    ];
+    let mut injected = HashSet::new();
+    injected.insert(2);
+    let result = searcher.dedup_events(events, &injected);
+    assert_eq!(result.len(), 2);
+    let ids: Vec<i64> = result.iter().map(|e| e.id).collect();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&3));
+    assert!(!ids.contains(&2));
+}
+
+// ── Summarize tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_summarize_short_text_preserved() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let events = vec![EventRecord {
+        id: 1,
+        content: "Short event".into(),
+        timestamp: 1000,
+        source_session_id: "s1".into(),
+    }];
+    let summary = searcher.summarize_events(&events);
+    assert!(summary.contains("Short event"));
+    assert!(summary.contains("1000"));
+}
+
+#[test]
+fn test_summarize_long_text_truncated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let config = ActiveSearcherConfig {
+        max_summary_chars: 50,
+        ..Default::default()
+    };
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), config);
+
+    let events = vec![EventRecord {
+        id: 1,
+        content: "A very long event description that should be truncated when exceeding the max summary chars limit".into(),
+        timestamp: 1000,
+        source_session_id: "s1".into(),
+    }];
+    let summary = searcher.summarize_events(&events);
+    assert!(
+        summary.len() <= 50,
+        "summary should be <= 50 chars, got {}",
+        summary.len()
+    );
+}
+
+#[test]
+fn test_summarize_empty_events_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+
+    let summary = searcher.summarize_events(&[]);
+    assert!(summary.is_empty());
+}
+
+// ── memory_injection slot tests ──────────────────────────────────────────
+
+#[test]
+fn test_memory_injection_set_and_take() {
+    let session = crate::llm::session::ConversationSession::new(
+        "test-session".into(),
+        "model".into(),
+        tempfile::tempdir().unwrap().keep(),
+    );
+
+    assert!(
+        session.take_memory_injection().is_none(),
+        "slot should be empty initially"
+    );
+
+    let inj = MemoryInjection::new("summary".into(), InjectionPosition::AfterCurrent);
+    session.set_memory_injection(inj);
+
+    let taken = session.take_memory_injection();
+    assert!(taken.is_some(), "slot should have content after set");
+    assert_eq!(taken.unwrap().content, "summary");
+
+    assert!(
+        session.take_memory_injection().is_none(),
+        "slot should be empty after take"
+    );
+}
+
+#[test]
+fn test_memory_injection_position_mode() {
+    let after = MemoryInjection::new("a".into(), InjectionPosition::AfterCurrent);
+    let before = MemoryInjection::new("b".into(), InjectionPosition::BeforeNext);
+    assert_eq!(after.position_mode, InjectionPosition::AfterCurrent);
+    assert_eq!(before.position_mode, InjectionPosition::BeforeNext);
+    assert_ne!(after.position_mode, before.position_mode);
+}
+
+#[test]
+fn test_memory_injection_event_id_dedup() {
+    let mut inj = MemoryInjection::new("s".into(), InjectionPosition::AfterCurrent);
+    assert!(!inj.is_event_injected(42));
+    inj.add_injected_event_id(42);
+    assert!(inj.is_event_injected(42));
+    assert!(!inj.is_event_injected(99));
+    inj.add_injected_event_id(42);
+    assert_eq!(inj.injected_event_ids.len(), 1);
+}
+
+#[test]
+fn test_memory_injection_add_event_id_noop_when_empty_slot() {
+    let session = crate::llm::session::ConversationSession::new(
+        "test".into(),
+        "model".into(),
+        tempfile::tempdir().unwrap().keep(),
+    );
+    session.add_injected_event_id(42);
+    assert!(!session.is_event_injected(42));
+}
+
+// ── Role exclusion tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_role_exclusion_memory_miner() {
+    assert!(!should_trigger_role("memory-miner"));
+}
+
+#[test]
+fn test_role_exclusion_dreaming() {
+    assert!(!should_trigger_role("dreaming"));
+}
+
+#[test]
+fn test_role_inclusion_normal_session() {
+    assert!(should_trigger_role("user"));
+    assert!(should_trigger_role("assistant"));
+    assert!(should_trigger_role("main_agent"));
+    assert!(should_trigger_role("sub_agent"));
+}
+
+#[test]
+fn test_active_searcher_should_trigger_delegates() {
+    assert!(!ActiveSearcher::should_trigger("memory-miner"));
+    assert!(!ActiveSearcher::should_trigger("dreaming"));
+    assert!(ActiveSearcher::should_trigger("user"));
+}
+
+// ── Timeout test ─────────────────────────────────────────────────────────
+
+struct SlowLlmCaller;
+
+#[async_trait::async_trait]
+impl LlmCaller for SlowLlmCaller {
+    async fn complete(&self, _prompt: &str) -> Result<String, ActiveSearcherError> {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        Ok("[]".into())
+    }
+}
+
+#[tokio::test]
+async fn test_run_timeout_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let config = ActiveSearcherConfig {
+        timeout_ms: 50,
+        ..Default::default()
+    };
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), config);
+    let llm = SlowLlmCaller;
+
+    let result = searcher
+        .run(
+            "agent-1",
+            "user",
+            "test message",
+            &[],
+            &HashSet::new(),
+            &llm,
+        )
+        .await;
+
+    assert!(result.is_none(), "timeout should return None");
+}
+
+// ── LLM integration tests (mock) ────────────────────────────────────────
+
+struct MockConceptLlm {
+    concepts: Vec<String>,
+}
+
+#[async_trait::async_trait]
+impl LlmCaller for MockConceptLlm {
+    async fn complete(&self, _prompt: &str) -> Result<String, ActiveSearcherError> {
+        let json = serde_json::to_string(&self.concepts).unwrap();
+        Ok(json)
+    }
+}
+
+#[tokio::test]
+async fn test_run_full_pipeline_mock() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+
+    let eid = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let ev1 = insert_event(&conn, "Alice met Bob", 1000, "sess-1");
+    let ev2 = insert_event(&conn, "Alice went home", 2000, "sess-1");
+    link_event_entity(&conn, ev1, eid);
+    link_event_entity(&conn, ev2, eid);
+    drop(conn);
+
+    let config = ActiveSearcherConfig {
+        timeout_ms: 5000,
+        max_summary_chars: 500,
+        min_entity_hits: 1,
+        top_k_events: 10,
+        context_turns: 3,
+        model: "mock".into(),
+    };
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), config);
+    let llm = MockConceptLlm {
+        concepts: vec!["alice".into()],
+    };
+
+    let result = searcher
+        .run(
+            "agent-1",
+            "user",
+            "Tell me about Alice",
+            &[],
+            &HashSet::new(),
+            &llm,
+        )
+        .await;
+
+    assert!(result.is_some(), "pipeline should produce an injection");
+    let injection = result.unwrap();
+    assert!(!injection.content.is_empty(), "content should not be empty");
+    assert_eq!(
+        injection.position_mode,
+        InjectionPosition::AfterCurrent,
+        "user role should use AfterCurrent"
+    );
+    assert_eq!(
+        injection.injected_event_ids.len(),
+        2,
+        "should record both event IDs"
+    );
+}
+
+#[tokio::test]
+async fn test_run_skips_excluded_role() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+    let llm = MockConceptLlm {
+        concepts: vec!["test".into()],
+    };
+
+    let result = searcher
+        .run(
+            "agent-1",
+            "memory-miner",
+            "test",
+            &[],
+            &HashSet::new(),
+            &llm,
+        )
+        .await;
+
+    assert!(
+        result.is_none(),
+        "memory-miner should not trigger active searcher"
+    );
+}
+
+#[tokio::test]
+async fn test_run_empty_concepts_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _conn = create_test_db(tmp.path());
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+    let llm = MockConceptLlm { concepts: vec![] };
+
+    let result = searcher
+        .run("agent-1", "user", "test", &[], &HashSet::new(), &llm)
+        .await;
+
+    assert!(result.is_none(), "empty concepts should return None");
+}
+
+#[tokio::test]
+async fn test_run_dedup_excludes_injected_events() {
+    let tmp = tempfile::tempdir().unwrap();
+    let conn = create_test_db(tmp.path());
+
+    let eid = insert_entity(&conn, "agent-1", "person", "Alice", "alice");
+    let ev1 = insert_event(&conn, "Alice met Bob", 1000, "sess-1");
+    let ev2 = insert_event(&conn, "Alice went home", 2000, "sess-1");
+    link_event_entity(&conn, ev1, eid);
+    link_event_entity(&conn, ev2, eid);
+    drop(conn);
+
+    let searcher = ActiveSearcher::new(tmp.path().join("test.db"), ActiveSearcherConfig::default());
+    let llm = MockConceptLlm {
+        concepts: vec!["alice".into()],
+    };
+
+    let mut injected = HashSet::new();
+    injected.insert(ev1);
+
+    let result = searcher
+        .run("agent-1", "user", "test", &[], &injected, &llm)
+        .await;
+
+    if let Some(inj) = result {
+        assert!(
+            !inj.injected_event_ids.contains(&ev1),
+            "ev1 should not be in injected set"
+        );
+        assert!(
+            inj.injected_event_ids.contains(&ev2),
+            "ev2 should be in injected set"
+        );
+    }
+}
+
+// ── Concept parser tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_parse_concepts_valid_json() {
+    let concepts = parse_concepts(r#"["Alice", "project X"]"#);
+    assert_eq!(concepts, vec!["Alice", "project X"]);
+}
+
+#[test]
+fn test_parse_concepts_with_extra_text() {
+    let concepts = parse_concepts(r#"Here are the concepts: ["Alice", "Bob"]"#);
+    assert_eq!(concepts, vec!["Alice", "Bob"]);
+}
+
+#[test]
+fn test_parse_concepts_empty_array() {
+    let concepts = parse_concepts("[]");
+    assert!(concepts.is_empty());
+}
+
+#[test]
+fn test_parse_concepts_invalid() {
+    let concepts = parse_concepts("no json here");
+    assert!(concepts.is_empty());
+}
+
+// ── Config defaults test ─────────────────────────────────────────────────
+
+#[test]
+fn test_active_searcher_config_defaults() {
+    let config = ActiveSearcherConfig::default();
+    assert_eq!(config.timeout_ms, 5000);
+    assert_eq!(config.max_summary_chars, 2000);
+    assert_eq!(config.min_entity_hits, 1);
+    assert_eq!(config.top_k_events, 10);
+    assert_eq!(config.context_turns, 3);
+    assert_eq!(config.model, "gpt-4o-mini");
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3,6 +3,7 @@
 //! Provides dreaming (three-stage memory promotion) and memory-mining
 //! (session transcript extraction) capabilities.
 
+pub mod active_searcher;
 pub mod dreaming;
 pub mod miner;
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -8,6 +8,11 @@ pub mod active_searcher_llm;
 pub mod dreaming;
 pub mod miner;
 
+pub use crate::llm::session::{InjectionPosition, MemoryInjection};
+pub use active_searcher::{ActiveSearcher, ActiveSearcherConfig};
+
+#[cfg(test)]
+mod active_searcher_tests;
 #[cfg(test)]
 mod dreaming_tests;
 #[cfg(test)]

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4,6 +4,7 @@
 //! (session transcript extraction) capabilities.
 
 pub mod active_searcher;
+pub mod active_searcher_llm;
 pub mod dreaming;
 pub mod miner;
 

--- a/src/session/storage/sqlite.rs
+++ b/src/session/storage/sqlite.rs
@@ -120,6 +120,59 @@ impl SqliteStorage {
 
             CREATE INDEX IF NOT EXISTS idx_sessions_agent_role
                 ON sessions(agent_id, role);
+
+            -- Entity types table (seed data for 11 SAG entity types)
+            CREATE TABLE IF NOT EXISTS entity_types (
+                id INTEGER PRIMARY KEY,
+                type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                weight REAL NOT NULL DEFAULT 1.0,
+                similarity_threshold REAL NOT NULL DEFAULT 0.80,
+                is_default INTEGER NOT NULL DEFAULT 0,
+                is_active INTEGER NOT NULL DEFAULT 1
+            );
+
+            INSERT OR IGNORE INTO entity_types (id, type, name, description, weight, similarity_threshold, is_default, is_active) VALUES
+                (1,  'time',         '时间',     '时间点、时期、日期、年份等时间表达', 1.0, 0.90, 0, 1),
+                (2,  'location',      '地点',     '国家、城市、地区、地点等物理位置', 1.0, 0.75, 0, 1),
+                (3,  'person',        '人物',     '人物和具名个体（含 agent 角色、用户身份）', 1.2, 0.80, 0, 1),
+                (4,  'organization',  '组织',     '公司、机构、团队等组织', 1.1, 0.80, 0, 1),
+                (5,  'subject',       '主题',     '主要主题、概念和课题', 1.5, 0.78, 1, 1),
+                (6,  'product',       '产品',     '产品、服务、项目和命名交付物', 1.1, 0.80, 0, 1),
+                (7,  'metric',        '指标',     '数字、指标、度量、金额和统计数据', 1.2, 0.85, 0, 1),
+                (8,  'action',        '动作',     '重要动作、变更、决策和操作', 1.3, 0.78, 1, 1),
+                (9,  'work',          '作品',     '创作物、文档、论文、书籍、报告', 1.0, 0.80, 0, 1),
+                (10, 'group',         '群体',     '群体、社区、受众和人口', 1.0, 0.78, 0, 1),
+                (11, 'tags',          '标签',     '兜底标签，当无特定类型匹配时使用', 0.5, 0.70, 1, 1);
+
+            -- Entities table (per-agent entity storage)
+            CREATE TABLE IF NOT EXISTS entities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                normalized_name TEXT NOT NULL,
+                description TEXT,
+                UNIQUE(agent_id, type, normalized_name)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_entities_agent_normalized
+                ON entities(agent_id, normalized_name);
+
+            -- Event-entity association table
+            CREATE TABLE IF NOT EXISTS event_entities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id INTEGER NOT NULL,
+                entity_id INTEGER NOT NULL,
+                FOREIGN KEY (entity_id) REFERENCES entities(id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_event_entities_entity_id
+                ON event_entities(entity_id);
+
+            CREATE INDEX IF NOT EXISTS idx_event_entities_event_id
+                ON event_entities(event_id);
             "#,
         )
         .map_err(|e| PersistenceError::Sqlite(e.to_string()))?;


### PR DESCRIPTION
feat: implement active-searcher module for per-message entity search

实现 active-searcher 模块——每条消息触发独立搜索，从 SQLite entities 表中查找与当前 agent 相关的 entity，通过 entity-event 关联找到对应 event，浓缩为摘要后注入消息列表的 `memory_injection` 槽位。

主要变更：
- SQLite schema 扩展：新增 entity_types、entities、event_entities 表及种子数据
- MemoryInjection 槽位：ConversationSession 新增 memory_injection 字段，支持 AfterCurrent/BeforeNext 位置模式
- active_searcher 核心模块：实体搜索（精确/模糊匹配、type weight 排序、agent 隔离）、event 关联、去重、浓缩
- LLM 集成：概念提取 prompt 构建、LLM 浓缩摘要、完整 run() 流程编排
- Session 集成：消息组装消费 memory_injection、触发逻辑排除特殊角色
- UTF-8 安全截断 + 提取 memory_injection 消费共享 helper
- 完整 UT 覆盖（schema、搜索、event 关联、去重、浓缩、槽位、角色排除、超时）

Source: design-doc
Type: feat
