### PR TITLE
fix: 完善 model-discovery 知识库填充 + 回退来源标注

### DIFF
--- a/src/cli/config_wizard/fetch.rs
+++ b/src/cli/config_wizard/fetch.rs
@@ -1,11 +1,11 @@
 //! Model fetching logic — delegated to ModelDiscovery
 
-use crate::llm::ModelInfo;
+use crate::llm::DiscoveryResult;
 
 /// Return model list from the knowledge base for the given provider name.
 ///
 /// Delegates to [`crate::llm::ModelDiscovery::knowledge_fallback`].
-pub async fn knowledge_fallback(provider_name: &str) -> Vec<ModelInfo> {
+pub async fn knowledge_fallback(provider_name: &str) -> DiscoveryResult {
     let discovery = crate::llm::ModelDiscovery::new();
     discovery.knowledge_fallback(provider_name)
 }

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -347,7 +347,7 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         std::io::Write::flush(&mut std::io::stdout()).ok();
         let discovery = ModelDiscovery::new();
         let ml = Arc::clone(&model_lister);
-        let models = discovery
+        let result = discovery
             .discover(info.id, cred, move |cred: &str| {
                 let ml = Arc::clone(&ml);
                 let cred = cred.to_string();
@@ -355,7 +355,7 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
             })
             .await;
         println!(" done");
-        ctx.fetched_models = models;
+        ctx.fetched_models = result.into_models();
     }
 
     ctx.current_state = WizardState::SelectModels;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -12,6 +12,8 @@ pub mod knowledge;
 pub mod minimax;
 pub mod model_cache;
 pub mod model_discovery;
+#[cfg(test)]
+mod model_discovery_tests;
 pub mod model_info;
 pub mod openai;
 pub mod protocol;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -54,7 +54,7 @@ pub use knowledge::{ModelRecommendParams, ProviderModelKnowledge, ReasoningLevel
 pub use minimax::MiniMaxProvider;
 pub use model_cache::{CacheEntry, ModelCache};
 pub use model_discovery::ModelDiscovery;
-pub use model_info::{InputType, ModelInfo};
+pub use model_info::{DiscoveryResult, DiscoverySource, InputType, ModelInfo};
 pub use openai::OpenAIProvider;
 pub use protocol::ChatProtocol;
 pub use provider::Provider;

--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::time::Duration;
 
 use super::model_cache::ModelCache;
-use super::model_info::ModelInfo;
+use super::model_info::{DiscoveryResult, DiscoverySource, ModelInfo};
 use super::{ErrorKind, ProviderModelKnowledge};
 
 /// Maximum number of fetch retries for transient errors.
@@ -40,14 +40,17 @@ impl ModelDiscovery {
         provider_id: &str,
         credential: &str,
         fetch: F,
-    ) -> Vec<ModelInfo>
+    ) -> DiscoveryResult
     where
         F: Fn(&str) -> Fut,
         Fut: Future<Output = Result<Vec<ModelInfo>, crate::llm::LLMError>>,
     {
         // Layer 1: cache
         if let Some(models) = self.cache.get(provider_id, credential) {
-            return models;
+            return DiscoveryResult {
+                models,
+                source: DiscoverySource::Cache,
+            };
         }
 
         // Layer 2: API fetch with retry
@@ -65,10 +68,21 @@ impl ModelDiscovery {
                             if params.max_tokens > model.max_tokens {
                                 model.max_tokens = params.max_tokens;
                             }
+                            // Fill default_temperature when API provides None
+                            if model.default_temperature.is_none() {
+                                model.default_temperature = Some(params.default_temperature);
+                            }
+                            // Fill input_types when API returns empty
+                            if model.input_types.is_empty() {
+                                model.input_types = params.input_types;
+                            }
                         }
                     }
                     self.cache.set(provider_id, credential, models.clone());
