### PR TITLE
refactor: configure Processor Chain in daemon path

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -19,12 +19,7 @@ use crate::llm::minimax::MiniMaxProvider;
 use crate::llm::openai::OpenAIProvider;
 use crate::llm::unified_fallback::{ChainEntry, UnifiedFallbackClient};
 use crate::llm::LLMRegistry;
-use crate::processor_chain::content_normalizer::ContentNormalizer;
-use crate::processor_chain::dsl_parser::DslParser;
-use crate::processor_chain::outbound_raw_log::OutboundRawLogProcessor;
-use crate::processor_chain::raw_log_processor::{RawLogConfig, RawLogProcessor};
-use crate::processor_chain::session_router::SessionRouter;
-use crate::processor_chain::ProcessorRegistry;
+use crate::processor_chain;
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use crate::slash::dispatcher::SlashDispatcher;
@@ -78,7 +73,7 @@ pub(crate) async fn build_gateway(agent_id: &str) -> (Arc<Gateway>, Arc<SessionM
         ReasoningLevel::default(),
     ));
 
-    let processor_registry = Arc::new(build_processor_registry(&gateway_config));
+    let processor_registry = Arc::new(processor_chain::build_processor_registry(&gateway_config));
     let gateway = Gateway::with_processor_registry(
         gateway_config,
         Arc::clone(&session_manager),
@@ -96,46 +91,6 @@ pub(crate) async fn build_gateway(agent_id: &str) -> (Arc<Gateway>, Arc<SessionM
     gateway.register_plugin(plugin).await;
 
     (gateway, session_manager)
-}
-
-/// Build a [`ProcessorRegistry`] with inbound [`RawLogProcessor`] and
-/// [`ContentNormalizer`], outbound [`DslParser`].
-pub(crate) fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegistry {
-    let mut registry = ProcessorRegistry::default();
-
-    // Inbound: RawLogProcessor (if raw_log_dir is configured)
-    if let Some(ref dir) = config.raw_log_dir {
-        let raw_log_config = RawLogConfig {
-            enabled: true,
-            dir: dir.clone(),
-            retention_days: 7,
-        };
-        let processor =
-            RawLogProcessor::new(raw_log_config).expect("RawLogProcessor initialization failed");
-        registry.register(Arc::new(processor));
-    }
-
-    // Inbound: SessionRouter (priority 20 — computes session_key)
-    registry.register(Arc::new(SessionRouter::new(config.dm_scope)));
-
-    // Inbound: ContentNormalizer
-    registry.register(Arc::new(ContentNormalizer::new()));
-
-    // Outbound: RawLogProcessor (if raw_log_dir is configured)
-    if let Some(ref dir) = config.raw_log_dir {
-        let raw_log_config = RawLogConfig {
-            enabled: true,
-            dir: dir.clone(),
-            retention_days: 7,
-        };
-        let processor = OutboundRawLogProcessor::new(raw_log_config);
-        registry.register(Arc::new(processor));
-    }
-
-    // Outbound: DslParser
-    registry.register(Arc::new(DslParser));
-
-    registry
 }
 
 /// Load credentials from the config directory, falling back to defaults.

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -9,7 +9,8 @@ use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use std::sync::Arc;
 
-use super::chat::{build_gateway, build_processor_registry};
+use super::chat::build_gateway;
+use crate::processor_chain::build_processor_registry;
 
 // ── Processor Registry tests ────────────────────────────────────────────────
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -23,6 +23,7 @@ type StartupPlan = (
 );
 use crate::cli::terminal::TerminalPlugin;
 use crate::gateway::{DmScope, Gateway, GatewayConfig, SessionManager};
+use crate::processor_chain;
 use crate::slash::dispatcher::SlashDispatcher;
 use crate::slash::handlers::{ReasoningHandler, SystemHandler, WorkdirHandler};
 use crate::slash::registry::HandlerRegistry;
@@ -231,7 +232,18 @@ impl Daemon {
             Self::read_bootstrap_mode(),
             ReasoningLevel::default(),
         ));
-        let gateway = Gateway::new(gateway_config, Arc::clone(&session_manager));
+        let processor_registry =
+            Arc::new(processor_chain::build_processor_registry(&gateway_config));
+        info!(
+            inbound_len = processor_registry.inbound_len(),
+            outbound_len = processor_registry.outbound_len(),
+            "processor registry built for daemon"
+        );
+        let gateway = Gateway::with_processor_registry(
+            gateway_config,
+            Arc::clone(&session_manager),
+            processor_registry,
+        );
         gateway
             .set_storage(Arc::clone(storage) as Arc<dyn PersistenceService>)
             .await;

