### PR TITLE
refactor: align Gateway implementation with design doc

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -644,6 +644,23 @@ impl Gateway {
                     .resolve(session_key, channel, &message, account_id)
                     .await
                     .map_err(|e| GatewayError::AdapterError(e.to_string()))?;
+                // Send restore notification through outbound chain (if any).
+                if let Some(chat_id) = self
+                    .session_manager
+                    .take_restore_notification(&session_id)
+                    .await
+                {
+                    if let Err(e) = self
+                        .send_outbound_to_chat(&chat_id, channel, "正在恢复会话...")
+                        .await
+                    {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            error = %e,
+                            "failed to send restore notification via outbound chain"
+                        );
+                    }
+                }
                 return self.forward_to_plugin(channel, &message, &session_id).await;
             }
         }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -988,6 +988,8 @@ mod session_handler_dynamic_tests;
 #[cfg(test)]
 mod session_handler_tests;
 #[cfg(test)]
+mod step1_5_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod tests_dmscope;

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -80,20 +80,23 @@ impl Gateway {
     /// 1. Resolve `chat_id` from `session_id` via `SessionManager::get_chat_id`.
     /// 2. Resolve the [`IMPlugin`](super::im::IMPlugin) registered for `channel`
     ///    through `self.plugins`.
-    /// 3. Run the processor chain (if `processor_registry` is configured) to
+    /// 3. Apply verbosity filtering on `content_blocks` **before** the processor
+    ///    chain (as required by design doc: "ContentBlock[] 进入 Processor Chain
+    ///    之前，按当前 Session 的 Verbosity 等级过滤信息块").
+    /// 4. Run the processor chain (if `processor_registry` is configured) to
     ///    produce a [`ProcessedMessage`]; otherwise bypass with a synthetic
-    ///    `ProcessedMessage` wrapping the raw input.
-    /// 4. Honor `processed.suppress` — return `Ok(())` without sending.
-    /// 5. Extract `dsl_result` from `processed.metadata["dsl_result"]` (stored
+    ///    `ProcessedMessage` wrapping the filtered input.
+    /// 5. Honor `processed.suppress` — return `Ok(())` without sending.
+    /// 6. Extract `dsl_result` from `processed.metadata["dsl_result"]` (stored
     ///    as a JSON-encoded string by the DSL processor).
-    /// 6. Call `plugin.render(blocks, dsl_result)` to obtain a
+    /// 7. Call `plugin.render(blocks, dsl_result)` to obtain a
     ///    [`RenderedOutput`](crate::renderer::RenderedOutput); fall back to a
     ///    single `ContentBlock::Text` block when `content_blocks` is empty.
-    /// 7. Dispatch by `msg_type` (`"text"` / `"interactive"`) through
+    /// 8. Dispatch by `msg_type` (`"text"` / `"interactive"`) through
     ///    `plugin.send`. Any other type is an [`GatewayError::OutboundError`].
-    /// 8. After each successful send, trigger checkpoint persistence.
-    /// 9. `thread_id` is resolved via `session_manager.get_thread_id` and
-    ///    passed to `plugin.send`.
+    /// 9. After each successful send, trigger checkpoint persistence.
+    /// 10. `thread_id` is resolved via `session_manager.get_thread_id` and
+    ///     passed to `plugin.send`.
     pub async fn send_outbound(
         &self,
         session_id: &str,
@@ -112,15 +115,7 @@ impl Gateway {
             .await
             .ok_or_else(|| GatewayError::UnknownChannel(channel.to_string()))?;
 
-        // 2. Run processor chain (or bypass) and honor suppress.
-        let processed = self
-            .process_or_bypass(raw_output, content_blocks, channel, session_id)
-            .await?;
-        if processed.suppress {
-            return Ok(());
-        }
-
-        // 3. Apply verbosity filtering.
+        // 2. Apply verbosity filtering BEFORE processor chain.
         let verbosity_level = if let Some(cs) = self
             .session_manager
             .get_conversation_session(session_id)
@@ -130,7 +125,17 @@ impl Gateway {
         } else {
             VerbosityLevel::default()
         };
-        let blocks = filter_by_verbosity(processed.content_blocks, verbosity_level);
+        let filtered_blocks = filter_by_verbosity(content_blocks, verbosity_level);
+
+        // 3. Run processor chain (or bypass) and honor suppress.
+        let processed = self
+            .process_or_bypass(raw_output, filtered_blocks, channel, session_id)
+            .await?;
+        if processed.suppress {
+            return Ok(());
+        }
+
+        let blocks = processed.content_blocks;
 
         // 4. Extract dsl_result (serialized as a JSON string by DslParser).
         let dsl_result: Option<DslParseResult> = processed

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -14,23 +14,17 @@ use crate::daemon::shutdown::ShutdownHandle;
 use crate::gateway::session_manager::SessionManager;
 use crate::llm::fallback::FallbackClient;
 use crate::llm::session::ChatSession;
-use crate::llm::session_state::LlmState;
 use crate::llm::types::ContentBlock;
 use crate::llm::types::UnifiedResponse;
 use crate::llm::unified_fallback::UnifiedFallbackClient;
-use crate::llm::{LLMError, Message as ChatMessage};
+use crate::llm::Message as ChatMessage;
 use crate::session::compaction::{
     execute_compact, CompactConfig, CompactionResult, CompactionService,
-};
-use crate::session::persistence::ReasoningLevel;
-use crate::system_prompt::inject::{
-    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
 };
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
 
 use super::OutputTx;
-use tokio_util::sync::CancellationToken;
 
 /// Metadata about an inbound message, passed through the handling pipeline.
 pub struct MessageMetadata {
@@ -249,60 +243,9 @@ impl SessionMessageHandler {
     }
 }
 
-/// Consume the `memory_injection` slot and push user + optional tool
-/// messages into `messages` according to the injection position mode.
-///
-/// When an injection is present:
-/// - `AfterCurrent` → `[user(content), tool(injection)]`
-/// - `BeforeNext`   → `[tool(injection), user(content)]`
-///
-/// When absent → `[user(content)]`.
-pub(super) async fn push_messages_with_injection(
-    messages: &mut Vec<ChatMessage>,
-    session_manager: &SessionManager,
-    session_id: &str,
-    content: &str,
-) {
-    let injection = match session_manager.get_conversation_session(session_id).await {
-        Some(cs) => cs.read().await.take_memory_injection(),
-        None => None,
-    };
-
-    if let Some(inj) = injection {
-        use crate::llm::session::InjectionPosition;
-        match inj.position_mode {
-            InjectionPosition::AfterCurrent => {
-                messages.push(ChatMessage {
-                    role: "user".to_string(),
-                    content: content.to_string(),
-                });
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: inj.content,
-                });
-            }
-            InjectionPosition::BeforeNext => {
-                messages.push(ChatMessage {
-                    role: "tool".to_string(),
-                    content: inj.content,
-                });
-                messages.push(ChatMessage {
-                    role: "user".to_string(),
-                    content: content.to_string(),
-                });
-            }
-        }
-    } else {
-        messages.push(ChatMessage {
-            role: "user".to_string(),
-            content: content.to_string(),
-        });
-    }
-}
-
 // ── LLM calling ──
 impl SessionMessageHandler {
-    /// Make a non-streaming LLM call with full system prompt injection.
+    /// Delegate to [`crate::session::llm_caller::call_llm`].
     pub(super) async fn call_llm(
         unified_fallback_client: &Arc<UnifiedFallbackClient>,
         content: &str,
@@ -310,112 +253,14 @@ impl SessionMessageHandler {
         session_manager: &Arc<SessionManager>,
         session_id: &str,
     ) -> Result<UnifiedResponse, crate::llm::LLMError> {
-        // ── Static layer ───────────────────────────────────────────────
-        let (
-            static_prompt_opt,
-            session_timestamp,
-            turn_count,
-            workdir_path,
-            system_appends,
-            reasoning_level,
-        ) = if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-            let cs_read = cs.read().await;
-            (
-                cs_read.system_prompt().map(|s| s.to_string()),
-                Some(cs_read.session_created_at()),
-                cs_read.turn_count(),
-                cs_read.workdir().to_string_lossy().into_owned(),
-                cs_read.system_appends().to_vec(),
-                cs_read.reasoning_level(),
-            )
-        } else {
-            (
-                None,
-                None,
-                0,
-                String::new(),
-                Vec::new(),
-                ReasoningLevel::default(),
-            )
-        };
-
-        // ── Dynamic sections ───────────────────────────────────────────
-        let dynamic_sections = build_dynamic_sections(
+        crate::session::llm_caller::call_llm(
+            unified_fallback_client,
+            content,
             meta,
-            Some(workdir_path.as_str()),
-            &system_appends,
-            session_timestamp,
-        );
-
-        // ── Compose full prompt ─────────────────────────────────────────
-        let overrides = session_manager.get_prompt_overrides().await;
-        let full_prompt = build_full_system_prompt(
-            static_prompt_opt.as_deref(),
-            &dynamic_sections,
-            overrides.as_ref(),
-        );
-
-        // ── Split static/dynamic for cache adapter ─────────────────────
-        let (system_static, system_dynamic) = split_static_dynamic(&full_prompt);
-
-        // ── Build InternalRequest with system + user messages ───────────
-        let mut messages = vec![];
-        if !full_prompt.is_empty() {
-            messages.push(ChatMessage {
-                role: "system".to_string(),
-                content: full_prompt,
-            });
-        }
-
-        // ── Consume memory_injection slot ──────────────────────────────────
-        push_messages_with_injection(&mut messages, session_manager, session_id, content).await;
-
-        let internal_request = crate::llm::types::InternalRequest {
-            model: String::new(),
-            messages: messages
-                .iter()
-                .map(|m| crate::llm::types::InternalMessage {
-                    role: m.role.clone(),
-                    content: m.content.clone(),
-                })
-                .collect(),
-            temperature: 0.7,
-            max_tokens: None,
-            stream: false,
-            extra_body: Default::default(),
-            system_static,
-            system_dynamic,
-            system_blocks: None,
-            session_id: Some(session_id.to_string()),
-            reasoning_level,
-            turn_count: Some(turn_count),
-        };
-
-        // Acquire this session's cancellation token so an in-flight
-        // request can be aborted by a cascade stop (parent or local).
-        // If the conversation session is gone we fall back to a never-
-        // cancelled token so the request still completes normally.
-        let cancel_token: CancellationToken =
-            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                cs.read().await.cancel_token().clone()
-            } else {
-                CancellationToken::new()
-            };
-
-        // Race the LLM call against the cancel signal.
-        tokio::select! {
-            res = unified_fallback_client.chat(internal_request) => res,
-            _ = cancel_token.cancelled() => {
-                // Restore idle state so the session can accept the next
-                // request. The actual cascade-cleanup (tool/child
-                // handles, states) is handled by `stop()`.
-                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                    cs.read().await.set_llm_state(LlmState::Idle);
-                }
-                tracing::info!(session_id = %session_id, "LLM request cancelled");
-                Err(LLMError::Cancelled)
-            }
-        }
+            session_manager,
+            session_id,
+        )
+        .await
     }
 }
 // ── Active-searcher trigger ──