-                    return models;
+                    return DiscoveryResult {
+                        models,
+                        source: DiscoverySource::Api,
+                    };
                 }
                 Ok(Err(err)) => {
                     let kind = err.kind();
@@ -106,9 +120,9 @@ impl ModelDiscovery {
     }
 
     /// Return all known models for a provider from the embedded knowledge base.
-    pub fn knowledge_fallback(&self, provider_id: &str) -> Vec<ModelInfo> {
+    pub fn knowledge_fallback(&self, provider_id: &str) -> DiscoveryResult {
         let model_ids = self.knowledge.all_models(provider_id);
-        model_ids
+        let models = model_ids
             .into_iter()
             .map(|id| {
                 let params = self.knowledge.find(provider_id, id).unwrap();
@@ -122,7 +136,11 @@ impl ModelDiscovery {
                     input_types: params.input_types,
                 }
             })
-            .collect()
+            .collect();
+        DiscoveryResult {
+            models,
+            source: DiscoverySource::KnowledgeFallback,
+        }
     }
 }
 
@@ -185,8 +203,8 @@ mod tests {
             })
             .await;
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "test-model-1");
+        assert_eq!(result.models().len(), 1);
+        assert_eq!(result.models()[0].id, "test-model-1");
         // fetch closure must NOT have been called
         assert_eq!(fetch_count.load(Ordering::SeqCst), 0);
 
@@ -202,8 +220,8 @@ mod tests {
             .discover("test-provider", "mytoken", |_| async { Ok(test_models()) })
             .await;
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "test-model-1");
+        assert_eq!(result.models().len(), 1);
+        assert_eq!(result.models()[0].id, "test-model-1");
 
         // Cache should now be populated — second call should not invoke fetch
         let fetch_count = Arc::new(AtomicUsize::new(0));
@@ -218,7 +236,7 @@ mod tests {
             })
             .await;
 
-        assert_eq!(result2.len(), 1);
+        assert_eq!(result2.models().len(), 1);
         assert_eq!(fetch_count.load(Ordering::SeqCst), 0);
 
         std::env::remove_var("MODEL_CACHE_FILE");
@@ -238,7 +256,7 @@ mod tests {
 
         // Should fall back to knowledge base — minimax has models
         assert!(
-            !result.is_empty(),
+            !result.models().is_empty(),
             "knowledge fallback should return models"
         );
 
@@ -275,8 +293,8 @@ mod tests {
             .await;
 
         // Should have re-fetched (not returned old-model)
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "test-model-1");
+        assert_eq!(result.models().len(), 1);
+        assert_eq!(result.models()[0].id, "test-model-1");
 
         std::env::remove_var("MODEL_CACHE_FILE");
     }
@@ -288,8 +306,11 @@ mod tests {
         let discovery = ModelDiscovery::new();
         std::env::remove_var("MODEL_CACHE_FILE");
 
-        let models = discovery.knowledge_fallback("minimax");
-        assert!(!models.is_empty(), "minimax should have known models");
+        let result = discovery.knowledge_fallback("minimax");
+        assert!(
+            !result.models().is_empty(),
+            "minimax should have known models"
+        );
     }
 
     // ── Knowledge base filling tests (Step 1.3) ──────────────────────
@@ -324,8 +345,8 @@ mod tests {
             })
             .await;
 
-        assert_eq!(result.len(), 1);
-        let m = &result[0];
+        assert_eq!(result.models().len(), 1);
+        let m = &result.models()[0];
         // Knowledge base fills reasoning: true for M2.7
         assert!(
             m.reasoning,
@@ -360,8 +381,8 @@ mod tests {
             })
             .await;
 
-        assert_eq!(result.len(), 1);
-        let m = &result[0];
+        assert_eq!(result.models().len(), 1);
+        let m = &result.models()[0];
         // Unknown model: no knowledge base fill, API values preserved
         assert_eq!(m.id, "some-new-future-model");
         assert_eq!(m.context_window, 16384);

