### PR TITLE
docs(design): fix streaming-render design doc contradictions

### DIFF
--- a/docs/design/im_adapter/streaming-render.md
+++ b/docs/design/im_adapter/streaming-render.md
@@ -6,14 +6,15 @@
 
 ## 架构
 
-流式渲染在各平台 Renderer 中增加增量处理能力，基于 LLM 流式事件逐块消费。平台通过覆盖 IMPlugin trait 的流式默认方法实现差异化：
+流式渲染是 IMPlugin 内部通用组件，由各平台插件持有。Gateway 通过 IMPlugin trait 的流式默认方法驱动渲染，平台通过覆盖默认方法实现差异化：
 
 ```
 LLM 流式事件（StreamEvent）
   ├── BlockStart — 新内容块开始
-  ├── BlockDelta — 内容块增量文本
+  ├── BlockDelta — 内容块增量数据（Text / Thinking / Tool）
   ├── BlockEnd   — 内容块结束
-  └── MessageEnd — 消息流结束
+  ├── MessageEnd — 消息流结束
+  └── Error      — 流错误（渲染器不处理，交由 Gateway 处理）
   ↓
 流式渲染
   ├── 行缓冲 — 累积不完整语义单元
@@ -21,6 +22,8 @@ LLM 流式事件（StreamEvent）
   └── 增量输出 — 完整行立即推送
   ↓
 Gateway → IMPlugin 立即发送
+
+流式渲染器仅处理内容块（Text、Thinking、Tool）的增量输出。交互式 UI 元素（按钮、选择器等）通过工具调用结果由 Gateway 直接处理，不属于流式渲染器职责范围，不经过流式文本渲染管线。
 ```
 
 **行缓冲规则**：
@@ -30,37 +33,42 @@ Gateway → IMPlugin 立即发送
 - 缓冲区超过固定阈值（约 100 字符）时强制输出，防止长时间无响应
 - 非 Text 块（Thinking、Tool 等）不参与流式行缓冲，在 BlockEnd 时一次性输出
 
-**首行输出时机**：首次收到 BlockDelta 后，缓冲到达首个句末标点或换行符时输出，目标延迟 200ms 内
+**首行输出时机**：首次收到 BlockDelta 后，缓冲到达首个句末标点或换行符时输出。若长时间未遇到标点，缓冲区超过固定阈值时强制输出
 
 ## 数据流
 
 ```
 LLM StreamEvent 序列到达 Gateway
   ↓
-Gateway 将事件转发给 Renderer
+Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
   ↓
-Renderer 按事件类型处理：
+流式渲染器按事件类型处理：
   ├── BlockStart → 标记块类型，初始化缓冲区
   ├── BlockDelta（Text）
   │     → 追加文本到行缓冲区
-  │     → 检测句末标点或换行
+  │     → 检测代码块边界标记（```），切换代码/文本模式
+  │     → 检测句末标点或换行（文本模式），或换行（代码模式）
   │       ├── 完整行 → 渲染该行 → 立即输出
-  │       └── 不完整 → 继续缓冲
+  │       └── 不完整 → 继续缓冲；若缓冲区超过阈值（约 100 字符）→ 强制输出
   ├── BlockDelta（Thinking/Tool）
   │     → 单独缓冲，不在流式阶段输出
   ├── BlockEnd
-  │     → 刷新剩余缓冲内容
+  │     → 刷新当前块剩余缓冲内容
   │     → Thinking/Tool 块 → 以原始 ContentBlock 传递，交由下游平台 Renderer 完成最终格式渲染（如飞书的折叠推理区、工具操作卡片）
   │     → Text 块 → 输出完整块内容