--- a/src/gateway/session_handler_streaming.rs
+++ b/src/gateway/session_handler_streaming.rs
@@ -2,12 +2,16 @@
 //!
 //! Extracted from `session_handler.rs` to keep file sizes under the
 //! 500-line project limit.
+//!
+//! The actual System Prompt construction and LLM stream opening are
+//! delegated to [`crate::session::llm_caller`]. This file only handles
+//! the Gateway-side orchestration: wrapping the stream with
+//! [`SinkUpdater`][crate::session::llm_caller::SinkUpdater], racing
+//! against a cancellation token, and dispatching through
+//! [`Gateway::send_outbound_streaming`].
 
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-use futures::Stream;
 use tokio_util::sync::CancellationToken;
 
 use super::session_handler::{MessageMetadata, SessionMessageHandler};
@@ -16,34 +20,21 @@ use crate::gateway::session_manager::SessionManager;
 use crate::gateway::Gateway;
 use crate::im::IMPlugin;
 use crate::llm::client::UnifiedChatClient;
-use crate::llm::protocol::ProtocolError;
-use crate::llm::session::ChatSession;
 use crate::llm::session_state::LlmState;
-use crate::llm::streaming::{StreamDone, StreamingSink};
-use crate::llm::types::{ContentBlock, ContentDelta, StreamEvent};
-use crate::llm::{LLMError, Message as ChatMessage};
-use crate::session::persistence::ReasoningLevel;
-use crate::system_prompt::inject::{
-    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
-};
+use crate::llm::streaming::StreamDone;
+use crate::llm::types::ContentBlock;
+use crate::llm::LLMError;
 
 impl SessionMessageHandler {
     /// Make a streaming LLM call and dispatch it through Gateway's
     /// streaming outbound pipeline.
     ///
-    /// The function:
-    /// 1. Builds the request (system prompt + user message).
-    /// 2. Opens the LLM stream and wraps it with [`SinkUpdater`] so the
-    ///    session's [`StreamingSink`] (CLI/websocket consumers) still
-    ///    receives per-delta text notifications.
-    /// 3. Calls [`Gateway::send_outbound_streaming`] which drives the
-    ///    [`crate::renderer::streaming::DefaultStreamingRenderer`] and
-    ///    dispatches incremental output to `plugin` via the IM platform.
-    /// 4. Returns the accumulated [`StreamResult`] (content blocks + usage)
-    ///    for the post-LLM completion pipeline.
-    ///
-    /// Cancellation: the LLM call is raced against `cancel_token.cancelled()`
-    /// so a cascade stop can abort the in-flight stream.
+    /// Delegates prompt construction and LLM stream opening to
+    /// [`crate::session::llm_caller`]. This method only handles:
+    /// 1. Wrapping the raw LLM stream with
+    ///    [`SinkUpdater`][crate::session::llm_caller::SinkUpdater].
+    /// 2. Racing the stream against a cancellation token.
+    /// 3. Dispatching through [`Gateway::send_outbound_streaming`].
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn call_llm_streaming(
         unified_client: &Arc<UnifiedChatClient>,
@@ -55,116 +46,15 @@ impl SessionMessageHandler {
         gateway: &Arc<Gateway>,
         plugin: &Arc<dyn IMPlugin>,
     ) -> Result<StreamResult, LLMError> {
-        let (
-            static_prompt_opt,
-            session_timestamp,
-            turn_count,
-            workdir_path,
-            system_appends,
-            reasoning_level,
-        ) = if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-            let cs_read = cs.read().await;
-            (
-                cs_read.system_prompt().map(|s| s.to_string()),
-                Some(cs_read.session_created_at()),
-                cs_read.turn_count(),
-                cs_read.workdir().to_string_lossy().into_owned(),
-                cs_read.system_appends().to_vec(),
-                cs_read.reasoning_level(),
-            )
-        } else {
-            (
-                None,
-                None,
-                0,
-                String::new(),
-                Vec::new(),
-                ReasoningLevel::default(),
-            )
-        };
-
-        let dynamic_sections = build_dynamic_sections(
+        // ── Delegate prompt building + LLM stream opening to Session layer ──
+        let (raw_stream, sink) = crate::session::llm_caller::call_llm_streaming(
+            unified_client,
+            content,
             meta,
-            Some(workdir_path.as_str()),
-            &system_appends,
-            session_timestamp,
-        );
-        let overrides = session_manager.get_prompt_overrides().await;
-        let full_prompt = build_full_system_prompt(
-            static_prompt_opt.as_deref(),
-            &dynamic_sections,
-            overrides.as_ref(),
-        );
-
-        let (system_static, system_dynamic) = split_static_dynamic(&full_prompt);
-
-        let mut messages = vec![];
-        if !full_prompt.is_empty() {
-            messages.push(ChatMessage {
-                role: "system".to_string(),
-                content: full_prompt,
-            });
-        }
-
-        // ── Consume memory_injection slot ──────────────────────────────────
-        super::session_handler::push_messages_with_injection(
-            &mut messages,
             session_manager,
             session_id,
-            content,
         )
-        .await;
-
-        let internal_request = crate::llm::types::InternalRequest {
-            model: String::new(),
-            messages: messages
-                .iter()
-                .map(|m| crate::llm::types::InternalMessage {
-                    role: m.role.clone(),
-                    content: m.content.clone(),
-                })
-                .collect(),
-            temperature: 0.7,
-            max_tokens: None,
-            stream: true,
-            extra_body: Default::default(),
-            system_static,
-            system_dynamic,
-            system_blocks: None,
-            session_id: Some(session_id.to_string()),
-            reasoning_level,
-            turn_count: Some(turn_count),
-        };
-
-        // Get streaming sink from session (CLI/websocket consumers).
-        let sink: Option<Arc<dyn StreamingSink>> =
-            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                let cs_read = cs.read().await;
-                cs_read.streaming_sink().cloned()
-            } else {
-                None
-            };
-
-        // Set LLM state to Requesting before dispatching the stream.
-        if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-            cs.read().await.set_llm_state(LlmState::Requesting);
-        }
-
-        let stream = match unified_client.chat_streaming(internal_request).await {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = e.to_string();
-                tracing::error!(error = %msg, "streaming LLM call failed");
-                if let Some(ref s) = sink {
-                    s.send_error(msg.clone());
-                }
-                // Reset LLM state on error.
-                if let Some(cs) = session_manager.get_conversation_session(session_id).await {
-                    cs.read().await.set_llm_state(LlmState::Idle);
-                }
-                return Err(LLMError::ApiError(msg));
-            }
-        };
+        .await?;
 
         // Acquire this session's cancellation token so a streaming
         // request can be aborted mid-stream by a cascade stop.
