### PR TITLE
fix: extract InboundChainInput struct to reduce process_inbound_chain parameters

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -321,17 +321,16 @@ async fn repl_loop(gateway: &Arc<Gateway>, _agent_id: &str, sender_id: &str) -> 
         );
 
         // Run the inbound processor chain (ContentNormalizer, RawLog, etc.).
-        let processed = gateway
-            .process_inbound_chain(
-                "terminal",
-                sender_id,
-                "cli",
-                &content,
-                &message_id,
-                chrono::Utc::now().timestamp_millis(),
-                None,
-            )
-            .await;
+        let input = crate::gateway::InboundChainInput {
+            platform: "terminal".to_string(),
+            sender_id: sender_id.to_string(),
+            peer_id: "cli".to_string(),
+            content,
+            message_id,
+            timestamp_ms: chrono::Utc::now().timestamp_millis(),
+            account_id: None,
+        };
+        let processed = gateway.process_inbound_chain(&input).await;
 
         if processed.suppress {
             continue;

--- a/src/cli/chat_tests.rs
+++ b/src/cli/chat_tests.rs
@@ -4,7 +4,7 @@
 //! configuration (processor registry, slash dispatcher, session handler) and
 //! that the TerminalAdapter quit/exit detection logic works correctly.
 
-use crate::gateway::{GatewayConfig, SessionManager};
+use crate::gateway::{GatewayConfig, InboundChainInput, SessionManager};
 use crate::session::bootstrap::BootstrapMode;
 use crate::session::persistence::ReasoningLevel;
 use std::sync::Arc;
@@ -273,7 +273,15 @@ async fn test_process_inbound_chain_cleans_control_characters() {
 
     let input = "hello\x1b[31mworld\x1b[0m";
     let processed = gateway
-        .process_inbound_chain("terminal", "u1", "cli", input, "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "u1".into(),
+            peer_id: "cli".into(),
+            content: input.into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
 
     assert_eq!(processed.content, "helloworld");
@@ -287,7 +295,15 @@ async fn test_process_inbound_chain_suppress_message() {
     let gateway = make_gw_with_registry(registry);
 
     let processed = gateway
-        .process_inbound_chain("terminal", "u1", "cli", "hello", "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "u1".into(),
+            peer_id: "cli".into(),
+            content: "hello".into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
 
     assert!(processed.suppress, "expected suppress flag to be set");
@@ -301,7 +317,15 @@ async fn test_process_inbound_chain_quit_exit_not_affected() {
 
     for cmd in &["quit", "exit", "/stop"] {
         let processed = gateway
-            .process_inbound_chain("terminal", "u1", "cli", cmd, "msg-1", 0, None)
+            .process_inbound_chain(&InboundChainInput {
+                platform: "terminal".into(),
+                sender_id: "u1".into(),
+                peer_id: "cli".into(),
+                content: cmd.to_string(),
+                message_id: "msg-1".into(),
+                timestamp_ms: 0,
+                account_id: None,
+            })
             .await;
         assert_eq!(processed.content.trim(), *cmd);
     }
@@ -379,15 +403,15 @@ async fn test_process_inbound_chain_peer_id_is_cli() {
     // We verify the call site contract: third argument must be "cli".
     let peer_id_argument = "cli";
     let processed = gateway
-        .process_inbound_chain(
-            "terminal",
-            "u1",
-            peer_id_argument,
-            "hello",
-            "msg-1",
-            0,
-            None,
-        )
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "u1".into(),
+            peer_id: peer_id_argument.into(),
+            content: "hello".into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
 
     assert!(!processed.suppress);

--- a/src/gateway/inbound_queue.rs
+++ b/src/gateway/inbound_queue.rs
@@ -129,17 +129,16 @@ pub(crate) fn start_inbound_consumer(
 
             // ── 3. Process through inbound chain ──────────────────────
             let sender_id = normalized.sender_id.clone();
-            let processed = gateway
-                .process_inbound_chain(
-                    &normalized.platform,
-                    &normalized.sender_id,
-                    &normalized.peer_id,
-                    &normalized.content,
-                    "", // message_id not in NormalizedMessage; empty for now
-                    normalized.timestamp,
-                    normalized.account_id.as_deref(),
-                )
-                .await;
+            let input = super::InboundChainInput {
+                platform: normalized.platform.clone(),
+                sender_id: normalized.sender_id.clone(),
+                peer_id: normalized.peer_id.clone(),
+                content: normalized.content.clone(),
+                message_id: String::new(), // message_id not in NormalizedMessage; empty for now
+                timestamp_ms: normalized.timestamp,
+                account_id: normalized.account_id.clone(),
+            };
+            let processed = gateway.process_inbound_chain(&input).await;
 
             // ── 4. Handle inbound message ─────────────────────────────
             gateway
@@ -205,17 +204,16 @@ async fn process_inbound_direct(gateway: &Gateway, request: &InboundRequest) {
     match plugin.parse_inbound(&request.raw_payload).await {
         Ok(Some(normalized)) => {
             let sender_id = normalized.sender_id.clone();
-            let processed = gateway
-                .process_inbound_chain(
-                    &normalized.platform,
-                    &normalized.sender_id,
-                    &normalized.peer_id,
-                    &normalized.content,
-                    "",
-                    normalized.timestamp,
-                    normalized.account_id.as_deref(),
-                )
-                .await;
+            let input = super::InboundChainInput {
+                platform: normalized.platform.clone(),
+                sender_id: normalized.sender_id.clone(),
+                peer_id: normalized.peer_id.clone(),
+                content: normalized.content.clone(),
+                message_id: String::new(),
+                timestamp_ms: normalized.timestamp,
+                account_id: normalized.account_id.clone(),
+            };
+            let processed = gateway.process_inbound_chain(&input).await;
             gateway
                 .handle_inbound_message(processed, Some(&sender_id), &normalized.platform)
                 .await;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -174,6 +174,18 @@ pub struct Session {
     pub depth: u32,
 }
 
+/// Groups inbound message fields into a single struct (≤ 6 params).
+#[derive(Debug, Clone)]
+pub(crate) struct InboundChainInput {
+    pub platform: String,
+    pub sender_id: String,
+    pub peer_id: String,
+    pub content: String,
+    pub message_id: String,
+    pub timestamp_ms: i64,
+    pub account_id: Option<String>,
+}
+
 /// Gateway - routes messages between IM plugins and agents
 pub struct Gateway {
     config: GatewayConfig,
@@ -896,45 +908,32 @@ impl Gateway {
         }
     }
 
-    /// Process an inbound message through the processor chain.
-    ///
-    /// Builds a [`RawMessage`] from the provided fields and runs it through
-    /// the inbound processor chain (if a [`ProcessorRegistry`] is configured).
-    ///
-    /// - When no registry exists, returns a bypass [`ProcessedMessage`]
-    ///   wrapping the original content.
-    /// - On processor failure, logs a warning and falls back to the
-    ///   original content.
+    /// Runs the inbound processor chain on a [`RawMessage`] built from `input`.
+    /// Falls back to raw content on registry absence or processor error.
     pub(crate) async fn process_inbound_chain(
         &self,
-        platform: &str,
-        sender_id: &str,
-        peer_id: &str,
-        content: &str,
-        message_id: &str,
-        timestamp_ms: i64,
-        account_id: Option<&str>,
+        input: &InboundChainInput,
     ) -> ProcessedMessage {
         let Some(registry) = &self.processor_registry else {
             return ProcessedMessage {
-                content: content.to_string(),
+                content: input.content.to_string(),
                 metadata: serde_json::Map::new(),
                 suppress: false,
                 content_blocks: vec![],
             };
         };
 
-        let timestamp =
-            chrono::DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_else(chrono::Utc::now);
+        let timestamp = chrono::DateTime::from_timestamp_millis(input.timestamp_ms)
+            .unwrap_or_else(chrono::Utc::now);
 
         let raw = RawMessage {
-            platform: platform.to_string(),
-            sender_id: sender_id.to_string(),
-            peer_id: peer_id.to_string(),
-            content: content.to_string(),
+            platform: input.platform.to_string(),
+            sender_id: input.sender_id.to_string(),
+            peer_id: input.peer_id.to_string(),
+            content: input.content.to_string(),
             timestamp,
-            message_id: message_id.to_string(),
-            account_id: account_id.map(String::from),
+            message_id: input.message_id.to_string(),
+            account_id: input.account_id.clone(),
         };
 
         match registry.process_inbound(raw).await {
@@ -942,7 +941,7 @@ impl Gateway {
             Err(e) => {
                 tracing::warn!(?e, "processor chain failed, falling back to raw content");
                 ProcessedMessage {
-                    content: content.to_string(),
+                    content: input.content.to_string(),
                     metadata: serde_json::Map::new(),
                     suppress: false,
                     content_blocks: vec![],

--- a/src/gateway/tests_processor_chain.rs
+++ b/src/gateway/tests_processor_chain.rs
@@ -3,7 +3,7 @@
 //! These tests live in a separate file so that src/gateway/tests.rs stays
 //! under the 500-line limit.
 
-use crate::gateway::{DmScope, GatewayConfig, Message, SessionManager};
+use crate::gateway::{DmScope, GatewayConfig, InboundChainInput, Message, SessionManager};
 use crate::im::IMPlugin;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -420,7 +420,15 @@ impl MessageProcessor for SuppressTestProcessor {
 async fn test_process_inbound_chain_no_registry() {
     let (gw, _sm) = make_gw(make_config());
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "hello world", "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "cli".into(),
+            content: "hello world".into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
     assert_eq!(result.content, "hello world");
     assert!(!result.suppress);
@@ -452,7 +460,15 @@ async fn test_process_inbound_chain_with_normalizer() {
     // Input with ANSI escape sequences and invisible control characters.
     let raw_input = "\x1b[31mhello\x1b[0m\x01world";
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "cli".into(),
+            content: raw_input.into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
     // ANSI stripped, control char stripped, plain text remains.
     assert_eq!(result.content, "helloworld");
@@ -481,7 +497,15 @@ async fn test_process_inbound_chain_with_session_router() {
     );
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "peer1", "hi", "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "peer1".into(),
+            content: "hi".into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
     assert_eq!(result.content, "hi");
     // SessionRouter injects session_key with real timestamp.
@@ -520,15 +544,15 @@ async fn test_process_inbound_chain_uses_system_time() {
 
     let before_ms = chrono::Utc::now().timestamp_millis();
     let result = gw
-        .process_inbound_chain(
-            "terminal",
-            "user1",
-            "peer1",
-            "hi",
-            "msg-ts",
-            1_700_000_000_123, // past timestamp — should NOT be used
-            None,
-        )
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "peer1".into(),
+            content: "hi".into(),
+            message_id: "msg-ts".into(),
+            timestamp_ms: 1_700_000_000_123, // past timestamp — should NOT be used
+            account_id: None,
+        })
         .await;
     let after_ms = chrono::Utc::now().timestamp_millis();
 
@@ -627,7 +651,15 @@ async fn test_process_inbound_chain_processor_error() {
     );
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "original", "msg-1", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "cli".into(),
+            content: "original".into(),
+            message_id: "msg-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
     // Fallback to original content.
     assert_eq!(result.content, "original");
@@ -653,15 +685,15 @@ async fn test_e2e_inbound_full_stack_strips_ansi_and_injects_session_key() {
 
     let raw_input = "\x1b[32mhello\x1b[0m\x01world\x1b[1;34m!";
     let result = gw
-        .process_inbound_chain(
-            "terminal",
-            "user1",
-            "peer1",
-            raw_input,
-            "msg-e2e-1",
-            0,
-            None,
-        )
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "peer1".into(),
+            content: raw_input.into(),
+            message_id: "msg-e2e-1".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
 
     assert_eq!(result.content, "helloworld!");
@@ -694,7 +726,15 @@ async fn test_e2e_processed_content_feeds_into_handle_inbound() {
 
     let raw_input = "\x1b[33mwhat is the weather\x1b[0m";
     let processed = gw
-        .process_inbound_chain("terminal", "user1", "cli", raw_input, "msg-e2e-2", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "cli".into(),
+            content: raw_input.into(),
+            message_id: "msg-e2e-2".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
 
     assert_eq!(processed.content, "what is the weather");
@@ -722,7 +762,15 @@ async fn test_e2e_suppress_flag_propagates_through_chain() {
     let gw = make_gw_with_registry(registry);
 
     let result = gw
-        .process_inbound_chain("terminal", "user1", "cli", "hello", "msg-e2e-4", 0, None)
+        .process_inbound_chain(&InboundChainInput {
+            platform: "terminal".into(),
+            sender_id: "user1".into(),
+            peer_id: "cli".into(),
+            content: "hello".into(),
+            message_id: "msg-e2e-4".into(),
+            timestamp_ms: 0,
+            account_id: None,
+        })
         .await;
     assert!(result.suppress, "suppress flag should propagate");
     assert_eq!(result.content, "hello");


### PR DESCRIPTION
fix: extract InboundChainInput struct to reduce process_inbound_chain parameters

Refactor `process_inbound_chain` in `src/gateway/mod.rs` to accept a single
`InboundChainInput` struct instead of 7 separate parameters, bringing the
function signature within the project's hard limit of 6 parameters
(CONTRIBUTING.md). The new struct groups the inbound message fields
(platform, sender_id, peer_id, content, message_id, timestamp_ms, account_id)
that naturally belong together. Callers in `inbound_queue.rs` and `cli/chat.rs`
as well as all test files are updated accordingly.

Source: CI
Type: fix