--- a/src/processor_chain/build_processor_registry_tests.rs
+++ b/src/processor_chain/build_processor_registry_tests.rs
@@ -1,0 +1,158 @@
+//! Tests for [`build_processor_registry`].
+
+use crate::gateway::{DmScope, GatewayConfig};
+use crate::processor_chain::build_processor_registry;
+use crate::processor_chain::context::{ProcessedMessage, RawMessage};
+
+use chrono::Utc;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_config(raw_log_dir: Option<std::path::PathBuf>, dm_scope: DmScope) -> GatewayConfig {
+    GatewayConfig {
+        name: "test-gw".to_string(),
+        rate_limit_per_minute: 0,
+        max_message_size: 0,
+        dm_scope,
+        raw_log_dir,
+        inbound_queue_capacity: 64,
+    }
+}
+
+fn make_raw_message() -> RawMessage {
+    RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "user_1".to_string(),
+        peer_id: "peer_1".to_string(),
+        content: "  hello   world  ".to_string(),
+        timestamp: Utc::now(),
+        message_id: "msg_1".to_string(),
+    }
+}
+
+// ── test 1: default config (no raw_log_dir) ─────────────────────────────────
+
+#[tokio::test]
+async fn test_default_config_no_raw_log() {
+    let config = make_config(None, DmScope::default());
+    let registry = build_processor_registry(&config);
+
+    // Inbound: SessionRouter (20) + ContentNormalizer (30) = 2
+    assert_eq!(
+        registry.inbound_len(),
+        2,
+        "default config should have 2 inbound processors"
+    );
+    // Outbound: DslParser (10) = 1
+    assert_eq!(
+        registry.outbound_len(),
+        1,
+        "default config should have 1 outbound processor"
+    );
+}
+
+// ── test 2: config with raw_log_dir ─────────────────────────────────────────
+
+#[tokio::test]
+async fn test_config_with_raw_log_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(Some(tmp.path().to_path_buf()), DmScope::default());
+    let registry = build_processor_registry(&config);
+
+    // Inbound: RawLogProcessor (10) + SessionRouter (20) + ContentNormalizer (30) = 3
+    // Outbound: DslParser (10) + OutboundRawLogProcessor (20) = 2
+    assert_eq!(
+        registry.inbound_len(),
+        3,
+        "config with raw_log_dir should have 3 inbound processors"
+    );
+    assert_eq!(
+        registry.outbound_len(),
+        2,
+        "config with raw_log_dir should have 2 outbound processors"
+    );
+}
+
+// ── test 3: dm_scope is correctly passed to SessionRouter ────────────────────
+
+/// Verify that different DmScope values produce different session keys,
+/// confirming the parameter is correctly forwarded to SessionRouter.
+#[tokio::test]
+async fn test_dm_scope_passed_to_session_router() {
+    let raw = make_raw_message();
+
+    // Build registry with PerChannelSender scope
+    let config_sender = make_config(None, DmScope::PerChannelSender);
+    let registry_sender = build_processor_registry(&config_sender);
+
+    // Build registry with default scope (PerAccountChannelPeer)
+    let config_default = make_config(None, DmScope::PerAccountChannelPeer);
+    let registry_default = build_processor_registry(&config_default);
+
+    let result_sender = registry_sender.process_inbound(raw.clone()).await.unwrap();
+    let result_default = registry_default.process_inbound(raw).await.unwrap();
+
+    let key_sender = result_sender
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap();
+    let key_default = result_default
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap();
+
+    // Session keys must differ because routing fields differ by scope
+    assert_ne!(
+        key_sender, key_default,
+        "different DmScope values should produce different session keys"
+    );
+    assert!(!key_sender.is_empty(), "session_key must not be empty");
+}
+
+// ── test 4: processor priority sorting ──────────────────────────────────────
+
+/// Verify that the inbound chain executes in priority order:
+/// RawLogProcessor(10) → SessionRouter(20) → ContentNormalizer(30).
+///
+/// We send a message with trailing whitespace and verify that
+/// ContentNormalizer (the last inbound processor) trims it,
+/// proving it ran after SessionRouter.
+#[tokio::test]
+async fn test_priority_sorting_inbound() {
+    let config = make_config(None, DmScope::default());
+    let registry = build_processor_registry(&config);
+
+    let raw = make_raw_message(); // "  hello   world  "
+    let result = registry.process_inbound(raw).await.unwrap();
+
+    // ContentNormalizer strips trailing whitespace (not leading).
+    // Input: "  hello   world  " → Output: "  hello   world"
+    assert_eq!(
+        result.content, "  hello   world",
+        "ContentNormalizer (priority 30) must run after SessionRouter (priority 20)"
+    );
+}
+
+/// Verify that the outbound chain executes in priority order:
+/// DslParser(10) → OutboundRawLogProcessor(20) (when raw_log_dir is set).
+#[tokio::test]
+async fn test_priority_sorting_outbound() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config = make_config(Some(tmp.path().to_path_buf()), DmScope::default());
+    let registry = build_processor_registry(&config);
+
+    let llm_output = ProcessedMessage {
+        content: "test output".to_string(),
+        metadata: serde_json::Map::new(),
+        suppress: false,
+        content_blocks: vec![],
+    };
+    let result = registry.process_outbound(llm_output).await.unwrap();
+
+    // Outbound chain should pass content through (DslParser doesn't modify
+    // plain text, OutboundRawLogProcessor logs without changing content)
+    assert_eq!(result.content, "test output");
+    assert!(!result.suppress);
+}

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -10,6 +10,8 @@
 //! - [`RawMessageLog`] — snapshot of raw message at each processing step
 //! - [`ProcessError`] — error types
 
