### PR TITLE
feat: implement inbound queue and SideEffectContext pattern

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -276,6 +276,8 @@ impl Daemon {
         crate::im_adapter::platforms::register_platform_plugins(&gateway, config_dir).await;
         Self::init_terminal_plugin(&gateway).await;
         Self::init_slash_dispatcher(&gateway, &session_manager, permission_engine).await;
+        // Start the inbound queue consumer so webhook messages are buffered.
+        gateway.start_inbound_queue();
         let shutdown = shutdown::ShutdownHandle::new();
         // Wire shutdown handle into SessionManager for child-session
         // busy-count tracking during drain.

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -4,7 +4,12 @@
 //! providing a bounded buffer that protects the Gateway from burst traffic.
 //! When the queue is full, new messages are rejected with a busy reply.
 
+use std::sync::Arc;
 use tokio::sync::mpsc;
+
+use crate::renderer::RenderedOutput;
+
+use super::Gateway;
 
 /// An inbound message awaiting processing.
 ///
@@ -51,6 +56,7 @@ impl InboundQueueHandle {
     ///
     /// Returns `Ok(())` on success, or `Err(full)` when the queue is at
     /// capacity. The caller should reply with a busy message on `Err`.
+    #[allow(clippy::result_large_err)]
     pub fn try_send(&self, request: InboundRequest) -> Result<(), InboundQueueFull> {
         match self.tx.try_send(request) {
             Ok(()) => Ok(()),
@@ -75,6 +81,98 @@ impl InboundQueueHandle {
 pub struct InboundQueueFull {
     /// The request that could not be enqueued.
     pub request: InboundRequest,
+}
+
+/// Spawn a consumer task that drains the inbound queue and processes
+/// each message through the processor chain and inbound handler.
+///
+/// The task runs until the receiver is closed (Gateway shutdown).
+pub(crate) fn start_inbound_consumer(
+    mut rx: mpsc::Receiver<InboundRequest>,
+    gateway: Arc<Gateway>,
+    capacity: usize,
+) {
+    tokio::spawn(async move {
+        tracing::info!(capacity, "inbound queue consumer started");
+        while let Some(req) = rx.recv().await {
+            let processed = gateway
+                .process_inbound_chain(
+                    &req.platform,
+                    &req.sender_id,
+                    &req.peer_id,
+                    &req.content,
+                    &req.message_id,
+                    req.timestamp_ms,
+                )
+                .await;
+            gateway
+                .handle_inbound_message(processed, Some(&req.sender_id), &req.platform)
+                .await;
+        }
+        tracing::info!("inbound queue consumer stopped");
+    });
+}
+
+/// Try to enqueue an inbound request into the gateway's bounded queue.
+///
+/// On success the request will be processed by the consumer task.
+/// When the queue is at capacity, a busy reply is sent to the user
+/// via the registered IM plugin and the request is dropped.
+pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) {
+    let tx = match gateway
+        .inbound_tx
+        .lock()
+        .ok()
+        .and_then(|slot| slot.as_ref().cloned())
+    {
+        Some(tx) => tx,
+        None => {
+            tracing::warn!("inbound queue not started — processing directly");
+            let processed = gateway
+                .process_inbound_chain(
+                    &request.platform,
+                    &request.sender_id,
+                    &request.peer_id,
+                    &request.content,
+                    &request.message_id,
+                    request.timestamp_ms,
+                )
+                .await;
+            gateway
+                .handle_inbound_message(processed, Some(&request.sender_id), &request.platform)
+                .await;
+            return;
+        }
+    };
+
+    match tx.try_send(request.clone()) {
+        Ok(()) => {}
+        Err(e) => {
+            let req = match e {
+                tokio::sync::mpsc::error::TrySendError::Full(r)
+                | tokio::sync::mpsc::error::TrySendError::Closed(r) => r,
+            };
+            tracing::warn!(peer_id = %req.peer_id, "inbound queue full — sending busy reply");
+            send_busy_reply(gateway, &req).await;
+        }
+    }
+}
+
+/// Send a "service busy" reply via the IM plugin for the request's platform.
+async fn send_busy_reply(gateway: &Gateway, request: &InboundRequest) {
+    if let Some(plugin) = gateway.get_plugin(&request.platform).await {
+        let output = RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({
+                "content": {
+                    "text": "\u{274C} \u{670D}\u{52A1}\u{7E41}\u{5FD9}\u{FF0C}\u{8BF7}\u{7A0D}\u{540E}\u{91CD}\u{8BD5}"
+                }
+            }),
+        };
+        if let Err(e) = plugin.send(&output, &request.peer_id, None).await {
+            tracing::warn!(error = %e, "failed to send busy reply");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -149,6 +149,10 @@ pub(crate) fn start_inbound_consumer(
     });
 }
 
+/// Reply text sent when the inbound queue is at capacity.
+const BUSY_REPLY_TEXT: &str =
+    "\u{274C} \u{670D}\u{52A1}\u{7E41}\u{5FD9}\u{FF0C}\u{8BF7}\u{7A0D}\u{540E}\u{91CD}\u{8BD5}";
+
 /// Try to enqueue an inbound request into the gateway's bounded queue.
 ///
 /// On success the request will be processed by the consumer task.
@@ -166,50 +170,7 @@ pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) 
     {
         Some(tx) => tx,
         None => {
-            // ── Fallback: process inline when queue is not started ───
-            tracing::warn!("inbound queue not started — processing directly");
-            if let Some(plugin) = gateway.get_plugin(&request.platform).await {
-                match plugin.parse_inbound(&request.raw_payload).await {
-                    Ok(Some(normalized)) => {
-                        let sender_id = normalized.sender_id.clone();
-                        let processed = gateway
-                            .process_inbound_chain(
-                                &normalized.platform,
-                                &normalized.sender_id,
-                                &normalized.peer_id,
-                                &normalized.content,
-                                "",
-                                normalized.timestamp,
-                            )
-                            .await;
-                        gateway
-                            .handle_inbound_message(
-                                processed,
-                                Some(&sender_id),
-                                &normalized.platform,
-                            )
-                            .await;
-                    }
-                    Ok(None) => {
-                        tracing::debug!(
-                            platform = %request.platform,
-                            "inline fallback: parse returned None — dropping"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            platform = %request.platform,
-                            error = %e,
-                            "inline fallback: parse failed — dropping"
-                        );
-                    }
-                }
-            } else {
-                tracing::warn!(
-                    platform = %request.platform,
-                    "inline fallback: no plugin registered — dropping"
-                );
-            }
+            process_inbound_direct(gateway, &request).await;
             return;
         }
     };
@@ -227,16 +188,60 @@ pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) 
     }
 }
 
+/// Fallback: process an inbound request directly when the queue has not started.
+///
+/// Parses the raw payload through the IM plugin, runs the processor chain,
+/// and handles the inbound message inline.
+async fn process_inbound_direct(gateway: &Gateway, request: &InboundRequest) {
+    tracing::warn!("inbound queue not started — processing directly");
+    let Some(plugin) = gateway.get_plugin(&request.platform).await else {
+        tracing::warn!(
+            platform = %request.platform,
+            "inline fallback: no plugin registered — dropping"
+        );
+        return;
+    };
+    match plugin.parse_inbound(&request.raw_payload).await {
+        Ok(Some(normalized)) => {
+            let sender_id = normalized.sender_id.clone();
+            let processed = gateway
+                .process_inbound_chain(
+                    &normalized.platform,
+                    &normalized.sender_id,
+                    &normalized.peer_id,
+                    &normalized.content,
+                    "",
+                    normalized.timestamp,
+                )
+                .await;
+            gateway
+                .handle_inbound_message(processed, Some(&sender_id), &normalized.platform)
+                .await;
+        }
+        Ok(None) => {
+            tracing::debug!(
+                platform = %request.platform,
+                "inline fallback: parse returned None — dropping"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                platform = %request.platform,
+                error = %e,
+                "inline fallback: parse failed — dropping"
+            );
+        }
+    }
+}
+
 /// Send a "service busy" reply via the outbound Processor Chain.
 ///
 /// The reply text goes through the outbound chain (DslParser → RawLog)
 /// and is then rendered by the IM plugin, consistent with slash-command
 /// and LLM reply paths.
 async fn send_busy_reply(gateway: &Gateway, request: &InboundRequest) {
-    let text =
-        "\u{274C} \u{670D}\u{52A1}\u{7E41}\u{5FD9}\u{FF0C}\u{8BF7}\u{7A0D}\u{540E}\u{91CD}\u{8BD5}";
     if let Err(e) = gateway
-        .send_outbound_to_chat(&request.peer_id, &request.platform, text)
+        .send_outbound_to_chat(&request.peer_id, &request.platform, BUSY_REPLY_TEXT)
         .await
     {
         tracing::warn!(error = %e, "failed to send busy reply");

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -7,8 +7,6 @@
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-use crate::renderer::RenderedOutput;
-
 use super::Gateway;
 
 /// An inbound message awaiting processing.
@@ -229,20 +227,19 @@ pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) 
     }
 }
 
