### PR TITLE
feat: Model Discovery 知识库填充能力参数

### DIFF
--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -321,18 +321,37 @@ impl ModelLister for MiniMaxProvider {
 
         let data = api_resp["data"].as_array().cloned().unwrap_or_default();
 
+        let kb = crate::llm::ProviderModelKnowledge::new();
         let models: Vec<ModelInfo> = data
             .into_iter()
             .filter_map(|m| {
                 let model_id = m["id"].as_str()?.to_string();
+                let params = kb.find("minimax", &model_id);
+                let (context_window, max_tokens, default_temperature, reasoning, input_types) =
+                    match params {
+                        Some(p) => (
+                            p.context_window,
+                            p.max_tokens,
+                            Some(p.default_temperature),
+                            p.reasoning,
+                            p.input_types,
+                        ),
+                        None => (
+                            32_768,
+                            8_192,
+                            Some(0.7),
+                            false,
+                            vec![crate::llm::InputType::Text],
+                        ),
+                    };
                 Some(ModelInfo {
                     id: model_id.clone(),
                     name: format!("MiniMax {}", model_id.trim_start_matches("MiniMax-")),
-                    context_window: 32_768,
-                    max_tokens: 8_192,
-                    default_temperature: Some(0.7),
-                    reasoning: false,
-                    input_types: vec![crate::llm::InputType::Text],
+                    context_window,
+                    max_tokens,
+                    default_temperature,
+                    reasoning,
+                    input_types,
                 })
             })
             .collect();

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests for the MiniMax provider.
 
 use super::*;
-use crate::llm::Provider;
+use crate::llm::{ModelLister, Provider};
 
 // TODO: Rewrite with v2 fixture (minimax/MiniMax-M3/anthropic/)
 // #[test]
@@ -369,4 +369,84 @@ async fn test_provider_send_streaming_rate_limit_mock() {
 
     m.assert_async().await;
     assert!(matches!(err, ProviderError::Legacy(_)));
+}
+
+// --- fetch_model_list knowledge base filling tests ---
+
+#[tokio::test]
+async fn test_fetch_model_list_uses_knowledge_base() {
+    let mut server = mockito::Server::new_async().await;
+    let api_response = serde_json::json!({
+        "data": [
+            {"id": "MiniMax-M2.7", "owned_by": "minimax"},
+            {"id": "MiniMax-M2", "owned_by": "minimax"}
+        ]
+    });
+    let m = server
+        .mock("GET", "/v1/models")
+        .match_header(
+            "Authorization",
+            mockito::Matcher::Regex(r"Bearer .+".to_string()),
+        )
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(api_response.to_string())
+        .create_async()
+        .await;
+
+    let provider =
+        MiniMaxProvider::with_http_client("test-key".into(), server.url(), reqwest::Client::new());
+    let models = ModelLister::fetch_model_list(&provider, "test-key")
+        .await
+        .unwrap();
+
+    m.assert_async().await;
+    assert_eq!(models.len(), 2);
+
+    // MiniMax-M2.7: knowledge base has reasoning=true, context_window=204800
+    let m27 = models.iter().find(|m| m.id == "MiniMax-M2.7").unwrap();
+    assert!(
+        m27.reasoning,
+        "knowledge base should set reasoning=true for M2.7"
+    );
+    assert_eq!(m27.context_window, 204_800);
+
+    // MiniMax-M2: knowledge base has reasoning=true, context_window=204800
+    let m2 = models.iter().find(|m| m.id == "MiniMax-M2").unwrap();
+    assert!(
+        m2.reasoning,
+        "knowledge base should set reasoning=true for M2"
+    );
+    assert_eq!(m2.context_window, 204_800);
+}
+
+#[tokio::test]
+async fn test_fetch_model_list_unknown_model_uses_fallback() {
+    let mut server = mockito::Server::new_async().await;
+    let api_response = serde_json::json!({
+        "data": [
+            {"id": "unknown-future-model", "owned_by": "minimax"}
+        ]
+    });
+    let m = server
+        .mock("GET", "/v1/models")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(api_response.to_string())
+        .create_async()
+        .await;
+
+    let provider =
+        MiniMaxProvider::with_http_client("test-key".into(), server.url(), reqwest::Client::new());
+    let models = ModelLister::fetch_model_list(&provider, "test-key")
+        .await
+        .unwrap();
+
+    m.assert_async().await;
+    assert_eq!(models.len(), 1);
+    // Unknown model: fallback defaults (context_window=32768, reasoning=false)
+    let model = &models[0];
+    assert_eq!(model.id, "unknown-future-model");
+    assert_eq!(model.context_window, 32_768);
+    assert!(!model.reasoning);
 }

--- a/src/llm/model_cache.rs
+++ b/src/llm/model_cache.rs
@@ -73,6 +73,12 @@ impl ModelCache {
         Self { persist_path }
     }
 
+    /// Construct a `ModelCache` with an explicit file path.
+    #[cfg(test)]
+    pub(crate) fn with_path(persist_path: std::path::PathBuf) -> Self {
+        Self { persist_path }
+    }
+
     /// Retrieve cached models for the given provider + token.
     ///
     /// Returns `None` if:

--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -55,7 +55,18 @@ impl ModelDiscovery {
             let result = tokio::time::timeout(FETCH_TIMEOUT, fetch(credential)).await;
 
             match result {
-                Ok(Ok(models)) => {
+                Ok(Ok(mut models)) => {
+                    for model in &mut models {
+                        if let Some(params) = self.knowledge.find(provider_id, &model.id) {
+                            model.reasoning = params.reasoning;
+                            if params.context_window > model.context_window {
+                                model.context_window = params.context_window;
+                            }
+                            if params.max_tokens > model.max_tokens {
+                                model.max_tokens = params.max_tokens;
+                            }
+                        }
+                    }
                     self.cache.set(provider_id, credential, models.clone());
                     return models;
                 }
@@ -279,5 +290,82 @@ mod tests {
 
         let models = discovery.knowledge_fallback("minimax");
         assert!(!models.is_empty(), "minimax should have known models");
+    }
+
+    // ── Knowledge base filling tests (Step 1.3) ──────────────────────
+
+    fn make_test_discovery(dir: &tempfile::TempDir) -> ModelDiscovery {
+        ModelDiscovery {
+            cache: ModelCache::with_path(dir.path().join("cache.json")),
+            knowledge: ProviderModelKnowledge::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_discover_success_path_knowledge_fills() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        // API returns MiniMax-M2.7 with context_window=1000 (below knowledge base 32768)
+        let api_models = vec![ModelInfo {
+            id: "MiniMax-M2.7".into(),
+            name: "MiniMax M2.7".into(),
+            context_window: 1000,
+            max_tokens: 512,
+            default_temperature: Some(0.3),
+            reasoning: false,
+            input_types: vec![],
+        }];
+
+        let result = discovery
+            .discover("minimax", "key", |_| {
+                let value = api_models.clone();
+                async move { Ok(value) }
+            })
+            .await;
+
+        assert_eq!(result.len(), 1);
+        let m = &result[0];
+        // Knowledge base fills reasoning: true for M2.7
+        assert!(
+            m.reasoning,
+            "M2.7 should have reasoning=true from knowledge base"
+        );
+        // Knowledge base context_window (204800) > API (1000), so it overrides
+        assert_eq!(m.context_window, 204_800);
+        // Knowledge base max_tokens (131072) > API (512), so it overrides
+        assert_eq!(m.max_tokens, 131_072);
+    }
+
+    #[tokio::test]
+    async fn test_discover_knowledge_miss_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        // API returns an unknown model not in knowledge base
+        let api_models = vec![ModelInfo {
+            id: "some-new-future-model".into(),
+            name: "Future Model".into(),
+            context_window: 16384,
+            max_tokens: 4096,
+            default_temperature: Some(0.5),
+            reasoning: false,
+            input_types: vec![],
+        }];
+
+        let result = discovery
+            .discover("minimax", "key", |_| {
+                let value = api_models.clone();
+                async move { Ok(value) }
+            })
+            .await;
+
+        assert_eq!(result.len(), 1);
+        let m = &result[0];
+        // Unknown model: no knowledge base fill, API values preserved
+        assert_eq!(m.id, "some-new-future-model");
+        assert_eq!(m.context_window, 16384);
+        assert_eq!(m.max_tokens, 4096);
+        assert!(!m.reasoning);
     }
 }


### PR DESCRIPTION
feat: Model Discovery 知识库填充能力参数

- MiniMax `fetch_model_list()` 查询 `ProviderModelKnowledge` 填充 context_window、reasoning 等能力参数（与 GLM `build_model_info()` 保持一致）
- `ModelDiscovery::discover()` 成功路径用知识库填充 reasoning/context_window/max_tokens，知识库未命中时保留 API 原始值
- 单元测试覆盖知识库命中、未命中、填充生效场景

Source: user
Type: feat