-  └── MessageEnd
-        → 刷新所有缓冲
-        → 释放流式渲染上下文
+  ├── MessageEnd
+  │     → 刷新所有缓冲，输出剩余内容
+  │     → 清空当前块状态和行缓冲上下文
+  └── Error
+        → 空操作，流错误交由 Gateway 处理
   ↓
 增量输出 → Gateway → IMPlugin 发送
 ```
 
 ## 模块关系
 
-- **上游**：IMPlugin trait 默认方法（作为通用渲染能力供各平台继承）
-- **下游**：IMPlugin（接收增量渲染输出并发送）
+- **上游**：Gateway（通过 IMPlugin trait 流式方法驱动渲染，逐事件调用）
+- **下游**：IMPlugin（接收增量渲染输出并通过 Adapter 发送到 IM 平台）
+- **内部组件**：流式渲染器是 IMPlugin 的内部组件，由各平台插件通过 trait 默认方法持有和调用。平台可覆盖默认方法实现差异化渲染逻辑
+- **与 Processor Chain 的关系**：流式文本路径不经出站 Processor Chain（文本增量直接输出，无需 DslParser 参与；交互式 UI 元素由工具调用路径单独处理）。非流式出站路径由 Gateway 统一经 Processor Chain（DslParser → RawLog）处理后渲染，详见 [Gateway 文档](../../gateway/README.md)
 - **所属**：IM Adapter 模块的通用子功能

--- a/docs/design/im_adapter/streaming-render.md
+++ b/docs/design/im_adapter/streaming-render.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-流式渲染是 IM Adapter 模块的通用渲染子功能，负责在 LLM 流式输出时逐条渲染 ContentBlock 增量。用户无需等待完整响应即可看到输出内容。该能力作为 IMPlugin trait 的默认方法提供，各平台插件自动继承，按需覆盖平台差异化渲染逻辑。
+流式渲染是 IM Adapter 模块的通用渲染子功能，负责在 LLM 流式输出时逐条渲染 ContentBlock 增量。用户无需等待完整响应即可看到输出内容。该能力作为 IMPlugin trait 的默认方法提供——各平台插件通过组合持有流式渲染器实例，由 trait 默认方法委托调用，平台可按需覆盖方法实现差异化渲染逻辑。
 
 ## 架构
 
@@ -16,12 +16,10 @@ LLM 流式事件（StreamEvent）
   ├── MessageEnd — 消息流结束
   └── Error      — 流错误（渲染器不处理，交由 Gateway 处理）
   ↓
-流式渲染
+Gateway → IMPlugin（内部流式渲染器）
   ├── 行缓冲 — 累积不完整语义单元
   ├── 类型路由 — 按块类型选择渲染路径
-  └── 增量输出 — 完整行立即推送
-  ↓
-Gateway → IMPlugin 立即发送
+  └── 增量输出 — 完整行通过 IMPlugin 立即发送
 
 流式渲染器仅处理内容块（Text、Thinking、Tool）的增量输出。交互式 UI 元素（按钮、选择器等）通过工具调用结果由 Gateway 直接处理，不属于流式渲染器职责范围，不经过流式文本渲染管线。
 ```
@@ -54,15 +52,15 @@ Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
   │     → 单独缓冲，不在流式阶段输出
   ├── BlockEnd
   │     → 刷新当前块剩余缓冲内容
-  │     → Thinking/Tool 块 → 以原始 ContentBlock 传递，交由下游平台 Renderer 完成最终格式渲染（如飞书的折叠推理区、工具操作卡片）
+  │     → Thinking/Tool 块 → 以原始 ContentBlock 传递，交由平台插件的格式渲染器完成最终渲染（如飞书的折叠推理区、工具操作卡片）
   │     → Text 块 → 输出完整块内容
   ├── MessageEnd
   │     → 刷新所有缓冲，输出剩余内容
   │     → 清空当前块状态和行缓冲上下文
   └── Error
-        → 空操作，流错误交由 Gateway 处理
+        → 空操作，不产生增量输出，流错误直接交由 Gateway 处理
   ↓
-增量输出 → Gateway → IMPlugin 发送
+增量输出通过 IMPlugin 发送到 IM 平台
 ```
 
 ## 模块关系
@@ -70,5 +68,5 @@ Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
 - **上游**：Gateway（通过 IMPlugin trait 流式方法驱动渲染，逐事件调用）
 - **下游**：IMPlugin（接收增量渲染输出并通过 Adapter 发送到 IM 平台）
 - **内部组件**：流式渲染器是 IMPlugin 的内部组件，由各平台插件通过 trait 默认方法持有和调用。平台可覆盖默认方法实现差异化渲染逻辑
-- **与 Processor Chain 的关系**：流式文本路径不经出站 Processor Chain（文本增量直接输出，无需 DslParser 参与；交互式 UI 元素由工具调用路径单独处理）。非流式出站路径由 Gateway 统一经 Processor Chain（DslParser → RawLog）处理后渲染，详见 [Gateway 文档](../../gateway/README.md)
+- **与 Processor Chain 的关系**：流式文本路径不经出站 Processor Chain（文本增量直接输出，无需 DSL 解析器参与；交互式 UI 元素由工具调用路径单独处理）。非流式出站路径由 Gateway 统一经 Processor Chain（DSL 解析 → 出站日志记录）处理后渲染，详见 [Gateway 文档](../../gateway/README.md)
 - **所属**：IM Adapter 模块的通用子功能

--- a/docs/design/im_adapter/streaming-render.md
+++ b/docs/design/im_adapter/streaming-render.md
@@ -28,8 +28,8 @@ Gateway → IMPlugin（内部流式渲染器）
 
 - 以句末标点（`。！？.!?\n`）为行边界，达到边界立即输出当前行
 - 代码块内按换行符输出，不做句末标点等待
-- 缓冲区超过固定阈值（约 100 字符）时强制输出，防止长时间无响应
-- 非 Text 块（Thinking、Tool 等）不参与流式行缓冲，在 BlockEnd 时一次性输出
+- 缓冲区超过固定阈值（约 100 字符）时强制输出并清空缓冲区，防止长时间无响应
+- 非 Text 块（Thinking、Tool 等）不参与流式行缓冲，在 BlockEnd 时作为完整 ContentBlock 交由平台格式渲染器处理
 
 **首行输出时机**：首次收到 BlockDelta 后，缓冲到达首个句末标点或换行符时输出。若长时间未遇到标点，缓冲区超过固定阈值时强制输出
 
@@ -41,7 +41,7 @@ LLM StreamEvent 序列到达 Gateway
 Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
   ↓
 流式渲染器按事件类型处理：
-  ├── BlockStart → 标记块类型，初始化缓冲区
+  ├── BlockStart → 标记块类型，按块类型准备缓冲区（Text 块初始化行缓冲，Thinking/Tool 块初始化独立累积器）
   ├── BlockDelta（Text）
   │     → 追加文本到行缓冲区
   │     → 检测代码块边界标记（```），切换代码/文本模式
