### PR TITLE
fix: 移除流式渲染 DSL 行路由，对齐 design doc

### DIFF
--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -9,7 +9,6 @@ use crate::im::IMPlugin;
 use crate::llm::types::{
     ContentBlock, ContentBlockType, ContentDelta, StreamEvent, UnifiedResponse, UnifiedUsage,
 };
-use crate::processor_chain::dsl_parser::DslParser;
 use crate::processor_chain::{DslParseResult, ProcessedMessage};
 use crate::renderer::streaming::StreamingOutput;
 use crate::renderer::RenderedOutput;
@@ -355,8 +354,7 @@ impl Gateway {
     /// dispatching incremental output to `plugin` as it becomes available:
     /// - Text delta → line buffer → complete lines → `plugin.send` (text)
     /// - BlockEnd (non-Text) → `plugin.render(&[block], None)` → `plugin.send`
-    /// - MessageEnd → flush + `DslParser::parse` on accumulated DSL lines →
-    ///   `plugin.render` + `plugin.send`
+    /// - MessageEnd → flush remaining content → `plugin.send`
     ///
     /// Accumulated `content_blocks` and the LLM-reported `usage` are returned
     /// in a [`StreamResult`]. `thread_id` is resolved from the session
@@ -417,10 +415,10 @@ impl Gateway {
                 let is_text_delta = matches!(delta, ContentDelta::Text { .. });
                 // Delegate to the plugin's streaming method.
                 let out = plugin.handle_stream_event(StreamEvent::BlockDelta { index, delta });
-                // For Text deltas, the renderer may emit completed text lines
-                // and dsl lines; non-Text deltas only update internal state.
+                // For Text deltas, the renderer may emit completed text lines;
+                // non-Text deltas only update internal state.
                 if is_text_delta {
-                    dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
+                    dispatch_text(plugin, chat_id, thread_id, out, state).await?;
                 }
             }
             StreamEvent::BlockEnd { block_type, .. } => {
@@ -432,17 +430,16 @@ impl Gateway {
                         state.content_blocks.push(block);
                     }
                 }
-                dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
+                dispatch_text(plugin, chat_id, thread_id, out, state).await?;
             }
             StreamEvent::MessageEnd { usage, .. } => {
                 let mut out = plugin.flush_stream();
                 let render_blocks = std::mem::take(&mut out.render_blocks);
-                dispatch_text_and_dsl(plugin, chat_id, thread_id, out, state).await?;
+                dispatch_text(plugin, chat_id, thread_id, out, state).await?;
                 for block in render_blocks {
                     send_render_block(plugin, chat_id, thread_id, &block).await?;
                     state.content_blocks.push(block);
                 }
-                send_dsl_lines(plugin, chat_id, thread_id, &state.dsl_lines).await?;
                 if let Some(u) = usage {
                     state.usage = u;
                 }
@@ -465,7 +462,6 @@ impl Gateway {
 /// Mutable state carried across stream events in `send_outbound_streaming`.
 struct StreamState {
     content_blocks: Vec<ContentBlock>,
-    dsl_lines: Vec<String>,
     usage: UnifiedUsage,
 }
 
@@ -473,7 +469,6 @@ impl StreamState {
     fn new() -> Self {
         Self {
             content_blocks: Vec::new(),
-            dsl_lines: Vec::new(),
             usage: UnifiedUsage {
                 prompt_tokens: 0,
                 completion_tokens: 0,
@@ -493,8 +488,8 @@ impl StreamState {
     }
 }
 
-/// Send any text messages from `out` and accumulate dsl lines into `state`.
-async fn dispatch_text_and_dsl(
+/// Send any text messages from `out` into `state`.
+async fn dispatch_text(
     plugin: &std::sync::Arc<dyn IMPlugin>,
     chat_id: &str,
     thread_id: Option<&str>,
@@ -505,7 +500,6 @@ async fn dispatch_text_and_dsl(
         send_text(plugin, chat_id, thread_id, &text).await?;
         state.content_blocks.push(ContentBlock::Text(text));
     }
-    state.dsl_lines.extend(out.dsl_lines);
     Ok(())
 }
 
@@ -532,24 +526,6 @@ async fn send_render_block(
     block: &ContentBlock,
 ) -> Result<(), GatewayError> {
     let rendered = plugin.render(std::slice::from_ref(block), None);
-    plugin.send(&rendered, chat_id, thread_id).await?;
-    Ok(())
-}
-
-/// Parse accumulated DSL lines and dispatch via `plugin.render + plugin.send`.
-async fn send_dsl_lines(
-    plugin: &std::sync::Arc<dyn IMPlugin>,
-    chat_id: &str,
-    thread_id: Option<&str>,
-    dsl_lines: &[String],
-) -> Result<(), GatewayError> {
-    if dsl_lines.is_empty() {
-        return Ok(());
-    }
-    let dsl_text = dsl_lines.join("\n");
-    let dsl_result = DslParser.parse(&dsl_text);
-    let blocks = vec![ContentBlock::Text(dsl_result.clean_content.clone())];
-    let rendered = plugin.render(&blocks, Some(&dsl_result));
     plugin.send(&rendered, chat_id, thread_id).await?;
     Ok(())
 }

--- a/src/im_adapter/plugin_tests.rs
+++ b/src/im_adapter/plugin_tests.rs
@@ -798,7 +798,6 @@ mod tests {
         let out = plugin.flush_stream();
         assert!(out.text_messages.is_empty());
         assert!(out.render_blocks.is_empty());
-        assert!(out.dsl_lines.is_empty());
     }
 
     #[test]

--- a/src/im_adapter/streaming.rs
+++ b/src/im_adapter/streaming.rs
@@ -7,10 +7,9 @@
 //!   (`。！？.!?\n`) when outside fenced code blocks, and on `\n` when
 //!   inside. Forces emission when the buffer exceeds a character threshold.
 //! - [`DefaultStreamingRenderer`] — implements [`StreamingRenderer`]:
-//!   feeds Text deltas through [`LineBuffer`], accumulates non-Text blocks,
-//!   and routes DSL lines to a dedicated slot in [`StreamingOutput`].
+//!   feeds Text deltas through [`LineBuffer`] and accumulates non-Text blocks.
 //! - [`StreamingOutput`] — incremental output struct carrying completed
-//!   text lines, non-Text [`ContentBlock`]s, and parsed DSL lines.
+//!   text lines and non-Text [`ContentBlock`]s.
 
 use crate::llm::types::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent};
 
@@ -24,8 +23,6 @@ pub struct StreamingOutput {
     pub text_messages: Vec<String>,
     /// Non-Text content blocks completed in this batch.
     pub render_blocks: Vec<ContentBlock>,
-    /// DSL lines (e.g. `::button[...]`) extracted from text content.
-    pub dsl_lines: Vec<String>,
 }
 
 /// Line buffer for incremental text rendering.
@@ -135,20 +132,12 @@ fn count_trailing_backticks(s: &str) -> usize {
     s.chars().rev().take_while(|&c| c == '`').count()
 }
 
-pub(crate) fn is_dsl_line(line: &str) -> bool {
-    line.trim_start().starts_with("::")
-}
-
 fn route_line(line: &str, out: &mut StreamingOutput) {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return;
     }
-    if is_dsl_line(trimmed) {
-        out.dsl_lines.push(trimmed.to_string());
-    } else {
-        out.text_messages.push(line.to_string());
-    }
+    out.text_messages.push(line.to_string());
 }
 
 /// Per-block accumulator for non-Text blocks (Thinking / ToolUse).

--- a/src/im_adapter/streaming_tests.rs
+++ b/src/im_adapter/streaming_tests.rs
@@ -36,8 +36,8 @@ fn block_end(index: usize, bt: ContentBlockType) -> StreamEvent {
 fn line_buffer_pure_text_splits_on_punctuation() {
     let mut buf = LineBuffer::new();
     // English and Chinese sentence terminators, plus newlines.
-    let out = buf.feed("Hello world. 你好世界！\nDone?");
-    assert_eq!(out, vec!["Hello world.", " 你好世界！", "\n", "Done?"]);
+    let out = buf.feed("Hello world. 你好世界!\nDone?");
+    assert_eq!(out, vec!["Hello world.", " 你好世界!", "\n", "Done?"]);
 }
 
 #[test]
@@ -85,7 +85,6 @@ fn renderer_pure_text_emits_complete_lines() {
     r.handle_event(block_start(0, ContentBlockType::Text));
     let out = r.handle_event(text_delta("Hello world."));
     assert_eq!(out.text_messages, vec!["Hello world."]);
-    assert!(out.dsl_lines.is_empty());
     assert!(out.render_blocks.is_empty());
 }
 
@@ -99,13 +98,12 @@ fn renderer_with_code_block_preserves_inner_periods() {
 }
 
 #[test]
-fn renderer_routes_dsl_line_to_dsl_lines() {
+fn renderer_routes_dsl_line_to_text_messages() {
     let mut r = DefaultStreamingRenderer::new();
     r.handle_event(block_start(0, ContentBlockType::Text));
     let dsl = "::button[label:Yes;action:vote;value:1]";
     let out = r.handle_event(text_delta(&format!("{}\n", dsl)));
-    assert_eq!(out.dsl_lines, vec![dsl]);
-    assert!(out.text_messages.is_empty());
+    assert_eq!(out.text_messages, vec![format!("{}\n", dsl)]);
 }
 
 #[test]
@@ -198,7 +196,7 @@ fn renderer_flush_resets_block_state() {
             signature: None,
         },
     });
-    // Flush mid-block — should reset block state.
+    // Flush mid-block - should reset block state.
     let out = r.flush();
     assert!(out.render_blocks.is_empty());
     // Now start a new Thinking block (index 1). If old state leaked,
@@ -236,21 +234,6 @@ fn renderer_message_end_then_new_block() {
     r.handle_event(block_start(0, ContentBlockType::Text));
     let out = r.handle_event(text_delta("Fresh start."));
     assert_eq!(out.text_messages, vec!["Fresh start."]);
-    // No DSL lines or render blocks leaked from the previous message.
-    assert!(out.dsl_lines.is_empty());
+    // No render blocks leaked from the previous message.
     assert!(out.render_blocks.is_empty());
-}
-
-#[test]
-fn is_dsl_line_detects_various_dsl_formats() {
-    // All of these should be detected as DSL lines.
-    assert!(is_dsl_line("::button[label:Yes;action:vote;value:1]"));
-    assert!(is_dsl_line("  ::select[options:a,b,c]"));
-    assert!(is_dsl_line("\t::alert[message:Hello]"));
-    assert!(is_dsl_line("::"));
-    // These should NOT be DSL lines.
-    assert!(!is_dsl_line("normal text"));
-    assert!(!is_dsl_line(":not_dsl"));
-    assert!(!is_dsl_line(""));
-    assert!(!is_dsl_line("some::text"));
 }


### PR DESCRIPTION
移除流式渲染路径中的 DSL 行路由机制，使代码与 design doc 对齐。

DSL 行（`::` 前缀）在流式模式下作为普通文本输出，不再被 DslParser 解析。非流式 DSL 渲染路径不受影响。

变更：
- `streaming.rs`：移除 `StreamingOutput.dsl_lines` 字段和 `is_dsl_line()` 函数，`route_line()` 所有行推入 `text_messages`
- `gateway/outbound.rs`：移除 `StreamState.dsl_lines` 累积和 `send_dsl_lines()` 调用，流式路径不再使用 `DslParser`
- 更新相关测试断言

Source: CI
Type: fix