--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -16,8 +16,8 @@ const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Model discovery service combining local cache, API fetch, and knowledge base.
 pub struct ModelDiscovery {
-    cache: ModelCache,
-    knowledge: ProviderModelKnowledge,
+    pub(crate) cache: ModelCache,
+    pub(crate) knowledge: ProviderModelKnowledge,
 }
 
 impl ModelDiscovery {
@@ -154,7 +154,6 @@ impl Default for ModelDiscovery {
 mod tests {
     use super::*;
     use crate::llm::model_cache::{CacheEntry, CacheKey};
-    use crate::llm::InputType;
     use crate::llm::LLMError;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -389,111 +388,5 @@ mod tests {
         assert_eq!(m.context_window, 16384);
         assert_eq!(m.max_tokens, 4096);
         assert!(!m.reasoning);
-    }
-
-    // ── Step 1.4: source attribution + field filling tests ─────────
-
-    #[tokio::test]
-    async fn test_discover_returns_api_source() {
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = make_test_discovery(&dir);
-
-        let result = discovery
-            .discover("minimax", "key", |_| {
-                let value = test_models();
-                async move { Ok(value) }
-            })
-            .await;
-
-        assert_eq!(result.source, DiscoverySource::Api);
-    }
-
-    #[tokio::test]
-    async fn test_cache_hit_returns_cache_source() {
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = make_test_discovery(&dir);
-
-        discovery
-            .cache
-            .set("test-provider", "mytoken", test_models());
-
-        let result = discovery
-            .discover("test-provider", "mytoken", |_| async {
-                unreachable!("fetch should not be called")
-            })
-            .await;
-
-        assert_eq!(result.source, DiscoverySource::Cache);
-    }
-
-    #[tokio::test]
-    async fn test_knowledge_fallback_returns_fallback_source() {
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = make_test_discovery(&dir);
-
-        let result = discovery.knowledge_fallback("minimax");
-        assert_eq!(result.source, DiscoverySource::KnowledgeFallback);
-    }
-
-    #[tokio::test]
-    async fn test_discover_success_path_fills_default_temperature() {
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = make_test_discovery(&dir);
-
-        // API returns default_temperature: None — knowledge base should fill it.
-        let api_models = vec![ModelInfo {
-            id: "MiniMax-M2.7".into(),
-            name: "MiniMax M2.7".into(),
-            context_window: 204_800,
-            max_tokens: 131_072,
-            default_temperature: None,
-            reasoning: false,
-            input_types: vec![],
-        }];
-
-        let result = discovery
-            .discover("minimax", "key", |_| {
-                let value = api_models.clone();
-                async move { Ok(value) }
-            })
-            .await;
-
-        let m = &result.models()[0];
-        assert_eq!(
-            m.default_temperature,
-            Some(1.0),
-            "knowledge base should fill default_temperature when API is None"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_discover_success_path_fills_input_types() {
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = make_test_discovery(&dir);
-
-        // API returns empty input_types — knowledge base should fill it.
-        let api_models = vec![ModelInfo {
-            id: "MiniMax-M2.7".into(),
-            name: "MiniMax M2.7".into(),
-            context_window: 204_800,
-            max_tokens: 131_072,
-            default_temperature: Some(0.8),
-            reasoning: false,
-            input_types: vec![],
-        }];
-
-        let result = discovery
-            .discover("minimax", "key", |_| {
-                let value = api_models.clone();
-                async move { Ok(value) }
-            })
-            .await;
-
-        let m = &result.models()[0];
-        assert_eq!(
-            m.input_types,
-            vec![InputType::Text],
-            "knowledge base should fill input_types when API returns empty"
-        );
     }
 }

--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -154,6 +154,7 @@ impl Default for ModelDiscovery {
 mod tests {
     use super::*;
     use crate::llm::model_cache::{CacheEntry, CacheKey};
+    use crate::llm::InputType;
     use crate::llm::LLMError;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -388,5 +389,111 @@ mod tests {
         assert_eq!(m.context_window, 16384);
         assert_eq!(m.max_tokens, 4096);
         assert!(!m.reasoning);
+    }
+
+    // ── Step 1.4: source attribution + field filling tests ─────────
+
+    #[tokio::test]
+    async fn test_discover_returns_api_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        let result = discovery
+            .discover("minimax", "key", |_| {
+                let value = test_models();
+                async move { Ok(value) }
+            })
+            .await;
+
+        assert_eq!(result.source, DiscoverySource::Api);
+    }
+
+    #[tokio::test]
+    async fn test_cache_hit_returns_cache_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        discovery
+            .cache
+            .set("test-provider", "mytoken", test_models());
+
+        let result = discovery
+            .discover("test-provider", "mytoken", |_| async {
+                unreachable!("fetch should not be called")
+            })
+            .await;
+
+        assert_eq!(result.source, DiscoverySource::Cache);
+    }
+
+    #[tokio::test]
+    async fn test_knowledge_fallback_returns_fallback_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        let result = discovery.knowledge_fallback("minimax");
+        assert_eq!(result.source, DiscoverySource::KnowledgeFallback);
+    }
+
+    #[tokio::test]
+    async fn test_discover_success_path_fills_default_temperature() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        // API returns default_temperature: None — knowledge base should fill it.
+        let api_models = vec![ModelInfo {
+            id: "MiniMax-M2.7".into(),
+            name: "MiniMax M2.7".into(),
+            context_window: 204_800,
+            max_tokens: 131_072,
+            default_temperature: None,
+            reasoning: false,
+            input_types: vec![],
+        }];
+
+        let result = discovery
+            .discover("minimax", "key", |_| {
+                let value = api_models.clone();
+                async move { Ok(value) }
+            })
+            .await;
+
+        let m = &result.models()[0];
+        assert_eq!(
+            m.default_temperature,
+            Some(1.0),
+            "knowledge base should fill default_temperature when API is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_discover_success_path_fills_input_types() {
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = make_test_discovery(&dir);
+
+        // API returns empty input_types — knowledge base should fill it.
+        let api_models = vec![ModelInfo {
+            id: "MiniMax-M2.7".into(),
+            name: "MiniMax M2.7".into(),
+            context_window: 204_800,
+            max_tokens: 131_072,
+            default_temperature: Some(0.8),
+            reasoning: false,
+            input_types: vec![],
+        }];
+
+        let result = discovery
+            .discover("minimax", "key", |_| {
+                let value = api_models.clone();
+                async move { Ok(value) }
+            })
+            .await;
+
+        let m = &result.models()[0];
+        assert_eq!(
+            m.input_types,
+            vec![InputType::Text],
+            "knowledge base should fill input_types when API returns empty"
+        );
     }
 }

--- a/src/llm/model_discovery_tests.rs
+++ b/src/llm/model_discovery_tests.rs
@@ -1,0 +1,132 @@
+//! Unit tests for ModelDiscovery — separated from implementation per CONTRIBUTING.md.
+
+use super::model_cache::ModelCache;
+use super::model_discovery::ModelDiscovery;
+use super::model_info::{DiscoverySource, ModelInfo};
+use super::ProviderModelKnowledge;
+
+/// Helper: create a ModelDiscovery with an isolated temp-dir cache.
+fn make_test_discovery(dir: &tempfile::TempDir) -> ModelDiscovery {
+    ModelDiscovery {
+        cache: ModelCache::with_path(dir.path().join("cache.json")),
+        knowledge: ProviderModelKnowledge::new(),
+    }
+}
+
+fn test_models() -> Vec<ModelInfo> {
+    vec![ModelInfo {
+        id: "test-model-1".into(),
+        name: "Test Model 1".into(),
+        context_window: 4096,
+        max_tokens: 1024,
+        default_temperature: Some(0.7),
+        reasoning: false,
+        input_types: vec![],
+    }]
+}
+
+// ── Step 1.4: source attribution + field filling tests ─────────
+
+#[tokio::test]
+async fn test_discover_returns_api_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let discovery = make_test_discovery(&dir);
+
+    let result = discovery
+        .discover("minimax", "key", |_| {
+            let value = test_models();
+            async move { Ok(value) }
+        })
+        .await;
+
+    assert_eq!(result.source, DiscoverySource::Api);
+}
+
+#[tokio::test]
+async fn test_cache_hit_returns_cache_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let discovery = make_test_discovery(&dir);
+
+    discovery
+        .cache
+        .set("test-provider", "mytoken", test_models());
+
+    let result = discovery
+        .discover("test-provider", "mytoken", |_| async {
+            unreachable!("fetch should not be called")
+        })
+        .await;
+
+    assert_eq!(result.source, DiscoverySource::Cache);
+}
+
+#[tokio::test]
+async fn test_knowledge_fallback_returns_fallback_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let discovery = make_test_discovery(&dir);
+
+    let result = discovery.knowledge_fallback("minimax");
+    assert_eq!(result.source, DiscoverySource::KnowledgeFallback);
+}
+
+#[tokio::test]
+async fn test_discover_success_path_fills_default_temperature() {
+    let dir = tempfile::tempdir().unwrap();
+    let discovery = make_test_discovery(&dir);
+
+    // API returns default_temperature: None — knowledge base should fill it.
+    let api_models = vec![ModelInfo {
+        id: "MiniMax-M2.7".into(),
+        name: "MiniMax M2.7".into(),
+        context_window: 204_800,
+        max_tokens: 131_072,
+        default_temperature: None,
+        reasoning: false,
+        input_types: vec![],
+    }];
+
+    let result = discovery
+        .discover("minimax", "key", |_| {
+            let value = api_models.clone();
+            async move { Ok(value) }
+        })
+        .await;
+
+    let m = &result.models()[0];
+    assert_eq!(
+        m.default_temperature,
+        Some(1.0),
+        "knowledge base should fill default_temperature when API is None"
+    );
+}
+
+#[tokio::test]
+async fn test_discover_success_path_fills_input_types() {
+    let dir = tempfile::tempdir().unwrap();
+    let discovery = make_test_discovery(&dir);
+
+    // API returns empty input_types — knowledge base should fill it.
+    let api_models = vec![ModelInfo {
+        id: "MiniMax-M2.7".into(),
+        name: "MiniMax M2.7".into(),
+        context_window: 204_800,
+        max_tokens: 131_072,
+        default_temperature: Some(0.8),
+        reasoning: false,
+        input_types: vec![],
+    }];
+
+    let result = discovery
+        .discover("minimax", "key", |_| {
+            let value = api_models.clone();
+            async move { Ok(value) }
+        })
+        .await;
+
+    let m = &result.models()[0];
+    assert_eq!(
+        m.input_types,
+        vec![super::InputType::Text],
+        "knowledge base should fill input_types when API returns empty"
+    );
+}

