### PR TITLE
feat: complete Anthropic protocol mapping for parse_response and parse_sse_stream

### DIFF
--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -1,15 +1,15 @@
 //! Anthropic ChatProtocol implementation.
 //!
-//! This is a **stub** implementation: SSE streaming is not yet supported
-//! (`parse_sse_stream` returns an empty stream). The HTTP request/response
-//! path (`build_request` / `parse_response`) is fully implemented.
+//! Implements `parse_response` with full content block parsing and
+//! `parse_sse_stream` with complete Anthropic SSE event handling.
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 
 use crate::llm::types::{
-    InternalMessage, InternalRequest, InternalResponse, ProtocolId, RawContentBlock, RawUsage,
-    SseStateMachine,
+    ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
+    RawContentBlock, RawUsage, SseStateMachine, StreamEvent,
 };
 use crate::session::persistence::ReasoningLevel;
 
@@ -287,11 +287,224 @@ impl ChatProtocol for AnthropicProtocol {
 
     async fn parse_sse_stream(
         &self,
-        _incoming: IncomingSseStream,
+        incoming: IncomingSseStream,
         _machine: SseStateMachine,
     ) -> OutgoingEventStream {
-        // Stub: streaming not yet implemented — return an empty stream.
-        Box::pin(futures::stream::empty())
+        Box::pin(async_stream::try_stream! {
+            let mut stream = incoming;
+            let mut stop_reason: Option<String> = None;
+            let mut usage: Option<RawUsage> = None;
+
+            while let Some(chunk) = stream.next().await {
+                let data = chunk.data.trim();
+                if data.is_empty() {
+                    continue;
+                }
+
+                let parsed: serde_json::Value = match serde_json::from_str(data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                let event_type = chunk.event_type.as_str();
+                match event_type {
+                    "message_start" => {
+                        let message = parsed.get("message");
+                        if let Some(msg_usage) = message
+                            .and_then(|m| m.get("usage"))
+                        {
+                            usage = Some(parse_usage(
+                                msg_usage,
+                            ));
+                        }
+                    }
+                    "content_block_start" => {
+                        let index = parsed
+                            .get("index")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as usize;
+                        let block_type = match parsed
+                            .get("content_block")
+                            .and_then(|cb| cb.get("type"))
+                            .and_then(|v| v.as_str())
+                        {
+                            Some("text") => {
+                                ContentBlockType::Text
+                            }
+                            Some("thinking") => {
+                                ContentBlockType::Thinking
+                            }
+                            Some("tool_use") => {
+                                ContentBlockType::ToolUse
+                            }
+                            _ => continue,
+                        };
+                        yield StreamEvent::BlockStart {
+                            index,
+                            block_type,
+                        };
+                        if block_type
+                            == ContentBlockType::ToolUse
+                        {
+                            let cb = parsed
+                                .get("content_block")
+                                .unwrap();
+                            if let Some(id) = cb
+                                .get("id")
+                                .and_then(|v| v.as_str())
+                            {
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::ToolUseId {
+                                        id: id.to_string(),
+                                    },
+                                };
+                            }
+                            if let Some(name) = cb
+                                .get("name")
+                                .and_then(|v| v.as_str())
+                            {
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::ToolUseName {
+                                        name: name.to_string(),
+                                    },
+                                };
+                            }
+                        }
+                    }
+                    "content_block_delta" => {
+                        let index = parsed
+                            .get("index")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as usize;
+                        let delta = parsed.get("delta");
+                        match delta
+                            .and_then(|d| d.get("type"))
+                            .and_then(|v| v.as_str())
+                        {
+                            Some("text_delta") => {
+                                let text = delta
+                                    .and_then(|d| d.get("text"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::Text {
+                                        text: text.to_string(),
+                                    },
+                                };
+                            }
+                            Some("thinking_delta") => {
+                                let thinking = delta
+                                    .and_then(|d| d.get("thinking"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::Thinking {
+                                        thinking: thinking.to_string(),
+                                        signature: None,
+                                    },
+                                };
+                            }
+                            Some("signature_delta") => {
+                                let value = delta
+                                    .and_then(|d| d.get("signature"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::Thinking {
+                                        thinking: String::new(),
+                                        signature: Some(
+                                            value.to_string(),
+                                        ),
+                                    },
+                                };
+                            }
+                            Some("input_json_delta") => {
+                                let input = delta
+                                    .and_then(|d| d.get("partial_json"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                yield StreamEvent::BlockDelta {
+                                    index,
+                                    delta: ContentDelta::ToolUseInputChunk {
+                                        input: input.to_string(),
+                                    },
+                                };
+                            }
+                            _ => {}
+                        }
+                    }
+                    "content_block_stop" => {
+                        let index = parsed
+                            .get("index")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as usize;
+                        yield StreamEvent::BlockEnd {
+                            index,
+                            block_type: ContentBlockType::Text,
+                        };
+                    }
+                    "message_delta" => {
+                        if let Some(sr) = parsed
+                            .get("delta")
+                            .and_then(|d| d.get("stop_reason"))
+                            .and_then(|v| v.as_str())
+                        {
+                            stop_reason = Some(
+                                sr.to_string(),
+                            );
+                        }
+                        if let Some(msg_usage) = parsed
+                            .get("usage")
+                        {
+                            let output_tokens = msg_usage
+                                .get("output_tokens")
+                                .and_then(|v| v.as_u64())
+                                .unwrap_or(0) as u32;
+                            usage = Some(RawUsage {
+                                prompt_tokens: usage
+                                    .as_ref()
+                                    .map(|u| u.prompt_tokens)
+                                    .unwrap_or(0),
+                                completion_tokens: output_tokens,
+                                total_tokens: usage
+                                    .as_ref()
+                                    .and_then(|u| u.total_tokens),
+                                cache_read_tokens: usage
+                                    .as_ref()
+                                    .and_then(|u| u.cache_read_tokens),
+                                cache_write_tokens: usage
+                                    .as_ref()
+                                    .and_then(|u| u.cache_write_tokens),
+                            });
+                        }
+                    }
+                    "message_stop" => {
+                        yield StreamEvent::MessageEnd {
+                            usage: usage.as_ref().map(|u| u.clone().into()),
+                            finish_reason: stop_reason
+                                .clone(),
+                        };
+                    }
+                    "error" => {
+                        let message = parsed
+                            .get("error")
+                            .and_then(|e| e.get("message"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown error");
+                        yield StreamEvent::Error {
+                            message: message.to_string(),
+                        };
+                    }
+                    "ping" => {}
+                    _ => {}
+                }
+            }
+        })
     }
 }
 

--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use std::collections::HashMap;
 
 use crate::llm::types::{
     ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
@@ -18,6 +19,8 @@ use crate::llm::protocol::{
 };
 
 const PATH: &str = "/v1/messages";
+
+// ─── AnthropicProtocol ───────────────────────────────────────────────────────
 
 /// Anthropic protocol implementation.
 #[derive(Debug, Clone)]
@@ -39,231 +42,24 @@ impl Default for AnthropicProtocol {
     }
 }
 
-/// Build an Anthropic `/v1/messages` request body.
-///
-/// Anthropic request format:
-/// ```json
-/// {
-///   "model": "claude-3-5-sonnet-20241022",
-///   "messages": [{"role": "user", "content": "..."}],
-///   "max_tokens": 1024,
-///   "system": "optional system prompt"
-/// }
-/// ```
-fn build_message(msg: &InternalMessage) -> serde_json::Value {
-    serde_json::json!({
-        "role": msg.role,
-        "content": msg.content,
-    })
-}
-
-/// Mark the last message with `cache_control` for Anthropic prefix caching.
-///
-/// The API allows mixing string and content-blocks content formats within
-/// the messages array, so only the final message is converted.
-fn mark_last_message_cache_control(messages: &mut [serde_json::Value]) {
-    if let Some(last_msg) = messages.last_mut() {
-        if let Some(content) = last_msg.get("content").and_then(|c| c.as_str()) {
-            let text = content.to_string();
-            last_msg.as_object_mut().unwrap().insert(
-                "content".to_string(),
-                serde_json::json!([{
-                    "type": "text",
-                    "text": text,
-                    "cache_control": { "type": "ephemeral" }
-                }]),
-            );
-        }
-    }
-}
-
-/// Build the Anthropic `system` array from system blocks.
-///
-/// Each block with `cache=true` gets a `cache_control` marker.
-fn build_system_array(blocks: &[crate::llm::types::SystemBlock]) -> Vec<serde_json::Value> {
-    blocks
-        .iter()
-        .map(|b| {
-            let mut obj = serde_json::json!({
-                "type": "text",
-                "text": b.text,
-            });
-            if b.cache {
-                obj.as_object_mut().unwrap().insert(
-                    "cache_control".to_string(),
-                    serde_json::json!({ "type": "ephemeral" }),
-                );
-            }
-            obj
-        })
-        .collect()
-}
+// ─── ChatProtocol trait implementation ───────────────────────────────────────
 
 #[async_trait]
 impl ChatProtocol for AnthropicProtocol {
     fn protocol_id(&self) -> &ProtocolId {
         &self.id
     }
+
     fn path(&self) -> &str {
         PATH
     }
 
     fn build_request(&self, request: &InternalRequest) -> Result<serde_json::Value> {
-        // Anthropic does not support reasoning level parameters.
-        if request.reasoning_level != ReasoningLevel::High {
-            tracing::warn!(
-                reasoning_level = %request.reasoning_level,
-                "Anthropic protocol does not support reasoning_level parameter, ignoring"
-            );
-        }
-
-        let mut messages: Vec<serde_json::Value> =
-            request.messages.iter().map(build_message).collect();
-
-        mark_last_message_cache_control(&mut messages);
-
-        let mut body = serde_json::json!({
-            "model": request.model,
-            "messages": messages,
-        });
-
-        if let Some(max_tokens) = request.max_tokens {
-            body.as_object_mut()
-                .unwrap()
-                .insert("max_tokens".to_string(), serde_json::json!(max_tokens));
-        }
-
-        // Only include temperature if it differs from the default (0.0).
-        if request.temperature != 0.0 {
-            body.as_object_mut().unwrap().insert(
-                "temperature".to_string(),
-                serde_json::json!(request.temperature),
-            );
-        }
-
-        if let Some(ref blocks) = request.system_blocks {
-            if !blocks.is_empty() {
-                let system_array = build_system_array(blocks);
-                body.as_object_mut()
-                    .unwrap()
-                    .insert("system".to_string(), serde_json::json!(system_array));
-            }
-        }
-
-        for (key, value) in &request.extra_body {
-            body.as_object_mut()
-                .unwrap()
-                .insert(key.clone(), value.clone());
-        }
-
-        Ok(body)
+        build_request_body(request)
     }
 
     fn parse_response(&self, body: serde_json::Value) -> Result<InternalResponse> {
-        // Anthropic response: { "content": [{"type": "text", "text": "..."}] }
-        let content_blocks: Vec<RawContentBlock> = body
-            .get("content")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|item| {
-                        let ty = item.get("type").and_then(|v| v.as_str());
-                        match ty {
-                            Some("text") => item
-                                .get("text")
-                                .and_then(|v| v.as_str())
-                                .map(|s| RawContentBlock::Text(s.to_string())),
-                            Some("thinking") => {
-                                let thinking =
-                                    item.get("thinking").and_then(|v| v.as_str()).unwrap_or("");
-                                let signature = item
-                                    .get("signature")
-                                    .and_then(|v| v.as_str())
-                                    .map(|s| s.to_string());
-                                Some(RawContentBlock::Thinking {
-                                    thinking: thinking.to_string(),
-                                    signature,
-                                })
-                            }
-                            Some("tool_use") => {
-                                let id = item
-                                    .get("id")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let name = item
-                                    .get("name")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let input = item
-                                    .get("input")
-                                    .map(|v| {
-                                        if v.is_object() && v.as_object().unwrap().is_empty() {
-                                            "{}".to_string()
-                                        } else {
-                                            v.to_string()
-                                        }
-                                    })
-                                    .unwrap_or_else(|| "{}".to_string());
-                                Some(RawContentBlock::ToolUse { id, name, input })
-                            }
-                            Some("tool_result") => {
-                                let tool_call_id = item
-                                    .get("tool_use_id")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let content = item
-                                    .get("content")
-                                    .map(|v| {
-                                        if let Some(s) = v.as_str() {
-                                            s.to_string()
-                                        } else if let Some(arr) = v.as_array() {
-                                            arr.iter()
-                                                .filter_map(|block| {
-                                                    if block.get("type").and_then(|t| t.as_str())
-                                                        == Some("text")
-                                                    {
-                                                        block
-                                                            .get("text")
-                                                            .and_then(|t| t.as_str())
-                                                            .map(|s| s.to_string())
-                                                    } else {
-                                                        None
-                                                    }
-                                                })
-                                                .collect::<Vec<_>>()
-                                                .join("")
-                                        } else {
-                                            String::new()
-                                        }
-                                    })
-                                    .unwrap_or_default();
-                                Some(RawContentBlock::ToolResult {
-                                    tool_call_id,
-                                    content,
-                                })
-                            }
-                            _ => None,
-                        }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let usage = parse_usage(&body);
-
-        let finish_reason = body
-            .get("stop_reason")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        Ok(InternalResponse {
-            content_blocks,
-            usage,
-            finish_reason,
-        })
+        parse_response_body(body)
     }
 
     fn decorate_headers(&self, headers: &mut HeaderMap) -> Result<()> {
@@ -290,232 +86,231 @@ impl ChatProtocol for AnthropicProtocol {
         incoming: IncomingSseStream,
         _machine: SseStateMachine,
     ) -> OutgoingEventStream {
-        Box::pin(async_stream::try_stream! {
-            let mut stream = incoming;
-            let mut stop_reason: Option<String> = None;
-            let mut usage: Option<RawUsage> = None;
-            let mut block_type_map: std::collections::HashMap<usize, ContentBlockType> =
-                std::collections::HashMap::new();
-
-            while let Some(chunk) = stream.next().await {
-                let data = chunk.data.trim();
-                if data.is_empty() {
-                    continue;
-                }
-
-                let parsed: serde_json::Value = match serde_json::from_str(data) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-
-                let event_type = chunk.event_type.as_str();
-                match event_type {
-                    "message_start" => {
-                        let message = parsed.get("message");
-                        if let Some(msg_usage) = message
-                            .and_then(|m| m.get("usage"))
-                        {
-                            usage = Some(parse_usage(
-                                msg_usage,
-                            ));
-                        }
-                    }
-                    "content_block_start" => {
-                        let index = parsed
-                            .get("index")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0) as usize;
-                        let block_type = match parsed
-                            .get("content_block")
-                            .and_then(|cb| cb.get("type"))
-                            .and_then(|v| v.as_str())
-                        {
-                            Some("text") => {
-                                ContentBlockType::Text
-                            }
-                            Some("thinking") => {
-                                ContentBlockType::Thinking
-                            }
-                            Some("tool_use") => {
-                                ContentBlockType::ToolUse
-                            }
-                            _ => continue,
-                        };
-                        block_type_map.insert(index, block_type);
-                        yield StreamEvent::BlockStart {
-                            index,
-                            block_type,
-                        };
-                        if block_type
-                            == ContentBlockType::ToolUse
-                        {
-                            let cb = parsed
-                                .get("content_block")
-                                .unwrap();
-                            if let Some(id) = cb
-                                .get("id")
-                                .and_then(|v| v.as_str())
-                            {
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::ToolUseId {
-                                        id: id.to_string(),
-                                    },
-                                };
-                            }
-                            if let Some(name) = cb
-                                .get("name")
-                                .and_then(|v| v.as_str())
-                            {
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::ToolUseName {
-                                        name: name.to_string(),
-                                    },
-                                };
-                            }
-                        }
-                    }
-                    "content_block_delta" => {
-                        let index = parsed
-                            .get("index")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0) as usize;
-                        let delta = parsed.get("delta");
-                        match delta
-                            .and_then(|d| d.get("type"))
-                            .and_then(|v| v.as_str())
-                        {
-                            Some("text_delta") => {
-                                let text = delta
-                                    .and_then(|d| d.get("text"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("");
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::Text {
-                                        text: text.to_string(),
-                                    },
-                                };
-                            }
-                            Some("thinking_delta") => {
-                                let thinking = delta
-                                    .and_then(|d| d.get("thinking"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("");
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::Thinking {
-                                        thinking: thinking.to_string(),
-                                        signature: None,
-                                    },
-                                };
-                            }
-                            Some("signature_delta") => {
-                                let value = delta
-                                    .and_then(|d| d.get("signature"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("");
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::Thinking {
-                                        thinking: String::new(),
-                                        signature: Some(
-                                            value.to_string(),
-                                        ),
-                                    },
-                                };
-                            }
-                            Some("input_json_delta") => {
-                                let input = delta
-                                    .and_then(|d| d.get("partial_json"))
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("");
-                                yield StreamEvent::BlockDelta {
-                                    index,
-                                    delta: ContentDelta::ToolUseInputChunk {
-                                        input: input.to_string(),
-                                    },
-                                };
-                            }
-                            _ => {}
-                        }
-                    }
-                    "content_block_stop" => {
-                        let index = parsed
-                            .get("index")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0) as usize;
-                        let block_type = block_type_map
-                            .remove(&index)
-                            .unwrap_or(ContentBlockType::Text);
-                        yield StreamEvent::BlockEnd {
-                            index,
-                            block_type,
-                        };
-                    }
-                    "message_delta" => {
-                        if let Some(sr) = parsed
-                            .get("delta")
-                            .and_then(|d| d.get("stop_reason"))
-                            .and_then(|v| v.as_str())
-                        {
-                            stop_reason = Some(
-                                sr.to_string(),
-                            );
-                        }
-                        if let Some(msg_usage) = parsed
-                            .get("usage")
-                        {
-                            let output_tokens = msg_usage
-                                .get("output_tokens")
-                                .and_then(|v| v.as_u64())
-                                .unwrap_or(0) as u32;
-                            usage = Some(RawUsage {
-                                prompt_tokens: usage
-                                    .as_ref()
-                                    .map(|u| u.prompt_tokens)
-                                    .unwrap_or(0),
-                                completion_tokens: output_tokens,
-                                total_tokens: usage
-                                    .as_ref()
-                                    .and_then(|u| u.total_tokens),
-                                cache_read_tokens: usage
-                                    .as_ref()
-                                    .and_then(|u| u.cache_read_tokens),
-                                cache_write_tokens: usage
-                                    .as_ref()
-                                    .and_then(|u| u.cache_write_tokens),
-                            });
-                        }
-                    }
-                    "message_stop" => {
-                        yield StreamEvent::MessageEnd {
-                            usage: usage.as_ref().map(|u| u.clone().into()),
-                            finish_reason: stop_reason
-                                .clone(),
-                        };
-                    }
-                    "error" => {
-                        let message = parsed
-                            .get("error")
-                            .and_then(|e| e.get("message"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown error");
-                        yield StreamEvent::Error {
-                            message: message.to_string(),
-                        };
-                    }
-                    "ping" => {}
-                    _ => {}
-                }
-            }
-        })
+        parse_sse(incoming)
     }
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── build_request helpers ───────────────────────────────────────────────────
 
+/// Build an Anthropic `/v1/messages` request body.
+fn build_request_body(request: &InternalRequest) -> Result<serde_json::Value> {
+    if request.reasoning_level != ReasoningLevel::High {
+        tracing::warn!(
+            reasoning_level = %request.reasoning_level,
+            "Anthropic protocol does not support reasoning_level parameter, ignoring"
+        );
+    }
+
+    let mut messages: Vec<serde_json::Value> = request.messages.iter().map(build_message).collect();
+
+    mark_last_message_cache_control(&mut messages);
+
+    let mut body = serde_json::json!({
+        "model": request.model,
+        "messages": messages,
+    });
+
+    if let Some(max_tokens) = request.max_tokens {
+        body.as_object_mut()
+            .unwrap()
+            .insert("max_tokens".to_string(), serde_json::json!(max_tokens));
+    }
+
+    // Only include temperature if it differs from the default (0.0).
+    if request.temperature != 0.0 {
+        body.as_object_mut().unwrap().insert(
+            "temperature".to_string(),
+            serde_json::json!(request.temperature),
+        );
+    }
+
+    if let Some(ref blocks) = request.system_blocks {
+        if !blocks.is_empty() {
+            let system_array = build_system_array(blocks);
+            body.as_object_mut()
+                .unwrap()
+                .insert("system".to_string(), serde_json::json!(system_array));
+        }
+    }
+
+    for (key, value) in &request.extra_body {
+        body.as_object_mut()
+            .unwrap()
+            .insert(key.clone(), value.clone());
+    }
+
+    Ok(body)
+}
+
+/// Build a single message JSON for Anthropic.
+fn build_message(msg: &InternalMessage) -> serde_json::Value {
+    serde_json::json!({
+        "role": msg.role,
+        "content": msg.content,
+    })
+}
+
+/// Mark the last message with `cache_control` for Anthropic prefix caching.
+fn mark_last_message_cache_control(messages: &mut [serde_json::Value]) {
+    if let Some(last_msg) = messages.last_mut() {
+        if let Some(content) = last_msg.get("content").and_then(|c| c.as_str()) {
+            let text = content.to_string();
+            last_msg.as_object_mut().unwrap().insert(
+                "content".to_string(),
+                serde_json::json!([{
+                    "type": "text",
+                    "text": text,
+                    "cache_control": { "type": "ephemeral" }
+                }]),
+            );
+        }
+    }
+}
+
+/// Build the Anthropic `system` array from system blocks.
+fn build_system_array(blocks: &[crate::llm::types::SystemBlock]) -> Vec<serde_json::Value> {
+    blocks
+        .iter()
+        .map(|b| {
+            let mut obj = serde_json::json!({
+                "type": "text",
+                "text": b.text,
+            });
+            if b.cache {
+                obj.as_object_mut().unwrap().insert(
+                    "cache_control".to_string(),
+                    serde_json::json!({ "type": "ephemeral" }),
+                );
+            }
+            obj
+        })
+        .collect()
+}
+
+// ─── parse_response helpers ──────────────────────────────────────────────────
+
+/// Parse Anthropic response body into `InternalResponse`.
+fn parse_response_body(body: serde_json::Value) -> Result<InternalResponse> {
+    let content_blocks: Vec<RawContentBlock> = body
+        .get("content")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(parse_content_block).collect())
+        .unwrap_or_default();
+
+    let usage = parse_usage(&body);
+    let finish_reason = body
+        .get("stop_reason")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok(InternalResponse {
+        content_blocks,
+        usage,
+        finish_reason,
+    })
+}
+
+/// Parse a single content block from the Anthropic response.
+fn parse_content_block(item: &serde_json::Value) -> Option<RawContentBlock> {
+    let ty = item.get("type").and_then(|v| v.as_str());
+    match ty {
+        Some("text") => parse_text_block(item),
+        Some("thinking") => parse_thinking_block(item),
+        Some("tool_use") => parse_tool_use_block(item),
+        Some("tool_result") => parse_tool_result_block(item),
+        _ => None,
+    }
+}
+
+/// Parse a text content block.
+fn parse_text_block(item: &serde_json::Value) -> Option<RawContentBlock> {
+    item.get("text")
+        .and_then(|v| v.as_str())
+        .map(|s| RawContentBlock::Text(s.to_string()))
+}
+
+/// Parse a thinking content block.
+fn parse_thinking_block(item: &serde_json::Value) -> Option<RawContentBlock> {
+    let thinking = item.get("thinking").and_then(|v| v.as_str()).unwrap_or("");
+    let signature = item
+        .get("signature")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    Some(RawContentBlock::Thinking {
+        thinking: thinking.to_string(),
+        signature,
+    })
+}
+
+/// Parse a tool_use content block from Anthropic response.
+fn parse_tool_use_block(item: &serde_json::Value) -> Option<RawContentBlock> {
+    let id = item
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let name = item
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let input = item
+        .get("input")
+        .map(|v| {
+            if v.is_object() && v.as_object().unwrap().is_empty() {
+                "{}".to_string()
+            } else {
+                v.to_string()
+            }
+        })
+        .unwrap_or_else(|| "{}".to_string());
+    Some(RawContentBlock::ToolUse { id, name, input })
+}
+
+/// Parse a tool_result content block from Anthropic response.
+fn parse_tool_result_block(item: &serde_json::Value) -> Option<RawContentBlock> {
+    let tool_call_id = item
+        .get("tool_use_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let content = extract_tool_result_content(item);
+    Some(RawContentBlock::ToolResult {
+        tool_call_id,
+        content,
+    })
+}
+
+/// Extract content from a tool_result block.
+///
+/// The `content` field can be a string or an array of content blocks.
+fn extract_tool_result_content(item: &serde_json::Value) -> String {
+    item.get("content")
+        .map(|v| {
+            if let Some(s) = v.as_str() {
+                s.to_string()
+            } else if let Some(arr) = v.as_array() {
+                arr.iter()
+                    .filter_map(|block| {
+                        if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                            block
+                                .get("text")
+                                .and_then(|t| t.as_str())
+                                .map(|s| s.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("")
+            } else {
+                String::new()
+            }
+        })
+        .unwrap_or_default()
+}
+
+/// Parse usage information from a JSON value.
 fn parse_usage(body: &serde_json::Value) -> RawUsage {
     let usage_obj = body.get("usage");
 
@@ -551,4 +346,227 @@ fn parse_usage(body: &serde_json::Value) -> RawUsage {
         cache_read_tokens,
         cache_write_tokens,
     }
+}
+
+// ─── parse_sse_stream helpers ────────────────────────────────────────────────
+
+/// Parse an Anthropic SSE stream into unified `StreamEvent`s.
+fn parse_sse(incoming: IncomingSseStream) -> OutgoingEventStream {
+    Box::pin(async_stream::try_stream! {
+        let mut stream = incoming;
+        let mut stop_reason: Option<String> = None;
+        let mut usage: Option<RawUsage> = None;
+        let mut block_type_map: HashMap<usize, ContentBlockType> = HashMap::new();
+
+        while let Some(chunk) = stream.next().await {
+            let data = chunk.data.trim();
+            if data.is_empty() {
+                continue;
+            }
+            let parsed: serde_json::Value = match serde_json::from_str(data) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            for event in dispatch_sse_event(&chunk.event_type, &parsed, &mut block_type_map, &mut usage, &mut stop_reason) {
+                yield event;
+            }
+        }
+    })
+}
+
+/// Dispatch a single SSE event into one or more `StreamEvent`s.
+fn dispatch_sse_event(
+    event_type: &str,
+    parsed: &serde_json::Value,
+    block_type_map: &mut HashMap<usize, ContentBlockType>,
+    usage: &mut Option<RawUsage>,
+    stop_reason: &mut Option<String>,
+) -> Vec<StreamEvent> {
+    match event_type {
+        "message_start" => {
+            *usage = parse_message_start_usage(parsed).or_else(|| usage.take());
+            vec![]
+        }
+        "content_block_start" => parse_content_block_start(parsed, block_type_map),
+        "content_block_delta" => parse_content_block_delta(parsed).into_iter().collect(),
+        "content_block_stop" => parse_content_block_stop(parsed, block_type_map)
+            .into_iter()
+            .collect(),
+        "message_delta" => {
+            if let Some(sr) = extract_stop_reason(parsed) {
+                *stop_reason = Some(sr);
+            }
+            update_usage_from_message_delta(parsed, usage);
+            vec![]
+        }
+        "message_stop" => {
+            vec![StreamEvent::MessageEnd {
+                usage: usage.as_ref().map(|u| u.clone().into()),
+                finish_reason: stop_reason.clone(),
+            }]
+        }
+        "error" => {
+            vec![StreamEvent::Error {
+                message: extract_error_message(parsed),
+            }]
+        }
+        _ => vec![],
+    }
+}
+
+/// Parse initial usage from `message_start` event.
+fn parse_message_start_usage(parsed: &serde_json::Value) -> Option<RawUsage> {
+    parsed
+        .get("message")
+        .and_then(|m| m.get("usage"))
+        .map(parse_usage)
+}
+
+/// Handle `content_block_start` event: record block type and emit events.
+fn parse_content_block_start(
+    parsed: &serde_json::Value,
+    block_type_map: &mut HashMap<usize, ContentBlockType>,
+) -> Vec<StreamEvent> {
+    let index = parsed.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+    let block_type = match parsed
+        .get("content_block")
+        .and_then(|cb| cb.get("type"))
+        .and_then(|v| v.as_str())
+    {
+        Some("text") => ContentBlockType::Text,
+        Some("thinking") => ContentBlockType::Thinking,
+        Some("tool_use") => ContentBlockType::ToolUse,
+        _ => return vec![],
+    };
+
+    block_type_map.insert(index, block_type);
+    let mut events = vec![StreamEvent::BlockStart { index, block_type }];
+
+    // For tool_use, also yield id and name deltas
+    if block_type == ContentBlockType::ToolUse {
+        let cb = parsed.get("content_block").unwrap();
+        if let Some(id) = cb.get("id").and_then(|v| v.as_str()) {
+            events.push(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::ToolUseId { id: id.to_string() },
+            });
+        }
+        if let Some(name) = cb.get("name").and_then(|v| v.as_str()) {
+            events.push(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::ToolUseName {
+                    name: name.to_string(),
+                },
+            });
+        }
+    }
+
+    events
+}
+
+/// Handle `content_block_delta` event.
+fn parse_content_block_delta(parsed: &serde_json::Value) -> Option<StreamEvent> {
+    let index = parsed.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let delta = parsed.get("delta")?;
+
+    match delta.get("type").and_then(|v| v.as_str()) {
+        Some("text_delta") => {
+            let text = delta.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            Some(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::Text {
+                    text: text.to_string(),
+                },
+            })
+        }
+        Some("thinking_delta") => {
+            let thinking = delta.get("thinking").and_then(|v| v.as_str()).unwrap_or("");
+            Some(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::Thinking {
+                    thinking: thinking.to_string(),
+                    signature: None,
+                },
+            })
+        }
+        Some("signature_delta") => {
+            let value = delta
+                .get("signature")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Some(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::Thinking {
+                    thinking: String::new(),
+                    signature: Some(value.to_string()),
+                },
+            })
+        }
+        Some("input_json_delta") => {
+            let input = delta
+                .get("partial_json")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Some(StreamEvent::BlockDelta {
+                index,
+                delta: ContentDelta::ToolUseInputChunk {
+                    input: input.to_string(),
+                },
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Handle `content_block_stop` event.
+fn parse_content_block_stop(
+    parsed: &serde_json::Value,
+    block_type_map: &mut HashMap<usize, ContentBlockType>,
+) -> Option<StreamEvent> {
+    let index = parsed.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let block_type = block_type_map
+        .remove(&index)
+        .unwrap_or(ContentBlockType::Text);
+    Some(StreamEvent::BlockEnd { index, block_type })
+}
+
+/// Extract stop_reason from `message_delta` event.
+fn extract_stop_reason(parsed: &serde_json::Value) -> Option<String> {
+    parsed
+        .get("delta")
+        .and_then(|d| d.get("stop_reason"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Update usage from `message_delta` event.
+fn update_usage_from_message_delta(parsed: &serde_json::Value, usage: &mut Option<RawUsage>) {
+    let msg_usage = match parsed.get("usage") {
+        Some(u) => u,
+        None => return,
+    };
+
+    let output_tokens = msg_usage
+        .get("output_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+
+    *usage = Some(RawUsage {
+        prompt_tokens: usage.as_ref().map(|u| u.prompt_tokens).unwrap_or(0),
+        completion_tokens: output_tokens,
+        total_tokens: usage.as_ref().and_then(|u| u.total_tokens),
+        cache_read_tokens: usage.as_ref().and_then(|u| u.cache_read_tokens),
+        cache_write_tokens: usage.as_ref().and_then(|u| u.cache_write_tokens),
+    });
+}
+
+/// Extract error message from an `error` event.
+fn extract_error_message(parsed: &serde_json::Value) -> String {
+    parsed
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown error")
+        .to_string()
 }

--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -185,6 +185,66 @@ impl ChatProtocol for AnthropicProtocol {
                                     signature,
                                 })
                             }
+                            Some("tool_use") => {
+                                let id = item
+                                    .get("id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let name = item
+                                    .get("name")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let input = item
+                                    .get("input")
+                                    .map(|v| {
+                                        if v.is_object() && v.as_object().unwrap().is_empty() {
+                                            "{}".to_string()
+                                        } else {
+                                            v.to_string()
+                                        }
+                                    })
+                                    .unwrap_or_else(|| "{}".to_string());
+                                Some(RawContentBlock::ToolUse { id, name, input })
+                            }
+                            Some("tool_result") => {
+                                let tool_call_id = item
+                                    .get("tool_use_id")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let content = item
+                                    .get("content")
+                                    .map(|v| {
+                                        if let Some(s) = v.as_str() {
+                                            s.to_string()
+                                        } else if let Some(arr) = v.as_array() {
+                                            arr.iter()
+                                                .filter_map(|block| {
+                                                    if block.get("type").and_then(|t| t.as_str())
+                                                        == Some("text")
+                                                    {
+                                                        block
+                                                            .get("text")
+                                                            .and_then(|t| t.as_str())
+                                                            .map(|s| s.to_string())
+                                                    } else {
+                                                        None
+                                                    }
+                                                })
+                                                .collect::<Vec<_>>()
+                                                .join("")
+                                        } else {
+                                            String::new()
+                                        }
+                                    })
+                                    .unwrap_or_default();
+                                Some(RawContentBlock::ToolResult {
+                                    tool_call_id,
+                                    content,
+                                })
+                            }
                             _ => None,
                         }
                     })

--- a/src/llm/protocol/anthropic.rs
+++ b/src/llm/protocol/anthropic.rs
@@ -294,6 +294,8 @@ impl ChatProtocol for AnthropicProtocol {
             let mut stream = incoming;
             let mut stop_reason: Option<String> = None;
             let mut usage: Option<RawUsage> = None;
+            let mut block_type_map: std::collections::HashMap<usize, ContentBlockType> =
+                std::collections::HashMap::new();
 
             while let Some(chunk) = stream.next().await {
                 let data = chunk.data.trim();
@@ -339,6 +341,7 @@ impl ChatProtocol for AnthropicProtocol {
                             }
                             _ => continue,
                         };
+                        block_type_map.insert(index, block_type);
                         yield StreamEvent::BlockStart {
                             index,
                             block_type,
@@ -443,9 +446,12 @@ impl ChatProtocol for AnthropicProtocol {
                             .get("index")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(0) as usize;
+                        let block_type = block_type_map
+                            .remove(&index)
+                            .unwrap_or(ContentBlockType::Text);
                         yield StreamEvent::BlockEnd {
                             index,
-                            block_type: ContentBlockType::Text,
+                            block_type,
                         };
                     }
                     "message_delta" => {

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -2,9 +2,14 @@
 
 use reqwest::header::{HeaderMap, CONTENT_TYPE};
 
-use crate::llm::protocol::{AnthropicProtocol, ChatProtocol};
-use crate::llm::types::{InternalMessage, InternalRequest, RawContentBlock};
+use crate::llm::protocol::{AnthropicProtocol, ChatProtocol, IncomingSseStream};
+use crate::llm::types::{
+    ContentBlockType, ContentDelta, InternalMessage, InternalRequest, RawContentBlock, RawSseChunk,
+    StreamEvent,
+};
 use crate::session::persistence::ReasoningLevel;
+
+use futures::StreamExt;
 
 fn make_request() -> InternalRequest {
     InternalRequest {
@@ -24,6 +29,13 @@ fn make_request() -> InternalRequest {
         session_id: None,
         reasoning_level: ReasoningLevel::default(),
         turn_count: None,
+    }
+}
+
+fn make_sse_chunk(event_type: &str, data: &str) -> RawSseChunk {
+    RawSseChunk {
+        event_type: event_type.to_string(),
+        data: data.to_string(),
     }
 }
 
@@ -210,6 +222,171 @@ fn test_parse_response_missing_usage_defaults() {
     assert!(resp.usage.total_tokens.is_none());
 }
 
+#[test]
+fn test_parse_response_tool_use_block() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_01A09q90qw90lq917835lq9",
+                "name": "get_weather",
+                "input": {"location": "Beijing", "unit": "celsius"}
+            }
+        ],
+        "stop_reason": "tool_use"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    match &resp.content_blocks[0] {
+        RawContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "toolu_01A09q90qw90lq917835lq9");
+            assert_eq!(name, "get_weather");
+            let parsed: serde_json::Value = serde_json::from_str(input).unwrap();
+            assert_eq!(parsed.get("location").unwrap(), "Beijing");
+            assert_eq!(parsed.get("unit").unwrap(), "celsius");
+        }
+        other => panic!("Expected ToolUse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_response_tool_use_empty_input() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_empty",
+                "name": "ping",
+                "input": {}
+            }
+        ],
+        "stop_reason": "tool_use"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    match &resp.content_blocks[0] {
+        RawContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "toolu_empty");
+            assert_eq!(name, "ping");
+            assert_eq!(input, "{}");
+        }
+        other => panic!("Expected ToolUse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_response_tool_result_block() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01A09q90qw90lq917835lq9",
+                "content": "25°C, sunny"
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    match &resp.content_blocks[0] {
+        RawContentBlock::ToolResult {
+            tool_call_id,
+            content,
+        } => {
+            assert_eq!(tool_call_id, "toolu_01A09q90qw90lq917835lq9");
+            assert_eq!(content, "25°C, sunny");
+        }
+        other => panic!("Expected ToolResult, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_response_tool_result_array_content() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_arr",
+                "content": [
+                    {"type": "text", "text": "Hello "},
+                    {"type": "text", "text": "world"}
+                ]
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    match &resp.content_blocks[0] {
+        RawContentBlock::ToolResult {
+            tool_call_id,
+            content,
+        } => {
+            assert_eq!(tool_call_id, "toolu_arr");
+            assert_eq!(content, "Hello world");
+        }
+        other => panic!("Expected ToolResult, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_response_mixed_blocks() {
+    let proto = AnthropicProtocol::new();
+    let body = serde_json::json!({
+        "content": [
+            {"type": "thinking", "thinking": "Analyzing..."},
+            {"type": "text", "text": "Here is the result."},
+            {
+                "type": "tool_use",
+                "id": "toolu_mix",
+                "name": "search",
+                "input": {"q": "test"}
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_mix",
+                "content": "Found it"
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 4);
+
+    assert!(matches!(
+        &resp.content_blocks[0],
+        RawContentBlock::Thinking { .. }
+    ));
+    assert!(matches!(
+        &resp.content_blocks[1],
+        RawContentBlock::Text(s) if s == "Here is the result."
+    ));
+    match &resp.content_blocks[2] {
+        RawContentBlock::ToolUse { id, name, .. } => {
+            assert_eq!(id, "toolu_mix");
+            assert_eq!(name, "search");
+        }
+        other => panic!("Expected ToolUse at index 2, got {:?}", other),
+    }
+    match &resp.content_blocks[3] {
+        RawContentBlock::ToolResult {
+            tool_call_id,
+            content,
+        } => {
+            assert_eq!(tool_call_id, "toolu_mix");
+            assert_eq!(content, "Found it");
+        }
+        other => panic!("Expected ToolResult at index 3, got {:?}", other),
+    }
+}
+
 // ── cache usage parsing tests ─────────────────────────────────────────────
 
 #[test]
@@ -252,7 +429,6 @@ fn test_decorate_headers_api_key() {
     let mut headers = HeaderMap::new();
     proto.decorate_headers(&mut headers).unwrap();
 
-    // decorate_headers always inserts x-api-key (empty string when env var is unset)
     let key_header = headers.get("x-api-key");
     assert!(
         key_header.is_some(),
@@ -334,13 +510,12 @@ fn test_build_request_high_reasoning_level_no_injection() {
 #[test]
 fn test_messages_cache_control_single_message() {
     let proto = AnthropicProtocol::new();
-    let request = make_request(); // single "Hello" message
+    let request = make_request();
     let body = proto.build_request(&request).unwrap();
 
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
 
-    // Content should be a content blocks array with cache_control
     let content = messages[0].get("content").unwrap().as_array().unwrap();
     assert_eq!(content.len(), 1);
     assert_eq!(content[0].get("type").unwrap(), "text");
@@ -374,7 +549,6 @@ fn test_messages_cache_control_multiple_messages() {
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 3);
 
-    // First two messages should keep string content
     assert!(messages[0].get("content").unwrap().is_string());
     assert_eq!(messages[0].get("content").unwrap().as_str().unwrap(), "Hi");
     assert!(messages[1].get("content").unwrap().is_string());
@@ -383,7 +557,6 @@ fn test_messages_cache_control_multiple_messages() {
         "Hey!"
     );
 
-    // Last message should be content blocks with cache_control
     let last_content = messages[2].get("content").unwrap().as_array().unwrap();
     assert_eq!(last_content.len(), 1);
     assert_eq!(last_content[0].get("type").unwrap(), "text");
@@ -401,21 +574,16 @@ fn test_messages_cache_control_empty_messages() {
     request.messages = vec![];
     let body = proto.build_request(&request).unwrap();
 
-    // Empty messages should produce an empty array with no cache_control added
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert!(messages.is_empty());
 }
 
-/// Verify that ToolsSection content in `system_blocks` produces `cache_control`
-/// in the Anthropic request body, confirming the prefix-cache path covers tool
-/// definitions embedded in the static layer.
 #[test]
 fn test_build_request_tools_section_cache_control() {
     use crate::llm::types::SystemBlock;
 
     let proto = AnthropicProtocol::new();
     let mut request = make_request();
-    // Simulate a system prompt with role section followed by ToolsSection content
     let system_static = "Role: You are a helpful assistant.";
     let tools_section = "\n\n## Tools\n\n- web_search: search the web\n- read: read files";
     let full_static = format!("{system_static}{tools_section}");
@@ -461,7 +629,6 @@ fn test_messages_cache_control_with_system_blocks() {
     }]);
     let body = proto.build_request(&request).unwrap();
 
-    // System should have cache_control
     let system = body.get("system").unwrap().as_array().unwrap();
     assert_eq!(system.len(), 1);
     assert_eq!(
@@ -469,7 +636,6 @@ fn test_messages_cache_control_with_system_blocks() {
         &serde_json::json!({ "type": "ephemeral" })
     );
 
-    // Messages should also have cache_control on the last message
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
     let content = messages[0].get("content").unwrap().as_array().unwrap();
@@ -478,4 +644,314 @@ fn test_messages_cache_control_with_system_blocks() {
         content[0].get("cache_control").unwrap(),
         &serde_json::json!({ "type": "ephemeral" })
     );
+}
+
+// ── parse_sse_stream tests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_sse_text_stream() {
+    let proto = AnthropicProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(
+            "message_start",
+            r#"{"message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_start",
+            r#"{"index":0,"content_block":{"type":"text"}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"text_delta","text":"Hello"}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"text_delta","text":" world"}}"#,
+        ),
+        make_sse_chunk("content_block_stop", r#"{"index":0}"#),
+        make_sse_chunk(
+            "message_delta",
+            r#"{"delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}"#,
+        ),
+        make_sse_chunk("message_stop", "{}"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    // BlockStart(Text)
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockStart {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }
+    ));
+
+    // Text delta "Hello"
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text { text },
+        } if text == "Hello"
+    ));
+
+    // Text delta " world"
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Text { text },
+        } if text == " world"
+    ));
+
+    // BlockEnd(Text)
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockEnd {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }
+    ));
+
+    // MessageEnd
+    let evt = stream.next().await.unwrap().unwrap();
+    match evt {
+        StreamEvent::MessageEnd {
+            usage,
+            finish_reason,
+        } => {
+            assert_eq!(finish_reason, Some("end_turn".to_string()));
+            assert!(usage.is_some());
+            let u = usage.unwrap();
+            assert_eq!(u.completion_tokens, 2);
+        }
+        other => panic!("Expected MessageEnd, got {:?}", other),
+    }
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_sse_thinking_stream() {
+    let proto = AnthropicProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(
+            "message_start",
+            r#"{"message":{"usage":{"input_tokens":5,"output_tokens":0}}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_start",
+            r#"{"index":0,"content_block":{"type":"thinking"}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"thinking_delta","thinking":"Let me think..."}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"signature_delta","signature":"sig_abc"}}"#,
+        ),
+        make_sse_chunk("content_block_stop", r#"{"index":0}"#),
+        make_sse_chunk("message_stop", "{}"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    // BlockStart(Thinking)
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockStart {
+            index: 0,
+            block_type: ContentBlockType::Thinking,
+        }
+    ));
+
+    // Thinking delta
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Thinking {
+                thinking: ref t,
+                signature: None,
+            },
+        } if t == "Let me think..."
+    ));
+
+    // Signature delta
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::Thinking {
+                thinking: ref t,
+                signature: Some(ref sig),
+            },
+        } if t.is_empty() && sig == "sig_abc"
+    ));
+
+    // BlockEnd — current impl always emits Text for content_block_stop
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockEnd {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }
+    ));
+
+    // MessageEnd
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_sse_tool_use_stream() {
+    let proto = AnthropicProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(
+            "message_start",
+            r#"{"message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_start",
+            r#"{"index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather"}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"input_json_delta","partial_json":"{\"loc"}}"#,
+        ),
+        make_sse_chunk(
+            "content_block_delta",
+            r#"{"index":0,"delta":{"type":"input_json_delta","partial_json":"ation\":\"Beijing\"}"}}"#,
+        ),
+        make_sse_chunk("content_block_stop", r#"{"index":0}"#),
+        make_sse_chunk("message_stop", "{}"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    // BlockStart(ToolUse)
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockStart {
+            index: 0,
+            block_type: ContentBlockType::ToolUse,
+        }
+    ));
+
+    // ToolUseId delta
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseId { id },
+        } if id == "toolu_01"
+    ));
+
+    // ToolUseName delta
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseName { name },
+        } if name == "get_weather"
+    ));
+
+    // Input chunk 1
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseInputChunk { input },
+        } if input == r#"{"loc"#
+    ));
+
+    // Input chunk 2
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            index: 0,
+            delta: ContentDelta::ToolUseInputChunk { input },
+        } if input == "ation\":\"Beijing\"}"
+    ));
+
+    // BlockEnd — current impl always emits Text for content_block_stop
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockEnd {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        }
+    ));
+
+    // MessageEnd
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_sse_error_event() {
+    let proto = AnthropicProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![make_sse_chunk(
+        "error",
+        r#"{"error":{"type":"api_error","message":"Rate limit exceeded"}}"#,
+    )]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::Error {
+            message
+        } if message == "Rate limit exceeded"
+    ));
+
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_sse_ping_ignored() {
+    let proto = AnthropicProtocol::new();
+    let machine = proto.create_sse_machine();
+
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk("ping", "{}"),
+        make_sse_chunk("message_stop", "{}"),
+    ]));
+
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+
+    // ping should be skipped, message_stop is the first event
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
+
+    assert!(stream.next().await.is_none());
 }

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -423,13 +423,14 @@ fn test_parse_usage_no_cache_fields() {
 
 // ── decorate_headers tests ────────────────────────────────────────────────
 
-#[test]
 /// x-api-key header should always be present after decorate_headers.
+#[test]
 fn test_decorate_headers_api_key() {
     let proto = AnthropicProtocol::new();
     let mut headers = HeaderMap::new();
     proto.decorate_headers(&mut headers).unwrap();
 
+    // decorate_headers always inserts x-api-key (empty string when env var is unset)
     let key_header = headers.get("x-api-key");
     assert!(
         key_header.is_some(),
@@ -508,16 +509,17 @@ fn test_build_request_high_reasoning_level_no_injection() {
 
 // ── messages cache_control tests ──────────────────────────────────────────
 
-#[test]
 /// Last message in the array should receive cache_control marker.
+#[test]
 fn test_messages_cache_control_single_message() {
     let proto = AnthropicProtocol::new();
-    let request = make_request();
+    let request = make_request(); // single "Hello" message
     let body = proto.build_request(&request).unwrap();
 
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
 
+    // Content should be a content blocks array with cache_control
     let content = messages[0].get("content").unwrap().as_array().unwrap();
     assert_eq!(content.len(), 1);
     assert_eq!(content[0].get("type").unwrap(), "text");
@@ -551,6 +553,7 @@ fn test_messages_cache_control_multiple_messages() {
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 3);
 
+    // First two messages should keep string content
     assert!(messages[0].get("content").unwrap().is_string());
     assert_eq!(messages[0].get("content").unwrap().as_str().unwrap(), "Hi");
     assert!(messages[1].get("content").unwrap().is_string());
@@ -559,6 +562,7 @@ fn test_messages_cache_control_multiple_messages() {
         "Hey!"
     );
 
+    // Last message should be content blocks with cache_control
     let last_content = messages[2].get("content").unwrap().as_array().unwrap();
     assert_eq!(last_content.len(), 1);
     assert_eq!(last_content[0].get("type").unwrap(), "text");
@@ -576,16 +580,21 @@ fn test_messages_cache_control_empty_messages() {
     request.messages = vec![];
     let body = proto.build_request(&request).unwrap();
 
+    // Empty messages should produce an empty array with no cache_control added
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert!(messages.is_empty());
 }
 
+/// Verify that ToolsSection content in `system_blocks` produces `cache_control`
+/// in the Anthropic request body, confirming the prefix-cache path covers tool
+/// definitions embedded in the static layer.
 #[test]
 fn test_build_request_tools_section_cache_control() {
     use crate::llm::types::SystemBlock;
 
     let proto = AnthropicProtocol::new();
     let mut request = make_request();
+    // Simulate a system prompt with role section followed by ToolsSection content
     let system_static = "Role: You are a helpful assistant.";
     let tools_section = "\n\n## Tools\n\n- web_search: search the web\n- read: read files";
     let full_static = format!("{system_static}{tools_section}");
@@ -631,6 +640,7 @@ fn test_messages_cache_control_with_system_blocks() {
     }]);
     let body = proto.build_request(&request).unwrap();
 
+    // System should have cache_control
     let system = body.get("system").unwrap().as_array().unwrap();
     assert_eq!(system.len(), 1);
     assert_eq!(
@@ -638,6 +648,7 @@ fn test_messages_cache_control_with_system_blocks() {
         &serde_json::json!({ "type": "ephemeral" })
     );
 
+    // Messages should also have cache_control on the last message
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
     let content = messages[0].get("content").unwrap().as_array().unwrap();

--- a/src/llm/protocol/anthropic_tests.rs
+++ b/src/llm/protocol/anthropic_tests.rs
@@ -424,6 +424,7 @@ fn test_parse_usage_no_cache_fields() {
 // ── decorate_headers tests ────────────────────────────────────────────────
 
 #[test]
+/// x-api-key header should always be present after decorate_headers.
 fn test_decorate_headers_api_key() {
     let proto = AnthropicProtocol::new();
     let mut headers = HeaderMap::new();
@@ -508,6 +509,7 @@ fn test_build_request_high_reasoning_level_no_injection() {
 // ── messages cache_control tests ──────────────────────────────────────────
 
 #[test]
+/// Last message in the array should receive cache_control marker.
 fn test_messages_cache_control_single_message() {
     let proto = AnthropicProtocol::new();
     let request = make_request();
@@ -802,13 +804,13 @@ async fn test_sse_thinking_stream() {
         } if t.is_empty() && sig == "sig_abc"
     ));
 
-    // BlockEnd — current impl always emits Text for content_block_stop
+    // BlockEnd(Thinking)
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
         StreamEvent::BlockEnd {
             index: 0,
-            block_type: ContentBlockType::Text,
+            block_type: ContentBlockType::Thinking,
         }
     ));
 
@@ -897,13 +899,13 @@ async fn test_sse_tool_use_stream() {
         } if input == "ation\":\"Beijing\"}"
     ));
 
-    // BlockEnd — current impl always emits Text for content_block_stop
+    // BlockEnd(ToolUse)
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
         StreamEvent::BlockEnd {
             index: 0,
-            block_type: ContentBlockType::Text,
+            block_type: ContentBlockType::ToolUse,
         }
     ));
 


### PR DESCRIPTION
feat: complete Anthropic protocol mapping for parse_response and parse_sse_stream

Implement the full Anthropic protocol mapping as defined in `docs/design/llm/protocol-mapping.md`:

- **parse_response**: Add `tool_use` and `tool_result` content block parsing. Previously only `text` and `thinking` were handled; other block types were silently dropped via `_ => None`.
- **parse_sse_stream**: Replace stub implementation with full Anthropic SSE streaming support. Handles the complete event sequence: `message_start` → `content_block_start` → `content_block_delta` → `content_block_stop` → `message_delta` → `message_stop`, plus `error` and `ping` events.
- Refactor: Split large functions to meet CONTRIBUTING.md line limits (function body ≤50, impl block ≤100).
- Unit tests: Full coverage for both `parse_response` (tool_use, tool_result, mixed blocks) and `parse_sse_stream` (text, thinking with signature, tool_use, error, ping).

Source: design-doc
Type: feat
