### PR TITLE
refactor: 将 LLM 知识库从硬编码 HashMap 迁移为 JSON 驱动加载

### DIFF
--- a/src/llm/assets/deepseek.json
+++ b/src/llm/assets/deepseek.json
@@ -1,4 +1,31 @@
 {
+  "deepseek-v3-flash": {
+    "context_window": 64000,
+    "max_tokens": 8192,
+    "default_temperature": 0.7,
+    "reasoning": false,
+    "reasoning_levels": { "type": "levels", "value": { "off": false, "base": true, "reasoner": true } },
+    "input_types": ["text"],
+    "recommended_protocol": "anthropic"
+  },
+  "deepseek-v3": {
+    "context_window": 64000,
+    "max_tokens": 8192,
+    "default_temperature": 0.7,
+    "reasoning": false,
+    "reasoning_levels": { "type": "levels", "value": { "off": false, "base": true, "reasoner": true } },
+    "input_types": ["text"],
+    "recommended_protocol": "anthropic"
+  },
+  "deepseek-v4": {
+    "context_window": 64000,
+    "max_tokens": 8192,
+    "default_temperature": 0.7,
+    "reasoning": true,
+    "reasoning_levels": { "type": "levels", "value": { "off": false, "base": true, "reasoner": true } },
+    "input_types": ["text"],
+    "recommended_protocol": "anthropic"
+  },
   "deepseek-v4-pro": {
     "context_window": 1000000,
     "max_tokens": 384000,

--- a/src/llm/assets/volcengine.json
+++ b/src/llm/assets/volcengine.json
@@ -1,0 +1,20 @@
+{
+  "doubao-1.5-pro": {
+    "context_window": 32768,
+    "max_tokens": 8192,
+    "default_temperature": 0.7,
+    "reasoning": false,
+    "reasoning_levels": { "type": "none" },
+    "input_types": ["text"],
+    "recommended_protocol": "openai"
+  },
+  "doubao-1.5-lite": {
+    "context_window": 32768,
+    "max_tokens": 8192,
+    "default_temperature": 0.7,
+    "reasoning": false,
+    "reasoning_levels": { "type": "none" },
+    "input_types": ["text"],
+    "recommended_protocol": "openai"
+  }
+}

--- a/src/llm/knowledge.rs
+++ b/src/llm/knowledge.rs
@@ -74,246 +74,30 @@ pub struct ProviderModelKnowledge {
 
 impl ProviderModelKnowledge {
     /// Create the knowledge base populated with all known providers.
+    ///
+    /// Each provider's models are loaded from a JSON file at compile time
+    /// via `include_str!` and parsed at runtime with `serde_json`.
     pub fn new() -> Self {
-        let mut inner = HashMap::new();
+        let mut inner: HashMap<String, HashMap<&'static str, ModelRecommendParams>> =
+            HashMap::new();
 
-        // ──────────────────────────────────────────────────────────────────────
-        // MiniMax
-        // MiniMax 官方文档 + 实测 API 响应
-        // ──────────────────────────────────────────────────────────────────────
-        let mut minimax_models = HashMap::new();
-        minimax_models.insert(
-            "MiniMax-M2",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        minimax_models.insert(
-            "MiniMax-M2.1",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        minimax_models.insert(
-            "MiniMax-M2.5",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        minimax_models.insert(
-            "MiniMax-M2.7",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        inner.insert("minimax".to_string(), minimax_models);
+        macro_rules! load_provider {
+            ($provider:expr, $file:expr) => {{
+                let json = include_str!(concat!("assets/", $file));
+                let models: HashMap<String, ModelRecommendParams> = serde_json::from_str(json)
+                    .unwrap_or_else(|e| panic!("failed to parse {}: {}", $file, e));
+                let static_models: HashMap<&'static str, ModelRecommendParams> = models
+                    .into_iter()
+                    .map(|(k, v)| (&*Box::leak(k.into_boxed_str()), v))
+                    .collect();
+                inner.insert($provider.to_string(), static_models);
+            }};
+        }
 
-        // ──────────────────────────────────────────────────────────────────────
-        // GLM
-        // 实测 API 响应 + 官方文档 (bigmodel.cn)
-        // reasoning_content 字段表示支持思考内容
-        // ──────────────────────────────────────────────────────────────────────
-        let mut glm_models = HashMap::new();
-        glm_models.insert(
-            "GLM-4.5-Air",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        glm_models.insert(
-            "GLM-4.5-AirX",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text, InputType::Image],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        glm_models.insert(
-            "glm-4.5-air",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        glm_models.insert(
-            "glm-4.5-airx",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text, InputType::Image],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        glm_models.insert(
-            "glm-4.7",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::Toggle { on: false },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        glm_models.insert(
-            "glm-5.1",
-            ModelRecommendParams {
-                context_window: 128_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::Toggle { on: false },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        inner.insert("glm".to_string(), glm_models);
-
-        // ──────────────────────────────────────────────────────────────────────
-        // VolcEngine (火山引擎 ARTVC)
-        // 火山引擎 ARTVC API 文档
-        // ──────────────────────────────────────────────────────────────────────
-        let mut volcengine_models = HashMap::new();
-        volcengine_models.insert(
-            "doubao-1.5-pro",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        volcengine_models.insert(
-            "doubao-1.5-lite",
-            ModelRecommendParams {
-                context_window: 32_768,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::None,
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("openai"),
-            },
-        );
-        inner.insert("volcengine".to_string(), volcengine_models);
-
-        // ──────────────────────────────────────────────────────────────────────
-        // DeepSeek
-        // 实测 API 响应 + 官方文档 (deepseek.com)
-        // reasoning_levels 支持 off/base/reasoner 三档
-        // ──────────────────────────────────────────────────────────────────────
-        let mut deepseek_models = HashMap::new();
-        deepseek_models.insert(
-            "deepseek-v3-flash",
-            ModelRecommendParams {
-                context_window: 64_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::Levels {
-                    off: false,
-                    base: true,
-                    reasoner: true,
-                },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        deepseek_models.insert(
-            "deepseek-v3",
-            ModelRecommendParams {
-                context_window: 64_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: false,
-                reasoning_levels: ReasoningLevels::Levels {
-                    off: false,
-                    base: true,
-                    reasoner: true,
-                },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        deepseek_models.insert(
-            "deepseek-v4-flash",
-            ModelRecommendParams {
-                context_window: 64_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::Levels {
-                    off: false,
-                    base: true,
-                    reasoner: true,
-                },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        deepseek_models.insert(
-            "deepseek-v4",
-            ModelRecommendParams {
-                context_window: 64_000,
-                max_tokens: 8_192,
-                default_temperature: 0.7,
-                reasoning: true,
-                reasoning_levels: ReasoningLevels::Levels {
-                    off: false,
-                    base: true,
-                    reasoner: true,
-                },
-                input_types: vec![InputType::Text],
-                recommended_protocol: ProtocolId::from("anthropic"),
-            },
-        );
-        inner.insert("deepseek".to_string(), deepseek_models);
+        load_provider!("deepseek", "deepseek.json");
+        load_provider!("glm", "glm.json");
+        load_provider!("minimax", "minimax.json");
+        load_provider!("volcengine", "volcengine.json");
 
         Self { inner }
     }
@@ -365,9 +149,12 @@ mod tests {
         let params = kb.find("minimax", "MiniMax-M2.7");
         assert!(params.is_some());
         let p = params.unwrap();
-        assert_eq!(p.context_window, 32_768);
+        assert_eq!(p.context_window, 204_800);
         assert!(p.reasoning);
-        assert!(matches!(p.reasoning_levels, ReasoningLevels::None));
+        assert!(matches!(
+            p.reasoning_levels,
+            ReasoningLevels::Toggle { on: true }
+        ));
     }
 
     #[test]
@@ -423,7 +210,7 @@ mod tests {
         let p = kb.find("glm", "glm-5.1").unwrap();
         assert!(matches!(
             p.reasoning_levels,
-            ReasoningLevels::Toggle { on: false }
+            ReasoningLevels::Toggle { on: true }
         ));
     }
 
@@ -434,7 +221,7 @@ mod tests {
         assert!(matches!(
             p.reasoning_levels,
             ReasoningLevels::Levels {
-                off: false,
+                off: true,
                 base: true,
                 reasoner: true
             }
@@ -442,10 +229,13 @@ mod tests {
     }
 
     #[test]
-    fn test_minimax_reasoning_levels_none() {
+    fn test_minimax_reasoning_levels_toggle() {
         let kb = kb();
         let p = kb.find("minimax", "MiniMax-M2.7").unwrap();
-        assert!(matches!(p.reasoning_levels, ReasoningLevels::None));
+        assert!(matches!(
+            p.reasoning_levels,
+            ReasoningLevels::Toggle { on: true }
+        ));
     }
 
     // ── recommended_protocol ──────────────────────────────────────────────

--- a/src/llm/knowledge.rs
+++ b/src/llm/knowledge.rs
@@ -238,6 +238,93 @@ mod tests {
         ));
     }
 
+    // ── JSON loading: model counts ──────────────────────────────────────
+
+    #[test]
+    fn test_json_load_deepseek_model_count() {
+        let kb = kb();
+        let models = kb.all_models("deepseek");
+        assert_eq!(models.len(), 5, "deepseek should have 5 models from JSON");
+    }
+
+    #[test]
+    fn test_json_load_glm_model_count() {
+        let kb = kb();
+        let models = kb.all_models("glm");
+        assert_eq!(models.len(), 9, "glm should have 9 models from JSON");
+    }
+
+    #[test]
+    fn test_json_load_minimax_model_count() {
+        let kb = kb();
+        let models = kb.all_models("minimax");
+        assert_eq!(models.len(), 7, "minimax should have 7 models from JSON");
+    }
+
+    #[test]
+    fn test_json_load_volcengine_model_count() {
+        let kb = kb();
+        let models = kb.all_models("volcengine");
+        assert_eq!(models.len(), 2, "volcengine should have 2 models from JSON");
+    }
+
+    // ── new models: discoverable via find() ──────────────────────────────
+
+    #[test]
+    fn test_find_new_deepseek_v4_pro() {
+        let kb = kb();
+        let p = kb.find("deepseek", "deepseek-v4-pro");
+        assert!(p.is_some(), "deepseek-v4-pro should be in knowledge base");
+        let p = p.unwrap();
+        assert!(p.reasoning);
+        assert_eq!(p.context_window, 1_000_000);
+        assert_eq!(p.max_tokens, 384_000);
+    }
+
+    #[test]
+    fn test_find_new_minimax_m2() {
+        let kb = kb();
+        let p = kb.find("minimax", "MiniMax-M2");
+        assert!(p.is_some(), "MiniMax-M2 should be in knowledge base");
+        let p = p.unwrap();
+        assert!(p.reasoning);
+        assert_eq!(p.context_window, 204_800);
+    }
+
+    #[test]
+    fn test_find_new_volcengine_models() {
+        let kb = kb();
+        for model in "doubao-1.5-pro,doubao-1.5-lite".split(',') {
+            let p = kb.find("volcengine", model);
+            assert!(p.is_some(), "{model} should be in knowledge base");
+        }
+    }
+
+    #[test]
+    fn test_find_new_deepseek_v3_flash() {
+        let kb = kb();
+        let p = kb.find("deepseek", "deepseek-v3-flash");
+        assert!(p.is_some(), "deepseek-v3-flash should be in knowledge base");
+        let p = p.unwrap();
+        assert_eq!(p.context_window, 64_000);
+    }
+
+    // ── updated values ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_updated_deepseek_v4_flash_context_window() {
+        let kb = kb();
+        let p = kb.find("deepseek", "deepseek-v4-flash").unwrap();
+        assert_eq!(
+            p.context_window, 1_000_000,
+            "deepseek-v4-flash context_window should be 1,000,000"
+        );
+        assert_eq!(
+            p.max_tokens, 384_000,
+            "deepseek-v4-flash max_tokens should be 384,000"
+        );
+    }
+
     // ── recommended_protocol ──────────────────────────────────────────────
 
     #[test]

--- a/src/llm/model_info.rs
+++ b/src/llm/model_info.rs
@@ -153,9 +153,9 @@ mod tests {
         let model = ModelInfo::from_str("deepseek/deepseek-v4-flash").unwrap();
         assert_eq!(model.id, "deepseek-v4-flash");
         assert!(model.reasoning);
-        assert_eq!(model.context_window, 64_000);
-        assert_eq!(model.max_tokens, 8_192);
-        assert_eq!(model.default_temperature, Some(0.7));
+        assert_eq!(model.context_window, 1_000_000);
+        assert_eq!(model.max_tokens, 384_000);
+        assert_eq!(model.default_temperature, Some(1.0));
     }
 
     #[test]


### PR DESCRIPTION
refactor: 将 LLM 知识库从硬编码 HashMap 迁移为 JSON 驱动加载

将 `ProviderModelKnowledge::new()` 从硬编码 HashMap 改为通过 `include_str!` 加载 `src/llm/assets/<provider>.json` 文件，用 `serde_json::from_str` 解析。以 JSON 文件为 single source of truth，同步更新数值并补全缺失模型（deepseek-v3-flash、deepseek-v3、deepseek-v4、volcengine models）。

变更内容：
- knowledge.rs: 移除硬编码 HashMap insert，改为 include_str! + serde_json 加载
- deepseek.json: 补充 deepseek-v3-flash、deepseek-v3、deepseek-v4 模型
- volcengine.json: 新建 volcengine provider JSON 文件（doubao-1.5-pro、doubao-1.5-lite）
- model_info.rs: 更新 test_from_str_known_model 断言以匹配 JSON 数据

Source: design doc docs/design/llm/model-discovery.md
Type: refactor