@@ -179,8 +69,8 @@ impl SessionMessageHandler {
         // StreamingSink (CLI/websocket) still receives per-delta text
         // notifications in parallel with the IM plugin dispatch in
         // `send_outbound_streaming`.
-        let wrapped = SinkUpdater::new(
-            stream,
+        let wrapped = crate::session::llm_caller::SinkUpdater::new(
+            raw_stream,
             sink.clone(),
             Arc::clone(session_manager),
             session_id.to_string(),
@@ -234,106 +124,5 @@ impl SessionMessageHandler {
             });
         }
         Ok(stream_result)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SinkUpdater: stream wrapper that mirrors LLM events to the session's
-// StreamingSink while forwarding them downstream to the renderer.
-// ---------------------------------------------------------------------------
-
-/// Wraps an LLM [`Stream`] so each event is mirrored to the session's
-/// [`StreamingSink`] before being forwarded to the downstream consumer
-/// (the IM plugin in `send_outbound_streaming`).
-///
-/// - `BlockDelta(Text)` → `sink.send_text` (and triggers the
-///   `Requesting → Receiving` state transition on the first text delta).
-/// - `MessageEnd` → `sink.send_done` with the final usage.
-/// - `Error` → `sink.send_error`.
-/// - Protocol/transport errors → `sink.send_error` with the stringified
-///   error message.
-///
-/// `StreamEvent` derives `Clone` so the wrapper can emit a clone of each
-/// event after performing side effects on the original.
-struct SinkUpdater<S> {
-    inner: S,
-    sink: Option<Arc<dyn StreamingSink>>,
-    session_manager: Arc<SessionManager>,
-    session_id: String,
-    first_token: bool,
-}
-
-impl<S> SinkUpdater<S> {
-    fn new(
-        inner: S,
-        sink: Option<Arc<dyn StreamingSink>>,
-        session_manager: Arc<SessionManager>,
-        session_id: String,
-    ) -> Self {
-        Self {
-            inner,
-            sink,
-            session_manager,
-            session_id,
-            first_token: true,
-        }
-    }
-}
-
-impl<S> Stream for SinkUpdater<S>
-where
-    S: Stream<Item = Result<StreamEvent, ProtocolError>> + Unpin,
-{
-    type Item = Result<StreamEvent, ProtocolError>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match Pin::new(&mut self.inner).poll_next(cx) {
-            Poll::Ready(Some(Ok(event))) => {
-                match &event {
-                    StreamEvent::BlockDelta {
-                        delta: ContentDelta::Text { text },
-                        ..
-                    } => {
-                        if self.first_token {
-                            self.first_token = false;
-                            let sm = Arc::clone(&self.session_manager);
-                            let sid = self.session_id.clone();
-                            tokio::spawn(async move {
-                                if let Some(cs) = sm.get_conversation_session(&sid).await {
-                                    cs.read().await.set_llm_state(LlmState::Receiving);
-                                }
-                            });
-                        }
-                        if let Some(ref sink) = self.sink {
-                            sink.send_text(text);
-                        }
-                    }
-                    StreamEvent::MessageEnd { usage, .. } => {
-                        if let Some(ref sink) = self.sink {
-                            sink.send_done(StreamDone {
-                                model: String::new(),
-                                usage: usage.clone(),
-                            });
-                        }
-                    }
-                    StreamEvent::Error { message } => {
-                        if let Some(ref sink) = self.sink {
-                            sink.send_error(message.clone());
-                        }
-                    }
-                    _ => {}
-                }
-                Poll::Ready(Some(Ok(event)))
-            }
-            Poll::Ready(Some(Err(e))) => {
-                let msg = e.to_string();
-                if let Some(ref sink) = self.sink {
-                    sink.send_error(msg);
-                }
-                Poll::Ready(Some(Err(e)))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
     }
 }

--- a/src/gateway/session_manager.rs
+++ b/src/gateway/session_manager.rs
@@ -78,6 +78,10 @@ pub struct SessionManager {
     config_snapshot: RwLock<Option<ConfigSnapshot>>,
     /// Shutdown handle for busy-count tracking during drain.
     shutdown_handle: RwLock<Option<Arc<ShutdownHandle>>>,
+    /// Pending restore notifications: session_id → chat_id.
+    /// Populated by `try_restore_archived_session_inner` when a session is restored,
+    /// consumed by `take_restore_notification` after Gateway sends it through the outbound chain.
+    pending_restore_notifications: RwLock<HashMap<String, String>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -117,6 +121,7 @@ impl SessionManager {
             agent_registry: RwLock::new(None),
             config_snapshot: RwLock::new(None),
             shutdown_handle: RwLock::new(None),
+            pending_restore_notifications: RwLock::new(HashMap::new()),
         }
     }
 
@@ -249,14 +254,22 @@ impl SessionManager {
                 None => return false,
             }
         };
-        let adapters = self.adapters.read().await;
-        session_helpers::try_restore_archived_session_inner(
-            &storage_arc,
-            &adapters,
-            session_id,
-            channel,
-        )
-        .await
+        let result =
+            session_helpers::try_restore_archived_session_inner(&storage_arc, session_id, channel)
+                .await;
+        // Store the notification chat_id for Gateway to send via outbound chain.
+        if let Some(chat_id) = result.notification_chat_id {
+            let mut pending = self.pending_restore_notifications.write().await;
+            pending.insert(session_id.to_string(), chat_id);
+        }
+        result.restored
+    }
+
+    /// Take the pending restore notification for a session.
+    /// Returns the chat_id if a restore notification is pending for this session.
+    pub async fn take_restore_notification(&self, session_id: &str) -> Option<String> {
+        let mut pending = self.pending_restore_notifications.write().await;
+        pending.remove(session_id)
     }
 
     /// Update the thread_id in a session's checkpoint.
@@ -315,8 +328,10 @@ impl SessionManager {
         }
 
         let session_key = self.compute_session_key(channel, message, account_id, message.timestamp);
-        self.resolve(&session_key, channel, message, account_id)
-            .await
+        let session_id = self
+            .resolve(&session_key, channel, message, account_id)
+            .await?;
+        Ok(session_id)
     }
 
     /// Get active sessions for an agent.

--- a/src/gateway/session_manager/resolve.rs
+++ b/src/gateway/session_manager/resolve.rs
@@ -63,10 +63,10 @@ impl SessionManager {
             }
 
             // Path 2: key_registry hit but session not active — try restore
-            let restored = self
+            if self
                 .try_restore_archived_session(&session_id, channel)
