### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -131,5 +131,12 @@
     "commit_time": "",
     "confirmed_time": "2026-06-26T05:40:09.261967+08:00",
     "comment": "blocked: Two design doc problems found in F2b deep comparison: (1) First-line output 200ms delay target has no time-based logic in LineBuffer implementation; unclear if hard requirement or aspirational. (2) MessageEnd handling: doc says automatic flush but code MessageEnd branch is no-op requiring explicit caller flush(). Design intent unclear for both."
+  },
+  {
+    "path": "docs/design/llm/cache-adapter.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-26T13:19:05.908214+08:00",
+    "comment": "blocked: doc has responsibility attribution issues"
   }
 ]


### PR DESCRIPTION
## 变更内容

- **文档路径**: `docs/design/llm/cache-adapter.md`
- **操作类型**: blocked
- **原因简述**: CI 流水线中标记该设计文档为 blocked 状态