+#[cfg(test)]
+mod build_processor_registry_tests;
 pub mod content_normalizer;
 pub mod context;
 #[cfg(test)]

--- a/src/processor_chain/mod.rs
+++ b/src/processor_chain/mod.rs
@@ -35,3 +35,60 @@ pub use session_router::SessionRouter;
 pub use context::{MessageContext, ProcessedMessage, RawMessage, RawMessageLog};
 pub use error::ProcessError;
 pub use processor::{MessageProcessor, ProcessPhase};
+
+use std::sync::Arc;
+
+use crate::gateway::GatewayConfig;
+
+use self::content_normalizer::ContentNormalizer;
+use self::outbound_raw_log::OutboundRawLogProcessor;
+use self::raw_log_processor::{RawLogConfig, RawLogProcessor};
+
+/// Build a [`ProcessorRegistry`] with the standard inbound/outbound chains.
+///
+/// Inbound (by priority): [`RawLogProcessor`] (10) → [`SessionRouter`] (20) →
+/// [`ContentNormalizer`] (30).
+///
+/// Outbound (by priority): [`DslParser`] (10) → [`OutboundRawLogProcessor`] (20).
+///
+/// [`RawLogProcessor`] and [`OutboundRawLogProcessor`] are registered only when
+/// `config.raw_log_dir` is `Some`. When `raw_log_dir` is `None` the inbound
+/// chain contains [`SessionRouter`] + [`ContentNormalizer`] and the outbound
+/// chain contains [`DslParser`] only.
+pub fn build_processor_registry(config: &GatewayConfig) -> ProcessorRegistry {
+    let mut registry = ProcessorRegistry::default();
+
+    // Inbound: RawLogProcessor (priority 10 — if raw_log_dir is configured)
+    if let Some(ref dir) = config.raw_log_dir {
+        let raw_log_config = RawLogConfig {
+            enabled: true,
+            dir: dir.clone(),
+            retention_days: 7,
+        };
+        let processor =
+            RawLogProcessor::new(raw_log_config).expect("RawLogProcessor initialization failed");
+        registry.register(Arc::new(processor));
+    }
+
+    // Inbound: SessionRouter (priority 20 — computes session_key)
+    registry.register(Arc::new(SessionRouter::new(config.dm_scope)));
+
+    // Inbound: ContentNormalizer (priority 30)
+    registry.register(Arc::new(ContentNormalizer::new()));
+
+    // Outbound: RawLogProcessor (priority 20 — if raw_log_dir is configured)
+    if let Some(ref dir) = config.raw_log_dir {
+        let raw_log_config = RawLogConfig {
+            enabled: true,
+            dir: dir.clone(),
+            retention_days: 7,
+        };
+        let processor = OutboundRawLogProcessor::new(raw_log_config);
+        registry.register(Arc::new(processor));
+    }
+
+    // Outbound: DslParser (priority 10)
+    registry.register(Arc::new(DslParser));
+
+    registry
+}


### PR DESCRIPTION
Configure Processor Chain in daemon path to align with design doc.

Extract `build_processor_registry()` from CLI path to `processor_chain` module as shared public API, then use it in both daemon and CLI paths. Daemon path now uses `Gateway::with_processor_registry()` with the full inbound chain (RawLog→SessionRouter→ContentNormalizer) and outbound chain (DslParser→RawLog). CLI path deduplicated to use the same shared function. Unit tests added for the shared registry builder.

Source: user
Type: refactor