@@ -53,7 +53,7 @@ Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
   ├── BlockEnd
   │     → 刷新当前块剩余缓冲内容
   │     → Thinking/Tool 块 → 以原始 ContentBlock 传递，交由平台插件的格式渲染器完成最终渲染（如飞书的折叠推理区、工具操作卡片）
-  │     → Text 块 → 输出完整块内容
+  │     → Text 块 → 输出当前缓冲残余内容
   ├── MessageEnd
   │     → 刷新所有缓冲，输出剩余内容
   │     → 清空当前块状态和行缓冲上下文
@@ -68,5 +68,5 @@ Gateway 调用 IMPlugin 流式方法，内部驱动流式渲染器
 - **上游**：Gateway（通过 IMPlugin trait 流式方法驱动渲染，逐事件调用）
 - **下游**：IMPlugin（接收增量渲染输出并通过 Adapter 发送到 IM 平台）
 - **内部组件**：流式渲染器是 IMPlugin 的内部组件，由各平台插件通过 trait 默认方法持有和调用。平台可覆盖默认方法实现差异化渲染逻辑
-- **与 Processor Chain 的关系**：流式文本路径不经出站 Processor Chain（文本增量直接输出，无需 DSL 解析器参与；交互式 UI 元素由工具调用路径单独处理）。非流式出站路径由 Gateway 统一经 Processor Chain（DSL 解析 → 出站日志记录）处理后渲染，详见 [Gateway 文档](../../gateway/README.md)
+- **与 Processor Chain 的关系**：流式文本路径不经出站 Processor Chain（文本增量直接输出，无需 DSL 解析器参与；交互式 UI 元素由工具调用路径单独处理）。非流式出站路径由 Gateway 统一经 Processor Chain（DSL 解析 → 出站日志记录）处理后渲染，详见 [Gateway 文档](../gateway/README.md)
 - **所属**：IM Adapter 模块的通用子功能

--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -127,10 +127,10 @@
   },
   {
     "path": "docs/design/im_adapter/streaming-render.md",
-    "commit": "",
-    "commit_time": "",
-    "confirmed_time": "2026-06-26T05:40:09.261967+08:00",
-    "comment": "blocked: Two design doc problems found in F2b deep comparison: (1) First-line output 200ms delay target has no time-based logic in LineBuffer implementation; unclear if hard requirement or aspirational. (2) MessageEnd handling: doc says automatic flush but code MessageEnd branch is no-op requiring explicit caller flush(). Design intent unclear for both."
+    "commit": "41048d97e2d1b70a4a3d8160376937df1ec7cb79",
+    "commit_time": "2026-06-26T20:05:34+08:00",
+    "confirmed_time": "2026-06-26T20:07:45.804053+08:00",
+    "comment": ""
   },
   {
     "path": "docs/design/llm/cache-adapter.md",


### PR DESCRIPTION
设计文档：im_adapter/streaming-render.md — 修复内部矛盾和架构不清晰问题

## 问题来源
Issue #1228 通过 F2b 深度对比发现 2 处文档问题：
1. 首行输出 200ms 延迟目标无实现机制
2. MessageEnd 事件处理方式不一致

经 guided-design-qna 讨论后，进一步发现 streaming-render 文档与 Gateway/IM Adapter 文档的架构矛盾，以及 DSL 路由职责归属问题。

## 修改内容

### streaming-render.md
- 移除"目标延迟 200ms 内"表述（期望性目标，无对应机制；100 字符阈值作为兜底）
- StreamEvent 枚举补全 Error 变体，数据流增 Error 处理分支
- 数据流：
  - 纠正 Gateway → Renderer → IMPlugin 链为 Gateway → IMPlugin（Renderer 是 IMPlugin 内部组件）
  - 增加代码块边界检测（```标记）逻辑
  - 增加缓冲区阈值强制输出分支
  - MessageEnd 明确为"刷新所有缓冲 + 清空块状态和行缓冲上下文"
- 架构：BlockDelta 描述从"增量文本"改为"增量数据（Text/Thinking/Tool）"
- 模块关系：修复上游自指问题（"IMPlugin trait 默认方法"→"Gateway"），增加"内部组件"说明
- 增加范围说明：交互式 UI 元素（按钮、选择器等）通过工具调用结果由 Gateway 处理，不经过流式文本渲染管线

## 附带修改
- `scripts/design-doc-tracker/records.json` — 清除 streaming-render.md 的 blocked 标记

## 代码对照发现
（Step 3 发现的差异已通过架构讨论确认方向，本次仅修改文档对齐设计）

Source: user
Type: docs
