### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -127,9 +127,9 @@
   },
   {
     "path": "docs/design/im_adapter/streaming-render.md",
-    "commit": "",
-    "commit_time": "",
-    "confirmed_time": "2026-06-26T20:07:45.804053+08:00",
+    "commit": "64c74f4f368ef292d11b143a218603ac913402fc",
+    "commit_time": "2026-06-27T14:32:35+08:00",
+    "confirmed_time": "2026-06-27T14:39:39.852794+08:00",
     "comment": ""
   },
   {


### PR DESCRIPTION
操作：finished\n文档路径：docs/design/im_adapter/streaming-render.md\n原因：流式渲染设计文档已完成，标记为 finished