### PR TITLE
fix: align protocol mapping layer with design doc

### DIFF
--- a/src/cli/renderer.rs
+++ b/src/cli/renderer.rs
@@ -728,7 +728,7 @@ impl TerminalRenderer {
     pub(crate) fn render_block(&self, block: &ContentBlock) -> String {
         match block {
             ContentBlock::Text(text) => render_markdown_ansi(text, self.ansi),
-            ContentBlock::Thinking(text) => self.render_thinking(text),
+            ContentBlock::Thinking { thinking: text, .. } => self.render_thinking(text),
             ContentBlock::ToolUse { name, input, .. } => self.render_tool_use(name, input),
             ContentBlock::ToolResult { content, .. } => self.render_tool_result(content),
             ContentBlock::Image(name) => self.render_placeholder("image", name),

--- a/src/cli/renderer_tests.rs
+++ b/src/cli/renderer_tests.rs
@@ -41,7 +41,10 @@ fn test_render_block_text() {
 #[test]
 fn test_render_block_thinking_no_ansi() {
     let renderer = TerminalRenderer::with_ansi(false);
-    let result = renderer.render_block(&ContentBlock::Thinking("reasoning".into()));
+    let result = renderer.render_block(&ContentBlock::Thinking {
+        thinking: "reasoning".into(),
+        signature: None,
+    });
     assert!(result.contains("[Thinking]"));
     assert!(result.contains("reasoning"));
     assert!(result.contains("[end of thinking]"));
@@ -50,7 +53,10 @@ fn test_render_block_thinking_no_ansi() {
 #[test]
 fn test_render_block_thinking_ansi() {
     let renderer = TerminalRenderer::with_ansi(true);
-    let result = renderer.render_block(&ContentBlock::Thinking("thought".into()));
+    let result = renderer.render_block(&ContentBlock::Thinking {
+        thinking: "thought".into(),
+        signature: None,
+    });
     assert!(result.contains(DIM));
     assert!(result.contains("[Thinking]"));
     assert!(result.contains("[end of thinking]"));
@@ -376,7 +382,10 @@ fn test_render_text_empty_string() {
 #[test]
 fn test_render_thinking_empty() {
     let renderer = TerminalRenderer::with_ansi(false);
-    let result = renderer.render_block(&ContentBlock::Thinking(String::new()));
+    let result = renderer.render_block(&ContentBlock::Thinking {
+        thinking: String::new(),
+        signature: None,
+    });
     assert!(result.contains("[Thinking]"));
 }
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -571,7 +571,7 @@ pub(crate) fn filter_by_verbosity(
         VerbosityLevel::Full => blocks,
         VerbosityLevel::Normal => blocks
             .into_iter()
-            .filter(|b| !matches!(b, ContentBlock::Thinking(_)))
+            .filter(|b| !matches!(b, ContentBlock::Thinking { .. }))
             .collect(),
         VerbosityLevel::Off => blocks
             .into_iter()

--- a/src/gateway/outbound_tests.rs
+++ b/src/gateway/outbound_tests.rs
@@ -9,7 +9,10 @@ use super::outbound::filter_by_verbosity;
 fn test_filter_by_verbosity_full() {
     let blocks = vec![
         ContentBlock::Text("hello".into()),
-        ContentBlock::Thinking("reasoning".into()),
+        ContentBlock::Thinking {
+            thinking: "reasoning".into(),
+            signature: None,
+        },
         ContentBlock::ToolUse {
             id: "t1".into(),
             name: "tool_a".into(),
@@ -19,7 +22,7 @@ fn test_filter_by_verbosity_full() {
     let result = filter_by_verbosity(blocks.clone(), VerbosityLevel::Full);
     assert_eq!(result.len(), 3);
     assert!(matches!(result[0], ContentBlock::Text(_)));
-    assert!(matches!(result[1], ContentBlock::Thinking(_)));
+    assert!(matches!(result[1], ContentBlock::Thinking { .. }));
     assert!(matches!(result[2], ContentBlock::ToolUse { .. }));
 }
 
@@ -27,7 +30,10 @@ fn test_filter_by_verbosity_full() {
 fn test_filter_by_verbosity_normal() {
     let blocks = vec![
         ContentBlock::Text("hello".into()),
-        ContentBlock::Thinking("reasoning".into()),
+        ContentBlock::Thinking {
+            thinking: "reasoning".into(),
+            signature: None,
+        },
         ContentBlock::ToolUse {
             id: "t1".into(),
             name: "tool_a".into(),
@@ -44,7 +50,10 @@ fn test_filter_by_verbosity_normal() {
 fn test_filter_by_verbosity_off() {
     let blocks = vec![
         ContentBlock::Text("hello".into()),
-        ContentBlock::Thinking("reasoning".into()),
+        ContentBlock::Thinking {
+            thinking: "reasoning".into(),
+            signature: None,
+        },
         ContentBlock::ToolUse {
             id: "t1".into(),
             name: "tool_a".into(),

--- a/src/gateway/session_handler.rs
+++ b/src/gateway/session_handler.rs
@@ -425,7 +425,7 @@ fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
         .iter()
         .map(|b| match b {
             ContentBlock::Text(t) => t.as_str(),
-            ContentBlock::Thinking(t) => t.as_str(),
+            ContentBlock::Thinking { thinking: t, .. } => t.as_str(),
             ContentBlock::ToolUse { input, .. } => input.as_str(),
             ContentBlock::ToolResult { content, .. } => content.as_str(),
             _ => "",

--- a/src/gateway/session_handler_compaction.rs
+++ b/src/gateway/session_handler_compaction.rs
@@ -31,7 +31,7 @@ fn flatten_content_blocks(blocks: &[ContentBlock]) -> String {
         .iter()
         .filter_map(|b| match b {
             ContentBlock::Text(t) => Some(t.as_str()),
-            ContentBlock::Thinking(t) => Some(t.as_str()),
+            ContentBlock::Thinking { thinking: t, .. } => Some(t.as_str()),
             ContentBlock::ToolUse { input, .. } => Some(input.as_str()),
             ContentBlock::ToolResult { content, .. } => Some(content.as_str()),
             _ => Some(""),

--- a/src/gateway/session_manager/announce_tests.rs
+++ b/src/gateway/session_manager/announce_tests.rs
@@ -275,7 +275,10 @@ async fn test_thinking_blocks_excluded() {
         &mgr,
         &child_id,
         vec![
-            ContentBlock::Thinking("secret reasoning that should NOT leak".to_string()),
+            ContentBlock::Thinking {
+                thinking: "secret reasoning that should NOT leak".to_string(),
+                signature: None,
+            },
             ContentBlock::Text("final answer that MUST be present".to_string()),
         ],
     )

--- a/src/gateway/step1_5_tests.rs
+++ b/src/gateway/step1_5_tests.rs
@@ -261,7 +261,10 @@ async fn test_verbosity_filter_before_processor_chain() {
 
     let blocks = vec![
         ContentBlock::Text("visible".to_string()),
-        ContentBlock::Thinking("hidden reasoning".to_string()),
+        ContentBlock::Thinking {
+            thinking: "hidden reasoning".to_string(),
+            signature: None,
+        },
     ];
 
     gw.send_outbound("sess-verb-off", "mock", "raw output", blocks)
@@ -293,7 +296,10 @@ async fn test_verbosity_normal_strips_thinking_before_chain() {
 
     let blocks = vec![
         ContentBlock::Text("hello".to_string()),
-        ContentBlock::Thinking("reasoning".to_string()),
+        ContentBlock::Thinking {
+            thinking: "reasoning".to_string(),
+            signature: None,
+        },
         ContentBlock::ToolUse {
             id: "t1".into(),
             name: "tool_a".into(),
@@ -328,7 +334,10 @@ async fn test_verbosity_full_all_blocks_before_chain() {
 
     let blocks = vec![
         ContentBlock::Text("hello".to_string()),
-        ContentBlock::Thinking("reasoning".to_string()),
+        ContentBlock::Thinking {
+            thinking: "reasoning".to_string(),
+            signature: None,
+        },
     ];
 
     gw.send_outbound("sess-verb-full", "mock", "raw", blocks)

--- a/src/im_adapter/platforms/feishu/renderer.rs
+++ b/src/im_adapter/platforms/feishu/renderer.rs
@@ -239,7 +239,9 @@ pub(crate) fn dispatch_blocks(
                     elements.extend(to_elements(text.trim()));
                 }
             }
-            ContentBlock::Thinking(content) => {
+            ContentBlock::Thinking {
+                thinking: content, ..
+            } => {
                 elements.push(render_thinking_block(content));
             }
             ContentBlock::ToolUse { name, input, .. } => {
@@ -406,7 +408,10 @@ mod tests {
     #[test]
     fn dispatch_blocks_with_thinking_includes_collapsible_panel() {
         let blocks = vec![
-            ContentBlock::Thinking("reasoning here".into()),
+            ContentBlock::Thinking {
+                thinking: "reasoning here".into(),
+                signature: None,
+            },
             ContentBlock::Text("Hello".into()),
         ];
         let (_, elements) = dispatch_blocks(&blocks, None);

--- a/src/im_adapter/plugin_tests.rs
+++ b/src/im_adapter/plugin_tests.rs
@@ -733,6 +733,7 @@ mod tests {
             index: 0,
             delta: ContentDelta::Thinking {
                 thinking: "reasoning...".to_string(),
+                signature: None,
             },
         });
         let out = plugin.handle_stream_event(StreamEvent::BlockEnd {
@@ -743,7 +744,10 @@ mod tests {
         assert_eq!(out.render_blocks.len(), 1);
         assert_eq!(
             out.render_blocks[0],
-            ContentBlock::Thinking("reasoning...".to_string())
+            ContentBlock::Thinking {
+                thinking: "reasoning...".to_string(),
+                signature: None
+            }
         );
     }
 
@@ -859,6 +863,7 @@ mod tests {
             index: 1,
             delta: ContentDelta::Thinking {
                 thinking: "hmm".to_string(),
+                signature: None,
             },
         });
         let out = plugin.handle_stream_event(StreamEvent::BlockEnd {

--- a/src/im_adapter/streaming.rs
+++ b/src/im_adapter/streaming.rs
@@ -170,7 +170,10 @@ impl BlockAccumulator {
     /// Convert the accumulated data into a [`ContentBlock`].
     fn into_block(self, block_type: ContentBlockType) -> ContentBlock {
         match block_type {
-            ContentBlockType::Thinking => ContentBlock::Thinking(self.text),
+            ContentBlockType::Thinking => ContentBlock::Thinking {
+                thinking: self.text,
+                signature: None,
+            },
             ContentBlockType::ToolUse => ContentBlock::ToolUse {
                 id: self.tool_id.unwrap_or_default(),
                 name: self.tool_name.unwrap_or_default(),
@@ -295,7 +298,7 @@ impl StreamingRenderer for DefaultStreamingRenderer {
             }
             StreamEvent::BlockDelta { delta, .. } => match delta {
                 ContentDelta::Text { text } => self.handle_text_delta(&text, &mut out),
-                ContentDelta::Thinking { thinking } => self.handle_thinking_delta(&thinking),
+                ContentDelta::Thinking { thinking, .. } => self.handle_thinking_delta(&thinking),
                 ContentDelta::ToolUseId { id } => self.handle_tool_id(id),
                 ContentDelta::ToolUseName { name } => self.handle_tool_name(name),
                 ContentDelta::ToolUseInputChunk { input } => self.handle_tool_input(&input),
@@ -441,12 +444,16 @@ mod tests {
             index: 0,
             delta: ContentDelta::Thinking {
                 thinking: "Let me think.".to_string(),
+                signature: None,
             },
         });
         let out = r.handle_event(block_end(0, ContentBlockType::Thinking));
         assert_eq!(
             out.render_blocks,
-            vec![ContentBlock::Thinking("Let me think.".to_string())]
+            vec![ContentBlock::Thinking {
+                thinking: "Let me think.".to_string(),
+                signature: None
+            }]
         );
     }
 

--- a/src/llm/deepseek.rs
+++ b/src/llm/deepseek.rs
@@ -226,7 +226,10 @@ impl Provider for DeepSeekProvider {
         // reasoning_content → Thinking block (DeepSeek reasoning models)
         if let Some(reasoning) = choice.message.reasoning_content {
             if !reasoning.is_empty() {
-                content_blocks.push(RawContentBlock::Thinking(reasoning));
+                content_blocks.push(RawContentBlock::Thinking {
+                    thinking: reasoning,
+                    signature: None,
+                });
             }
         }
 

--- a/src/llm/deepseek/tests.rs
+++ b/src/llm/deepseek/tests.rs
@@ -107,7 +107,10 @@ async fn test_send_success_with_reasoning_content() {
     assert_eq!(resp.content_blocks.len(), 2);
     assert_eq!(
         resp.content_blocks[0],
-        RawContentBlock::Thinking("Let me think step by step...".into())
+        RawContentBlock::Thinking {
+            thinking: "Let me think step by step...".into(),
+            signature: None
+        }
     );
     assert_eq!(
         resp.content_blocks[1],

--- a/src/llm/glm/tests/mock_integration.rs
+++ b/src/llm/glm/tests/mock_integration.rs
@@ -43,7 +43,7 @@ fn assert_first_text(resp: &InternalResponse, expected: &str) {
         RawContentBlock::Text(s) => {
             assert!(s.contains(expected), "expected '{}', got: {}", expected, s)
         }
-        RawContentBlock::Thinking(s) => {
+        RawContentBlock::Thinking { thinking: s, .. } => {
             assert!(s.contains(expected), "expected '{}', got: {}", expected, s)
         }
         other => panic!("Expected Text/Thinking, got: {:?}", other),

--- a/src/llm/glm/types.rs
+++ b/src/llm/glm/types.rs
@@ -203,7 +203,10 @@ impl GlmProvider {
         let mut content_blocks = Vec::new();
         if let Some(ref rc) = msg.reasoning_content {
             if !rc.trim().is_empty() {
-                content_blocks.push(RawContentBlock::Thinking(rc.trim().to_string()));
+                content_blocks.push(RawContentBlock::Thinking {
+                    thinking: rc.trim().to_string(),
+                    signature: None,
+                });
             }
         }
         if !content.is_empty() {

--- a/src/llm/interpreter.rs
+++ b/src/llm/interpreter.rs
@@ -168,7 +168,10 @@ impl Default for InterpreterRegistry {
 fn raw_content_block_to_content_block(raw: RawContentBlock) -> ContentBlock {
     match raw {
         RawContentBlock::Text(s) => ContentBlock::Text(s),
-        RawContentBlock::Thinking(s) => ContentBlock::Thinking(s),
+        RawContentBlock::Thinking { thinking: s, .. } => ContentBlock::Thinking {
+            thinking: s,
+            signature: None,
+        },
         RawContentBlock::ToolUse { id, name, input } => ContentBlock::ToolUse { id, name, input },
         RawContentBlock::ToolResult {
             tool_call_id,
@@ -203,7 +206,7 @@ impl ModelInterpreter for MinimaxInterpreter {
         for block in response.content_blocks {
             match block {
                 RawContentBlock::Text(s) => text_parts.push(s),
-                RawContentBlock::Thinking(s) => thinking_parts.push(s),
+                RawContentBlock::Thinking { thinking: s, .. } => thinking_parts.push(s),
                 RawContentBlock::ToolUse { id, name, input } => {
                     text_parts.push(format!("id:{id} name:{name} input:{input}"))
                 }
@@ -215,7 +218,10 @@ impl ModelInterpreter for MinimaxInterpreter {
         }
         let content_blocks: Vec<ContentBlock> = if text_parts.iter().all(|s| s.is_empty()) {
             if !thinking_parts.is_empty() {
-                vec![ContentBlock::Thinking(thinking_parts.join(""))]
+                vec![ContentBlock::Thinking {
+                    thinking: thinking_parts.join(""),
+                    signature: None,
+                }]
             } else {
                 vec![]
             }
@@ -264,7 +270,7 @@ impl ModelInterpreter for GlmInterpreter {
         for block in response.content_blocks {
             match block {
                 RawContentBlock::Text(s) => text_parts.push(s),
-                RawContentBlock::Thinking(s) => thinking_parts.push(s),
+                RawContentBlock::Thinking { thinking: s, .. } => thinking_parts.push(s),
                 RawContentBlock::ToolUse { id, name, input } => {
                     text_parts.push(format!("id:{id} name:{name} input:{input}"))
                 }
@@ -277,7 +283,10 @@ impl ModelInterpreter for GlmInterpreter {
         let content_blocks: Vec<ContentBlock> = if text_parts.iter().all(|s| s.is_empty()) {
             let reasoning = thinking_parts.join("");
             if reasoning.len() > 10 {
-                vec![ContentBlock::Thinking(reasoning)]
+                vec![ContentBlock::Thinking {
+                    thinking: reasoning,
+                    signature: None,
+                }]
             } else {
                 vec![ContentBlock::Text(reasoning)]
             }
@@ -327,7 +336,7 @@ impl ModelInterpreter for DeepSeekInterpreter {
         for block in response.content_blocks {
             match block {
                 RawContentBlock::Text(s) => text_parts.push(s),
-                RawContentBlock::Thinking(s) => thinking_parts.push(s),
+                RawContentBlock::Thinking { thinking: s, .. } => thinking_parts.push(s),
                 RawContentBlock::ToolUse { id, name, input } => {
                     text_parts.push(format!("id:{id} name:{name} input:{input}"))
                 }
@@ -339,7 +348,10 @@ impl ModelInterpreter for DeepSeekInterpreter {
         }
         let content_blocks: Vec<ContentBlock> = if text_parts.iter().all(|s| s.is_empty()) {
             if !thinking_parts.is_empty() {
-                vec![ContentBlock::Thinking(thinking_parts.join(""))]
+                vec![ContentBlock::Thinking {
+                    thinking: thinking_parts.join(""),
+                    signature: None,
+                }]
             } else {
                 vec![]
             }

--- a/src/llm/interpreter_test.rs
+++ b/src/llm/interpreter_test.rs
@@ -18,7 +18,10 @@ fn test_default_interpreter_response_identity() {
     let response = InternalResponse {
         content_blocks: vec![
             RawContentBlock::Text("hello".into()),
-            RawContentBlock::Thinking("thinking...".into()),
+            RawContentBlock::Thinking {
+                thinking: "thinking...".into(),
+                signature: None,
+            },
         ],
         usage: RawUsage {
             prompt_tokens: 10,
@@ -32,7 +35,9 @@ fn test_default_interpreter_response_identity() {
     let unified = DefaultInterpreter.interpret_response(response);
     assert_eq!(unified.content_blocks.len(), 2);
     assert!(matches!(&unified.content_blocks[0], ContentBlock::Text(s) if s == "hello"));
-    assert!(matches!(&unified.content_blocks[1], ContentBlock::Thinking(s) if s == "thinking..."));
+    assert!(
+        matches!(&unified.content_blocks[1], ContentBlock::Thinking { thinking: s, .. } if s == "thinking...")
+    );
     assert_eq!(unified.usage.prompt_tokens, 10);
     assert_eq!(unified.finish_reason, Some("stop".into()));
 }
@@ -148,9 +153,10 @@ fn test_minimax_interpreter_name() {
 #[test]
 fn test_minimax_interpreter_empty_content_uses_reasoning() {
     let response = InternalResponse {
-        content_blocks: vec![RawContentBlock::Thinking(
-            "Let me think step by step...".into(),
-        )],
+        content_blocks: vec![RawContentBlock::Thinking {
+            thinking: "Let me think step by step...".into(),
+            signature: None,
+        }],
         usage: RawUsage {
             prompt_tokens: 10,
             completion_tokens: 5,
@@ -163,7 +169,7 @@ fn test_minimax_interpreter_empty_content_uses_reasoning() {
     let unified = MinimaxInterpreter.interpret_response(response);
     assert_eq!(unified.content_blocks.len(), 1);
     assert!(
-        matches!(&unified.content_blocks[0], ContentBlock::Thinking(s) if s == "Let me think step by step..."),
+        matches!(&unified.content_blocks[0], ContentBlock::Thinking { thinking: s, .. } if s == "Let me think step by step..."),
         "expected Thinking block, got {:?}",
         unified.content_blocks[0]
     );
@@ -215,7 +221,10 @@ fn test_glm_interpreter_name() {
 #[test]
 fn test_glm_interpreter_reasoning_threshold_short() {
     let response = InternalResponse {
-        content_blocks: vec![RawContentBlock::Thinking("Hi".into())],
+        content_blocks: vec![RawContentBlock::Thinking {
+            thinking: "Hi".into(),
+            signature: None,
+        }],
         usage: RawUsage {
             prompt_tokens: 0,
             completion_tokens: 0,
@@ -237,7 +246,10 @@ fn test_glm_interpreter_reasoning_threshold_short() {
 #[test]
 fn test_glm_interpreter_reasoning_threshold_exact_boundary() {
     let response = InternalResponse {
-        content_blocks: vec![RawContentBlock::Thinking("12345678901".into())],
+        content_blocks: vec![RawContentBlock::Thinking {
+            thinking: "12345678901".into(),
+            signature: None,
+        }],
         usage: RawUsage {
             prompt_tokens: 0,
             completion_tokens: 0,
@@ -250,7 +262,7 @@ fn test_glm_interpreter_reasoning_threshold_exact_boundary() {
     let unified = GlmInterpreter.interpret_response(response);
     assert_eq!(unified.content_blocks.len(), 1);
     assert!(
-        matches!(&unified.content_blocks[0], ContentBlock::Thinking(s) if s == "12345678901"),
+        matches!(&unified.content_blocks[0], ContentBlock::Thinking { thinking: s, .. } if s == "12345678901"),
         "expected Thinking block for 11-byte reasoning, got {:?}",
         unified.content_blocks[0]
     );
@@ -284,6 +296,7 @@ fn test_glm_interpreter_stream_event_passthrough() {
         index: 0,
         delta: ContentDelta::Thinking {
             thinking: "thinking...".into(),
+            signature: None,
         },
     };
     assert_eq!(
@@ -304,9 +317,10 @@ fn test_deepseek_interpreter_name() {
 #[test]
 fn test_deepseek_interpreter_empty_content_uses_reasoning() {
     let response = InternalResponse {
-        content_blocks: vec![RawContentBlock::Thinking(
-            "Let me think step by step...".into(),
-        )],
+        content_blocks: vec![RawContentBlock::Thinking {
+            thinking: "Let me think step by step...".into(),
+            signature: None,
+        }],
         usage: RawUsage {
             prompt_tokens: 10,
             completion_tokens: 5,
@@ -319,7 +333,7 @@ fn test_deepseek_interpreter_empty_content_uses_reasoning() {
     let unified = DeepSeekInterpreter.interpret_response(response);
     assert_eq!(unified.content_blocks.len(), 1);
     assert!(
-        matches!(&unified.content_blocks[0], ContentBlock::Thinking(s) if s == "Let me think step by step..."),
+        matches!(&unified.content_blocks[0], ContentBlock::Thinking { thinking: s, .. } if s == "Let me think step by step..."),
         "expected Thinking block, got {:?}",
         unified.content_blocks[0]
     );
@@ -352,7 +366,10 @@ fn test_deepseek_interpreter_text_and_reasoning_prefers_text() {
     let response = InternalResponse {
         content_blocks: vec![
             RawContentBlock::Text("hello".into()),
-            RawContentBlock::Thinking("thinking...".into()),
+            RawContentBlock::Thinking {
+                thinking: "thinking...".into(),
+                signature: None,
+            },
         ],
         usage: RawUsage {
             prompt_tokens: 10,

--- a/src/llm/minimax.rs
+++ b/src/llm/minimax.rs
@@ -181,7 +181,10 @@ impl MiniMaxProvider {
         let mut content_blocks = Vec::new();
         if let Some(ref rc) = msg.reasoning_content {
             if !rc.trim().is_empty() {
-                content_blocks.push(RawContentBlock::Thinking(rc.trim().to_string()));
+                content_blocks.push(RawContentBlock::Thinking {
+                    thinking: rc.trim().to_string(),
+                    signature: None,
+                });
             }
         }
         if !content.is_empty() {

--- a/src/llm/minimax/tests.rs
+++ b/src/llm/minimax/tests.rs
@@ -214,7 +214,7 @@ async fn test_provider_send_reasoning_content_mock() {
     assert!(resp
         .content_blocks
         .iter()
-        .any(|b| matches!(b, RawContentBlock::Thinking(_))));
+        .any(|b| matches!(b, RawContentBlock::Thinking { .. })));
 }
 
 // --- Provider send_streaming() via mockito ---

--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -173,10 +173,18 @@ impl ChatProtocol for AnthropicProtocol {
                                 .get("text")
                                 .and_then(|v| v.as_str())
                                 .map(|s| RawContentBlock::Text(s.to_string())),
-                            Some("thinking") => item
-                                .get("thinking")
-                                .and_then(|v| v.as_str())
-                                .map(|s| RawContentBlock::Thinking(s.to_string())),
+                            Some("thinking") => {
+                                let thinking =
+                                    item.get("thinking").and_then(|v| v.as_str()).unwrap_or("");
+                                let signature = item
+                                    .get("signature")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| s.to_string());
+                                Some(RawContentBlock::Thinking {
+                                    thinking: thinking.to_string(),
+                                    signature,
+                                })
+                            }
                             _ => None,
                         }
                     })

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -156,7 +156,7 @@ fn test_parse_response_thinking_block() {
     assert_eq!(resp.content_blocks.len(), 2);
     assert!(matches!(
         resp.content_blocks[0],
-        RawContentBlock::Thinking(ref s) if s == "Let me think..."
+        RawContentBlock::Thinking { thinking: ref s, .. } if s == "Let me think..."
     ));
     assert!(matches!(
         resp.content_blocks[1],

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -165,6 +165,29 @@ fn test_parse_response_thinking_block() {
 }
 
 #[test]
+fn test_parse_response_thinking_block_with_signature() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {"type": "thinking", "thinking": "Let me think...", "signature": "sig_abc123"},
+            {"type": "text", "text": "Final answer."}
+        ],
+        "stop_reason": "end_turn"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(matches!(
+        resp.content_blocks[0],
+        RawContentBlock::Thinking { thinking: ref s, signature: Some(ref sig) } if s == "Let me think..." && sig == "sig_abc123"
+    ));
+    assert!(matches!(
+        resp.content_blocks[1],
+        RawContentBlock::Text(ref s) if s == "Final answer."
+    ));
+}
+
+#[test]
 fn test_parse_response_empty_content() {
     let proto = AnthropicProtocol::new();
     let body = serde_json::json!({ "content": [], "stop_reason": "end_turn" });

--- a/src/llm/protocol/glm.rs
+++ b/src/llm/protocol/glm.rs
@@ -124,7 +124,10 @@ impl ChatProtocol for GlmProtocol {
 
         let content_blocks = match (text, reasoning) {
             (Some(t), _) => vec![RawContentBlock::Text(t)],
-            (_, Some(r)) => vec![RawContentBlock::Thinking(r)],
+            (_, Some(r)) => vec![RawContentBlock::Thinking {
+                thinking: r,
+                signature: None,
+            }],
             (None, None) => vec![],
         };
 
@@ -217,7 +220,7 @@ impl ChatProtocol for GlmProtocol {
 
                     let delta = match btype {
                         ContentBlockType::Thinking => {
-                            ContentDelta::Thinking { thinking: text.to_string() }
+                            ContentDelta::Thinking { thinking: text.to_string(), signature: None }
                         }
                         _ => ContentDelta::Text { text: text.to_string() },
                     };

--- a/src/llm/protocol/glm_test.rs
+++ b/src/llm/protocol/glm_test.rs
@@ -84,7 +84,7 @@ fn test_parse_response_reasoning_content() {
     let resp = proto.parse_response(body).unwrap();
     assert_eq!(resp.content_blocks.len(), 1);
     assert!(
-        matches!(resp.content_blocks[0], RawContentBlock::Thinking(ref s) if s == "Let me think step by step...")
+        matches!(resp.content_blocks[0], RawContentBlock::Thinking { thinking: ref s, .. } if s == "Let me think step by step...")
     );
 }
 
@@ -178,11 +178,11 @@ async fn test_parse_sse_reasoning_content_delta() {
     ));
     let evt2 = stream.next().await.unwrap().unwrap();
     assert!(
-        matches!(evt2, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == "step 1")
+        matches!(evt2, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s, .. }, .. } if s == "step 1")
     );
     let evt3 = stream.next().await.unwrap().unwrap();
     assert!(
-        matches!(evt3, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == "step 2")
+        matches!(evt3, StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s, .. }, .. } if s == "step 2")
     );
     let evt4 = stream.next().await.unwrap().unwrap();
     assert!(matches!(
@@ -382,14 +382,14 @@ async fn test_parse_sse_reasoning_then_tool_calls() {
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
-        StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == "Let me think..."
+        StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s, .. }, .. } if s == "Let me think..."
     ));
 
     // Thinking content 2
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
-        StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s }, .. } if s == " done."
+        StreamEvent::BlockDelta { delta: ContentDelta::Thinking { thinking: s, .. }, .. } if s == " done."
     ));
 
     // Thinking BlockEnd

--- a/src/llm/protocol/openai.rs
+++ b/src/llm/protocol/openai.rs
@@ -217,9 +217,24 @@ impl ChatProtocol for OpenAiProtocol {
                 }
 
                 // Content delta
+                // Document rule: content is prioritized over reasoning_content.
+                // If a Text block is already active, append to it.
+                // If a Thinking block is active and non-empty content arrives,
+                // end Thinking and start Text (content wins).
                 if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
                     if text.is_empty() {
                         continue;
+                    }
+                    // If Thinking block is active, content takes priority: end it
+                    if active_block_type == Some(ContentBlockType::Thinking) {
+                        if let Some(prev_idx) = block_index {
+                            yield StreamEvent::BlockEnd {
+                                index: prev_idx,
+                                block_type: ContentBlockType::Thinking,
+                            };
+                        }
+                        block_index = None;
+                        active_block_type = None;
                     }
                     let idx = match block_index {
                         Some(i) => i,
@@ -228,52 +243,63 @@ impl ChatProtocol for OpenAiProtocol {
                             next_block_index += 1;
                             block_index = Some(idx);
                             active_block_type = Some(ContentBlockType::Text);
-                            yield StreamEvent::BlockStart { index: idx, block_type: ContentBlockType::Text };
+                            yield StreamEvent::BlockStart {
+                                index: idx,
+                                block_type: ContentBlockType::Text,
+                            };
                             idx
                         }
                     };
-                    yield StreamEvent::BlockDelta { index: idx, delta: ContentDelta::Text { text: text.to_string() } };
+                    yield StreamEvent::BlockDelta {
+                        index: idx,
+                        delta: ContentDelta::Text {
+                            text: text.to_string(),
+                        },
+                    };
                 }
 
                 // reasoning_content delta
+                // If a Text block is already active, content is non-empty so
+                // reasoning_content is ignored (content priority).
                 if let Some(thinking) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
                     if thinking.is_empty() {
+                        continue;
+                    }
+                    // If Text block is active, ignore reasoning_content
+                    if active_block_type == Some(ContentBlockType::Text) {
                         continue;
                     }
                     let idx = match block_index {
                         Some(i) if active_block_type == Some(ContentBlockType::Thinking) => i,
                         _ => {
-                            // End current block if any
+                            // End current block if any (e.g., tool_calls → thinking)
                             if let Some(prev_idx) = block_index {
                                 let prev_type = active_block_type.unwrap_or(
                                     ContentBlockType::Text,
                                 );
-                                let event = StreamEvent::BlockEnd {
+                                yield StreamEvent::BlockEnd {
                                     index: prev_idx,
                                     block_type: prev_type,
                                 };
-                                yield event;
                             }
                             let idx = next_block_index;
                             next_block_index += 1;
                             block_index = Some(idx);
                             active_block_type = Some(ContentBlockType::Thinking);
-                            let event = StreamEvent::BlockStart {
+                            yield StreamEvent::BlockStart {
                                 index: idx,
                                 block_type: ContentBlockType::Thinking,
                             };
-                            yield event;
                             idx
                         }
                     };
-                    let delta = ContentDelta::Thinking {
-                        thinking: thinking.to_string(),
-                    };
-                    let event = StreamEvent::BlockDelta {
+                    yield StreamEvent::BlockDelta {
                         index: idx,
-                        delta,
+                        delta: ContentDelta::Thinking {
+                            thinking: thinking.to_string(),
+                            signature: None,
+                        },
                     };
-                    yield event;
                 }
 
                 // tool_calls delta

--- a/src/llm/protocol/openai.rs
+++ b/src/llm/protocol/openai.rs
@@ -113,6 +113,7 @@ impl ChatProtocol for OpenAiProtocol {
         let content = message
             .and_then(|msg| msg.get("content"))
             .and_then(|c| c.as_str())
+            .filter(|s| !s.trim().is_empty())
             .map(|s| s.to_string());
 
         let reasoning_content = message
@@ -131,10 +132,19 @@ impl ChatProtocol for OpenAiProtocol {
 
         let usage = parse_usage(&body);
 
-        let mut content_blocks = vec![RawContentBlock::Text(content.unwrap_or_default())];
-        if let Some(thinking) = reasoning_content {
-            content_blocks.push(RawContentBlock::Thinking(thinking));
-        }
+        let content_blocks = if let Some(ref text) = content {
+            // content 非空 → 仅产出 Text（文档规则：content 非空优先取 content）
+            vec![RawContentBlock::Text(text.clone())]
+        } else if let Some(thinking) = reasoning_content {
+            // content 为空/仅空白且 reasoning_content 非空 → 仅产出 Thinking
+            vec![RawContentBlock::Thinking {
+                thinking,
+                signature: None,
+            }]
+        } else {
+            // 两者都为空 → 产出空 Text
+            vec![RawContentBlock::Text(String::new())]
+        };
 
         Ok(InternalResponse {
             content_blocks,

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -242,7 +242,7 @@ fn test_parse_response_with_reasoning_content() {
     assert_eq!(resp.content_blocks.len(), 2);
     assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
     assert!(
-        matches!(&resp.content_blocks[1], RawContentBlock::Thinking(s) if s == "Let me think about this...")
+        matches!(&resp.content_blocks[1], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
     );
 }
 
@@ -271,7 +271,7 @@ fn test_parse_response_with_both_content_and_reasoning() {
         matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "The answer is 42.")
     );
     assert!(
-        matches!(&resp.content_blocks[1], RawContentBlock::Thinking(s) if s == "Let me think about this...")
+        matches!(&resp.content_blocks[1], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
     );
 }
 

--- a/src/llm/protocol/openai_tests.rs
+++ b/src/llm/protocol/openai_tests.rs
@@ -238,11 +238,10 @@ fn test_parse_response_with_reasoning_content() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Empty content → Text(""), reasoning → Thinking block
-    assert_eq!(resp.content_blocks.len(), 2);
-    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
+    // Empty content → only Thinking block (no empty Text)
+    assert_eq!(resp.content_blocks.len(), 1);
     assert!(
-        matches!(&resp.content_blocks[1], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
+        matches!(&resp.content_blocks[0], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
     );
 }
 
@@ -265,14 +264,35 @@ fn test_parse_response_with_both_content_and_reasoning() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Both content and reasoning → Text + Thinking
-    assert_eq!(resp.content_blocks.len(), 2);
+    // Both content and reasoning → only Text (content non-empty takes priority)
+    assert_eq!(resp.content_blocks.len(), 1);
     assert!(
         matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "The answer is 42.")
     );
-    assert!(
-        matches!(&resp.content_blocks[1], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
-    );
+}
+
+#[test]
+fn test_parse_response_both_content_and_reasoning_empty() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": null
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 0,
+            "total_tokens": 100
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // Both empty → single empty Text block
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
 }
 
 #[test]

--- a/src/llm/session/session_chat.rs
+++ b/src/llm/session/session_chat.rs
@@ -82,7 +82,7 @@ impl ConversationSession {
                 if msg.role == "assistant" {
                     !msg.content_blocks
                         .iter()
-                        .all(|b| matches!(b, ContentBlock::Thinking(_)))
+                        .all(|b| matches!(b, ContentBlock::Thinking { .. }))
                 } else {
                     true
                 }
@@ -95,7 +95,7 @@ impl ConversationSession {
             while last_assistant
                 .content_blocks
                 .last()
-                .is_some_and(|b| matches!(b, ContentBlock::Thinking(_)))
+                .is_some_and(|b| matches!(b, ContentBlock::Thinking { .. }))
             {
                 last_assistant.content_blocks.pop();
             }
@@ -160,7 +160,9 @@ impl ChatSession for ConversationSession {
                 .iter()
                 .flat_map(|b| match b {
                     ContentBlock::Text(t) => vec![t.clone()],
-                    ContentBlock::Thinking(t) => vec![format!("<thinking>{}</thinking>", t)],
+                    ContentBlock::Thinking { thinking: t, .. } => {
+                        vec![format!("<thinking>{}</thinking>", t)]
+                    }
                     ContentBlock::ToolUse { name, input, .. } => {
                         vec![format!("[tool:{}] {}", name, input)]
                     }

--- a/src/llm/session/tests/extract_pending_tool_calls_tests.rs
+++ b/src/llm/session/tests/extract_pending_tool_calls_tests.rs
@@ -138,7 +138,10 @@ fn test_extract_pending_tool_calls_last_has_mixed_blocks() {
                     name: "tool_a".to_string(),
                     input: "a".to_string(),
                 },
-                ContentBlock::Thinking("internal note".to_string()),
+                ContentBlock::Thinking {
+                    thinking: "internal note".to_string(),
+                    signature: None,
+                },
                 ContentBlock::ToolUse {
                     id: "call_b".to_string(),
                     name: "tool_b".to_string(),

--- a/src/llm/session/tests/thinking_clean_tests.rs
+++ b/src/llm/session/tests/thinking_clean_tests.rs
@@ -14,7 +14,10 @@ fn test_clean_thinking_mixed_text_and_thinking_unchanged() {
             role: "assistant".into(),
             content_blocks: vec![
                 ContentBlock::Text("reply".into()),
-                ContentBlock::Thinking("thought".into()),
+                ContentBlock::Thinking {
+                    thinking: "thought".into(),
+                    signature: None,
+                },
             ],
             timestamp: Utc::now(),
         },
@@ -36,7 +39,10 @@ fn test_clean_thinking_pure_thinking_removed() {
         },
         SessionMessage {
             role: "assistant".into(),
-            content_blocks: vec![ContentBlock::Thinking("only thinking".into())],
+            content_blocks: vec![ContentBlock::Thinking {
+                thinking: "only thinking".into(),
+                signature: None,
+            }],
             timestamp: Utc::now(),
         },
     ];
@@ -52,9 +58,15 @@ fn test_clean_thinking_trailing_removed_middle_kept() {
         role: "assistant".into(),
         content_blocks: vec![
             ContentBlock::Text("start".into()),
-            ContentBlock::Thinking("middle thought".into()),
+            ContentBlock::Thinking {
+                thinking: "middle thought".into(),
+                signature: None,
+            },
             ContentBlock::Text("end".into()),
-            ContentBlock::Thinking("trailing thought".into()),
+            ContentBlock::Thinking {
+                thinking: "trailing thought".into(),
+                signature: None,
+            },
         ],
         timestamp: Utc::now(),
     }];
@@ -64,7 +76,7 @@ fn test_clean_thinking_trailing_removed_middle_kept() {
     assert!(matches!(&cleaned[0].content_blocks[0], ContentBlock::Text(t) if t == "start"));
     assert!(matches!(
         &cleaned[0].content_blocks[1],
-        ContentBlock::Thinking(_)
+        ContentBlock::Thinking { .. }
     ));
     assert!(matches!(&cleaned[0].content_blocks[2], ContentBlock::Text(t) if t == "end"));
 }
@@ -76,7 +88,10 @@ fn test_clean_thinking_all_thinking_replaced_with_empty_text() {
         role: "assistant".into(),
         content_blocks: vec![
             ContentBlock::Text("real content".into()),
-            ContentBlock::Thinking("trailing".into()),
+            ContentBlock::Thinking {
+                thinking: "trailing".into(),
+                signature: None,
+            },
         ],
         timestamp: Utc::now(),
     }];
@@ -93,8 +108,14 @@ fn test_clean_thinking_last_assistant_only_thinking_becomes_empty_text() {
         role: "assistant".into(),
         content_blocks: vec![
             ContentBlock::Text(String::new()),
-            ContentBlock::Thinking("t1".into()),
-            ContentBlock::Thinking("t2".into()),
+            ContentBlock::Thinking {
+                thinking: "t1".into(),
+                signature: None,
+            },
+            ContentBlock::Thinking {
+                thinking: "t2".into(),
+                signature: None,
+            },
         ],
         timestamp: Utc::now(),
     }];
@@ -109,13 +130,18 @@ fn test_clean_thinking_isolation_original_unchanged() {
     // clean_thinking_content does not modify original messages
     let messages = vec![SessionMessage {
         role: "assistant".into(),
-        content_blocks: vec![ContentBlock::Thinking("secret".into())],
+        content_blocks: vec![ContentBlock::Thinking {
+            thinking: "secret".into(),
+            signature: None,
+        }],
         timestamp: Utc::now(),
     }];
     let original_len = messages[0].content_blocks.len();
     let _cleaned = ConversationSession::clean_thinking_content(&messages);
     assert_eq!(messages[0].content_blocks.len(), original_len);
-    assert!(matches!(&messages[0].content_blocks[0], ContentBlock::Thinking(t) if t == "secret"));
+    assert!(
+        matches!(&messages[0].content_blocks[0], ContentBlock::Thinking { thinking: t, .. } if t == "secret")
+    );
 }
 
 #[test]
@@ -125,7 +151,10 @@ fn test_build_api_request_does_not_modify_self_messages() {
     session.append_response(UnifiedResponse {
         content_blocks: vec![
             ContentBlock::Text("hi".into()),
-            ContentBlock::Thinking("think".into()),
+            ContentBlock::Thinking {
+                thinking: "think".into(),
+                signature: None,
+            },
         ],
         usage: UnifiedUsage {
             prompt_tokens: 1,

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -102,7 +102,13 @@ pub enum ContentDelta {
     /// Text delta.
     Text { text: String },
     /// Thinking delta.
-    Thinking { thinking: String },
+    Thinking {
+        /// The thinking/reasoning content.
+        thinking: String,
+        /// Optional signature (e.g., Anthropic thinking signature).
+        /// Always None in OpenAI streaming.
+        signature: Option<String>,
+    },
     /// Tool use call ID delta.
     ToolUseId { id: String },
     /// Tool use name delta.

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -30,8 +30,13 @@ pub enum ContentBlockType {
 pub enum ContentBlock {
     /// Text content block with a string payload.
     Text(String),
-    /// Thinking content block with a string payload.
-    Thinking(String),
+    /// Thinking content block with a reasoning trace and optional signature.
+    Thinking {
+        /// The thinking/reasoning content.
+        thinking: String,
+        /// Optional signature for traceability (e.g., Anthropic thinking signature).
+        signature: Option<String>,
+    },
     /// Tool use invocation block.
     ToolUse {
         /// Tool call identifier.
@@ -155,8 +160,13 @@ pub enum StreamEvent {
 pub enum RawContentBlock {
     /// Text content block with a string payload.
     Text(String),
-    /// Thinking content block with a string payload.
-    Thinking(String),
+    /// Thinking content block with a reasoning trace and optional signature.
+    Thinking {
+        /// The thinking/reasoning content.
+        thinking: String,
+        /// Optional signature for traceability (e.g., Anthropic thinking signature).
+        signature: Option<String>,
+    },
     /// Tool use invocation block.
     ToolUse {
         /// Tool call identifier.
@@ -220,7 +230,13 @@ impl From<RawContentBlock> for ContentBlock {
     fn from(block: RawContentBlock) -> Self {
         match block {
             RawContentBlock::Text(s) => ContentBlock::Text(s),
-            RawContentBlock::Thinking(s) => ContentBlock::Thinking(s),
+            RawContentBlock::Thinking {
+                thinking,
+                signature,
+            } => ContentBlock::Thinking {
+                thinking,
+                signature,
+            },
             RawContentBlock::ToolUse { id, name, input } => {
                 ContentBlock::ToolUse { id, name, input }
             }

--- a/src/llm/types_tests.rs
+++ b/src/llm/types_tests.rs
@@ -17,7 +17,10 @@ fn test_content_block_text_serde_roundtrip() {
 
 #[test]
 fn test_content_block_thinking_serde_roundtrip() {
-    let original = ContentBlock::Thinking("let me think...".into());
+    let original = ContentBlock::Thinking {
+        thinking: "let me think...".into(),
+        signature: None,
+    };
     let json = serde_json::to_string(&original).unwrap();
     let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
     assert_eq!(original, parsed);
@@ -199,9 +202,18 @@ fn test_raw_content_block_text_conversion() {
 
 #[test]
 fn test_raw_content_block_thinking_conversion() {
-    let raw = RawContentBlock::Thinking("let me think".to_string());
+    let raw = RawContentBlock::Thinking {
+        thinking: "let me think".to_string(),
+        signature: None,
+    };
     let block: ContentBlock = raw.into();
-    assert_eq!(block, ContentBlock::Thinking("let me think".to_string()));
+    assert_eq!(
+        block,
+        ContentBlock::Thinking {
+            thinking: "let me think".to_string(),
+            signature: None
+        }
+    );
 }
 
 #[test]
@@ -283,7 +295,10 @@ fn test_internal_response_conversion() {
     let resp = InternalResponse {
         content_blocks: vec![
             RawContentBlock::Text("hi".to_string()),
-            RawContentBlock::Thinking("hmm".to_string()),
+            RawContentBlock::Thinking {
+                thinking: "hmm".to_string(),
+                signature: None,
+            },
             RawContentBlock::ToolUse {
                 id: "c1".to_string(),
                 name: "do".to_string(),
@@ -311,7 +326,10 @@ fn test_internal_response_conversion() {
     );
     assert_eq!(
         unified.content_blocks[1],
-        ContentBlock::Thinking("hmm".to_string())
+        ContentBlock::Thinking {
+            thinking: "hmm".to_string(),
+            signature: None
+        }
     );
     assert_eq!(
         unified.content_blocks[2],

--- a/src/processor_chain/dsl_parser.rs
+++ b/src/processor_chain/dsl_parser.rs
@@ -462,8 +462,14 @@ mod tests {
     fn test_parse_content_blocks_only_thinking() {
         let parser = DslParser;
         let blocks = vec![
-            ContentBlock::Thinking("Let me think about this...".to_string()),
-            ContentBlock::Thinking("Maybe I should try...".to_string()),
+            ContentBlock::Thinking {
+                thinking: "Let me think about this...".to_string(),
+                signature: None,
+            },
+            ContentBlock::Thinking {
+                thinking: "Maybe I should try...".to_string(),
+                signature: None,
+            },
         ];
         let result = parser.parse_content_blocks(&blocks);
         assert!(result.instructions.is_empty());
@@ -520,7 +526,10 @@ mod tests {
     fn test_parse_content_blocks_mixed_with_non_text_skipped() {
         let parser = DslParser;
         let blocks = vec![
-            ContentBlock::Thinking("thinking...".to_string()),
+            ContentBlock::Thinking {
+                thinking: "thinking...".to_string(),
+                signature: None,
+            },
             ContentBlock::Text("::button[label:Click;action:go;value:ok]".to_string()),
             ContentBlock::ToolResult {
                 tool_call_id: "call_1".to_string(),
@@ -553,7 +562,10 @@ mod tests {
     fn test_from_content_blocks_equivalence() {
         let blocks = vec![
             ContentBlock::Text("Some text\n::button[label:X;action:a;value:1]".to_string()),
-            ContentBlock::Thinking("ignored".to_string()),
+            ContentBlock::Thinking {
+                thinking: "ignored".to_string(),
+                signature: None,
+            },
             ContentBlock::Text("More text\n::button[label:Y;action:b;value:2]".to_string()),
         ];
         let result_convenience = DslParseResult::from_content_blocks(&blocks);

--- a/src/processor_chain/dsl_parser_tests.rs
+++ b/src/processor_chain/dsl_parser_tests.rs
@@ -24,7 +24,10 @@ fn test_with_result_mixed_blocks_preserves_non_text() {
     let parser = DslParser;
     let blocks = vec![
         ContentBlock::Text("Hello world".to_string()),
-        ContentBlock::Thinking("thinking...".to_string()),
+        ContentBlock::Thinking {
+            thinking: "thinking...".to_string(),
+            signature: None,
+        },
         ContentBlock::Text("::button[label:A;action:x;value:1]".to_string()),
         ContentBlock::ToolUse {
             id: "call_1".to_string(),
@@ -46,7 +49,7 @@ fn test_with_result_mixed_blocks_preserves_non_text() {
     // Non-Text blocks preserved, empty Text blocks (DSL-only) dropped
     assert_eq!(updated_blocks.len(), 5);
     assert!(matches!(&updated_blocks[0], ContentBlock::Text(s) if s == "Hello world"));
-    assert!(matches!(&updated_blocks[1], ContentBlock::Thinking(_)));
+    assert!(matches!(&updated_blocks[1], ContentBlock::Thinking { .. }));
     assert!(matches!(&updated_blocks[2], ContentBlock::ToolUse { .. }));
     assert!(matches!(&updated_blocks[3], ContentBlock::Text(s) if s == "Done"));
     assert!(matches!(
@@ -100,7 +103,10 @@ fn test_with_result_empty_input() {
 fn test_with_result_only_non_text_blocks() {
     let parser = DslParser;
     let blocks = vec![
-        ContentBlock::Thinking("hmm".to_string()),
+        ContentBlock::Thinking {
+            thinking: "hmm".to_string(),
+            signature: None,
+        },
         ContentBlock::ToolUse {
             id: "c1".to_string(),
             name: "fn".to_string(),
@@ -128,7 +134,10 @@ async fn test_process_with_content_blocks_non_empty() {
         "fallback content",
         vec![
             ContentBlock::Text("Hello\n::button[label:X;action:a;value:1]".to_string()),
-            ContentBlock::Thinking("think".to_string()),
+            ContentBlock::Thinking {
+                thinking: "think".to_string(),
+                signature: None,
+            },
             ContentBlock::Text("World".to_string()),
         ],
     );
@@ -139,7 +148,7 @@ async fn test_process_with_content_blocks_non_empty() {
     assert!(matches!(&result.content_blocks[0], ContentBlock::Text(s) if s == "Hello"));
     assert!(matches!(
         &result.content_blocks[1],
-        ContentBlock::Thinking(_)
+        ContentBlock::Thinking { .. }
     ));
     assert!(matches!(&result.content_blocks[2], ContentBlock::Text(s) if s == "World"));
 }

--- a/tests/minimax_mock_tests.rs
+++ b/tests/minimax_mock_tests.rs
@@ -104,10 +104,9 @@ async fn test_provider_send_reasoning_content_mock() {
         .unwrap();
 
     m.assert_async().await;
-    assert!(resp
-        .content_blocks
-        .iter()
-        .any(|b| { matches!(b, RawContentBlock::Thinking(s) if s.contains("thinking")) }));
+    assert!(resp.content_blocks.iter().any(|b| {
+        matches!(b, RawContentBlock::Thinking { thinking: s, .. } if s.contains("thinking"))
+    }));
 }
 
 // --- send() error cases ---


### PR DESCRIPTION
fix: align protocol mapping layer with design doc

修复协议映射层代码与设计文档的两处不一致：

1. OpenAI content/reasoning_content 互斥回退规则：content 非空优先取 content，为空时回退到 reasoning_content（非流式+流式）
2. Anthropic thinking signature 字段保留：Thinking block 增加 signature 字段，非流式提取时保留签名

涉及类型变更（Thinking tuple → struct）、全局 40+ 处下游更新、测试用例补充。

Source: user
Type: fix
