### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -127,9 +127,9 @@
   },
   {
     "path": "docs/design/im_adapter/streaming-render.md",
-    "commit": "",
-    "commit_time": "",
-    "confirmed_time": "2026-06-26T20:07:45.804053+08:00",
+    "commit": "64c74f4f368ef292d11b143a218603ac913402fc",
+    "commit_time": "2026-06-27T14:32:35+08:00",
+    "confirmed_time": "2026-06-27T14:39:39.852794+08:00",
     "comment": ""
   },
   {
@@ -145,5 +145,12 @@
     "commit_time": "2026-06-26T17:48:33+08:00",
     "confirmed_time": "2026-06-26T17:55:59.491929+08:00",
     "comment": ""
+  },
+  {
+    "path": "docs/design/llm/protocol-mapping.md",
+    "commit": "",
+    "commit_time": "",
+    "confirmed_time": "2026-06-27T14:47:02.621121+08:00",
+    "comment": "blocked: doc inaccuracies found in F2b"
   }
 ]


### PR DESCRIPTION
## Design Doc Tracker Update

- **Doc**: docs/design/llm/protocol-mapping.md
- **Type**: blocked
- **Source**: CI
- **Reason**: Design doc automatically marked as blocked by DDT