### PR TITLE
fix: simplify force_emit to drain entire buffer on threshold

### DIFF
--- a/src/im_adapter/streaming.rs
+++ b/src/im_adapter/streaming.rs
@@ -115,10 +115,7 @@ impl LineBuffer {
     }
 
     fn force_emit(&mut self, emitted: &mut Vec<String>) {
-        if let Some((byte_idx, _)) = self.buffer.char_indices().nth(self.threshold) {
-            let line: String = self.buffer.drain(..byte_idx).collect();
-            emitted.push(line);
-        } else {
+        if !self.buffer.is_empty() {
             emitted.push(std::mem::take(&mut self.buffer));
         }
     }

--- a/src/im_adapter/streaming_tests.rs
+++ b/src/im_adapter/streaming_tests.rs
@@ -62,8 +62,9 @@ fn line_buffer_force_emits_at_threshold() {
     let mut buf = LineBuffer::with_threshold(10);
     let out = buf.feed("a]long string without any terminator");
     assert_eq!(out.len(), 1);
-    assert_eq!(out[0].chars().count(), 10);
-    assert_eq!(out[0], "a]long str");
+    // force_emit outputs entire buffer, not truncated at threshold.
+    assert_eq!(out[0], "a]long string without any terminator");
+    assert!(buf.flush().is_none());
 }
 
 #[test]
@@ -109,12 +110,12 @@ fn renderer_routes_dsl_line_to_text_messages() {
 #[test]
 fn renderer_force_emits_long_text_at_threshold() {
     let mut r = DefaultStreamingRenderer::new();
-    // No terminator in 150-char string; first 100 chars must be emitted.
+    // No terminator in 150-char string; all 150 chars must be emitted at once.
     let long_text = "a".repeat(150);
     r.handle_event(block_start(0, ContentBlockType::Text));
     let out = r.handle_event(text_delta(&long_text));
     assert_eq!(out.text_messages.len(), 1);
-    assert_eq!(out.text_messages[0].chars().count(), 100);
+    assert_eq!(out.text_messages[0].chars().count(), 150);
 }
 
 #[test]


### PR DESCRIPTION
fix: simplify force_emit to drain entire buffer on threshold

force_emit now uses std::mem::take to output the full buffer contents
and clear it, matching the design doc semantics of 'output and empty
the buffer'. Removes the previous truncation logic that only emitted
the first threshold characters.

Updated tests to verify force_emit emits complete content instead of
a truncated subset.

Source: CI
Type: fix
