### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -124,5 +124,12 @@
     "commit_time": "2026-06-26T01:02:53+08:00",
     "confirmed_time": "2026-06-26T01:11:16.404415+08:00",
     "comment": ""
+  },
+  {
+    "path": "docs/design/im_adapter/streaming-render.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-26T05:40:09.261967+08:00",
+    "comment": "blocked: Two design doc problems found in F2b deep comparison: (1) First-line output 200ms delay target has no time-based logic in LineBuffer implementation; unclear if hard requirement or aspirational. (2) MessageEnd handling: doc says automatic flush but code MessageEnd branch is no-op requiring explicit caller flush(). Design intent unclear for both."
   }
 ]


### PR DESCRIPTION
Doc: docs/design/im_adapter/streaming-render.md
Type: blocked
Reason: F2b 深度对比发现两个文档问题：(1) 首行输出 200ms 延迟目标在代码中无实现；(2) MessageEnd 事件处理方式文档描述自动刷新与代码实际手动 flush 不一致