--- a/src/llm/model_info.rs
+++ b/src/llm/model_info.rs
@@ -6,6 +6,39 @@ use serde::{Deserialize, Serialize};
 
 use super::knowledge::ProviderModelKnowledge;
 
+/// Indicates where the model list came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiscoverySource {
+    /// Data returned from the local cache.
+    Cache,
+    /// Data returned directly from the provider API.
+    Api,
+    /// Data returned from the built-in knowledge base
+    /// (API unavailable or not returning enough info).
+    KnowledgeFallback,
+}
+
+/// Wraps a discovered model list together with its source.
+#[derive(Debug, Clone)]
+pub struct DiscoveryResult {
+    /// The list of discovered models.
+    pub models: Vec<ModelInfo>,
+    /// Where these models came from.
+    pub source: DiscoverySource,
+}
+
+impl DiscoveryResult {
+    /// Borrow the model list.
+    pub fn models(&self) -> &Vec<ModelInfo> {
+        &self.models
+    }
+
+    /// Consume and return the model list.
+    pub fn into_models(self) -> Vec<ModelInfo> {
+        self.models
+    }
+}
+
 /// Supported input types for a model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
完善 model-discovery 知识库填充 + 回退来源标注

修复 Design Doc 差异扫描发现的两个 must_fix 差异：

1. **知识库填充不完整**：discover() 成功路径仅填充 reasoning/context_window/max_tokens，补充 default_temperature 和 input_types 的知识库填充逻辑
2. **回退来源未标注**：新增 DiscoverySource 枚举（Cache/Api/KnowledgeFallback）和 DiscoveryResult 结构体，每个返回路径标注来源

变更：
- src/llm/model_info.rs：新增 DiscoverySource 和 DiscoveryResult 类型
- src/llm/model_discovery.rs：完善 discover() 知识库填充 + 返回 DiscoveryResult
- src/cli/config_wizard/mod.rs、fetch.rs：适配新返回类型
- src/llm/model_discovery_tests.rs：新增 5 个测试覆盖填充和来源标注

Source: user
Type: fix