-/// Send a "service busy" reply via the IM plugin for the request's platform.
+/// Send a "service busy" reply via the outbound Processor Chain.
+///
+/// The reply text goes through the outbound chain (DslParser → RawLog)
+/// and is then rendered by the IM plugin, consistent with slash-command
+/// and LLM reply paths.
 async fn send_busy_reply(gateway: &Gateway, request: &InboundRequest) {
-    if let Some(plugin) = gateway.get_plugin(&request.platform).await {
-        let output = RenderedOutput {
-            msg_type: "text".into(),
-            payload: serde_json::json!({
-                "content": {
-                    "text": "\u{274C} \u{670D}\u{52A1}\u{7E41}\u{5FD9}\u{FF0C}\u{8BF7}\u{7A0D}\u{540E}\u{91CD}\u{8BD5}"
-                }
-            }),
-        };
-        if let Err(e) = plugin.send(&output, &request.peer_id, None).await {
-            tracing::warn!(error = %e, "failed to send busy reply");
-        }
+    let text =
+        "\u{274C} \u{670D}\u{52A1}\u{7E41}\u{5FD9}\u{FF0C}\u{8BF7}\u{7A0D}\u{540E}\u{91CD}\u{8BD5}";
+    if let Err(e) = gateway
+        .send_outbound_to_chat(&request.peer_id, &request.platform, text)
+        .await
+    {
+        tracing::warn!(error = %e, "failed to send busy reply");
     }
 }
 

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -1,0 +1,159 @@
+//! Inbound bounded queue for buffering IM webhook messages.
+//!
+//! The queue sits between IM platform webhooks and the Processor Chain,
+//! providing a bounded buffer that protects the Gateway from burst traffic.
+//! When the queue is full, new messages are rejected with a busy reply.
+
+use tokio::sync::mpsc;
+
+/// An inbound message awaiting processing.
+///
+/// Carries all fields needed by `process_inbound_chain` and
+/// `handle_inbound_message` so the consumer task can replay the
+/// full inbound path without the original webhook context.
+#[derive(Debug, Clone)]
+pub struct InboundRequest {
+    /// IM platform identifier (e.g. "feishu", "discord").
+    pub platform: String,
+    /// Sender's user ID on the platform.
+    pub sender_id: String,
+    /// Peer / chat ID the message was sent to.
+    pub peer_id: String,
+    /// Message content (text).
+    pub content: String,
+    /// Platform-specific message ID for deduplication.
+    pub message_id: String,
+    /// Message timestamp in milliseconds since epoch.
+    pub timestamp_ms: i64,
+    /// Optional thread / topic ID.
+    pub thread_id: Option<String>,
+    /// Optional account identifier (for multi-account setups).
+    pub account_id: Option<String>,
+}
+
+/// Handle to the inbound queue producer side.
+///
+/// Wraps the [`mpsc::Sender`] so callers only need to call
+/// [`try_send`](InboundQueueHandle::try_send) without knowing the
+/// channel internals.
+pub struct InboundQueueHandle {
+    tx: mpsc::Sender<InboundRequest>,
+}
+
+impl InboundQueueHandle {
+    /// Create a new handle from a channel sender.
+    #[allow(dead_code)]
+    pub(crate) fn new(tx: mpsc::Sender<InboundRequest>) -> Self {
+        Self { tx }
+    }
+
+    /// Try to enqueue an inbound request without blocking.
+    ///
+    /// Returns `Ok(())` on success, or `Err(full)` when the queue is at
+    /// capacity. The caller should reply with a busy message on `Err`.
+    pub fn try_send(&self, request: InboundRequest) -> Result<(), InboundQueueFull> {
+        match self.tx.try_send(request) {
+            Ok(()) => Ok(()),
+            Err(tokio::sync::mpsc::error::TrySendError::Full(req))
+            | Err(tokio::sync::mpsc::error::TrySendError::Closed(req)) => {
+                Err(InboundQueueFull { request: req })
+            }
+        }
+    }
+
+    /// Returns the channel capacity.
+    pub fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
+}
+
+/// Error returned when the inbound queue is full.
+///
+/// Contains the original request so the caller can decide what to do
+/// (e.g. log it, drop it, or reply with a busy message).
+#[derive(Debug)]
+pub struct InboundQueueFull {
+    /// The request that could not be enqueued.
+    pub request: InboundRequest,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inbound_request_fields() {
+        let req = InboundRequest {
+            platform: "feishu".into(),
+            sender_id: "u1".into(),
+            peer_id: "p1".into(),
+            content: "hello".into(),
+            message_id: "m1".into(),
+            timestamp_ms: 1_700_000_000_000,
+            thread_id: Some("t1".into()),
+            account_id: Some("a1".into()),
+        };
+        assert_eq!(req.platform, "feishu");
+        assert_eq!(req.sender_id, "u1");
+        assert_eq!(req.peer_id, "p1");
+        assert_eq!(req.content, "hello");
+        assert_eq!(req.message_id, "m1");
+        assert_eq!(req.timestamp_ms, 1_700_000_000_000);
+        assert_eq!(req.thread_id.as_deref(), Some("t1"));
+        assert_eq!(req.account_id.as_deref(), Some("a1"));
+    }
+
+    #[test]
+    fn inbound_queue_handle_try_send_ok() {
+        let (tx, _rx) = mpsc::channel::<InboundRequest>(2);
+        let handle = InboundQueueHandle::new(tx);
+        let req = InboundRequest {
+            platform: "feishu".into(),
+            sender_id: "u1".into(),
+            peer_id: "p1".into(),
+            content: "hello".into(),
+            message_id: "m1".into(),
+            timestamp_ms: 0,
+            thread_id: None,
+            account_id: None,
+        };
+        assert!(handle.try_send(req).is_ok());
+    }
+
+    #[test]
+    fn inbound_queue_handle_try_send_full() {
+        let (tx, _rx) = mpsc::channel::<InboundRequest>(1);
+        let handle = InboundQueueHandle::new(tx);
+        let req1 = InboundRequest {
+            platform: "feishu".into(),
+            sender_id: "u1".into(),
+            peer_id: "p1".into(),
+            content: "a".into(),
+            message_id: "m1".into(),
+            timestamp_ms: 0,
+            thread_id: None,
+            account_id: None,
+        };
+        let req2 = InboundRequest {
+            platform: "feishu".into(),
+            sender_id: "u2".into(),
+            peer_id: "p2".into(),
+            content: "b".into(),
+            message_id: "m2".into(),
+            timestamp_ms: 0,
+            thread_id: None,
+            account_id: None,
+        };
+        assert!(handle.try_send(req1).is_ok());
+        let err = handle.try_send(req2);
+        assert!(err.is_err());
+        assert_eq!(err.unwrap_err().request.content, "b");
+    }
+
+    #[test]
+    fn inbound_queue_handle_capacity() {
+        let (tx, _rx) = mpsc::channel::<InboundRequest>(32);
+        let handle = InboundQueueHandle::new(tx);
+        assert_eq!(handle.capacity(), 32);
+    }
+}

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -13,27 +13,20 @@ use super::Gateway;
 
 /// An inbound message awaiting processing.
 ///
-/// Carries all fields needed by `process_inbound_chain` and
-/// `handle_inbound_message` so the consumer task can replay the
-/// full inbound path without the original webhook context.
+/// Stores the raw webhook payload so the consumer task can parse it
+/// through the IM plugin _after_ entering the queue, matching the
+/// design doc architecture where the queue sits before plugin parsing.
+///
+/// `peer_id` is stored separately for the busy-reply path (when the
+/// queue is full, we need a target to reply to without parsing).
 #[derive(Debug, Clone)]
 pub struct InboundRequest {
     /// IM platform identifier (e.g. "feishu", "discord").
     pub platform: String,
-    /// Sender's user ID on the platform.
-    pub sender_id: String,
-    /// Peer / chat ID the message was sent to.
+    /// Raw webhook payload bytes.
+    pub raw_payload: Vec<u8>,
+    /// Peer / chat ID — used for busy-reply when the queue is full.
     pub peer_id: String,
-    /// Message content (text).
-    pub content: String,
-    /// Platform-specific message ID for deduplication.
-    pub message_id: String,
-    /// Message timestamp in milliseconds since epoch.
-    pub timestamp_ms: i64,
-    /// Optional thread / topic ID.
-    pub thread_id: Option<String>,
-    /// Optional account identifier (for multi-account setups).
-    pub account_id: Option<String>,
 }
 
 /// Handle to the inbound queue producer side.
@@ -84,9 +77,19 @@ pub struct InboundQueueFull {
 }
 
 /// Spawn a consumer task that drains the inbound queue and processes
-/// each message through the processor chain and inbound handler.
+/// each message through the IM plugin parser, processor chain, and
+/// inbound handler.
 ///
 /// The task runs until the receiver is closed (Gateway shutdown).
+///
+/// Flow per message:
+/// 1. Get the registered IM plugin for `platform`
+/// 2. Call `plugin.parse_inbound(raw_payload)` → `NormalizedMessage`
+/// 3. Run through `process_inbound_chain`
+/// 4. Hand off to `handle_inbound_message`
+///
+/// When the plugin is not registered or parsing returns `None` (e.g.
+/// unsupported message type), the message is silently dropped.
 pub(crate) fn start_inbound_consumer(
     mut rx: mpsc::Receiver<InboundRequest>,
     gateway: Arc<Gateway>,
@@ -95,18 +98,53 @@ pub(crate) fn start_inbound_consumer(
     tokio::spawn(async move {
         tracing::info!(capacity, "inbound queue consumer started");
         while let Some(req) = rx.recv().await {
+            // ── 1. Resolve plugin ─────────────────────────────────────
+            let Some(plugin) = gateway.get_plugin(&req.platform).await else {
+                tracing::warn!(
+                    platform = %req.platform,
+                    "inbound consumer: no plugin registered — dropping"
+                );
+                continue;
+            };
+
+            // ── 2. Parse raw webhook payload ──────────────────────────
+            let normalized = match plugin.parse_inbound(&req.raw_payload).await {
+                Ok(Some(msg)) => msg,
+                Ok(None) => {
+                    tracing::debug!(
+                        platform = %req.platform,
+                        peer_id = %req.peer_id,
+                        "inbound consumer: parse returned None — dropping"
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        platform = %req.platform,
+                        peer_id = %req.peer_id,
+                        error = %e,
+                        "inbound consumer: parse failed — dropping"
+                    );
+                    continue;
+                }
+            };
+
+            // ── 3. Process through inbound chain ──────────────────────
+            let sender_id = normalized.sender_id.clone();
             let processed = gateway
                 .process_inbound_chain(
-                    &req.platform,
-                    &req.sender_id,
-                    &req.peer_id,
-                    &req.content,
-                    &req.message_id,
-                    req.timestamp_ms,
+                    &normalized.platform,
+                    &normalized.sender_id,
+                    &normalized.peer_id,
+                    &normalized.content,
+                    "", // message_id not in NormalizedMessage; empty for now
+                    normalized.timestamp,
                 )
                 .await;
+
+            // ── 4. Handle inbound message ─────────────────────────────
             gateway
-                .handle_inbound_message(processed, Some(&req.sender_id), &req.platform)
+                .handle_inbound_message(processed, Some(&sender_id), &normalized.platform)
                 .await;
         }
         tracing::info!("inbound queue consumer stopped");
@@ -118,6 +156,9 @@ pub(crate) fn start_inbound_consumer(
 /// On success the request will be processed by the consumer task.
 /// When the queue is at capacity, a busy reply is sent to the user
 /// via the registered IM plugin and the request is dropped.
+///
+/// When the queue has not been started (fallback mode), the raw payload
+/// is parsed inline and processed immediately.
 pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) {
     let tx = match gateway
         .inbound_tx
@@ -127,20 +168,50 @@ pub(crate) async fn enqueue_inbound(gateway: &Gateway, request: InboundRequest) 
     {
         Some(tx) => tx,
         None => {
+            // ── Fallback: process inline when queue is not started ───
             tracing::warn!("inbound queue not started — processing directly");
-            let processed = gateway
-                .process_inbound_chain(
-                    &request.platform,
-                    &request.sender_id,
-                    &request.peer_id,
-                    &request.content,
-                    &request.message_id,
-                    request.timestamp_ms,
-                )
-                .await;
-            gateway
-                .handle_inbound_message(processed, Some(&request.sender_id), &request.platform)
-                .await;
+            if let Some(plugin) = gateway.get_plugin(&request.platform).await {
+                match plugin.parse_inbound(&request.raw_payload).await {
+                    Ok(Some(normalized)) => {
+                        let sender_id = normalized.sender_id.clone();
+                        let processed = gateway
+                            .process_inbound_chain(
+                                &normalized.platform,
+                                &normalized.sender_id,
+                                &normalized.peer_id,
+                                &normalized.content,
+                                "",
+                                normalized.timestamp,
+                            )
+                            .await;
+                        gateway
+                            .handle_inbound_message(
+                                processed,
+                                Some(&sender_id),
+                                &normalized.platform,
+                            )
+                            .await;
+                    }
+                    Ok(None) => {
+                        tracing::debug!(
+                            platform = %request.platform,
+                            "inline fallback: parse returned None — dropping"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            platform = %request.platform,
+                            error = %e,
+                            "inline fallback: parse failed — dropping"
+                        );
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    platform = %request.platform,
+                    "inline fallback: no plugin registered — dropping"
+                );
+            }
             return;
         }
     };
@@ -183,22 +254,12 @@ mod tests {
     fn inbound_request_fields() {
         let req = InboundRequest {
             platform: "feishu".into(),
-            sender_id: "u1".into(),
+            raw_payload: b"{\"event\":{}}".to_vec(),
             peer_id: "p1".into(),
-            content: "hello".into(),
-            message_id: "m1".into(),
-            timestamp_ms: 1_700_000_000_000,
-            thread_id: Some("t1".into()),
-            account_id: Some("a1".into()),
         };
         assert_eq!(req.platform, "feishu");
-        assert_eq!(req.sender_id, "u1");
+        assert_eq!(req.raw_payload, b"{\"event\":{}}");
         assert_eq!(req.peer_id, "p1");
-        assert_eq!(req.content, "hello");
-        assert_eq!(req.message_id, "m1");
-        assert_eq!(req.timestamp_ms, 1_700_000_000_000);
-        assert_eq!(req.thread_id.as_deref(), Some("t1"));
-        assert_eq!(req.account_id.as_deref(), Some("a1"));
     }
 
     #[test]
@@ -207,13 +268,8 @@ mod tests {
         let handle = InboundQueueHandle::new(tx);
         let req = InboundRequest {
             platform: "feishu".into(),
-            sender_id: "u1".into(),
+            raw_payload: b"hello".to_vec(),
             peer_id: "p1".into(),
-            content: "hello".into(),
-            message_id: "m1".into(),
-            timestamp_ms: 0,
-            thread_id: None,
-            account_id: None,
         };
         assert!(handle.try_send(req).is_ok());
     }
@@ -224,28 +280,18 @@ mod tests {
         let handle = InboundQueueHandle::new(tx);
         let req1 = InboundRequest {
             platform: "feishu".into(),
-            sender_id: "u1".into(),
+            raw_payload: b"a".to_vec(),
             peer_id: "p1".into(),
-            content: "a".into(),
-            message_id: "m1".into(),
-            timestamp_ms: 0,
-            thread_id: None,
-            account_id: None,
         };
         let req2 = InboundRequest {
             platform: "feishu".into(),
-            sender_id: "u2".into(),
+            raw_payload: b"b".to_vec(),
             peer_id: "p2".into(),
-            content: "b".into(),
-            message_id: "m2".into(),
-            timestamp_ms: 0,
-            thread_id: None,
-            account_id: None,
         };
         assert!(handle.try_send(req1).is_ok());
         let err = handle.try_send(req2);
         assert!(err.is_err());
-        assert_eq!(err.unwrap_err().request.content, "b");
+        assert_eq!(err.unwrap_err().request.peer_id, "p2");
     }
 
     #[test]

--- a/src/gateway/inbound_queue_tests.rs
+++ b/src/gateway/inbound_queue_tests.rs
@@ -17,16 +17,44 @@ use super::inbound_queue::{start_inbound_consumer, InboundQueueFull, InboundQueu
 // Helpers
 // ---------------------------------------------------------------------------
 
+fn make_raw_payload(text: &str) -> Vec<u8> {
+    serde_json::json!({
+        "header": {
+            "event_id": "ev_test",
+            "event_type": "im.message.receive_v1",
+            "create_time": "1700000000000",
+            "token": "t",
+            "app_id": "a"
+        },
+        "event": {
+            "sender": {
+                "sender_id": {
+                    "open_id": "u1"
+                },
+                "sender_type": "user",
+                "tenant_key": "tk"
+            },
+            "message": {
+                "message_id": "m1",
+                "root_id": "",
+                "parent_id": "",
+                "create_time": "1700000000000",
+                "chat_id": "p1",
+                "chat_type": "p2p",
+                "message_type": "text",
+                "content": format!("{{\"text\":\"{}\"}}", text)
+            }
+        }
+    })
+    .to_string()
+    .into_bytes()
+}
+
 fn make_request(content: &str) -> InboundRequest {
     InboundRequest {
         platform: "feishu".into(),
-        sender_id: "u1".into(),
+        raw_payload: make_raw_payload(content),
         peer_id: "p1".into(),
-        content: content.to_owned(),
-        message_id: format!("mid-{content}"),
-        timestamp_ms: 1_700_000_000_000,
-        thread_id: None,
-        account_id: None,
     }
 }
 
@@ -70,7 +98,7 @@ async fn test_try_send_full_returns_original_request() {
     let err: Result<(), InboundQueueFull> = handle.try_send(make_request("overflow"));
     assert!(err.is_err());
     let full = err.unwrap_err();
-    assert_eq!(full.request.content, "overflow");
+    assert_eq!(full.request.peer_id, "p1");
 }
 
 #[tokio::test]
@@ -87,10 +115,10 @@ async fn test_try_send_closed_channel() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_consumer_fires_process_and_handle() {
-    // The consumer task calls gateway.process_inbound_chain + handle_inbound_message.
-    // Without a session_handler installed, handle_inbound_message returns None,
-    // but the consumer should not panic or hang.
+async fn test_consumer_fires_parse_and_process() {
+    // The consumer task calls gateway.get_plugin → parse_inbound →
+    // process_inbound_chain → handle_inbound_message.
+    // Without a plugin registered, the consumer should not panic or hang.
     let gw = make_gateway();
     let (tx, rx) = mpsc::channel::<InboundRequest>(8);
     let capacity = 8;
@@ -102,9 +130,9 @@ async fn test_consumer_fires_process_and_handle() {
 
     // Give the consumer time to process.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    // Channel should be drained.
+    // Channel should be drained (messages dropped because no plugin registered).
     assert!(tx.try_send(make_request("z")).is_ok());
-    // No panic = consumer ran and handled missing session_handler gracefully.
+    // No panic = consumer ran and handled missing plugin gracefully.
 }
 
 #[tokio::test]
@@ -184,9 +212,6 @@ async fn test_inbound_request_clone_preserves_fields() {
     let req = make_request("clone-test");
     let cloned = req.clone();
     assert_eq!(cloned.platform, "feishu");
-    assert_eq!(cloned.sender_id, "u1");
     assert_eq!(cloned.peer_id, "p1");
-    assert_eq!(cloned.content, "clone-test");
-    assert_eq!(cloned.thread_id, None);
-    assert_eq!(cloned.account_id, None);
+    assert_eq!(cloned.raw_payload, make_raw_payload("clone-test"));
 }

--- a/src/gateway/inbound_queue_tests.rs
+++ b/src/gateway/inbound_queue_tests.rs
@@ -1,0 +1,192 @@
+//! Unit tests for the inbound bounded queue.
+//!
+//! Covers: enqueue success, full-queue rejection with busy reply,
+//! FIFO ordering, consumer task dispatch, and bypass mode.
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::{Gateway, GatewayConfig, InboundRequest};
+use crate::session::bootstrap::loader::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use tokio::sync::mpsc;
+
+use super::inbound_queue::{start_inbound_consumer, InboundQueueFull, InboundQueueHandle};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_request(content: &str) -> InboundRequest {
+    InboundRequest {
+        platform: "feishu".into(),
+        sender_id: "u1".into(),
+        peer_id: "p1".into(),
+        content: content.to_owned(),
+        message_id: format!("mid-{content}"),
+        timestamp_ms: 1_700_000_000_000,
+        thread_id: None,
+        account_id: None,
+    }
+}
+
+fn make_gateway() -> Arc<Gateway> {
+    let config = GatewayConfig {
+        name: "test".to_owned(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope: Default::default(),
+        inbound_queue_capacity: 4,
+        ..Default::default()
+    };
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+        ReasoningLevel::default(),
+    ));
+    Arc::new(Gateway::new(config, sm))
+}
+
+// ---------------------------------------------------------------------------
+// Handle-level tests (pure channel, no Gateway)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_try_send_ok_and_capacity() {
+    let (tx, _rx) = mpsc::channel::<InboundRequest>(8);
+    let handle = InboundQueueHandle::new(tx);
+    assert_eq!(handle.capacity(), 8);
+    assert!(handle.try_send(make_request("a")).is_ok());
+    assert!(handle.try_send(make_request("b")).is_ok());
+}
+
+#[tokio::test]
+async fn test_try_send_full_returns_original_request() {
+    let (tx, _rx) = mpsc::channel::<InboundRequest>(1);
+    let handle = InboundQueueHandle::new(tx);
+    assert!(handle.try_send(make_request("a")).is_ok());
+    let err: Result<(), InboundQueueFull> = handle.try_send(make_request("overflow"));
+    assert!(err.is_err());
+    let full = err.unwrap_err();
+    assert_eq!(full.request.content, "overflow");
+}
+
+#[tokio::test]
+async fn test_try_send_closed_channel() {
+    let (tx, rx) = mpsc::channel::<InboundRequest>(4);
+    let handle = InboundQueueHandle::new(tx);
+    drop(rx); // close receiver
+    let err: Result<(), InboundQueueFull> = handle.try_send(make_request("x"));
+    assert!(err.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Consumer task tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_consumer_fires_process_and_handle() {
+    // The consumer task calls gateway.process_inbound_chain + handle_inbound_message.
+    // Without a session_handler installed, handle_inbound_message returns None,
+    // but the consumer should not panic or hang.
+    let gw = make_gateway();
+    let (tx, rx) = mpsc::channel::<InboundRequest>(8);
+    let capacity = 8;
+    start_inbound_consumer(rx, Arc::clone(&gw), capacity);
+
+    // Send a message through the channel directly.
+    tx.send(make_request("hello")).await.unwrap();
+    tx.send(make_request("world")).await.unwrap();
+
+    // Give the consumer time to process.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Channel should be drained.
+    assert!(tx.try_send(make_request("z")).is_ok());
+    // No panic = consumer ran and handled missing session_handler gracefully.
+}
+
+#[tokio::test]
+async fn test_consumer_fifo_order() {
+    // Messages are processed in order; we verify by sending N messages
+    // and ensuring none are dropped.
+    let gw = make_gateway();
+    let (tx, rx) = mpsc::channel::<InboundRequest>(16);
+    start_inbound_consumer(rx, Arc::clone(&gw), 16);
+
+    for i in 0..10 {
+        tx.send(make_request(&format!("msg-{i}"))).await.unwrap();
+    }
+
+    // Wait for processing.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    // All messages consumed — channel should be empty.
+    assert!(tx.try_send(make_request("extra")).is_ok());
+}
+
+#[tokio::test]
+async fn test_consumer_stops_on_channel_close() {
+    let gw = make_gateway();
+    let (tx, rx) = mpsc::channel::<InboundRequest>(4);
+    start_inbound_consumer(rx, Arc::clone(&gw), 4);
+
+    tx.send(make_request("before")).await.unwrap();
+    drop(tx); // close sender — consumer should exit its loop
+
+    // Consumer task should terminate; we verify by waiting a bit.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // No panic = consumer exited cleanly.
+}
+
+// ---------------------------------------------------------------------------
+// Gateway-level enqueue_inbound tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_enqueue_inbound_without_queue_bypasses() {
+    // When inbound_tx is None (queue not started), enqueue_inbound
+    // processes the message directly without going through the channel.
+    let gw = make_gateway();
+    // No start_inbound_queue() call — inbound_tx remains None.
+    gw.enqueue_inbound(make_request("direct")).await;
+    // If we got here without panic, bypass mode works.
+}
+
+#[tokio::test]
+async fn test_start_inbound_queue_returns_handle() {
+    let gw = make_gateway();
+    let handle = gw.start_inbound_queue();
+    // Handle should have the configured capacity.
+    assert_eq!(handle.capacity(), 4);
+    // Enqueue via handle should succeed.
+    assert!(handle.try_send(make_request("ok")).is_ok());
+}
+
+#[tokio::test]
+async fn test_gateway_enqueue_inbound_full_triggers_busy_reply() {
+    // Fill the queue to capacity, then enqueue one more.
+    // Since no plugin is registered, the busy reply is silently dropped.
+    let gw = make_gateway();
+    let handle = gw.start_inbound_queue();
+
+    // Fill queue (capacity = 4).
+    for i in 0..4 {
+        handle.try_send(make_request(&format!("fill-{i}"))).unwrap();
+    }
+    // Next enqueue should trigger busy reply path (no plugin → silently skipped).
+    gw.enqueue_inbound(make_request("overflow")).await;
+    // No panic = busy reply path handled gracefully with no plugin.
+}
+
+#[tokio::test]
+async fn test_inbound_request_clone_preserves_fields() {
+    let req = make_request("clone-test");
+    let cloned = req.clone();
+    assert_eq!(cloned.platform, "feishu");
+    assert_eq!(cloned.sender_id, "u1");
+    assert_eq!(cloned.peer_id, "p1");
+    assert_eq!(cloned.content, "clone-test");
+    assert_eq!(cloned.thread_id, None);
+    assert_eq!(cloned.account_id, None);
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -14,6 +14,8 @@ pub mod session_manager;
 pub mod slash_permission;
 
 #[cfg(test)]
+mod inbound_queue_tests;
+#[cfg(test)]
 mod outbound_tests;
 #[cfg(test)]
 mod tests_plugin;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -188,7 +188,7 @@ pub struct Gateway {
     permission_engine: RwLock<Option<Arc<PermissionEngine>>>,
     /// Bounded inbound queue sender. `None` until the queue is started.
     #[allow(dead_code)]
-    inbound_tx: Option<mpsc::Sender<InboundRequest>>,
+    inbound_tx: std::sync::Mutex<Option<mpsc::Sender<InboundRequest>>>,
     /// Self-reference for back-pointer to the owning `Arc<Gateway>`.
     ///
     /// `handle_inbound_message` is called with `&self`, but
@@ -215,7 +215,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
-            inbound_tx: None,
+            inbound_tx: std::sync::Mutex::new(None),
             self_ref: std::sync::Mutex::new(None),
             shutdown_handle: std::sync::Mutex::new(None),
         }
@@ -237,7 +237,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
-            inbound_tx: None,
+            inbound_tx: std::sync::Mutex::new(None),
             self_ref: std::sync::Mutex::new(None),
             shutdown_handle: std::sync::Mutex::new(None),
         }
@@ -277,6 +277,35 @@ impl Gateway {
         if let Ok(mut slot) = self.shutdown_handle.lock() {
             *slot = Some(handle);
         }
+    }
+
+    /// Start the inbound bounded queue.
+    ///
+    /// Creates a bounded mpsc channel with capacity from
+    /// [`GatewayConfig::inbound_queue_capacity`], stores the sender
+    /// for later use by [`Self::enqueue_inbound`], and spawns a
+    /// consumer task that drains messages through the processor chain
+    /// and inbound handler.
+    ///
+    /// Returns an [`InboundQueueHandle`] that callers can use to
+    /// enqueue inbound requests.
+    pub fn start_inbound_queue(self: &Arc<Self>) -> inbound_queue::InboundQueueHandle {
+        let capacity = self.config.inbound_queue_capacity;
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        if let Ok(mut slot) = self.inbound_tx.lock() {
+            *slot = Some(tx.clone());
+        }
+        inbound_queue::start_inbound_consumer(rx, Arc::clone(self), capacity);
+        inbound_queue::InboundQueueHandle::new(tx)
+    }
+
+    /// Enqueue an inbound request into the bounded queue.
+    ///
+    /// When the queue is full, a busy reply is sent via the IM plugin.
+    /// If the queue has not been started, the message is processed
+    /// directly (bypass mode).
+    pub async fn enqueue_inbound(&self, request: inbound_queue::InboundRequest) {
+        inbound_queue::enqueue_inbound(self, request).await;
     }
 
     /// Get a clone of the shutdown handle, if set.

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -189,7 +189,6 @@ pub struct Gateway {
     /// Permission engine for slash command authorization.
     permission_engine: RwLock<Option<Arc<PermissionEngine>>>,
     /// Bounded inbound queue sender. `None` until the queue is started.
-    #[allow(dead_code)]
     inbound_tx: std::sync::Mutex<Option<mpsc::Sender<InboundRequest>>>,
     /// Self-reference for back-pointer to the owning `Arc<Gateway>`.
     ///

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -3,6 +3,7 @@
 //! Central hub that connects IM platforms (Feishu, Discord, etc.) to agents.
 
 pub mod approval;
+pub mod inbound_queue;
 pub mod message;
 pub mod outbound;
 pub mod session_handler;
@@ -33,6 +34,7 @@ use crate::slash::SlashDispatcher;
 
 use crate::processor_chain::context::{ProcessedMessage, RawMessage};
 pub use crate::processor_chain::ProcessorRegistry;
+pub use inbound_queue::{InboundQueueFull, InboundQueueHandle, InboundRequest};
 pub use session_handler::{HandleResult, SessionMessageHandler};
 pub use session_manager::SessionManager;
 
@@ -135,6 +137,14 @@ pub struct GatewayConfig {
     /// When `None` (default), raw logging is disabled.
     #[serde(default)]
     pub raw_log_dir: Option<std::path::PathBuf>,
+    /// Maximum number of messages the inbound queue can buffer.
+    /// Defaults to 64.
+    #[serde(default = "default_inbound_queue_capacity")]
+    pub inbound_queue_capacity: usize,
+}
+
+fn default_inbound_queue_capacity() -> usize {
+    64
 }
 
 #[allow(clippy::derivable_impls)]
@@ -146,6 +156,7 @@ impl Default for GatewayConfig {
             max_message_size: 0,
             dm_scope: DmScope::default(),
             raw_log_dir: None,
+            inbound_queue_capacity: default_inbound_queue_capacity(),
         }
     }
 }
@@ -175,6 +186,9 @@ pub struct Gateway {
     slash_dispatcher: RwLock<Option<Arc<SlashDispatcher>>>,
     /// Permission engine for slash command authorization.
     permission_engine: RwLock<Option<Arc<PermissionEngine>>>,
+    /// Bounded inbound queue sender. `None` until the queue is started.
+    #[allow(dead_code)]
+    inbound_tx: Option<mpsc::Sender<InboundRequest>>,
     /// Self-reference for back-pointer to the owning `Arc<Gateway>`.
     ///
     /// `handle_inbound_message` is called with `&self`, but
@@ -201,6 +215,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
+            inbound_tx: None,
             self_ref: std::sync::Mutex::new(None),
             shutdown_handle: std::sync::Mutex::new(None),
         }
@@ -222,6 +237,7 @@ impl Gateway {
             approval_flow: RwLock::new(None),
             slash_dispatcher: RwLock::new(None),
             permission_engine: RwLock::new(None),
+            inbound_tx: None,
             self_ref: std::sync::Mutex::new(None),
             shutdown_handle: std::sync::Mutex::new(None),
         }

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -295,6 +295,55 @@ impl Gateway {
         }
     }
 
+    /// Send an outbound message to a specific chat via the registered IM plugin.
+    ///
+    /// This is a lightweight variant of [`send_outbound`](Self::send_outbound) that
+    /// does not require a `session_id` — it takes a `chat_id` directly. Useful for
+    /// system messages (e.g. busy replies) that have no associated session.
+    ///
+    /// Flow:
+    /// 1. Resolve the [`IMPlugin`](super::im::IMPlugin) for `channel`.
+    /// 2. Run the outbound processor chain (DslParser → RawLog).
+    /// 3. Render via `plugin.render` and dispatch via `plugin.send`.
+    pub async fn send_outbound_to_chat(
+        &self,
+        chat_id: &str,
+        channel: &str,
+        raw_output: &str,
+    ) -> Result<(), GatewayError> {
+        let plugin = self
+            .get_plugin(channel)
+            .await
+            .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?;
+
+        // Run the outbound processor chain (DslParser → RawLog).
+        let processed = self
+            .process_or_bypass(raw_output, vec![], channel, "")
+            .await?;
+        if processed.suppress {
+            return Ok(());
+        }
+
+        // Extract dsl_result stored by the DSL processor.
+        let dsl_result: Option<DslParseResult> = processed
+            .metadata
+            .get("dsl_result")
+            .and_then(|v| v.as_str())
+            .and_then(|s| serde_json::from_str(s).ok());
+
+        // Render via the plugin.
+        let render_blocks = if processed.content_blocks.is_empty() {
+            vec![ContentBlock::Text(processed.content.clone())]
+        } else {
+            processed.content_blocks
+        };
+        let rendered = plugin.render(&render_blocks, dsl_result.as_ref());
+
+        // Dispatch via plugin.send.
+        plugin.send(&rendered, chat_id, None).await?;
+        Ok(())
+    }
+
     /// Send a streaming LLM response via the registered IM plugin.
     ///
     /// Drives a [`DefaultStreamingRenderer`] over the [`StreamEvent`] stream,

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -6,14 +6,14 @@
 
 use std::sync::Arc;
 
-use crate::llm::session::ChatSession;
 use crate::permission::engine::engine_eval::PermissionEngine;
 use crate::permission::engine::engine_types::{
     Caller, PermissionRequest, PermissionRequestBody, PermissionResponse,
 };
 use crate::slash::handler::SlashHandler;
-use crate::slash::handler::SystemAppendAction;
-use crate::slash::{parse_slash, SlashContext, SlashDispatcher, SlashResult};
+use crate::slash::side_effect::ReplyAction;
+use crate::slash::side_effect::SideEffectContext;
+use crate::slash::{parse_slash, SlashContext, SlashDispatcher};
 
 use super::{Gateway, HandleResult};
 
@@ -167,6 +167,9 @@ impl Gateway {
 
     /// Invoke the handler with a constructed `SlashContext`, then route the
     /// returned `SlashResult` to the appropriate side effect.
+    ///
+    /// Constructs a [`SideEffectContext`] and calls [`SlashResult::execute`],
+    /// then dispatches the produced [`ReplyAction`]s through the session handler.
     async fn execute_and_route(
         &self,
         handler: &dyn SlashHandler,
@@ -176,174 +179,42 @@ impl Gateway {
         sender_id: Option<&str>,
         channel: &str,
     ) -> Option<HandleResult> {
-        let ctx = SlashContext {
+        let slash_ctx = SlashContext {
             command: cmd_name.to_owned(),
             sender_id: sender_id.unwrap_or("").to_owned(),
             session_id: session_id.to_owned(),
             channel: channel.to_owned(),
         };
-        let result = handler.handle(args, &ctx).await;
+        let result = handler.handle(args, &slash_ctx).await;
 
-        match result {
-            SlashResult::Reply(text) => {
-                if let Some(sh) = self.session_handler.as_ref() {
-                    sh.send_reply(text).await;
-                }
-            }
-            SlashResult::Compact { instruction } => {
-                if let Some(sh) = self.session_handler.as_ref() {
-                    let compact_cmd = match &instruction {
-                        Some(inst) => format!("/compact {}", inst),
-                        None => "/compact".to_string(),
-                    };
-                    sh.handle_compact_command(session_id, &compact_cmd).await;
-                }
-            }
-            SlashResult::Exec { command: _ } => {
-                // Step 1.2 占位：ExecHandler 经权限引擎放行后，先以 Reply 模式
-                // 通知用户命令已提交审批。后续步骤接完整审批流。
-                if let Some(sh) = self.session_handler.as_ref() {
-                    sh.send_reply(format!("命令已提交审批：/{cmd_name}")).await;
-                }
-            }
-            SlashResult::SetReasoning { level } => {
-                if let Some(cs) = self
-                    .session_manager
-                    .get_conversation_session(session_id)
-                    .await
-                {
-                    cs.write().await.set_reasoning_level(level);
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(8);
+        let side_effect_ctx = SideEffectContext::new(
+            session_id.to_owned(),
+            channel.to_owned(),
+            Arc::clone(&self.session_manager),
+            reply_tx,
+        );
+
+        result.execute(&side_effect_ctx).await;
+        drop(side_effect_ctx);
+
+        while let Some(action) = reply_rx.recv().await {
+            match action {
+                ReplyAction::Reply(text) => {
                     if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply(format!("推理深度已设置为 {:?}", level)).await;
-                    }
-                } else {
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply("当前会话未激活，无法设置推理深度".to_owned())
-                            .await;
+                        sh.send_reply(text).await;
                     }
                 }
-            }
-            SlashResult::SetVerbosity { level } => {
-                if let Some(cs) = self
-                    .session_manager
-                    .get_conversation_session(session_id)
-                    .await
-                {
-                    cs.write().await.set_verbosity_level(level);
+                ReplyAction::TriggerCompact { instruction } => {
                     if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply(format!("输出详细度已设置为 {level}")).await;
-                    }
-                } else {
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply("当前会话未激活，无法设置输出详细度".to_owned())
-                            .await;
-                    }
-                }
-            }
-            SlashResult::SystemAppend {
-                action: SystemAppendAction::Add(content),
-            } => {
-                if let Some(cs) = self
-                    .session_manager
-                    .get_conversation_session(session_id)
-                    .await
-                {
-                    let mut session = cs.write().await;
-                    let index = session.add_system_append(content);
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply(format!("已追加指令（序号 {index}）")).await;
-                    }
-                } else {
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply("当前会话未激活，无法追加指令".to_owned())
-                            .await;
-                    }
-                }
-            }
-            SlashResult::SystemAppend {
-                action: SystemAppendAction::Clear,
-            } => {
-                if let Some(cs) = self
-                    .session_manager
-                    .get_conversation_session(session_id)
-                    .await
-                {
-                    let mut session = cs.write().await;
-                    let count = session.clear_system_appends();
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply(format!("已清除 {count} 条追加指令")).await;
-                    }
-                } else {
-                    if let Some(sh) = self.session_handler.as_ref() {
-                        sh.send_reply("当前会话未激活，无法清除指令".to_owned())
-                            .await;
-                    }
-                }
-            }
-            SlashResult::NewSession => {
-                let agent_id = self
-                    .session_manager
-                    .get_chat_id(session_id)
-                    .await
-                    .unwrap_or_default();
-                let new_session_id = self
-                    .session_manager
-                    .force_new_for_channel(channel, &agent_id)
-                    .await;
-                if let Some(sh) = self.session_handler.as_ref() {
-                    sh.send_reply(format!("已创建新 session：{new_session_id}"))
-                        .await;
-                }
-            }
-            SlashResult::Stop => {
-                match self
-                    .session_manager
-                    .get_conversation_session(session_id)
-                    .await
-                {
-                    None => {
-                        if let Some(sh) = self.session_handler.as_ref() {
-                            sh.send_reply("当前会话未激活".to_owned()).await;
-                        }
-                    }
-                    Some(conv) => {
-                        let busy = {
-                            let cs = conv.read().await;
-                            cs.is_llm_busy()
+                        let compact_cmd = match &instruction {
+                            Some(inst) => format!("/compact {}", inst),
+                            None => "/compact".to_string(),
                         };
-                        if busy {
-                            let mut cs = conv.write().await;
-                            cs.cancel_token.cancel();
-                            // Cascade stop to child handles.
-                            let handles_to_stop: Vec<_> = {
-                                let child_handles = cs
-                                    .child_handles
-                                    .read()
-                                    .expect("child_handles lock poisoned");
-                                child_handles.values().filter_map(|w| w.upgrade()).collect()
-                            };
-                            cs.clear_pending();
-                            drop(cs);
-                            for child in handles_to_stop {
-                                let child_cs = child.read().await;
-                                child_cs.cancel_token.cancel();
-                            }
-                        }
-                        if let Some(sh) = self.session_handler.as_ref() {
-                            sh.send_reply("已停止当前任务".to_owned()).await;
-                        }
+                        sh.handle_compact_command(session_id, &compact_cmd).await;
                     }
                 }
-            }
-            SlashResult::SetMode(_) => {
-                tracing::warn!(
-                    cmd = cmd_name,
-                    "SlashResult::SetMode not yet routed through dispatch_slash"
-                );
-            }
-            SlashResult::Unknown(_) => {
-                // Should not happen — dispatcher only invokes handler on match.
-                tracing::debug!("SlashResult::Unknown returned from handler");
+                ReplyAction::Nothing => {}
             }
         }
 

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -352,3 +352,272 @@ async fn test_slash_context_channel_propagates() {
     assert_eq!(captured.session_id, "sess42");
     assert_eq!(captured.sender_id, "user123");
 }
+
+// ===========================================================================
+// execute_and_route: SlashResult.execute() path tests
+// ===========================================================================
+//
+// These tests verify that `dispatch_slash` → `execute_and_route` correctly
+// routes every `SlashResult` variant through the new `SideEffectContext::
+// execute()` path. Each handler returns a specific variant, and we assert
+// that `dispatch_slash` returns `SlashHandled` (meaning the execute path
+// ran without panic).
+
+/// Handler that returns a configurable [`SlashResult`].
+struct ResultHandler {
+    command: &'static str,
+    result: SlashResult,
+    requires_permission: bool,
+}
+
+#[async_trait::async_trait]
+impl SlashHandler for ResultHandler {
+    fn commands(&self) -> &[&str] {
+        std::slice::from_ref(&self.command)
+    }
+    fn description(&self) -> &str {
+        "result handler"
+    }
+    fn requires_permission(&self) -> bool {
+        self.requires_permission
+    }
+    async fn handle(&self, _args: &str, _ctx: &SlashContext) -> SlashResult {
+        // Clone so each invocation returns the same variant.
+        match &self.result {
+            SlashResult::Reply(t) => SlashResult::Reply(t.clone()),
+            SlashResult::Compact { instruction } => SlashResult::Compact {
+                instruction: instruction.clone(),
+            },
+            SlashResult::Exec { command } => SlashResult::Exec {
+                command: command.clone(),
+            },
+            SlashResult::SetReasoning { level } => SlashResult::SetReasoning { level: *level },
+            SlashResult::SetVerbosity { level } => SlashResult::SetVerbosity { level: *level },
+            SlashResult::Unknown(t) => SlashResult::Unknown(t.clone()),
+            SlashResult::NewSession => SlashResult::NewSession,
+            SlashResult::Stop => SlashResult::Stop,
+            SlashResult::SetMode(t) => SlashResult::SetMode(t.clone()),
+            SlashResult::SystemAppend { action } => SlashResult::SystemAppend {
+                action: action.clone(),
+            },
+        }
+    }
+}
+
+fn result_dispatcher(command: &'static str, result: SlashResult) -> Arc<SlashDispatcher> {
+    let registry = HandlerRegistry::new();
+    registry.register(Arc::new(ResultHandler {
+        command,
+        result,
+        requires_permission: false,
+    }));
+    Arc::new(SlashDispatcher::new(registry))
+}
+
+#[tokio::test]
+async fn test_execute_route_reply_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "echo",
+        SlashResult::Reply("pong".to_owned()),
+    ))
+    .await;
+    let result = gw.dispatch_slash("s1", "/echo", Some("u1"), "feishu").await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_compact_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "compact",
+        SlashResult::Compact {
+            instruction: Some("keep summary".to_owned()),
+        },
+    ))
+    .await;
+    let result = gw
+        .dispatch_slash("s1", "/compact keep summary", Some("u1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_exec_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "exec",
+        SlashResult::Exec {
+            command: "ls".to_owned(),
+        },
+    ))
+    .await;
+    let result = gw
+        .dispatch_slash("s1", "/exec ls", Some("u1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_unknown_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "unk",
+        SlashResult::Unknown("not found".to_owned()),
+    ))
+    .await;
+    let result = gw.dispatch_slash("s1", "/unk", Some("u1"), "feishu").await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_set_reasoning_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "reasoning",
+        SlashResult::SetReasoning {
+            level: crate::session::persistence::ReasoningLevel::High,
+        },
+    ))
+    .await;
+    let result = gw
+        .dispatch_slash("s1", "/reasoning high", Some("u1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_set_verbosity_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "verbose",
+        SlashResult::SetVerbosity {
+            level: crate::common::VerbosityLevel::Off,
+        },
+    ))
+    .await;
+    let result = gw
+        .dispatch_slash("s1", "/verbose off", Some("u1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_new_session_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher("new", SlashResult::NewSession))
+        .await;
+    let result = gw.dispatch_slash("s1", "/new", Some("u1"), "feishu").await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_stop_variant() {
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher("stop", SlashResult::Stop))
+        .await;
+    let result = gw.dispatch_slash("s1", "/stop", Some("u1"), "feishu").await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_system_append_variant() {
+    use crate::slash::handler::SystemAppendAction;
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "sys",
+        SlashResult::SystemAppend {
+            action: SystemAppendAction::Add("test instruction".to_owned()),
+        },
+    ))
+    .await;
+    let result = gw
+        .dispatch_slash("s1", "/sys add test instruction", Some("u1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_all_variants_return_slash_handled() {
+    // Comprehensive: all recognized variants go through execute_and_route
+    // and return SlashHandled.
+    let gw = make_gateway();
+    let cases: Vec<(&str, SlashResult)> = vec![
+        ("a", SlashResult::Reply("r".to_owned())),
+        ("b", SlashResult::Compact { instruction: None }),
+        (
+            "c",
+            SlashResult::Exec {
+                command: "x".to_owned(),
+            },
+        ),
+        (
+            "d",
+            SlashResult::SetReasoning {
+                level: crate::session::persistence::ReasoningLevel::Low,
+            },
+        ),
+        (
+            "e",
+            SlashResult::SetVerbosity {
+                level: crate::common::VerbosityLevel::Normal,
+            },
+        ),
+        ("f", SlashResult::Unknown("?".to_owned())),
+        ("g", SlashResult::NewSession),
+        ("h", SlashResult::Stop),
+        ("i", SlashResult::SetMode("dark".to_owned())),
+    ];
+    for (cmd, result) in cases {
+        gw.set_slash_dispatcher(result_dispatcher(cmd, result))
+            .await;
+        let dispatch_result = gw
+            .dispatch_slash("s1", &format!("/{cmd}"), Some("u1"), "feishu")
+            .await;
+        assert!(
+            matches!(dispatch_result, Some(HandleResult::SlashHandled)),
+            "variant /{cmd} should return SlashHandled"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_execute_route_permission_check_before_execute() {
+    // Owner bypasses permission engine AND goes through execute_and_route.
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "exec",
+        SlashResult::Exec {
+            command: "ls".to_owned(),
+        },
+    ))
+    .await;
+    gw.set_permission_engine(deny_engine()).await;
+
+    // Owner must bypass the deny engine and still reach execute_and_route.
+    let result = gw
+        .dispatch_slash("s1", "/exec ls", Some("owner"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+}
+
+#[tokio::test]
+async fn test_execute_route_non_owner_denied_skips_execute() {
+    // Non-owner with requires_permission=true and deny engine
+    // → execute_and_route is never reached.
+    let gw = make_gateway();
+    gw.set_slash_dispatcher(result_dispatcher(
+        "exec",
+        SlashResult::Exec {
+            command: "ls".to_owned(),
+        },
+    ))
+    .await;
+    gw.set_permission_engine(deny_engine()).await;
+
+    let result = gw
+        .dispatch_slash("s1", "/exec ls", Some("user1"), "feishu")
+        .await;
+    assert!(matches!(result, Some(HandleResult::SlashHandled)));
+    // The handler was NOT invoked — engine denied before execute_and_route.
+}

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -1,6 +1,8 @@
 use crate::common::VerbosityLevel;
+use crate::llm::session::ChatSession;
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
+use crate::slash::side_effect::SideEffectContext;
 
 /// Action for the `SystemAppend` slash result.
 #[derive(Debug, Clone)]
@@ -34,6 +36,129 @@ pub enum SlashResult {
     SetVerbosity { level: VerbosityLevel },
     /// Unknown command — no handler matched.
     Unknown(String),
+}
+
+impl SlashResult {
+    /// Execute the side effects for this slash result variant.
+    ///
+    /// Side effects are communicated through `ctx`'s reply channel.
+    /// The Gateway collects these actions and dispatches them.
+    pub async fn execute(&self, ctx: &SideEffectContext) {
+        match self {
+            SlashResult::Reply(text) => {
+                ctx.reply(text.clone()).await;
+            }
+            SlashResult::Compact { instruction } => {
+                ctx.trigger_compact(instruction.clone()).await;
+            }
+            SlashResult::Exec { command } => {
+                ctx.reply(format!("命令已提交审批：/{command}")).await;
+            }
+            SlashResult::SetReasoning { level } => {
+                if let Some(cs) = ctx.get_conversation_session().await {
+                    cs.write().await.set_reasoning_level(*level);
+                    ctx.reply(format!("推理深度已设置为 {:?}", level)).await;
+                } else {
+                    ctx.reply("当前会话未激活，无法设置推理深度".to_owned())
+                        .await;
+                }
+            }
+            SlashResult::SetVerbosity { level } => {
+                if let Some(cs) = ctx.get_conversation_session().await {
+                    cs.write().await.set_verbosity_level(*level);
+                    ctx.reply(format!("输出详细度已设置为 {level}")).await;
+                } else {
+                    ctx.reply("当前会话未激活，无法设置输出详细度".to_owned())
+                        .await;
+                }
+            }
+            SlashResult::SystemAppend { action } => {
+                Self::execute_system_append(ctx, action).await;
+            }
+            SlashResult::NewSession => {
+                Self::execute_new_session(ctx).await;
+            }
+            SlashResult::Stop => {
+                Self::execute_stop(ctx).await;
+            }
+            SlashResult::SetMode(_) => {
+                tracing::warn!("SlashResult::SetMode not yet routed through dispatch_slash");
+            }
+            SlashResult::Unknown(_) => {
+                tracing::debug!("SlashResult::Unknown returned from handler");
+            }
+        }
+    }
+
+    async fn execute_system_append(ctx: &SideEffectContext, action: &SystemAppendAction) {
+        match action {
+            SystemAppendAction::Add(content) => {
+                if let Some(cs) = ctx.get_conversation_session().await {
+                    let mut session = cs.write().await;
+                    let index = session.add_system_append(content.clone());
+                    ctx.reply(format!("已追加指令（序号 {index}）")).await;
+                } else {
+                    ctx.reply("当前会话未激活，无法追加指令".to_owned()).await;
+                }
+            }
+            SystemAppendAction::Clear => {
+                if let Some(cs) = ctx.get_conversation_session().await {
+                    let mut session = cs.write().await;
+                    let count = session.clear_system_appends();
+                    ctx.reply(format!("已清除 {count} 条追加指令")).await;
+                } else {
+                    ctx.reply("当前会话未激活，无法清除指令".to_owned()).await;
+                }
+            }
+        }
+    }
+
+    async fn execute_new_session(ctx: &SideEffectContext) {
+        let agent_id = ctx
+            .session_manager
+            .get_chat_id(&ctx.session_id)
+            .await
+            .unwrap_or_default();
+        let new_session_id = ctx
+            .session_manager
+            .force_new_for_channel(&ctx.channel, &agent_id)
+            .await;
+        ctx.reply(format!("已创建新 session：{new_session_id}"))
+            .await;
+    }
+
+    async fn execute_stop(ctx: &SideEffectContext) {
+        let Some(conv) = ctx
+            .session_manager
+            .get_conversation_session(&ctx.session_id)
+            .await
+        else {
+            ctx.reply("当前会话未激活".to_owned()).await;
+            return;
+        };
+        let busy = {
+            let cs = conv.read().await;
+            cs.is_llm_busy()
+        };
+        if busy {
+            let mut cs = conv.write().await;
+            cs.cancel_token.cancel();
+            let handles_to_stop: Vec<_> = {
+                let child_handles = cs
+                    .child_handles
+                    .read()
+                    .expect("child_handles lock poisoned");
+                child_handles.values().filter_map(|w| w.upgrade()).collect()
+            };
+            cs.clear_pending();
+            drop(cs);
+            for child in handles_to_stop {
+                let child_cs = child.read().await;
+                child_cs.cancel_token.cancel();
+            }
+        }
+        ctx.reply("已停止当前任务".to_owned()).await;
+    }
 }
 
 /// Trait for slash command handlers.

--- a/src/slash/handler.rs
+++ b/src/slash/handler.rs
@@ -1,5 +1,4 @@
 use crate::common::VerbosityLevel;
-use crate::llm::session::ChatSession;
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::context::SlashContext;
 use crate::slash::side_effect::SideEffectContext;
@@ -73,13 +72,13 @@ impl SlashResult {
                 }
             }
             SlashResult::SystemAppend { action } => {
-                Self::execute_system_append(ctx, action).await;
+                crate::slash::side_effect::execute_system_append(ctx, action).await;
             }
             SlashResult::NewSession => {
-                Self::execute_new_session(ctx).await;
+                crate::slash::side_effect::execute_new_session(ctx).await;
             }
             SlashResult::Stop => {
-                Self::execute_stop(ctx).await;
+                crate::slash::side_effect::execute_stop(ctx).await;
             }
             SlashResult::SetMode(_) => {
                 tracing::warn!("SlashResult::SetMode not yet routed through dispatch_slash");
@@ -88,76 +87,6 @@ impl SlashResult {
                 tracing::debug!("SlashResult::Unknown returned from handler");
             }
         }
-    }
-
-    async fn execute_system_append(ctx: &SideEffectContext, action: &SystemAppendAction) {
-        match action {
-            SystemAppendAction::Add(content) => {
-                if let Some(cs) = ctx.get_conversation_session().await {
-                    let mut session = cs.write().await;
-                    let index = session.add_system_append(content.clone());
-                    ctx.reply(format!("已追加指令（序号 {index}）")).await;
-                } else {
-                    ctx.reply("当前会话未激活，无法追加指令".to_owned()).await;
-                }
-            }
-            SystemAppendAction::Clear => {
-                if let Some(cs) = ctx.get_conversation_session().await {
-                    let mut session = cs.write().await;
-                    let count = session.clear_system_appends();
-                    ctx.reply(format!("已清除 {count} 条追加指令")).await;
-                } else {
-                    ctx.reply("当前会话未激活，无法清除指令".to_owned()).await;
-                }
-            }
-        }
-    }
-
-    async fn execute_new_session(ctx: &SideEffectContext) {
-        let agent_id = ctx
-            .session_manager
-            .get_chat_id(&ctx.session_id)
-            .await
-            .unwrap_or_default();
-        let new_session_id = ctx
-            .session_manager
-            .force_new_for_channel(&ctx.channel, &agent_id)
-            .await;
-        ctx.reply(format!("已创建新 session：{new_session_id}"))
-            .await;
-    }
-
-    async fn execute_stop(ctx: &SideEffectContext) {
-        let Some(conv) = ctx
-            .session_manager
-            .get_conversation_session(&ctx.session_id)
-            .await
-        else {
-            ctx.reply("当前会话未激活".to_owned()).await;
-            return;
-        };
-        let busy = {
-            let cs = conv.read().await;
-            cs.is_llm_busy()
-        };
-        if busy {
-            let mut cs = conv.write().await;
-            cs.cancel_token.cancel();
-            let handles_to_stop: Vec<_> = {
-                let child_handles = cs
-                    .child_handles
-                    .read()
-                    .expect("child_handles lock poisoned");
-                child_handles.values().filter_map(|w| w.upgrade()).collect()
-            };
-            cs.clear_pending();
-            drop(cs);
-            for child in handles_to_stop {
-                let child_cs = child.read().await;
-                child_cs.cancel_token.cancel();
-            }
-        }
-        ctx.reply("已停止当前任务".to_owned()).await;
     }
 }
 

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -4,12 +4,14 @@ pub mod handler;
 pub mod handlers;
 pub mod handlers_session;
 pub mod registry;
+pub mod side_effect;
 
 pub use context::SlashContext;
 pub use dispatcher::{parse_slash, SlashDispatcher};
 pub use handler::{SlashHandler, SlashResult};
 pub use handlers::{ClearHandler, CompactHandler, ExecHandler, HelpHandler};
 pub use handlers_session::{NewSessionHandler, StatusHandler, StopHandler, VerboseHandler};
+pub use side_effect::SideEffectContext;
 
 #[cfg(test)]
 mod handlers_tests;

--- a/src/slash/mod.rs
+++ b/src/slash/mod.rs
@@ -26,4 +26,7 @@ mod handlers_tests_legacy;
 mod handlers_tests_system;
 
 #[cfg(test)]
+mod side_effect_tests;
+
+#[cfg(test)]
 mod tests;

--- a/src/slash/side_effect.rs
+++ b/src/slash/side_effect.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use crate::gateway::session_manager::SessionManager;
+use crate::llm::session::ChatSession;
 
 /// Action produced by [`SlashResult::execute`](super::SlashResult::execute)
 /// for the Gateway to dispatch.
@@ -71,4 +72,81 @@ impl SideEffectContext {
             .get_conversation_session(&self.session_id)
             .await
     }
+}
+
+/// Execute side effects for [`SlashResult::SystemAppend`](super::SlashResult::SystemAppend).
+pub(crate) async fn execute_system_append(
+    ctx: &SideEffectContext,
+    action: &super::handler::SystemAppendAction,
+) {
+    use super::handler::SystemAppendAction;
+    match action {
+        SystemAppendAction::Add(content) => {
+            if let Some(cs) = ctx.get_conversation_session().await {
+                let mut session = cs.write().await;
+                let index = session.add_system_append(content.clone());
+                ctx.reply(format!("已追加指令（序号 {index}）")).await;
+            } else {
+                ctx.reply("当前会话未激活，无法追加指令".to_owned()).await;
+            }
+        }
+        SystemAppendAction::Clear => {
+            if let Some(cs) = ctx.get_conversation_session().await {
+                let mut session = cs.write().await;
+                let count = session.clear_system_appends();
+                ctx.reply(format!("已清除 {count} 条追加指令")).await;
+            } else {
+                ctx.reply("当前会话未激活，无法清除指令".to_owned()).await;
+            }
+        }
+    }
+}
+
+/// Execute side effects for [`SlashResult::NewSession`](super::SlashResult::NewSession).
+pub(crate) async fn execute_new_session(ctx: &SideEffectContext) {
+    let agent_id = ctx
+        .session_manager
+        .get_chat_id(&ctx.session_id)
+        .await
+        .unwrap_or_default();
+    let new_session_id = ctx
+        .session_manager
+        .force_new_for_channel(&ctx.channel, &agent_id)
+        .await;
+    ctx.reply(format!("已创建新 session：{new_session_id}"))
+        .await;
+}
+
+/// Execute side effects for [`SlashResult::Stop`](super::SlashResult::Stop).
+pub(crate) async fn execute_stop(ctx: &SideEffectContext) {
+    let Some(conv) = ctx
+        .session_manager
+        .get_conversation_session(&ctx.session_id)
+        .await
+    else {
+        ctx.reply("当前会话未激活".to_owned()).await;
+        return;
+    };
+    let busy = {
+        let cs = conv.read().await;
+        cs.is_llm_busy()
+    };
+    if busy {
+        let mut cs = conv.write().await;
+        cs.cancel_token.cancel();
+        let handles_to_stop: Vec<_> = {
+            let child_handles = cs
+                .child_handles
+                .read()
+                .expect("child_handles lock poisoned");
+            child_handles.values().filter_map(|w| w.upgrade()).collect()
+        };
+        cs.clear_pending();
+        drop(cs);
+        for child in handles_to_stop {
+            let child_cs = child.read().await;
+            child_cs.cancel_token.cancel();
+        }
+    }
+    ctx.reply("已停止当前任务".to_owned()).await;
 }

--- a/src/slash/side_effect.rs
+++ b/src/slash/side_effect.rs
@@ -1,0 +1,74 @@
+//! Execution context for slash command side effects.
+//!
+//! [`SideEffectContext`] encapsulates the session reference and reply channel
+//! so that each [`SlashResult`](super::SlashResult) variant can complete its
+//! own side effects without the Gateway enumerating every variant.
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+
+/// Action produced by [`SlashResult::execute`](super::SlashResult::execute)
+/// for the Gateway to dispatch.
+#[derive(Debug)]
+pub enum ReplyAction {
+    /// Send a text reply to the user.
+    Reply(String),
+    /// Trigger manual compaction (Gateway delegates to session_handler).
+    TriggerCompact { instruction: Option<String> },
+    /// No action needed.
+    Nothing,
+}
+
+/// Execution context for [`SlashResult::execute`](super::SlashResult::execute).
+///
+/// Encapsulates the session reference, channel identity, and reply channel so
+/// that each `SlashResult` variant can complete its side effects internally.
+pub struct SideEffectContext {
+    /// The current session ID.
+    pub session_id: String,
+    /// The channel identifier (e.g. `"feishu"`).
+    pub channel: String,
+    /// Session manager for accessing conversation sessions.
+    pub session_manager: Arc<SessionManager>,
+    /// Channel to send reply actions back to the Gateway.
+    reply_tx: tokio::sync::mpsc::Sender<ReplyAction>,
+}
+
+impl SideEffectContext {
+    pub fn new(
+        session_id: String,
+        channel: String,
+        session_manager: Arc<SessionManager>,
+        reply_tx: tokio::sync::mpsc::Sender<ReplyAction>,
+    ) -> Self {
+        Self {
+            session_id,
+            channel,
+            session_manager,
+            reply_tx,
+        }
+    }
+
+    /// Send a text reply to the user.
+    pub async fn reply(&self, text: String) {
+        let _ = self.reply_tx.send(ReplyAction::Reply(text)).await;
+    }
+
+    /// Trigger manual compaction.
+    pub async fn trigger_compact(&self, instruction: Option<String>) {
+        let _ = self
+            .reply_tx
+            .send(ReplyAction::TriggerCompact { instruction })
+            .await;
+    }
+
+    /// Get the conversation session for the current session ID.
+    pub async fn get_conversation_session(
+        &self,
+    ) -> Option<Arc<tokio::sync::RwLock<crate::llm::session::ConversationSession>>> {
+        self.session_manager
+            .get_conversation_session(&self.session_id)
+            .await
+    }
+}

--- a/src/slash/side_effect_tests.rs
+++ b/src/slash/side_effect_tests.rs
@@ -1,0 +1,335 @@
+//! Unit tests for `SideEffectContext` and `SlashResult::execute()`.
+//!
+//! Covers: SideEffectContext construction, reply/trigger_compact helpers,
+//! and each SlashResult variant's execute() behavior.
+
+use std::sync::Arc;
+
+use crate::gateway::session_manager::SessionManager;
+use crate::gateway::{DmScope, GatewayConfig};
+use crate::session::bootstrap::loader::BootstrapMode;
+use crate::session::persistence::ReasoningLevel;
+use crate::slash::handler::{SlashResult, SystemAppendAction};
+use crate::slash::side_effect::{ReplyAction, SideEffectContext};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_sm() -> Arc<SessionManager> {
+    let config = GatewayConfig {
+        name: "test".to_owned(),
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    };
+    Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Minimal,
+        ReasoningLevel::default(),
+    ))
+}
+
+fn make_ctx() -> (SideEffectContext, mpsc::Receiver<ReplyAction>) {
+    let (reply_tx, reply_rx) = mpsc::channel(16);
+    let ctx = SideEffectContext::new("sess1".to_owned(), "feishu".to_owned(), make_sm(), reply_tx);
+    (ctx, reply_rx)
+}
+
+/// Helper: execute a SlashResult and collect all reply actions.
+async fn execute_and_collect(result: SlashResult) -> Vec<ReplyAction> {
+    let (ctx, mut rx) = make_ctx();
+    result.execute(&ctx).await;
+    drop(ctx);
+    let mut actions = Vec::new();
+    while let Some(a) = rx.recv().await {
+        actions.push(a);
+    }
+    actions
+}
+
+// ---------------------------------------------------------------------------
+// SideEffectContext tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_side_effect_context_construction() {
+    let (ctx, _rx) = make_ctx();
+    assert_eq!(ctx.session_id, "sess1");
+    assert_eq!(ctx.channel, "feishu");
+}
+
+#[tokio::test]
+async fn test_side_effect_context_reply() {
+    let (ctx, mut rx) = make_ctx();
+    ctx.reply("hello".to_owned()).await;
+    let action = rx.recv().await.expect("reply action expected");
+    match action {
+        ReplyAction::Reply(text) => assert_eq!(text, "hello"),
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_side_effect_context_trigger_compact() {
+    let (ctx, mut rx) = make_ctx();
+    ctx.trigger_compact(Some("keep summary".to_owned())).await;
+    let action = rx.recv().await.expect("compact action expected");
+    match action {
+        ReplyAction::TriggerCompact { instruction } => {
+            assert_eq!(instruction, Some("keep summary".to_owned()));
+        }
+        other => panic!("expected TriggerCompact, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_side_effect_context_trigger_compact_no_instruction() {
+    let (ctx, mut rx) = make_ctx();
+    ctx.trigger_compact(None).await;
+    let action = rx.recv().await.expect("compact action expected");
+    match action {
+        ReplyAction::TriggerCompact { instruction } => {
+            assert_eq!(instruction, None);
+        }
+        other => panic!("expected TriggerCompact with None, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_side_effect_context_get_conversation_session_none() {
+    let (ctx, _rx) = make_ctx();
+    // No session created in the manager — should return None.
+    let cs = ctx.get_conversation_session().await;
+    assert!(cs.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — Reply variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_reply() {
+    let actions = execute_and_collect(SlashResult::Reply("hi there".to_owned())).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => assert_eq!(text, "hi there"),
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — Compact variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_compact_with_instruction() {
+    let result = SlashResult::Compact {
+        instruction: Some("retain API list".to_owned()),
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::TriggerCompact { instruction } => {
+            assert_eq!(instruction.as_deref(), Some("retain API list"));
+        }
+        other => panic!("expected TriggerCompact, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_execute_compact_without_instruction() {
+    let result = SlashResult::Compact { instruction: None };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::TriggerCompact { instruction } => assert!(instruction.is_none()),
+        other => panic!("expected TriggerCompact, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — Exec variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_exec() {
+    let result = SlashResult::Exec {
+        command: "rm -rf /tmp/test".to_owned(),
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(text.contains("rm -rf /tmp/test"), "got: {text}");
+            assert!(text.contains("已提交审批"), "got: {text}");
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — SetReasoning variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_set_reasoning_no_session() {
+    let result = SlashResult::SetReasoning {
+        level: ReasoningLevel::High,
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("当前会话未激活"),
+                "expected no-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — SetVerbosity variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_set_verbosity_no_session() {
+    let result = SlashResult::SetVerbosity {
+        level: crate::common::VerbosityLevel::Off,
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("当前会话未激活"),
+                "expected no-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — Unknown variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_unknown_no_side_effects() {
+    let actions = execute_and_collect(SlashResult::Unknown("xyz".to_owned())).await;
+    assert!(
+        actions.is_empty(),
+        "Unknown variant should produce no reply actions, got: {actions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — SetMode variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_set_mode_no_side_effects() {
+    // SetMode is a future variant — currently logs a warning but produces
+    // no reply actions.
+    let actions = execute_and_collect(SlashResult::SetMode("dark".to_owned())).await;
+    assert!(
+        actions.is_empty(),
+        "SetMode variant should produce no reply actions, got: {actions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — SystemAppend variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_system_append_add_no_session() {
+    let result = SlashResult::SystemAppend {
+        action: SystemAppendAction::Add("new instruction".to_owned()),
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("当前会话未激活"),
+                "expected no-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_execute_system_append_clear_no_session() {
+    let result = SlashResult::SystemAppend {
+        action: SystemAppendAction::Clear,
+    };
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("当前会话未激活"),
+                "expected no-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — NewSession variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_new_session() {
+    let result = SlashResult::NewSession;
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("已创建新 session"),
+                "expected new-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlashResult::execute() — Stop variant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_stop_no_session() {
+    let result = SlashResult::Stop;
+    let actions = execute_and_collect(result).await;
+    assert_eq!(actions.len(), 1);
+    match &actions[0] {
+        ReplyAction::Reply(text) => {
+            assert!(
+                text.contains("当前会话未激活"),
+                "expected no-session message, got: {text}"
+            );
+        }
+        other => panic!("expected Reply, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReplyAction enum coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_reply_action_debug() {
+    // Ensure Debug is implemented and doesn't panic.
+    let _ = format!("{:?}", ReplyAction::Reply("x".to_owned()));
+    let _ = format!("{:?}", ReplyAction::TriggerCompact { instruction: None });
+    let _ = format!("{:?}", ReplyAction::Nothing);
+}


### PR DESCRIPTION
feat: implement inbound queue and SideEffectContext pattern

Gateway inbound queue (tokio mpsc bounded channel) + SideEffectContext for SlashResult.execute() pattern, aligning with design doc architecture.

- Add inbound queue with configurable capacity (default 64), stores raw webhook payload
- Consumer task parses via IM plugin, processes through Processor Chain, handles inbound message
- Busy reply sent through outbound Processor Chain (DslParser → RawLog → IM plugin render)
- Introduce SideEffectContext with session_id, session_manager, reply channel
- SlashResult.execute(ctx) encapsulates per-variant side effects
- Gateway execute_and_route simplified: construct ctx → execute → collect reply → outbound chain
- Queue integrated into daemon startup flow
- Code quality: function bodies ≤50 lines, impl blocks ≤100 lines, const extraction

Source: user
Type: feat