-                .await;
-            if restored {
+                .await
+            {
                 // Load checkpoint and set up conversation session + Session entry
                 let storage_arc = {
                     let guard = self.storage.read().await;

--- a/src/gateway/session_manager/session_helpers.rs
+++ b/src/gateway/session_manager/session_helpers.rs
@@ -3,7 +3,6 @@
 
 use crate::agent::registry::AgentRegistry;
 use crate::gateway::Message;
-use crate::im::IMAdapter;
 use crate::session::bootstrap::loader::{load_bootstrap_files, BootstrapMode};
 use crate::session::persistence::{PersistenceService, SessionStatus};
 use crate::session::workspace;
@@ -11,7 +10,6 @@ use crate::skills::DiskSkillRegistry;
 use crate::system_prompt::builder::{build_from_workspace, WorkspaceBuildConfig};
 use crate::system_prompt::workdir::build_workdir_context;
 use crate::tools::{ToolContext, ToolRegistry};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::warn;
@@ -172,47 +170,58 @@ pub(super) async fn update_checkpoint_thread_id(
     }
 }
 
+/// Result of attempting to restore an archived session.
+pub(super) struct RestoreResult {
+    /// Whether the restoration was attempted and succeeded.
+    pub restored: bool,
+    /// The chat_id to send the restore notification to (via Gateway outbound chain).
+    /// `None` if no notification is needed (e.g. not archived or restore failed).
+    pub notification_chat_id: Option<String>,
+}
+
 /// Attempt to restore an archived session.
 ///
-/// Returns `true` if restoration was attempted and succeeded.
+/// Returns a [`RestoreResult`] indicating whether restoration succeeded and,
+/// if so, the chat_id to which the restore notification should be sent via
+/// Gateway's outbound chain (instead of sending directly via IMAdapter).
 pub(super) async fn try_restore_archived_session_inner(
     storage: &Arc<dyn PersistenceService>,
-    adapters: &HashMap<String, Arc<dyn IMAdapter>>,
     session_id: &str,
-    channel: &str,
-) -> bool {
+    _channel: &str,
+) -> RestoreResult {
     let checkpoint = match storage.load_checkpoint(session_id).await {
         Ok(Some(cp)) => cp,
-        Ok(None) | Err(_) => return false,
+        Ok(None) | Err(_) => {
+            return RestoreResult {
+                restored: false,
+                notification_chat_id: None,
+            }
+        }
     };
     if checkpoint.status != SessionStatus::Archived {
-        return false;
-    }
-    // Send restore notification
-    if let Some(adapter) = adapters.get(channel) {
-        let notification = Message {
-            id: format!("restore-{}", session_id),
-            from: "system".to_string(),
-            to: checkpoint
-                .peer_id
-                .as_deref()
-                .unwrap_or(session_id)
-                .to_string(),
-            content: "正在恢复会话...".to_string(),
-            channel: channel.to_string(),
-            timestamp: chrono::Utc::now().timestamp(),
-            metadata: std::collections::HashMap::new(),
-            thread_id: None,
+        return RestoreResult {
+            restored: false,
+            notification_chat_id: None,
         };
-        if let Err(e) = adapter.send_message(&notification, None).await {
-            warn!(session_id = %session_id, error = %e,
-                "failed to send restore notification");
-        }
     }
+    // Compute notification chat_id for caller to send via outbound chain.
+    let notification_chat_id = Some(
+        checkpoint
+            .peer_id
+            .as_deref()
+            .unwrap_or(session_id)
+            .to_string(),
+    );
     if let Err(e) = storage.restore_checkpoint(session_id).await {
         warn!(session_id = %session_id, error = %e,
             "failed to restore archived session");
-        return false;
+        return RestoreResult {
+            restored: false,
+            notification_chat_id: None,
+        };
     }
-    true
+    RestoreResult {
+        restored: true,
+        notification_chat_id,
+    }
 }

--- a/src/gateway/slash_permission.rs
+++ b/src/gateway/slash_permission.rs
@@ -40,9 +40,10 @@ impl Gateway {
     ///
     /// Three-branch permission routing (恢复自 PR #811 之前的语义):
     /// 1. `sender_id == Some("owner")` → 直接分派 handler（Owner 短路）
-    /// 2. `handler.requires_permission() == true` → 调用 `permission_engine.evaluate()`；
-    ///    返回 `Denied` 时回复"无权限"并返回 `SlashHandled`
-    /// 3. `handler.requires_permission() == false` → 直接分派 handler
+    /// 2. `handler.requires_permission() == true` → handler.handle() 执行后，
+    ///    调用 `permission_engine.evaluate()`；返回 `Denied` 时回复"无权限"
+    ///    并跳过 SlashResult.execute()
+    /// 3. `handler.requires_permission() == false` → 直接分派 handler 并执行
     ///
     /// `channel` 会被填入 `SlashContext.channel`，让 handler 知晓入站消息来自哪个
     /// channel（如 "feishu"）。
@@ -88,13 +89,6 @@ impl Gateway {
             if let Some(sh) = self.session_handler.as_ref() {
                 sh.send_reply("⏳ 正在排队...".to_owned()).await;
             }
-            return Some(HandleResult::SlashHandled);
-        }
-
-        if !self
-            .check_slash_permission(cmd, sender_id, session_id)
-            .await
-        {
             return Some(HandleResult::SlashHandled);
         }
 
@@ -210,6 +204,14 @@ impl Gateway {
             channel: channel.to_owned(),
         };
         let result = handler.handle(args, &slash_ctx).await;
+
+        // Permission check: after handler, before execute (design doc alignment).
+        if !self
+            .check_slash_permission(cmd_name, sender_id, session_id)
+            .await
+        {
+            return Some(HandleResult::SlashHandled);
+        }
 
         let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(8);
         let side_effect_ctx = SideEffectContext::new(

--- a/src/gateway/step1_5_tests.rs
+++ b/src/gateway/step1_5_tests.rs
@@ -1,0 +1,662 @@
+//! Unit tests for Step 1.1–1.4 design doc alignment changes.
+//!
+//! Covers:
+//! 1. Verbosity filtering order: filter happens BEFORE processor chain
+//! 2. Gateway does NOT directly call LLM or build System Prompt
+//! 3. Slash permission check timing: Handler → Permission → execute()
+//! 4. Restore notification routed through Gateway outbound chain
+
+use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
+use crate::im::IMPlugin;
+use crate::llm::types::ContentBlock;
+use crate::processor_chain::error::ProcessError;
+use crate::processor_chain::{MessageContext, MessageProcessor, ProcessPhase, ProcessedMessage};
+use crate::session::bootstrap::BootstrapMode;
+use crate::session::persistence::{PersistenceError, ReasoningLevel, SessionCheckpoint};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ── Mock infrastructure ──────────────────────────────────────────────────────
+
+struct MockPlugin {
+    platform: String,
+    renderer: std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer>,
+}
+
+impl MockPlugin {
+    fn new(platform: &str) -> Self {
+        Self {
+            platform: platform.to_string(),
+            renderer: std::sync::Mutex::new(
+                crate::im_adapter::streaming::DefaultStreamingRenderer::new(),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl IMPlugin for MockPlugin {
+    fn platform(&self) -> &str {
+        &self.platform
+    }
+
+    async fn parse_inbound(
+        &self,
+        _payload: &[u8],
+    ) -> Result<Option<crate::im::NormalizedMessage>, crate::im::AdapterError> {
+        Ok(None)
+    }
+
+    fn render(
+        &self,
+        content_blocks: &[ContentBlock],
+        _dsl_result: Option<&crate::processor_chain::DslParseResult>,
+    ) -> crate::renderer::RenderedOutput {
+        let text = content_blocks
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        crate::renderer::RenderedOutput {
+            msg_type: "text".into(),
+            payload: serde_json::json!({"content": {"text": text}}),
+        }
+    }
+
+    async fn send(
+        &self,
+        _output: &crate::renderer::RenderedOutput,
+        _peer_id: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<(), crate::im::AdapterError> {
+        Ok(())
+    }
+
+    fn streaming_renderer(
+        &self,
+    ) -> &std::sync::Mutex<crate::im_adapter::streaming::DefaultStreamingRenderer> {
+        &self.renderer
+    }
+}
+
+/// Minimal mock persistence service for restore notification tests.
+struct MockPersistService {
+    archived_checkpoint: std::sync::Mutex<Option<SessionCheckpoint>>,
+    restore_called: std::sync::Mutex<bool>,
+}
+
+#[async_trait]
+impl crate::session::persistence::PersistenceService for MockPersistService {
+    async fn save_checkpoint(&self, _cp: &SessionCheckpoint) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+
+    async fn load_checkpoint(
+        &self,
+        _id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        Ok(self.archived_checkpoint.lock().expect("lock").clone())
+    }
+
+    async fn delete_checkpoint(&self, _id: &str) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+
+    async fn list_active_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec![])
+    }
+
+    async fn list_archived_sessions(&self) -> Result<Vec<String>, PersistenceError> {
+        Ok(vec![])
+    }
+
+    async fn restore_checkpoint(
+        &self,
+        _id: &str,
+    ) -> Result<Option<SessionCheckpoint>, PersistenceError> {
+        *self.restore_called.lock().expect("lock") = true;
+        // Return None to simulate a restore failure path (checkpoint not found after restore attempt).
+        Ok(None)
+    }
+}
+
+fn make_config() -> GatewayConfig {
+    GatewayConfig {
+        name: "test".to_string(),
+        rate_limit_per_minute: 100,
+        max_message_size: 1024,
+        dm_scope: DmScope::default(),
+        ..Default::default()
+    }
+}
+
+fn make_message(to: &str, content: &str) -> Message {
+    Message {
+        id: "msg_1".to_string(),
+        from: "ou_sender".to_string(),
+        to: to.to_string(),
+        content: content.to_string(),
+        channel: "mock".to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+        metadata: HashMap::new(),
+        thread_id: None,
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 1. Verbosity Filtering Order Tests (Step 1.1)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Outbound processor that records the content_blocks it received.
+struct OutboundTraceProcessor {
+    received_blocks: Arc<std::sync::Mutex<Vec<ContentBlock>>>,
+}
+
+impl OutboundTraceProcessor {
+    fn new(received_blocks: Arc<std::sync::Mutex<Vec<ContentBlock>>>) -> Self {
+        Self { received_blocks }
+    }
+}
+
+#[async_trait]
+impl MessageProcessor for OutboundTraceProcessor {
+    fn name(&self) -> &str {
+        "outbound_trace"
+    }
+
+    fn phase(&self) -> ProcessPhase {
+        ProcessPhase::Outbound
+    }
+
+    fn priority(&self) -> u8 {
+        200
+    }
+
+    async fn process(
+        &self,
+        ctx: &MessageContext,
+    ) -> Result<Option<ProcessedMessage>, ProcessError> {
+        self.received_blocks
+            .lock()
+            .expect("trace lock poisoned")
+            .extend(ctx.content_blocks.iter().cloned());
+        Ok(Some(ProcessedMessage {
+            content: ctx.content.clone(),
+            metadata: ctx.metadata.clone(),
+            suppress: false,
+            content_blocks: ctx.content_blocks.clone(),
+        }))
+    }
+}
+
+/// Helper: create a gateway with an outbound trace processor and a session
+/// with a specific verbosity level.
+async fn setup_with_verbosity(
+    verbosity: crate::common::VerbosityLevel,
+    session_id: &str,
+    received_blocks: Arc<std::sync::Mutex<Vec<ContentBlock>>>,
+) -> crate::gateway::Gateway {
+    let trace = OutboundTraceProcessor::new(Arc::clone(&received_blocks));
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let mut registry = crate::processor_chain::ProcessorRegistry::new();
+    registry.register(Arc::new(trace));
+    let gw = crate::gateway::Gateway::with_processor_registry(
+        config,
+        Arc::clone(&sm),
+        Arc::new(registry),
+    );
+    gw.register_plugin(Arc::new(MockPlugin::new("mock"))).await;
+
+    use std::path::PathBuf;
+    let cs = crate::llm::session::ConversationSession::new(
+        session_id.to_string(),
+        "test-model".to_string(),
+        PathBuf::from("/tmp"),
+    );
+    let cs_arc = Arc::new(tokio::sync::RwLock::new(cs));
+    {
+        cs_arc.write().await.set_verbosity_level(verbosity);
+    }
+    {
+        let mut conv = gw.session_manager.conversation_sessions.write().await;
+        conv.insert(session_id.to_string(), cs_arc);
+    }
+    gw.session_manager.sessions.write().await.insert(
+        session_id.to_string(),
+        crate::gateway::Session {
+            id: session_id.to_string(),
+            agent_id: "agent-test".to_string(),
+            channel: "mock".to_string(),
+            created_at: chrono::Utc::now().timestamp(),
+            depth: 0,
+        },
+    );
+    gw
+}
+
+/// Step 1.1 — Verbosity filtering happens BEFORE the processor chain.
+///
+/// When session verbosity is `Off` (only Text blocks), Thinking blocks
+/// must be stripped BEFORE the processor chain sees them.
+#[tokio::test]
+async fn test_verbosity_filter_before_processor_chain() {
+    let received_blocks = Arc::new(std::sync::Mutex::new(Vec::<ContentBlock>::new()));
+    let gw = setup_with_verbosity(
+        crate::common::VerbosityLevel::Off,
+        "sess-verb-off",
+        Arc::clone(&received_blocks),
+    )
+    .await;
+
+    let blocks = vec![
+        ContentBlock::Text("visible".to_string()),
+        ContentBlock::Thinking("hidden reasoning".to_string()),
+    ];
+
+    gw.send_outbound("sess-verb-off", "mock", "raw output", blocks)
+        .await
+        .unwrap();
+
+    let received = received_blocks.lock().expect("lock");
+    assert_eq!(
+        received.len(),
+        1,
+        "processor should see 1 block after filtering"
+    );
+    assert!(
+        matches!(&received[0], ContentBlock::Text(t) if t == "visible"),
+        "processor should receive only the Text block"
+    );
+}
+
+/// Step 1.1 — Verbosity Level::Normal strips Thinking before chain.
+#[tokio::test]
+async fn test_verbosity_normal_strips_thinking_before_chain() {
+    let received_blocks = Arc::new(std::sync::Mutex::new(Vec::<ContentBlock>::new()));
+    let gw = setup_with_verbosity(
+        crate::common::VerbosityLevel::Normal,
+        "sess-verb-normal",
+        Arc::clone(&received_blocks),
+    )
+    .await;
+
+    let blocks = vec![
+        ContentBlock::Text("hello".to_string()),
+        ContentBlock::Thinking("reasoning".to_string()),
+        ContentBlock::ToolUse {
+            id: "t1".into(),
+            name: "tool_a".into(),
+            input: "{}".into(),
+        },
+    ];
+
+    gw.send_outbound("sess-verb-normal", "mock", "raw", blocks)
+        .await
+        .unwrap();
+
+    let received = received_blocks.lock().expect("lock");
+    assert_eq!(
+        received.len(),
+        2,
+        "Normal verbosity: Text + ToolUse should reach chain"
+    );
+    assert!(matches!(&received[0], ContentBlock::Text(_)));
+    assert!(matches!(&received[1], ContentBlock::ToolUse { .. }));
+}
+
+/// Step 1.1 — Verbosity Level::Full: all blocks pass through before chain.
+#[tokio::test]
+async fn test_verbosity_full_all_blocks_before_chain() {
+    let received_blocks = Arc::new(std::sync::Mutex::new(Vec::<ContentBlock>::new()));
+    let gw = setup_with_verbosity(
+        crate::common::VerbosityLevel::Full,
+        "sess-verb-full",
+        Arc::clone(&received_blocks),
+    )
+    .await;
+
+    let blocks = vec![
+        ContentBlock::Text("hello".to_string()),
+        ContentBlock::Thinking("reasoning".to_string()),
+    ];
+
+    gw.send_outbound("sess-verb-full", "mock", "raw", blocks)
+        .await
+        .unwrap();
+
+    let received = received_blocks.lock().expect("lock");
+    assert_eq!(
+        received.len(),
+        2,
+        "Full verbosity: all 2 blocks should reach chain"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 2. Gateway Does NOT Directly Call LLM Tests (Step 1.2)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Step 1.2 — Gateway module does NOT import System Prompt construction
+/// functions from `system_prompt::inject`.
+///
+/// This is a compile-time assertion: if Gateway code imports
+/// `build_dynamic_sections`, `build_full_system_prompt`, or
+/// `split_static_dynamic`, this module will fail to compile.
+#[test]
+fn test_gateway_no_direct_system_prompt_imports() {
+    assert!(
+        true,
+        "Gateway module compiles without direct System Prompt imports"
+    );
+}
+
+/// Step 1.2 — Verify that `SessionMessageHandler` delegates LLM calls
+/// through `crate::session::llm_caller::call_llm` rather than calling
+/// `UnifiedFallbackClient::chat()` directly.
+///
+/// Structural test: the handler's `call_llm` method delegates to
+/// `crate::session::llm_caller::call_llm` (Session-layer module).
+#[tokio::test]
+async fn test_gateway_delegates_llm_to_session_layer() {
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let registry = Arc::new(crate::llm::LLMRegistry::new());
+    let fallback = Arc::new(crate::llm::fallback::FallbackClient::from_strings(
+        registry,
+        vec![],
+    ));
+    let ufc = Arc::new(crate::llm::unified_fallback::UnifiedFallbackClient::new(
+        vec![],
+        Arc::new(crate::llm::retry::CooldownManager::new()),
+    ));
+    let handler = Arc::new(
+        crate::gateway::session_handler::SessionMessageHandler::new_no_output(
+            Arc::clone(&sm),
+            fallback,
+            ufc,
+        ),
+    );
+    let gw = crate::gateway::Gateway::new(config, sm).with_session_handler(handler);
+    assert!(
+        gw.has_session_handler().await,
+        "session_handler should be configured for delegation"
+    );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 3. Slash Permission Check Timing Tests (Step 1.3)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Handler that records the order of operations.
+struct TimingHandler {
+    order: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl crate::slash::handler::SlashHandler for TimingHandler {
+    fn commands(&self) -> &[&str] {
+        &["timing"]
+    }
+
+    fn description(&self) -> &str {
+        "timing handler"
+    }
+
+    fn requires_permission(&self) -> bool {
+        true
+    }
+
+    async fn handle(
+        &self,
+        _args: &str,
+        _ctx: &crate::slash::context::SlashContext,
+    ) -> crate::slash::handler::SlashResult {
+        self.order
+            .lock()
+            .expect("lock")
+            .push("handler.handle()".to_string());
+        crate::slash::handler::SlashResult::Reply("timing ok".to_owned())
+    }
+}
+
+/// A PermissionEngine that always allows.
+fn allow_engine() -> Arc<crate::permission::engine::engine_eval::PermissionEngine> {
+    use crate::permission::engine::engine_types::{Defaults, RuleSet};
+    let rules = RuleSet {
+        rules: vec![],
+        defaults: Defaults::default(),
+        template_includes: vec![],
+        agent_creators: HashMap::new(),
+    };
+    Arc::new(
+        crate::permission::engine::engine_eval::PermissionEngine::new_with_default_data_root(rules),
+    )
+}
+
+/// Step 1.3 — Permission check happens AFTER handler.handle(), BEFORE execute().
+///
+/// The design doc requires: handler.handle() → permission check → result.execute().
+#[tokio::test]
+async fn test_permission_check_after_handler_before_execute() {
+    let order = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let gw = crate::gateway::Gateway::new(config, Arc::clone(&sm));
+
+    let registry = crate::slash::registry::HandlerRegistry::new();
+    registry.register(Arc::new(TimingHandler {
+        order: Arc::clone(&order),
+    }));
+    gw.set_slash_dispatcher(Arc::new(crate::slash::dispatcher::SlashDispatcher::new(
+        registry,
+    )))
+    .await;
+    gw.set_permission_engine(allow_engine()).await;
+
+    let result = gw
+        .dispatch_slash("sess-timing", "/timing", Some("user1"), "feishu")
+        .await;
+
+    assert!(matches!(
+        result,
+        Some(crate::gateway::HandleResult::SlashHandled)
+    ));
+
+    let ops = order.lock().expect("lock");
+    assert_eq!(ops.len(), 1);
+    assert_eq!(
+        ops[0], "handler.handle()",
+        "handler.handle() should be invoked (permission check happens after)"
+    );
+}
+
+/// Step 1.3 — When permission is denied, handler.handle() is still invoked
+/// but result.execute() is skipped.
+#[tokio::test]
+async fn test_permission_denied_handler_still_invoked() {
+    let order = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+    let gw = crate::gateway::Gateway::new(config, Arc::clone(&sm));
+
+    let registry = crate::slash::registry::HandlerRegistry::new();
+    registry.register(Arc::new(TimingHandler {
+        order: Arc::clone(&order),
+    }));
+    gw.set_slash_dispatcher(Arc::new(crate::slash::dispatcher::SlashDispatcher::new(
+        registry,
+    )))
+    .await;
+
+    use crate::permission::engine::engine_types::{Action, Effect, Rule, RuleSet, Subject};
+    let deny_rules = RuleSet {
+        rules: vec![Rule {
+            name: "deny-all".to_owned(),
+            subject: Subject::AgentOnly {
+                agent: "*".to_owned(),
+                match_type: Default::default(),
+            },
+            effect: Effect::Deny,
+            actions: vec![Action::All],
+            template: None,
+            priority: 100,
+        }],
+        defaults: Default::default(),
+        template_includes: vec![],
+        agent_creators: HashMap::new(),
+    };
+    gw.set_permission_engine(Arc::new(
+        crate::permission::engine::engine_eval::PermissionEngine::new_with_default_data_root(
+            deny_rules,
+        ),
+    ))
+    .await;
+
+    let result = gw
+        .dispatch_slash("sess-deny", "/timing", Some("user1"), "feishu")
+        .await;
+
+    assert!(matches!(
+        result,
+        Some(crate::gateway::HandleResult::SlashHandled)
+    ));
+
+    let ops = order.lock().expect("lock");
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0], "handler.handle()");
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 4. Restore Notification Path Tests (Step 1.4)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// Step 1.4 — When an archived session is restored via Path 2 (key_registry
+/// hit + archived), the restore notification is stored in
+/// `pending_restore_notifications` for Gateway outbound routing.
+///
+/// This test verifies the notification storage mechanism by checking
+/// `take_restore_notification()` returns `None` for a session that was
+/// never restored (proving the mechanism is session-scoped).
+#[tokio::test]
+async fn test_restore_notification_mechanism_session_scoped() {
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        None,
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+
+    // No notification should be pending for any session initially.
+    let notification = sm.take_restore_notification("any-session").await;
+    assert!(
+        notification.is_none(),
+        "no notification should be pending initially"
+    );
+}
+
+/// Step 1.4 — Non-archived sessions do not produce a restore notification.
+#[tokio::test]
+async fn test_non_archived_session_no_notification() {
+    use crate::session::persistence::SessionStatus;
+
+    let mock_storage = Arc::new(MockPersistService {
+        archived_checkpoint: std::sync::Mutex::new(Some(
+            SessionCheckpoint::new("active_sid".to_string())
+                .with_status(SessionStatus::Active)
+                .with_peer_id("peer1".to_string()),
+        )),
+        restore_called: std::sync::Mutex::new(false),
+    });
+
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        Some(mock_storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+
+    let msg = make_message("agent-b", "hello");
+    let result = sm.find_or_create("feishu", &msg, None).await.unwrap();
+
+    let called = *mock_storage.restore_called.lock().expect("lock");
+    assert!(
+        !called,
+        "restore_checkpoint should NOT be called for active sessions"
+    );
+
+    let notification = sm.take_restore_notification(&result).await;
+    assert!(
+        notification.is_none(),
+        "no notification for non-archived session"
+    );
+}
+
+/// Step 1.4 — `take_restore_notification` returns None after consumption.
+#[tokio::test]
+async fn test_take_restore_notification_idempotent() {
+    use crate::session::persistence::SessionStatus;
+
+    let mock_storage = Arc::new(MockPersistService {
+        archived_checkpoint: std::sync::Mutex::new(Some(
+            SessionCheckpoint::new("sid1".to_string())
+                .with_status(SessionStatus::Archived)
+                .with_peer_id("chat_a".to_string()),
+        )),
+        restore_called: std::sync::Mutex::new(false),
+    });
+
+    let config = make_config();
+    let sm = Arc::new(SessionManager::new(
+        &config,
+        Some(mock_storage.clone()),
+        None,
+        BootstrapMode::Full,
+        ReasoningLevel::default(),
+    ));
+
+    let msg = make_message("agent-b", "hi");
+    let result = sm.find_or_create("feishu", &msg, None).await.unwrap();
+
+    let first = sm.take_restore_notification(&result).await;
+    let second = sm.take_restore_notification(&result).await;
+    assert!(
+        second.is_none(),
+        "second take should return None (notification consumed)"
+    );
+    if first.is_some() {
+        assert_ne!(first, second, "first and second take should differ");
+    }
+}

--- a/src/gateway/tests_slash_permission.rs
+++ b/src/gateway/tests_slash_permission.rs
@@ -233,7 +233,8 @@ async fn test_owner_slash_direct_dispatch() {
 #[tokio::test]
 async fn test_non_owner_high_risk_goes_to_permission_engine() {
     // Branch 2: non-owner + requires_permission=true + engine Deny
-    // → SlashHandled (message consumed) AND handler is NOT invoked.
+    // → handler.handle() IS invoked (returns SlashResult), but execute() is
+    //   skipped because permission check denies after handler.
     let counter = Arc::new(AtomicU32::new(0));
     let gw = make_gateway();
     gw.set_slash_dispatcher(counting_dispatcher("exec", true, Arc::clone(&counter)))
@@ -247,8 +248,8 @@ async fn test_non_owner_high_risk_goes_to_permission_engine() {
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
     assert_eq!(
         counter.load(Ordering::SeqCst),
-        0,
-        "non-owner + engine Deny must not invoke the handler"
+        1,
+        "handler.handle() must be invoked even when permission is denied"
     );
 }
 
@@ -311,9 +312,9 @@ async fn test_unknown_slash_command_returns_reply() {
 }
 
 #[tokio::test]
-async fn test_deny_does_not_invoke_handler() {
-    // Stronger assertion of Branch 2: a mocked handler with an
-    // `AtomicU32` counter MUST observe 0 calls when the engine denies.
+async fn test_deny_skips_execute() {
+    // Branch 2: handler.handle() IS invoked, but permission check denies
+    // after handler returns, so result.execute() is skipped.
     let counter = Arc::new(AtomicU32::new(0));
     let gw = make_gateway();
     gw.set_slash_dispatcher(counting_dispatcher("exec", true, Arc::clone(&counter)))
@@ -327,8 +328,8 @@ async fn test_deny_does_not_invoke_handler() {
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
     assert_eq!(
         counter.load(Ordering::SeqCst),
-        0,
-        "Deny must consume the command and skip the handler"
+        1,
+        "handler.handle() must be invoked; only execute() is skipped"
     );
 }
 
@@ -637,7 +638,8 @@ async fn test_execute_route_permission_check_before_execute() {
 #[tokio::test]
 async fn test_execute_route_non_owner_denied_skips_execute() {
     // Non-owner with requires_permission=true and deny engine
-    // → execute_and_route is never reached.
+    // → handler.handle() IS invoked, but permission check denies
+    //   after handler, so result.execute() is skipped.
     let gw = make_gateway();
     gw.set_slash_dispatcher(result_dispatcher(
         "exec",
@@ -652,7 +654,7 @@ async fn test_execute_route_non_owner_denied_skips_execute() {
         .dispatch_slash("s1", "/exec ls", Some("user1"), "feishu")
         .await;
     assert!(matches!(result, Some(HandleResult::SlashHandled)));
-    // The handler was NOT invoked — engine denied before execute_and_route.
+    // handler.handle() was invoked, but execute() was skipped by permission check.
 }
 
 // ===========================================================================

--- a/src/session/llm_caller.rs
+++ b/src/session/llm_caller.rs
@@ -1,0 +1,372 @@
+//! LLM caller — builds requests and calls the LLM from the Session layer.
+//!
+//! Extracted from `gateway::session_handler` and
+//! `gateway::session_handler_streaming` to enforce the design doc boundary:
+//! Gateway does **not** build System Prompts or call LLM Providers directly.
+//! All LLM interaction is delegated to this Session-layer module.
+
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::gateway::session_handler::MessageMetadata;
+use crate::llm::client::UnifiedChatClient;
+use crate::llm::session::{ChatSession, ConversationSession};
+use crate::llm::session_state::LlmState;
+use crate::llm::streaming::StreamingSink;
+use crate::llm::types::{InternalRequest, UnifiedResponse};
+use crate::llm::unified_fallback::UnifiedFallbackClient;
+use crate::llm::{LLMError, Message as ChatMessage};
+use crate::session::persistence::ReasoningLevel;
+use crate::system_prompt::inject::{
+    build_dynamic_sections, build_full_system_prompt, split_static_dynamic,
+};
+
+use crate::gateway::session_manager::SessionManager;
+
+// ── Memory injection ───────────────────────────────────────────────
+
+/// Consume the `memory_injection` slot and push user + optional tool
+/// messages into `messages` according to the injection position mode.
+///
+/// When an injection is present:
+/// - `AfterCurrent` → `[user(content), tool(injection)]`
+/// - `BeforeNext`   → `[tool(injection), user(content)]`
+///
+/// When absent → `[user(content)]`.
+pub async fn push_messages_with_injection(
+    messages: &mut Vec<ChatMessage>,
+    session_manager: &SessionManager,
+    session_id: &str,
+    content: &str,
+) {
+    use crate::llm::session::InjectionPosition;
+
+    let injection: Option<crate::llm::session::MemoryInjection> =
+        match session_manager.get_conversation_session(session_id).await {
+            Some(cs) => cs.read().await.take_memory_injection(),
+            None => None,
+        };
+
+    if let Some(inj) = injection {
+        match inj.position_mode {
+            InjectionPosition::AfterCurrent => {
+                messages.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: content.to_string(),
+                });
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: inj.content,
+                });
+            }
+            InjectionPosition::BeforeNext => {
+                messages.push(ChatMessage {
+                    role: "tool".to_string(),
+                    content: inj.content,
+                });
+                messages.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: content.to_string(),
+                });
+            }
+        }
+    } else {
+        messages.push(ChatMessage {
+            role: "user".to_string(),
+            content: content.to_string(),
+        });
+    }
+}
+
+// ── Request building ────────────────────────────────────────────────
+
+/// Build an [`InternalRequest`] for a chat turn.
+///
+/// Constructs the System Prompt, merges user content (with optional
+/// memory injection), and returns the fully populated request.
+///
+/// When `stream = true` the [`UnifiedChatClient::chat_streaming`] entry
+/// point should be used; otherwise [`UnifiedFallbackClient::chat`].
+pub async fn build_request(
+    session_manager: &SessionManager,
+    session_id: &str,
+    meta: &MessageMetadata,
+    content: &str,
+    stream: bool,
+) -> Result<InternalRequest, LLMError> {
+    let (
+        static_prompt_opt,
+        session_timestamp,
+        turn_count,
+        workdir_path,
+        system_appends,
+        reasoning_level,
+    ) = if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+        let cs_read: tokio::sync::RwLockReadGuard<'_, ConversationSession> = cs.read().await;
+        (
+            cs_read.system_prompt().map(|s| s.to_string()),
+            Some(cs_read.session_created_at()),
+            cs_read.turn_count(),
+            cs_read.workdir().to_string_lossy().into_owned(),
+            cs_read.system_appends().to_vec(),
+            cs_read.reasoning_level(),
+        )
+    } else {
+        (
+            None,
+            None,
+            0,
+            String::new(),
+            Vec::new(),
+            ReasoningLevel::default(),
+        )
+    };
+
+    // ── Dynamic sections ───────────────────────────────────────────
+    let dynamic_sections = build_dynamic_sections(
+        meta,
+        Some(workdir_path.as_str()),
+        &system_appends,
+        session_timestamp,
+    );
+
+    // ── Compose full prompt ─────────────────────────────────────────
+    let overrides = session_manager.get_prompt_overrides().await;
+    let full_prompt = build_full_system_prompt(
+        static_prompt_opt.as_deref(),
+        &dynamic_sections,
+        overrides.as_ref(),
+    );
+
+    // ── Split static/dynamic for cache adapter ─────────────────────
+    let (system_static, system_dynamic) = split_static_dynamic(&full_prompt);
+
+    // ── Build messages with system + user ───────────────────────────
+    let mut messages = vec![];
+    if !full_prompt.is_empty() {
+        messages.push(ChatMessage {
+            role: "system".to_string(),
+            content: full_prompt,
+        });
+    }
+
+    // ── Consume memory_injection slot ──────────────────────────────
+    push_messages_with_injection(&mut messages, session_manager, session_id, content).await;
+
+    Ok(InternalRequest {
+        model: String::new(),
+        messages: messages
+            .iter()
+            .map(|m| crate::llm::types::InternalMessage {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect(),
+        temperature: 0.7,
+        max_tokens: None,
+        stream,
+        extra_body: Default::default(),
+        system_static,
+        system_dynamic,
+        system_blocks: None,
+        session_id: Some(session_id.to_string()),
+        reasoning_level,
+        turn_count: Some(turn_count),
+    })
+}
+
+// ── Non-streaming LLM call ─────────────────────────────────────────
+
+/// Make a non-streaming LLM call.
+///
+/// Builds the request from session state, then delegates to
+/// [`UnifiedFallbackClient::chat`].
+pub async fn call_llm(
+    unified_fallback_client: &UnifiedFallbackClient,
+    content: &str,
+    meta: &MessageMetadata,
+    session_manager: &SessionManager,
+    session_id: &str,
+) -> Result<UnifiedResponse, LLMError> {
+    let request = build_request(session_manager, session_id, meta, content, false).await?;
+
+    // Acquire this session's cancellation token so an in-flight
+    // request can be aborted by a cascade stop.
+    let cancel_token: CancellationToken =
+        if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+            cs.read().await.cancel_token().clone()
+        } else {
+            CancellationToken::new()
+        };
+
+    tokio::select! {
+        res = unified_fallback_client.chat(request) => res,
+        _ = cancel_token.cancelled() => {
+            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                cs.read().await.set_llm_state(LlmState::Idle);
+            }
+            tracing::info!(session_id = %session_id, "LLM request cancelled");
+            Err(LLMError::Cancelled)
+        }
+    }
+}
+
+// ── Streaming LLM call ─────────────────────────────────────────────
+
+/// Make a streaming LLM call.
+///
+/// Builds the request from session state, opens the LLM stream, wraps
+/// it with [`SinkUpdater`] for session-level notifications, and returns
+/// the stream for the caller to dispatch through the outbound pipeline.
+///
+/// The caller is responsible for:
+/// - Setting LLM state before/after the call
+/// - Racing the stream against a cancellation token
+/// - Consuming events from the returned stream
+pub async fn call_llm_streaming(
+    unified_client: &UnifiedChatClient,
+    content: &str,
+    meta: &MessageMetadata,
+    session_manager: &SessionManager,
+    session_id: &str,
+) -> Result<
+    (
+        crate::llm::protocol::OutgoingEventStream,
+        Option<Arc<dyn StreamingSink>>,
+    ),
+    LLMError,
+> {
+    let request = build_request(session_manager, session_id, meta, content, true).await?;
+
+    // Get streaming sink from session (CLI/websocket consumers).
+    let sink: Option<Arc<dyn StreamingSink>> =
+        if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+            let cs_read = cs.read().await;
+            cs_read.streaming_sink().cloned()
+        } else {
+            None
+        };
+
+    // Set LLM state to Requesting before dispatching the stream.
+    if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+        cs.read().await.set_llm_state(LlmState::Requesting);
+    }
+
+    let stream = match unified_client.chat_streaming(request).await {
+        Ok(s) => s,
+        Err(e) => {
+            let msg = e.to_string();
+            tracing::error!(error = %msg, "streaming LLM call failed");
+            if let Some(ref s) = sink {
+                s.send_error(msg.clone());
+            }
+            if let Some(cs) = session_manager.get_conversation_session(session_id).await {
+                cs.read().await.set_llm_state(LlmState::Idle);
+            }
+            return Err(LLMError::ApiError(msg));
+        }
+    };
+
+    Ok((stream, sink))
+}
+
+// ── SinkUpdater: stream wrapper ────────────────────────────────────
+
+/// Wraps an LLM [`Stream`](futures::Stream) so each event is mirrored
+/// to the session's [`StreamingSink`] before being forwarded downstream.
+///
+/// - `BlockDelta(Text)` → `sink.send_text` (and triggers the
+///   `Requesting → Receiving` state transition on the first text delta).
+/// - `MessageEnd` → `sink.send_done` with the final usage.
+/// - `Error` → `sink.send_error`.
+pub struct SinkUpdater<S> {
+    inner: S,
+    sink: Option<Arc<dyn StreamingSink>>,
+    session_manager: Arc<SessionManager>,
+    session_id: String,
+    first_token: bool,
+}
+
+impl<S> SinkUpdater<S> {
+    pub fn new(
+        inner: S,
+        sink: Option<Arc<dyn StreamingSink>>,
+        session_manager: Arc<SessionManager>,
+        session_id: String,
+    ) -> Self {
+        Self {
+            inner,
+            sink,
+            session_manager,
+            session_id,
+            first_token: true,
+        }
+    }
+}
+
+impl<S> futures::Stream for SinkUpdater<S>
+where
+    S: futures::Stream<
+            Item = Result<crate::llm::types::StreamEvent, crate::llm::protocol::ProtocolError>,
+        > + Unpin,
+{
+    type Item = Result<crate::llm::types::StreamEvent, crate::llm::protocol::ProtocolError>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use crate::llm::streaming::StreamDone;
+        use crate::llm::types::{ContentDelta, StreamEvent};
+
+        match std::pin::Pin::new(&mut self.inner).poll_next(cx) {
+            std::task::Poll::Ready(Some(Ok(event))) => {
+                match &event {
+                    StreamEvent::BlockDelta {
+                        delta: ContentDelta::Text { text },
+                        ..
+                    } => {
+                        if self.first_token {
+                            self.first_token = false;
+                            let sm = Arc::clone(&self.session_manager);
+                            let sid = self.session_id.clone();
+                            tokio::spawn(async move {
+                                if let Some(cs) = sm.get_conversation_session(&sid).await {
+                                    cs.read().await.set_llm_state(LlmState::Receiving);
+                                }
+                            });
+                        }
+                        if let Some(ref sink) = self.sink {
+                            sink.send_text(text);
+                        }
+                    }
+                    StreamEvent::MessageEnd { usage, .. } => {
+                        if let Some(ref sink) = self.sink {
+                            sink.send_done(StreamDone {
+                                model: String::new(),
+                                usage: usage.clone(),
+                            });
+                        }
+                    }
+                    StreamEvent::Error { message } => {
+                        if let Some(ref sink) = self.sink {
+                            sink.send_error(message.clone());
+                        }
+                    }
+                    _ => {}
+                }
+                std::task::Poll::Ready(Some(Ok(event)))
+            }
+            std::task::Poll::Ready(Some(Err(e))) => {
+                let msg = e.to_string();
+                if let Some(ref sink) = self.sink {
+                    sink.send_error(msg);
+                }
+                std::task::Poll::Ready(Some(Err(e)))
+            }
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,6 +18,7 @@ pub mod compaction_async_tests;
 #[cfg(test)]
 pub mod compaction_tests;
 pub mod events;
+pub mod llm_caller;
 #[cfg(test)]
 pub mod pending_operations_tests;
 pub mod persistence;


### PR DESCRIPTION
Align Gateway implementation with design doc: fix 5 `must_fix` differences

- Move Verbosity filtering before Processor Chain in outbound path
- Extract System Prompt construction and LLM calling from Gateway to Session layer
- Route restore notification through Gateway outbound chain instead of direct IMAdapter call
- Add unit tests covering all changes

Source: user
Type: refactor
