### PR TITLE
fix: align model-discovery with design doc

### DIFF
--- a/src/llm/model_discovery.rs
+++ b/src/llm/model_discovery.rs
@@ -10,7 +10,7 @@ use super::model_info::{DiscoveryResult, DiscoverySource, ModelInfo};
 use super::{ErrorKind, ProviderModelKnowledge};
 
 /// Maximum number of fetch retries for transient errors.
-const FETCH_MAX_RETRIES: u32 = 3;
+const FETCH_MAX_RETRIES: u32 = 4;
 /// Per-attempt API timeout.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -61,21 +61,13 @@ impl ModelDiscovery {
                 Ok(Ok(mut models)) => {
                     for model in &mut models {
                         if let Some(params) = self.knowledge.find(provider_id, &model.id) {
+                            // Knowledge base is the authoritative source for
+                            // capability parameters — always override API values.
                             model.reasoning = params.reasoning;
-                            if params.context_window > model.context_window {
-                                model.context_window = params.context_window;
-                            }
-                            if params.max_tokens > model.max_tokens {
-                                model.max_tokens = params.max_tokens;
-                            }
-                            // Fill default_temperature when API provides None
-                            if model.default_temperature.is_none() {
-                                model.default_temperature = Some(params.default_temperature);
-                            }
-                            // Fill input_types when API returns empty
-                            if model.input_types.is_empty() {
-                                model.input_types = params.input_types;
-                            }
+                            model.context_window = params.context_window;
+                            model.max_tokens = params.max_tokens;
+                            model.default_temperature = Some(params.default_temperature);
+                            model.input_types = params.input_types;
                         }
                     }
                     self.cache.set(provider_id, credential, models.clone());
@@ -154,6 +146,7 @@ impl Default for ModelDiscovery {
 mod tests {
     use super::*;
     use crate::llm::model_cache::{CacheEntry, CacheKey};
+    use crate::llm::model_info::InputType;
     use crate::llm::LLMError;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -323,11 +316,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_discover_success_path_knowledge_fills() {
+    async fn test_discover_success_path_knowledge_always_overrides() {
         let dir = tempfile::tempdir().unwrap();
         let discovery = make_test_discovery(&dir);
 
-        // API returns MiniMax-M2.7 with context_window=1000 (below knowledge base 32768)
+        // API returns MiniMax-M2.7 with values that differ from knowledge base
         let api_models = vec![ModelInfo {
             id: "MiniMax-M2.7".into(),
             name: "MiniMax M2.7".into(),
@@ -347,15 +340,23 @@ mod tests {
 
         assert_eq!(result.models().len(), 1);
         let m = &result.models()[0];
-        // Knowledge base fills reasoning: true for M2.7
+        // Knowledge base is authoritative — always overrides API values
         assert!(
             m.reasoning,
             "M2.7 should have reasoning=true from knowledge base"
         );
-        // Knowledge base context_window (204800) > API (1000), so it overrides
-        assert_eq!(m.context_window, 204_800);
-        // Knowledge base max_tokens (131072) > API (512), so it overrides
-        assert_eq!(m.max_tokens, 131_072);
+        assert_eq!(m.context_window, 204_800, "knowledge base overrides API");
+        assert_eq!(m.max_tokens, 131_072, "knowledge base overrides API");
+        assert_eq!(
+            m.default_temperature,
+            Some(1.0),
+            "knowledge base overrides API temperature"
+        );
+        assert_eq!(
+            m.input_types,
+            vec![InputType::Text],
+            "knowledge base overrides API input_types"
+        );
     }
 
     #[tokio::test]

--- a/src/llm/model_discovery_tests.rs
+++ b/src/llm/model_discovery_tests.rs
@@ -70,11 +70,11 @@ async fn test_knowledge_fallback_returns_fallback_source() {
 }
 
 #[tokio::test]
-async fn test_discover_success_path_fills_default_temperature() {
+async fn test_discover_success_path_knowledge_overrides_default_temperature() {
     let dir = tempfile::tempdir().unwrap();
     let discovery = make_test_discovery(&dir);
 
-    // API returns default_temperature: None — knowledge base should fill it.
+    // 知识库始终覆盖 API 的 default_temperature
     let api_models = vec![ModelInfo {
         id: "MiniMax-M2.7".into(),
         name: "MiniMax M2.7".into(),
@@ -101,11 +101,11 @@ async fn test_discover_success_path_fills_default_temperature() {
 }
 
 #[tokio::test]
-async fn test_discover_success_path_fills_input_types() {
+async fn test_discover_success_path_knowledge_overrides_input_types() {
     let dir = tempfile::tempdir().unwrap();
     let discovery = make_test_discovery(&dir);
 
-    // API returns empty input_types — knowledge base should fill it.
+    // 知识库始终覆盖 API 的 input_types
     let api_models = vec![ModelInfo {
         id: "MiniMax-M2.7".into(),
         name: "MiniMax M2.7".into(),


### PR DESCRIPTION
## 概述

修正 model-discovery 代码与设计文档的 2 处不一致：

1. **重试次数**：`FETCH_MAX_RETRIES` 从 3 改为 4（4 次尝试 = 3 次重试），使退避序列 ~1s → ~2s → ~4s 与文档描述一致
2. **知识库覆盖逻辑**：知识库值始终覆盖 API 返回的能力参数（reasoning、context_window、max_tokens 等），而非仅在 API 值为空/较小时补充

## 变更文件

- `src/llm/model_discovery.rs` — 重试常量 + 知识库填充逻辑
- `src/llm/model_discovery_tests.rs` — 测试用例更新

Source: CI
Type: fix