### PR TITLE
fix: 入站流程代码对齐设计文档

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -138,5 +138,12 @@
     "commit_time": "",
     "confirmed_time": "2026-06-26T13:19:05.908214+08:00",
     "comment": "blocked: doc has responsibility attribution issues"
+  },
+  {
+    "path": "docs/design/llm/model-discovery.md",
+    "commit": "136edef20d57977748391e78287803c88180fc28",
+    "commit_time": "2026-06-26T17:48:33+08:00",
+    "confirmed_time": "2026-06-26T17:55:59.491929+08:00",
+    "comment": ""
   }
 ]

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -329,6 +329,7 @@ async fn repl_loop(gateway: &Arc<Gateway>, _agent_id: &str, sender_id: &str) -> 
                 &content,
                 &message_id,
                 chrono::Utc::now().timestamp_millis(),
+                None,
             )
             .await;
 

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -273,7 +273,7 @@ async fn test_process_inbound_chain_cleans_control_characters() {
 
     let input = "hello\x1b[31mworld\x1b[0m";
     let processed = gateway
-        .process_inbound_chain("terminal", "u1", "cli", input, "msg-1", 0)
+        .process_inbound_chain("terminal", "u1", "cli", input, "msg-1", 0, None)
         .await;
 
     assert_eq!(processed.content, "helloworld");
@@ -287,7 +287,7 @@ async fn test_process_inbound_chain_suppress_message() {
     let gateway = make_gw_with_registry(registry);
 
     let processed = gateway
-        .process_inbound_chain("terminal", "u1", "cli", "hello", "msg-1", 0)
+        .process_inbound_chain("terminal", "u1", "cli", "hello", "msg-1", 0, None)
         .await;
 
     assert!(processed.suppress, "expected suppress flag to be set");
@@ -301,7 +301,7 @@ async fn test_process_inbound_chain_quit_exit_not_affected() {
 
     for cmd in &["quit", "exit", "/stop"] {
         let processed = gateway
-            .process_inbound_chain("terminal", "u1", "cli", cmd, "msg-1", 0)
+            .process_inbound_chain("terminal", "u1", "cli", cmd, "msg-1", 0, None)
             .await;
         assert_eq!(processed.content.trim(), *cmd);
     }
@@ -379,7 +379,15 @@ async fn test_process_inbound_chain_peer_id_is_cli() {
     // We verify the call site contract: third argument must be "cli".
     let peer_id_argument = "cli";
     let processed = gateway
-        .process_inbound_chain("terminal", "u1", peer_id_argument, "hello", "msg-1", 0)
+        .process_inbound_chain(
+            "terminal",
+            "u1",
+            peer_id_argument,
+            "hello",
+            "msg-1",
+            0,
+            None,
+        )
         .await;
 
     assert!(!processed.suppress);

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -137,6 +137,7 @@ pub(crate) fn start_inbound_consumer(
                     &normalized.content,
                     "", // message_id not in NormalizedMessage; empty for now
                     normalized.timestamp,
+                    normalized.account_id.as_deref(),
                 )
                 .await;
 
@@ -212,6 +213,7 @@ async fn process_inbound_direct(gateway: &Gateway, request: &InboundRequest) {
                     &normalized.content,
                     "",
                     normalized.timestamp,
+                    normalized.account_id.as_deref(),
                 )
                 .await;
             gateway

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -913,6 +913,7 @@ impl Gateway {
         content: &str,
         message_id: &str,
         timestamp_ms: i64,
+        account_id: Option<&str>,
     ) -> ProcessedMessage {
         let Some(registry) = &self.processor_registry else {
             return ProcessedMessage {
@@ -933,6 +934,7 @@ impl Gateway {
             content: content.to_string(),
             timestamp,
             message_id: message_id.to_string(),
+            account_id: account_id.map(String::from),
         };
 
         match registry.process_inbound(raw).await {
@@ -966,7 +968,6 @@ pub enum GatewayError {
 
     #[error("Missing session ID in message metadata")]
     MissingSessionId,
-
     #[error("No routing key: both session_key and session_id missing from metadata")]
     NoRoutingKey,
 

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -496,10 +496,10 @@ async fn test_process_inbound_chain_with_session_router() {
     );
 }
 
-/// Verifies that `process_inbound_chain` uses the provided `timestamp_ms`
-/// parameter for the session key, not `Utc::now()`.
+/// Verifies that `process_inbound_chain` uses system time (not the provided
+/// timestamp parameter) for the session key, aligning with design doc.
 #[tokio::test]
-async fn test_process_inbound_chain_uses_provided_timestamp() {
+async fn test_process_inbound_chain_uses_system_time() {
     let config = make_config();
     let sm = Arc::new(SessionManager::new(
         &config,
@@ -518,10 +518,19 @@ async fn test_process_inbound_chain_uses_provided_timestamp() {
         Arc::new(registry),
     );
 
-    let ts_ms: i64 = 1_700_000_000_123;
+    let before_ms = chrono::Utc::now().timestamp_millis();
     let result = gw
-        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-ts", ts_ms, None)
+        .process_inbound_chain(
+            "terminal",
+            "user1",
+            "peer1",
+            "hi",
+            "msg-ts",
+            1_700_000_000_123, // past timestamp — should NOT be used
+            None,
+        )
         .await;
+    let after_ms = chrono::Utc::now().timestamp_millis();
 
     let key = result
         .metadata
@@ -529,10 +538,13 @@ async fn test_process_inbound_chain_uses_provided_timestamp() {
         .and_then(|v| v.as_str())
         .expect("session_key should be set");
 
-    // Key must start with the exact timestamp we passed in
+    // Key prefix must be between before_ms and after_ms (system time), not 1700000000123
+    let ts_prefix: i64 = key[..key.find('-').unwrap()]
+        .parse()
+        .expect("key prefix should be parseable as i64");
     assert!(
-        key.starts_with(&format!("{ts_ms}-")),
-        "session_key should start with provided timestamp {ts_ms}, got: {key}"
+        ts_prefix >= before_ms && ts_prefix <= after_ms,
+        "session_key timestamp should reflect system time ({before_ms}..{after_ms}), got {ts_prefix}: {key}"
     );
     let hash_part = &key[key.find('-').unwrap() + 1..];
     assert_eq!(hash_part.len(), 64, "hash should be 64 hex chars: {key}");

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -420,7 +420,7 @@ impl MessageProcessor for SuppressTestProcessor {
 async fn test_process_inbound_chain_no_registry() {
     let (gw, _sm) = make_gw(make_config());
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "hello world", "msg-1", 0)
+        .process_inbound_chain("terminal", "user1", "cli", "hello world", "msg-1", 0, None)
         .await;
     assert_eq!(result.content, "hello world");
     assert!(!result.suppress);
@@ -452,7 +452,7 @@ async fn test_process_inbound_chain_with_normalizer() {
     // Input with ANSI escape sequences and invisible control characters.
     let raw_input = "\x1b[31mhello\x1b[0m\x01world";
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-1", 0)
+        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-1", 0, None)
         .await;
     // ANSI stripped, control char stripped, plain text remains.
     assert_eq!(result.content, "helloworld");
@@ -481,7 +481,7 @@ async fn test_process_inbound_chain_with_session_router() {
     );
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-1", 0)
+        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-1", 0, None)
         .await;
     assert_eq!(result.content, "hi");
     // SessionRouter injects session_key with real timestamp.
@@ -520,7 +520,7 @@ async fn test_process_inbound_chain_uses_provided_timestamp() {
 
     let ts_ms: i64 = 1_700_000_000_123;
     let result = gw
-        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-ts", ts_ms)
+        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-ts", ts_ms, None)
         .await;
 
     let key = result
@@ -557,6 +557,7 @@ async fn test_content_normalizer_does_not_strip_platform_residue() {
         content: r#"Hello <at user_id="u123">Alice</at>, welcome!"#.to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_at".to_string(),
+        account_id: None,
     };
     let ctx = crate::processor_chain::context::MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap().unwrap();
@@ -614,7 +615,7 @@ async fn test_process_inbound_chain_processor_error() {
     );
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "original", "msg-1", 0)
+        .process_inbound_chain("terminal", "user1", "cli", "original", "msg-1", 0, None)
         .await;
     // Fallback to original content.
     assert_eq!(result.content, "original");
@@ -640,7 +641,15 @@ async fn test_e2e_inbound_full_stack_strips_ansi_and_injects_session_key() {
 
     let raw_input = "\x1b[32mhello\x1b[0m\x01world\x1b[1;34m!";
     let result = gw
-        .process_inbound_chain("terminal", "user1", "peer1", raw_input, "msg-e2e-1", 0)
+        .process_inbound_chain(
+            "terminal",
+            "user1",
+            "peer1",
+            raw_input,
+            "msg-e2e-1",
+            0,
+            None,
+        )
         .await;
 
     assert_eq!(result.content, "helloworld!");
@@ -673,7 +682,7 @@ async fn test_e2e_processed_content_feeds_into_handle_inbound() {
 
     let raw_input = "\x1b[33mwhat is the weather\x1b[0m";
     let processed = gw
-        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-e2e-2", 0)
+        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-e2e-2", 0, None)
         .await;
 
     assert_eq!(processed.content, "what is the weather");
@@ -701,7 +710,7 @@ async fn test_e2e_suppress_flag_propagates_through_chain() {
     let gw = make_gw_with_registry(registry);
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "hello", "msg-e2e-4", 0)
+        .process_inbound_chain("terminal", "user1", "cli", "hello", "msg-e2e-4", 0, None)
         .await;
     assert!(result.suppress, "suppress flag should propagate");
     assert_eq!(result.content, "hello");

--- a/src/im_adapter/normalized.rs
+++ b/src/im_adapter/normalized.rs
@@ -1,4 +1,6 @@
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 /// Reference to a media attachment (image, file, audio) in a message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,6 +19,123 @@ pub struct QuotedMessage {
     /// Sender ID of the quoted message, if available.
     pub sender_id: Option<String>,
 }
+
+// ---------------------------------------------------------------------------
+// URL normalization
+// ---------------------------------------------------------------------------
+
+/// Adds `https://` prefix to bare URLs that lack an http/https scheme.
+///
+/// Skips URLs already inside markdown link syntax `[text](url)`.
+pub fn normalize_urls(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let len = text.len();
+    let mut i = 0;
+
+    while i < len {
+        // Skip non-ASCII bytes (multi-byte UTF-8) — just copy them as a string slice
+        if !bytes[i].is_ascii() {
+            let start = i;
+            i += 1;
+            while i < len && !bytes[i].is_ascii() {
+                i += 1;
+            }
+            out.push_str(&text[start..i]);
+            continue;
+        }
+
+        // Skip markdown links [text](url)
+        if bytes[i] == b'[' {
+            let mut j = i + 1;
+            while j < len && bytes[j] != b']' {
+                j += 1;
+            }
+            if j < len && j + 1 < len && bytes[j + 1] == b'(' {
+                let mut k = j + 1;
+                while k < len && bytes[k] != b')' {
+                    k += 1;
+                }
+                out.push_str(&text[i..=k]);
+                i = k + 1;
+                continue;
+            }
+            out.push('[');
+            i += 1;
+            continue;
+        }
+
+        if i + 4 <= len && &text[i..i + 4] == "www." {
+            out.push_str("https://www.");
+            i += 4;
+            while i < len
+                && !bytes[i].is_ascii_whitespace()
+                && bytes[i] != b'"'
+                && bytes[i] != b'\''
+                && bytes[i] != b')'
+                && bytes[i] != b']'
+            {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+            continue;
+        }
+
+        let preceded_by_scheme =
+            i >= 3 && bytes[i - 3] == b':' && bytes[i - 2] == b'/' && bytes[i - 1] == b'/';
+        if !preceded_by_scheme
+            && i > 0
+            && !bytes[i - 1].is_ascii_alphanumeric()
+            && i < len
+            && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'.')
+        {
+            let start = i;
+            let mut j = i;
+            while j < len
+                && !bytes[j].is_ascii_whitespace()
+                && bytes[j] != b'"'
+                && bytes[j] != b'\''
+                && bytes[j] != b'<'
+                && bytes[j] != b')'
+                && bytes[j] != b']'
+            {
+                j += 1;
+            }
+            let token = &text[start..j];
+
+            if token.contains('.')
+                && !token.starts_with("http://")
+                && !token.starts_with("https://")
+                && !token.starts_with("ftp://")
+                && !token.starts_with("file://")
+            {
+                out.push_str("https://");
+                out.push_str(token);
+                i = j;
+                continue;
+            }
+        }
+
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Code block language hint
+// ---------------------------------------------------------------------------
+
+/// Adds ` ```text` language hint to code blocks that lack a language tag.
+pub fn add_code_block_language_hint(text: &str) -> String {
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^(\`\`\`)([^\w\n]|$)").unwrap());
+    RE.replace_all(text, "```text$1").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Message types
+// ---------------------------------------------------------------------------
 
 /// Default message type when not specified.
 fn default_message_type() -> String {

--- a/src/im_adapter/platforms/feishu/mod.rs
+++ b/src/im_adapter/platforms/feishu/mod.rs
@@ -12,7 +12,9 @@ pub mod tools;
 
 use crate::gateway::Message;
 use crate::im_adapter::error::AdapterError;
-use crate::im_adapter::normalized::NormalizedMessage;
+use crate::im_adapter::normalized::{
+    add_code_block_language_hint, normalize_urls, NormalizedMessage,
+};
 use crate::im_adapter::plugin::{IMPlugin, RenderedOutput};
 use crate::im_adapter::streaming::DefaultStreamingRenderer;
 use crate::im_adapter::IMAdapter;
@@ -85,7 +87,12 @@ impl IMPlugin for FeishuPlugin {
         &self,
         payload: &[u8],
     ) -> Result<Option<NormalizedMessage>, AdapterError> {
-        self.adapter.handle_webhook(payload).await
+        let mut msg = self.adapter.handle_webhook(payload).await?;
+        if let Some(ref mut m) = msg {
+            m.content = normalize_urls(&m.content);
+            m.content = add_code_block_language_hint(&m.content);
+        }
+        Ok(msg)
     }
 
     async fn validate_signature(&self, signature: &str, payload: &[u8]) -> bool {

--- a/src/processor_chain/build_processor_registry_tests.rs
+++ b/src/processor_chain/build_processor_registry_tests.rs
@@ -27,6 +27,7 @@ fn make_raw_message() -> RawMessage {
         content: "  hello   world  ".to_string(),
         timestamp: Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     }
 }
 

--- a/src/processor_chain/content_normalizer.rs
+++ b/src/processor_chain/content_normalizer.rs
@@ -6,11 +6,10 @@
 //!    control characters (preserving `\n`, `\t`, `\r`)
 //! 2. `normalize_empty_lines` — compress consecutive blank lines
 //! 3. `trim_trailing_whitespace` — strip trailing spaces per line
-//! 4. `normalize_urls` — ensure all bare URLs have `https://` prefix
-//! 5. `add_code_block_language_hint` — annotate code fences without language
 //!
-//! Note: Platform-specific format conversion (e.g. rich-text → Markdown)
-//! is handled by each IM plugin during parsing, not by this processor.
+//! Note: Platform-specific format conversion (e.g. rich-text → Markdown),
+//! URL completion, and code block language hints are handled by each IM
+//! plugin during parsing, not by this processor.
 
 use crate::processor_chain::context::{MessageContext, ProcessedMessage};
 use crate::processor_chain::error::ProcessError;
@@ -78,111 +77,6 @@ pub fn trim_trailing_whitespace(text: &str) -> String {
         .join("\n")
 }
 
-/// Adds `https://` prefix to bare URLs that lack an http/https scheme.
-///
-/// Skips URLs already inside markdown link syntax `[text](url)`.
-pub fn normalize_urls(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let bytes = text.as_bytes();
-    let len = text.len();
-    let mut i = 0;
-
-    while i < len {
-        // Skip non-ASCII bytes (multi-byte UTF-8) — just copy them as a string slice
-        if !bytes[i].is_ascii() {
-            let start = i;
-            i += 1;
-            while i < len && !bytes[i].is_ascii() {
-                i += 1;
-            }
-            out.push_str(&text[start..i]);
-            continue;
-        }
-
-        // Skip markdown links [text](url)
-        if bytes[i] == b'[' {
-            let mut j = i + 1;
-            while j < len && bytes[j] != b']' {
-                j += 1;
-            }
-            if j < len && j + 1 < len && bytes[j + 1] == b'(' {
-                let mut k = j + 1;
-                while k < len && bytes[k] != b')' {
-                    k += 1;
-                }
-                out.push_str(&text[i..=k]);
-                i = k + 1;
-                continue;
-            }
-            out.push('[');
-            i += 1;
-            continue;
-        }
-
-        if i + 4 <= len && &text[i..i + 4] == "www." {
-            out.push_str("https://www.");
-            i += 4;
-            while i < len
-                && !bytes[i].is_ascii_whitespace()
-                && bytes[i] != b'"'
-                && bytes[i] != b'\''
-                && bytes[i] != b')'
-                && bytes[i] != b']'
-            {
-                out.push(bytes[i] as char);
-                i += 1;
-            }
-            continue;
-        }
-
-        let preceded_by_scheme =
-            i >= 3 && bytes[i - 3] == b':' && bytes[i - 2] == b'/' && bytes[i - 1] == b'/';
-        if !preceded_by_scheme
-            && i > 0
-            && !bytes[i - 1].is_ascii_alphanumeric()
-            && i < len
-            && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'.')
-        {
-            let start = i;
-            let mut j = i;
-            while j < len
-                && !bytes[j].is_ascii_whitespace()
-                && bytes[j] != b'"'
-                && bytes[j] != b'\''
-                && bytes[j] != b'<'
-                && bytes[j] != b')'
-                && bytes[j] != b']'
-            {
-                j += 1;
-            }
-            let token = &text[start..j];
-
-            if token.contains('.')
-                && !token.starts_with("http://")
-                && !token.starts_with("https://")
-                && !token.starts_with("ftp://")
-                && !token.starts_with("file://")
-            {
-                out.push_str("https://");
-                out.push_str(token);
-                i = j;
-                continue;
-            }
-        }
-
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-
-    out
-}
-
-/// Adds ` ```text` language hint to code blocks that lack a language tag.
-pub fn add_code_block_language_hint(text: &str) -> String {
-    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^(```)([^\w\n]|$)").unwrap());
-    RE.replace_all(text, "```text$1").to_string()
-}
-
 // ---------------------------------------------------------------------------
 // ContentNormalizer
 // ---------------------------------------------------------------------------
@@ -194,11 +88,10 @@ pub fn add_code_block_language_hint(text: &str) -> String {
 /// 1. `strip_control_chars` — remove ANSI sequences and invisible characters
 /// 2. `normalize_empty_lines` — compress consecutive blank lines
 /// 3. `trim_trailing_whitespace` — strip trailing spaces per line
-/// 4. `normalize_urls` — ensure bare URLs have `https://` prefix
-/// 5. `add_code_block_language_hint` — annotate unlabeled code fences
 ///
-/// Note: Platform-specific format conversion is handled by each IM plugin
-/// during parsing, not by this processor.
+/// Note: Platform-specific format conversion, URL completion, and code block
+/// language hints are handled by each IM plugin during parsing, not by this
+/// processor.
 #[derive(Debug)]
 pub struct ContentNormalizer;
 
@@ -235,8 +128,6 @@ impl MessageProcessor for ContentNormalizer {
         let mut normalized = strip_control_chars(&ctx.content);
         normalized = normalize_empty_lines(&normalized);
         normalized = trim_trailing_whitespace(&normalized);
-        normalized = normalize_urls(&normalized);
-        normalized = add_code_block_language_hint(&normalized);
 
         Ok(Some(ProcessedMessage {
             content: normalized,

--- a/src/processor_chain/content_normalizer_tests.rs
+++ b/src/processor_chain/content_normalizer_tests.rs
@@ -88,6 +88,7 @@ async fn test_process_plain_text() {
         content: "hello world".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap();
@@ -106,6 +107,7 @@ async fn test_process_normalizes_empty_lines() {
         content: "hello\n\n\n\nworld  ".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_2".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap().unwrap();
@@ -122,6 +124,7 @@ async fn test_process_strips_ansi() {
         content: "\x1b[31mError:\x1b[0m something went wrong".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_3".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap().unwrap();
@@ -138,6 +141,7 @@ async fn test_process_strips_control_chars() {
         content: "hello\x00\x01\x02world".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_4".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap().unwrap();
@@ -154,6 +158,7 @@ async fn test_process_preserves_newlines_and_tabs() {
         content: "line1\nline2\ttab".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_5".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = processor.process(&ctx).await.unwrap().unwrap();

--- a/src/processor_chain/content_normalizer_tests.rs
+++ b/src/processor_chain/content_normalizer_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::im_adapter::normalized::{add_code_block_language_hint, normalize_urls};
 use crate::processor_chain::context::{MessageContext, RawMessage};
 use crate::processor_chain::processor::MessageProcessor;
 

--- a/src/processor_chain/content_normalizer_tests.rs
+++ b/src/processor_chain/content_normalizer_tests.rs
@@ -165,6 +165,86 @@ async fn test_process_preserves_newlines_and_tabs() {
     assert_eq!(result.content, "line1\nline2\ttab");
 }
 
+// -----------------------------------------------------------------------
+// ContentNormalizer does NOT normalize URLs or add code block language hints
+// (these are handled by IM Adapter layer during parsing)
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_process_does_not_normalize_urls() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "terminal".to_string(),
+        sender_id: "user_1".to_string(),
+        peer_id: "cli".to_string(),
+        content: "visit www.example.com today".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_url".to_string(),
+        account_id: None,
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap().unwrap();
+    // ContentNormalizer should NOT add https:// prefix
+    assert_eq!(result.content, "visit www.example.com today");
+}
+
+#[tokio::test]
+async fn test_process_does_not_normalize_bare_domain() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "terminal".to_string(),
+        sender_id: "user_1".to_string(),
+        peer_id: "cli".to_string(),
+        content: "go to google.com/path please".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_url2".to_string(),
+        account_id: None,
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap().unwrap();
+    assert_eq!(result.content, "go to google.com/path please");
+}
+
+#[tokio::test]
+async fn test_process_does_not_add_code_block_language_hint() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "terminal".to_string(),
+        sender_id: "user_1".to_string(),
+        peer_id: "cli".to_string(),
+        content: "```\ncode here\n```".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_code".to_string(),
+        account_id: None,
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap().unwrap();
+    // ContentNormalizer should NOT add ```text language hint
+    assert_eq!(result.content, "```\ncode here\n```");
+    assert!(!result.content.contains("```text"));
+}
+
+#[tokio::test]
+async fn test_process_combined_url_and_code_block_unchanged() {
+    let processor = ContentNormalizer::new();
+    let raw = RawMessage {
+        platform: "terminal".to_string(),
+        sender_id: "user_1".to_string(),
+        peer_id: "cli".to_string(),
+        content: "see www.example.com and ```\nfn main() {}\n```".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_combo".to_string(),
+        account_id: None,
+    };
+    let ctx = MessageContext::from_raw(raw);
+    let result = processor.process(&ctx).await.unwrap().unwrap();
+    // Neither URL nor code block should be modified
+    assert_eq!(
+        result.content,
+        "see www.example.com and ```\nfn main() {}\n```"
+    );
+}
+
 // -------------------------------------------------------------------------
 // Markdown normalization functions
 // -------------------------------------------------------------------------

--- a/src/processor_chain/context.rs
+++ b/src/processor_chain/context.rs
@@ -28,6 +28,9 @@ pub struct RawMessage {
     pub timestamp: DateTime<Utc>,
     /// Message ID assigned by the platform.
     pub message_id: String,
+    /// Optional account ID filled by IM Adapter via identity mapping.
+    #[serde(default)]
+    pub account_id: Option<String>,
 }
 
 /// Metadata for logging a raw message snapshot.
@@ -128,6 +131,7 @@ mod tests {
             content: "hello".to_string(),
             timestamp: Utc::now(),
             message_id: "msg_1".to_string(),
+            account_id: None,
         };
         let ctx = MessageContext::from_raw(raw.clone());
         assert_eq!(ctx.content, "hello");
@@ -146,6 +150,7 @@ mod tests {
             content: "hello".to_string(),
             timestamp: Utc::now(),
             message_id: "msg_1".to_string(),
+            account_id: None,
         };
         let processed = ProcessedMessage::from_raw(raw);
         assert_eq!(processed.content, "hello");

--- a/src/processor_chain/context_tests.rs
+++ b/src/processor_chain/context_tests.rs
@@ -13,6 +13,7 @@ fn test_message_context_content_blocks_default_empty() {
         content: "hello".to_string(),
         timestamp: Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     assert!(ctx.content_blocks.is_empty());
@@ -27,6 +28,7 @@ fn test_processed_message_content_blocks_default_empty() {
         content: "hello".to_string(),
         timestamp: Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     };
     let processed = ProcessedMessage::from_raw(raw);
     assert!(processed.content_blocks.is_empty());

--- a/src/processor_chain/outbound_raw_log_tests.rs
+++ b/src/processor_chain/outbound_raw_log_tests.rs
@@ -11,6 +11,7 @@ fn make_ctx(content: &str, channel: &str, message_id: &str) -> MessageContext {
         content: content.to_string(),
         timestamp: Utc::now(),
         message_id: message_id.to_string(),
+        account_id: None,
     };
     let mut ctx = MessageContext::from_raw(raw);
     ctx.metadata.insert(
@@ -111,6 +112,7 @@ async fn test_outbound_and_independent_from_inbound() {
         content: "hello".to_string(),
         timestamp: Utc::now(),
         message_id: "msg_99".to_string(),
+        account_id: None,
     };
     let inbound_ctx = MessageContext::from_raw(raw.clone());
     inbound.process(&inbound_ctx).await.unwrap();

--- a/src/processor_chain/raw_log_processor.rs
+++ b/src/processor_chain/raw_log_processor.rs
@@ -185,6 +185,7 @@ mod tests {
             content: "hello".to_string(),
             timestamp: Utc::now(),
             message_id: message_id.to_string(),
+            account_id: None,
         }
     }
 
@@ -240,6 +241,7 @@ mod tests {
             content: "hello".to_string(),
             timestamp: Utc::now(),
             message_id: "msg_99".to_string(),
+            account_id: None,
         };
         let ctx = make_ctx(raw);
 

--- a/src/processor_chain/registry.rs
+++ b/src/processor_chain/registry.rs
@@ -117,6 +117,7 @@ impl ProcessorRegistry {
             content: llm_output.content.clone(),
             timestamp: chrono::Utc::now(),
             message_id: String::new(),
+            account_id: None,
         };
         let mut ctx = MessageContext::from_raw(synthetic_raw);
         ctx.metadata = llm_output.metadata.clone();

--- a/src/processor_chain/registry_tests.rs
+++ b/src/processor_chain/registry_tests.rs
@@ -23,6 +23,7 @@ fn make_raw(content: &str) -> RawMessage {
         content: content.to_string(),
         timestamp: Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     }
 }
 

--- a/src/processor_chain/session_router.rs
+++ b/src/processor_chain/session_router.rs
@@ -103,7 +103,9 @@ impl MessageProcessor for SessionRouter {
         let peer_id = raw.peer_id;
         let account_id = raw.account_id;
 
-        let timestamp_ms = raw.timestamp.timestamp_millis();
+        // Use system time instead of message timestamp to align with design doc:
+        // "timestamp_ms 为当前系统时间的毫秒级时间戳"
+        let timestamp_ms = chrono::Utc::now().timestamp_millis();
         let session_key = self.compute_key(
             &sender_id,
             &peer_id,

--- a/src/processor_chain/session_router.rs
+++ b/src/processor_chain/session_router.rs
@@ -95,15 +95,13 @@ impl MessageProcessor for SessionRouter {
                 content: ctx.content.clone(),
                 timestamp: chrono::Utc::now(),
                 message_id: String::new(),
+                account_id: None,
             });
 
         let platform = raw.platform;
         let sender_id = raw.sender_id;
         let peer_id = raw.peer_id;
-        let account_id = ctx
-            .metadata
-            .get("account_id")
-            .and_then(|v| v.as_str().map(String::from));
+        let account_id = raw.account_id;
 
         let timestamp_ms = raw.timestamp.timestamp_millis();
         let session_key = self.compute_key(

--- a/src/processor_chain/session_router_tests.rs
+++ b/src/processor_chain/session_router_tests.rs
@@ -170,47 +170,28 @@ async fn test_fallback_when_no_initial_raw() {
 }
 
 #[tokio::test]
-async fn test_different_timestamps_produce_different_keys() {
-    // Concurrency scenario: same routing fields, different timestamps → different keys
+async fn test_system_time_used_for_session_key() {
+    // SessionRouter uses system time, not message timestamp
     let router = make_router(DmScope::PerChannelPeer);
+    let before_ms = chrono::Utc::now().timestamp_millis();
 
-    let ts1 = chrono::Utc::now();
-    let ts2 = ts1 + chrono::Duration::milliseconds(1);
-
-    let raw1 = RawMessage {
+    let raw = RawMessage {
         platform: "feishu".to_string(),
         sender_id: "ou_abc".to_string(),
         peer_id: "oc_xyz".to_string(),
         content: "msg1".to_string(),
-        timestamp: ts1,
+        // Message timestamp is in the past — should NOT be used
+        timestamp: chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
         message_id: "msg_c1".to_string(),
         account_id: None,
     };
-    let raw2 = RawMessage {
-        platform: "feishu".to_string(),
-        sender_id: "ou_abc".to_string(),
-        peer_id: "oc_xyz".to_string(),
-        content: "msg2".to_string(),
-        timestamp: ts2,
-        message_id: "msg_c2".to_string(),
-        account_id: None,
-    };
+    let after_ms = chrono::Utc::now().timestamp_millis();
+    let ctx = make_ctx(raw);
 
-    let ctx1 = make_ctx(raw1);
-    let ctx2 = make_ctx(raw2);
-
-    let k1 = router
-        .process(&ctx1)
-        .await
-        .unwrap()
-        .unwrap()
-        .metadata
-        .get("session_key")
-        .and_then(|v| v.as_str())
-        .unwrap()
-        .to_string();
-    let k2 = router
-        .process(&ctx2)
+    let key = router
+        .process(&ctx)
         .await
         .unwrap()
         .unwrap()
@@ -220,64 +201,45 @@ async fn test_different_timestamps_produce_different_keys() {
         .unwrap()
         .to_string();
 
-    assert_ne!(k1, k2, "different timestamps must produce different keys");
-    // Verify each key starts with its own timestamp and has 64-hex-char hash
+    // Key prefix must be between before_ms and after_ms, not 2020
+    let ts_prefix: i64 = key[..key.find('-').unwrap()]
+        .parse()
+        .expect("key prefix should be parseable as i64");
     assert!(
-        k1.starts_with(&format!("{}-", ts1.timestamp_millis())),
-        "k1 should start with ts1: {k1}"
+        ts_prefix >= before_ms && ts_prefix <= after_ms,
+        "session_key timestamp should reflect system time ({before_ms}..{after_ms}), got {ts_prefix}: {key}"
     );
+    let hash = &key[key.find('-').unwrap() + 1..];
+    assert_eq!(hash.len(), 64, "hash should be 64 hex chars: {key}");
     assert!(
-        k2.starts_with(&format!("{}-", ts2.timestamp_millis())),
-        "k2 should start with ts2: {k2}"
-    );
-    let h1 = &k1[k1.find('-').unwrap() + 1..];
-    let h2 = &k2[k2.find('-').unwrap() + 1..];
-    assert_eq!(h1.len(), 64, "k1 hash should be 64 hex chars: {k1}");
-    assert_eq!(h2.len(), 64, "k2 hash should be 64 hex chars: {k2}");
-    assert!(
-        h1.chars().all(|c| c.is_ascii_hexdigit()),
-        "k1 hash should be hex: {k1}"
-    );
-    assert!(
-        h2.chars().all(|c| c.is_ascii_hexdigit()),
-        "k2 hash should be hex: {k2}"
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
     );
 }
 
 #[tokio::test]
-async fn test_same_routing_different_timestamps_different_keys() {
-    // Verifies that PerAccountChannelPeer also differentiates by timestamp
+async fn test_per_account_channel_peer_uses_system_time() {
+    // Verifies that PerAccountChannelPeer also uses system time
     let router = make_router(DmScope::PerAccountChannelPeer);
+    let before_ms = chrono::Utc::now().timestamp_millis();
 
-    let base = chrono::Utc::now();
-    let ts_a = base;
-    let ts_b = base + chrono::Duration::milliseconds(5);
-
-    let make_raw = |ts: chrono::DateTime<chrono::Utc>| RawMessage {
+    let raw = RawMessage {
         platform: "discord".to_string(),
         sender_id: "user_99".to_string(),
         peer_id: "dm_1".to_string(),
         content: "test".to_string(),
-        timestamp: ts,
+        // Past message timestamp — should NOT appear in session_key
+        timestamp: chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
         message_id: "msg_s1".to_string(),
         account_id: None,
     };
+    let after_ms = chrono::Utc::now().timestamp_millis();
+    let ctx = make_ctx(raw);
 
-    let ctx_a = make_ctx(make_raw(ts_a));
-    let ctx_b = make_ctx(make_raw(ts_b));
-
-    let ka = router
-        .process(&ctx_a)
-        .await
-        .unwrap()
-        .unwrap()
-        .metadata
-        .get("session_key")
-        .and_then(|v| v.as_str())
-        .unwrap()
-        .to_string();
-    let kb = router
-        .process(&ctx_b)
+    let key = router
+        .process(&ctx)
         .await
         .unwrap()
         .unwrap()
@@ -287,29 +249,17 @@ async fn test_same_routing_different_timestamps_different_keys() {
         .unwrap()
         .to_string();
 
-    assert_ne!(
-        ka, kb,
-        "same routing fields with different timestamps must differ"
-    );
-    // Both should have timestamp prefix and 64-hex-char hash
+    let ts_prefix: i64 = key[..key.find('-').unwrap()]
+        .parse()
+        .expect("key prefix should be parseable as i64");
     assert!(
-        ka.starts_with(&format!("{}-", ts_a.timestamp_millis())),
-        "ka should start with ts_a: {ka}"
+        ts_prefix >= before_ms && ts_prefix <= after_ms,
+        "session_key timestamp should reflect system time ({before_ms}..{after_ms}), got {ts_prefix}: {key}"
     );
+    let hash = &key[key.find('-').unwrap() + 1..];
+    assert_eq!(hash.len(), 64, "hash should be 64 hex chars: {key}");
     assert!(
-        kb.starts_with(&format!("{}-", ts_b.timestamp_millis())),
-        "kb should start with ts_b: {kb}"
-    );
-    let ha = &ka[ka.find('-').unwrap() + 1..];
-    let hb = &kb[kb.find('-').unwrap() + 1..];
-    assert_eq!(ha.len(), 64, "ka hash should be 64 hex chars: {ka}");
-    assert_eq!(hb.len(), 64, "kb hash should be 64 hex chars: {kb}");
-    assert!(
-        ha.chars().all(|c| c.is_ascii_hexdigit()),
-        "ka hash should be hex: {ka}"
-    );
-    assert!(
-        hb.chars().all(|c| c.is_ascii_hexdigit()),
-        "kb hash should be hex: {kb}"
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash should be hex: {key}"
     );
 }

--- a/src/processor_chain/session_router_tests.rs
+++ b/src/processor_chain/session_router_tests.rs
@@ -263,3 +263,174 @@ async fn test_per_account_channel_peer_uses_system_time() {
         "hash should be hex: {key}"
     );
 }
+
+// -----------------------------------------------------------------------
+// account_id tests
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_different_account_ids_produce_different_session_keys() {
+    // Different account_id values must produce different session_key hashes
+    let router = make_router(DmScope::PerAccountChannelPeer);
+
+    let raw_a = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "msg".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_acct_a".to_string(),
+        account_id: Some("account_1".to_string()),
+    };
+    let raw_b = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "msg".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_acct_b".to_string(),
+        account_id: Some("account_2".to_string()),
+    };
+
+    let ctx_a = make_ctx(raw_a);
+    let ctx_b = make_ctx(raw_b);
+
+    let key_a = router
+        .process(&ctx_a)
+        .await
+        .unwrap()
+        .unwrap()
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap()
+        .to_string();
+    let key_b = router
+        .process(&ctx_b)
+        .await
+        .unwrap()
+        .unwrap()
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap()
+        .to_string();
+
+    assert_ne!(
+        key_a, key_b,
+        "different account_id must produce different session_key"
+    );
+    // Both must have valid format
+    assert!(
+        key_a.contains('-'),
+        "key_a should contain timestamp separator: {key_a}"
+    );
+    assert!(
+        key_b.contains('-'),
+        "key_b should contain timestamp separator: {key_b}"
+    );
+}
+
+#[tokio::test]
+async fn test_account_id_none_vs_some_produce_different_keys() {
+    // account_id=None vs account_id=Some(...) must produce different keys
+    let router = make_router(DmScope::PerAccountChannelPeer);
+
+    let raw_none = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "msg".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_n1".to_string(),
+        account_id: None,
+    };
+    let raw_some = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "msg".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_s1".to_string(),
+        account_id: Some("tenant_x".to_string()),
+    };
+
+    let ctx_none = make_ctx(raw_none);
+    let ctx_some = make_ctx(raw_some);
+
+    let key_none = router
+        .process(&ctx_none)
+        .await
+        .unwrap()
+        .unwrap()
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap()
+        .to_string();
+    let key_some = router
+        .process(&ctx_some)
+        .await
+        .unwrap()
+        .unwrap()
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap()
+        .to_string();
+
+    assert_ne!(
+        key_none, key_some,
+        "account_id None vs Some must produce different session_key"
+    );
+}
+
+#[tokio::test]
+async fn test_account_id_read_from_raw_message() {
+    // Verify account_id is read from RawMessage, not from ctx.metadata
+    let router = make_router(DmScope::PerAccountChannelPeer);
+    let raw = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "hi".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_a1".to_string(),
+        account_id: Some("tenant_42".to_string()),
+    };
+    let mut ctx = make_ctx(raw);
+    // Even if metadata has a different account_id, RawMessage should win
+    ctx.metadata.insert(
+        "account_id".to_string(),
+        serde_json::json!("metadata_account"),
+    );
+    let result = router.process(&ctx).await.unwrap().unwrap();
+    let key = result
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap();
+    assert!(!key.is_empty(), "session_key should be set");
+    // Verify key hash differs from one computed with "metadata_account"
+    let raw_meta = RawMessage {
+        platform: "feishu".to_string(),
+        sender_id: "ou_user".to_string(),
+        peer_id: "oc_group".to_string(),
+        content: "hi".to_string(),
+        timestamp: chrono::Utc::now(),
+        message_id: "msg_a2".to_string(),
+        account_id: Some("metadata_account".to_string()),
+    };
+    let ctx_meta = make_ctx(raw_meta);
+    let result_meta = router.process(&ctx_meta).await.unwrap().unwrap();
+    let key_meta = result_meta
+        .metadata
+        .get("session_key")
+        .and_then(|v| v.as_str())
+        .unwrap();
+    // They should differ because account_id comes from RawMessage
+    assert_ne!(
+        key, key_meta,
+        "account_id should be read from RawMessage, not metadata"
+    );
+}

--- a/src/processor_chain/session_router_tests.rs
+++ b/src/processor_chain/session_router_tests.rs
@@ -19,6 +19,7 @@ async fn test_terminal_session_key_computed() {
         content: "hello".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_1".to_string(),
+        account_id: None,
     };
     let ts_ms = raw.timestamp.timestamp_millis();
     let ctx = make_ctx(raw);
@@ -52,6 +53,7 @@ async fn test_deterministic_key() {
         content: "hi".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_d".to_string(),
+        account_id: None,
     };
     let ctx = make_ctx(raw);
     let r1 = router.process(&ctx).await.unwrap().unwrap();
@@ -71,6 +73,7 @@ async fn test_missing_peer_id_yields_empty_key() {
         content: "hi".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_e".to_string(),
+        account_id: None,
     };
     let ctx = make_ctx(raw);
     let result = router.process(&ctx).await.unwrap().unwrap();
@@ -93,6 +96,7 @@ async fn test_dm_scope_affects_key() {
         content: "test".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_f".to_string(),
+        account_id: None,
     };
     let ctx = make_ctx(raw);
     let k1 = r1
@@ -126,6 +130,7 @@ async fn test_metadata_preserves_upstream() {
         content: "hi".to_string(),
         timestamp: chrono::Utc::now(),
         message_id: "msg_g".to_string(),
+        account_id: None,
     };
     let mut ctx = make_ctx(raw);
     ctx.metadata.insert(
@@ -153,6 +158,7 @@ async fn test_fallback_when_no_initial_raw() {
         content: String::new(),
         timestamp: chrono::Utc::now(),
         message_id: String::new(),
+        account_id: None,
     };
     let ctx = MessageContext::from_raw(raw);
     let result = router.process(&ctx).await.unwrap().unwrap();
@@ -178,6 +184,7 @@ async fn test_different_timestamps_produce_different_keys() {
         content: "msg1".to_string(),
         timestamp: ts1,
         message_id: "msg_c1".to_string(),
+        account_id: None,
     };
     let raw2 = RawMessage {
         platform: "feishu".to_string(),
@@ -186,6 +193,7 @@ async fn test_different_timestamps_produce_different_keys() {
         content: "msg2".to_string(),
         timestamp: ts2,
         message_id: "msg_c2".to_string(),
+        account_id: None,
     };
 
     let ctx1 = make_ctx(raw1);
@@ -252,6 +260,7 @@ async fn test_same_routing_different_timestamps_different_keys() {
         content: "test".to_string(),
         timestamp: ts,
         message_id: "msg_s1".to_string(),
+        account_id: None,
     };
 
     let ctx_a = make_ctx(make_raw(ts_a));

--- a/tests/feishu_message_cleaner_tests.rs
+++ b/tests/feishu_message_cleaner_tests.rs
@@ -65,6 +65,7 @@ fn webhook_to_raw_message(webhook: &serde_json::Value) -> RawMessage {
         content,
         timestamp: chrono::Utc::now(),
         message_id,
+        account_id: None,
     }
 }
 

--- a/tests/im_inbound_e2e_tests.rs
+++ b/tests/im_inbound_e2e_tests.rs
@@ -62,6 +62,7 @@ fn webhook_to_raw_message(webhook: &serde_json::Value) -> RawMessage {
         content,
         timestamp: chrono::Utc::now(),
         message_id,
+        account_id: None,
     }
 }
 


### PR DESCRIPTION
## 入站流程代码对齐设计文档

Design Doc 差异扫描发现 3 个 must_fix 差异，本次逐一修复：

1. **ContentNormalizer 简化**：移除不属于该处理器的 URL 补全和代码块语言标签功能，移至 IM Adapter 层（feishu plugin）按需调用
2. **account_id 传递**：在 RawMessage 中新增 account_id 字段，从 gateway 入站链路传递到 Processor Chain，SessionRouter 直接消费
3. **SessionRouter 系统时间**：timestamp_ms 从消息时间戳改为当前系统时间，对齐文档描述的"消息处理时间"语义

补充了覆盖 account_id 传递、系统时间戳、ContentNormalizer 简化逻辑的测试。

Source: user
Type: fix
