### PR TITLE
chore: clear stale block comment on gateway/inbound-flow.md

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -102,7 +102,7 @@
     "commit": "b4770d160d417335ea2ce5d75e57320b065e36fc",
     "commit_time": "2026-06-25T02:31:02+08:00",
     "confirmed_time": "2026-06-25T02:31:02+08:00",
-    "comment": "blocked: hash-includes-timestamp_ms contradicts session-reuse-via-resolve"
+    "comment": ""
   },
   {
     "path": "docs/design/im_adapter/README.md",


### PR DESCRIPTION
## 修改内容

清除 `docs/design/gateway/inbound-flow.md` 的 stale block comment。

### 背景

Issue #1219 报告的 "hash-includes-timestamp_ms contradicts session-reuse-via-resolve" 矛盾，经 owner 确认：当前文档设计是自洽的——hash 含 timestamp_ms 防并发碰撞，SessionManager 从消息路由字段提取稳定路由键做 registry 查找。代码需要跟上文档（而非反之）。

原 block comment 基于旧认知，现清除。

## 修改文件

- `scripts/design-doc-tracker/records.json` — 清除 inbound-flow.md 的 block comment

## 代码对照发现

无（纯 DDT 记录清理）

Source: user
Type: chore
