### PR TITLE
chore(ddt): revert errant finished, clear block comment only

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -127,8 +127,8 @@
   },
   {
     "path": "docs/design/im_adapter/streaming-render.md",
-    "commit": "41048d97e2d1b70a4a3d8160376937df1ec7cb79",
-    "commit_time": "2026-06-26T20:05:34+08:00",
+    "commit": "",
+    "commit_time": "",
     "confirmed_time": "2026-06-26T20:07:45.804053+08:00",
     "comment": ""
   },


### PR DESCRIPTION
PR #1248 误用了 `ddt.py finished` 而非 `ddt.py comment` 来清除 block comment。`finished` 会记录 merge-base commit，不应在此场景使用。

本 PR 仅将 records.json 中 streaming-render.md 条目的 `commit` 和 `commit_time` 恢复为空字符串。`comment` 已为空。

Refs: #1228
Source: user