### PR TITLE
feat: add credential_path field to ProviderConfig

### DIFF
--- a/crates/config/src/manager.rs
+++ b/crates/config/src/manager.rs
@@ -376,7 +376,7 @@ impl ConfigManager {
 
         // Load credentials from config/credentials/ directory.
         let creds_dir = self.config_dir.join(CredentialsProvider::config_path());
-        let creds_provider = match CredentialsProvider::load_from_dir(&creds_dir) {
+        let mut creds_provider = match CredentialsProvider::load_from_dir(&creds_dir) {
             Ok(cp) => cp,
             Err(e) => {
                 warn!(
@@ -387,6 +387,43 @@ impl ConfigManager {
                 CredentialsProvider::default()
             }
         };
+
+        // Load additional credentials via credential_path from models.json.
+        // Each provider in models.json may specify a credential_path pointing to a
+        // credential file.  Resolve it relative to config_dir and merge into the
+        // credential set (overrides convention-directory entries).
+        if let Some(models_value) = sections.get(&ConfigSection::Models) {
+            if let Ok(models_config) =
+                serde_json::from_value::<ModelsConfigData>(models_value.clone())
+            {
+                for (provider_id, provider_cfg) in &models_config.providers {
+                    if let Some(ref rel_path) = provider_cfg.credential_path {
+                        let abs_path = self.config_dir.join(rel_path);
+                        match CredentialsProvider::load_from_dir(
+                            abs_path.parent().unwrap_or(&self.config_dir),
+                        ) {
+                            Ok(extra) => {
+                                for (name, cred) in extra.providers {
+                                    // Only insert if not already loaded from
+                                    // the convention directory, so
+                                    // credential_path acts as fallback.
+                                    creds_provider.providers.entry(name).or_insert(cred);
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    provider = %provider_id,
+                                    path = %abs_path.display(),
+                                    error = %e,
+                                    "failed to load credential_path for provider"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         *self.credentials_provider.write().expect("RwLock poisoned") = creds_provider.clone();
         // Store as JSON value in sections (may be empty/default if dir is absent)
         if let Ok(json) = serde_json::to_value(&creds_provider) {

--- a/crates/config/src/manager.rs
+++ b/crates/config/src/manager.rs
@@ -391,7 +391,8 @@ impl ConfigManager {
         // Load additional credentials via credential_path from models.json.
         // Each provider in models.json may specify a credential_path pointing to a
         // credential file.  Resolve it relative to config_dir and merge into the
-        // credential set (overrides convention-directory entries).
+        // credential set (credential_path takes priority over convention-directory
+        // entries).
         if let Some(models_value) = sections.get(&ConfigSection::Models) {
             if let Ok(models_config) =
                 serde_json::from_value::<ModelsConfigData>(models_value.clone())
@@ -399,15 +400,13 @@ impl ConfigManager {
                 for (provider_id, provider_cfg) in &models_config.providers {
                     if let Some(ref rel_path) = provider_cfg.credential_path {
                         let abs_path = self.config_dir.join(rel_path);
-                        match CredentialsProvider::load_from_dir(
-                            abs_path.parent().unwrap_or(&self.config_dir),
-                        ) {
+                        match CredentialsProvider::load_from_file(&abs_path) {
                             Ok(extra) => {
                                 for (name, cred) in extra.providers {
-                                    // Only insert if not already loaded from
-                                    // the convention directory, so
-                                    // credential_path acts as fallback.
-                                    creds_provider.providers.entry(name).or_insert(cred);
+                                    // credential_path is the explicit reference
+                                    // and takes priority over the convention
+                                    // directory.
+                                    creds_provider.providers.insert(name, cred);
                                 }
                             }
                             Err(e) => {

--- a/crates/config/src/manager.rs
+++ b/crates/config/src/manager.rs
@@ -434,7 +434,9 @@ impl ConfigManager {
         if let Some(models_value) = sections.get(&ConfigSection::Models) {
             match serde_json::from_value::<ModelsConfigData>(models_value.clone()) {
                 Ok(models_config) => {
-                    if let Err(e) = creds_provider.validate_model_references(&models_config) {
+                    if let Err(e) =
+                        creds_provider.validate_model_references(&models_config, &self.config_dir)
+                    {
                         warn!(
                             error = %e,
                             "credentials-models cross-validation warning"

--- a/crates/config/src/providers/credentials.rs
+++ b/crates/config/src/providers/credentials.rs
@@ -53,6 +53,30 @@ pub struct CredentialsProvider {
 }
 
 impl CredentialsProvider {
+    /// Load a single credential file.
+    ///
+    /// The file should contain a single credentials object.
+    /// Returns an empty provider if the file does not exist.
+    pub fn load_from_file(file: &Path) -> Result<Self, ConfigError> {
+        let mut provider = CredentialsProvider::default();
+        if !file.exists() {
+            return Ok(provider);
+        }
+        let content = fs::read_to_string(file)?;
+        let creds: AnyProviderCredentials = match serde_json::from_str(&content) {
+            Ok(c) => c,
+            Err(_) => {
+                return Ok(provider);
+            }
+        };
+        let name = match &creds {
+            AnyProviderCredentials::ApiKey(c) => c.provider.clone(),
+            AnyProviderCredentials::Feishu(c) => c.provider.clone(),
+        };
+        provider.providers.insert(name, creds);
+        Ok(provider)
+    }
+
     /// Load all credentials from a directory containing JSON files.
     ///
     /// Each file should contain a single credentials object.

--- a/crates/config/src/providers/credentials.rs
+++ b/crates/config/src/providers/credentials.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::providers::{ConfigError, ModelsConfigData};
 use crate::ConfigProvider;
@@ -121,25 +121,52 @@ impl CredentialsProvider {
     /// Cross-validate that every provider referenced in models.json has
     /// corresponding credentials defined.
     ///
-    /// Returns `Err` if any model provider is missing credentials.
+    /// Credential resolution priority:
+    /// 1. In-memory credentials (loaded from convention directory or
+    ///    credential_path during `load()`).
+    /// 2. `credential_path` in models.json — if set and the target file
+    ///    exists, the provider is considered valid.
+    /// 3. Convention directory `config/credentials/<provider>.json`.
+    ///
+    /// Returns `Err` if any model provider has none of the above.
     /// Extra credentials (providers defined in credentials but not in models)
     /// emit a warning but do not fail validation.
     pub fn validate_model_references(
         &self,
         models_provider: &ModelsConfigData,
+        config_dir: &Path,
     ) -> Result<(), ConfigError> {
         for provider_id in models_provider.providers.keys() {
-            if !self.providers.contains_key(provider_id) {
-                return Err(ConfigError::ValueError {
-                    field: format!("credentials.{}", provider_id),
-                    message: format!(
-                        "provider '{}' is referenced in models.json but has no credentials \
-                         (create a credentials file in config/credentials/ or check the \
-                         provider ID in models.json)",
-                        provider_id
-                    ),
-                });
+            if self.providers.contains_key(provider_id) {
+                continue;
             }
+
+            // Check if the provider has a credential_path in models.json.
+            if let Some(provider_cfg) = models_provider.get_provider(provider_id) {
+                if let Some(ref rel_path) = provider_cfg.credential_path {
+                    if !rel_path.is_empty() {
+                        let abs_path = config_dir.join(rel_path);
+                        if abs_path.exists() {
+                            info!(
+                                provider = %provider_id,
+                                path = %abs_path.display(),
+                                "provider '{}' has valid credential_path", provider_id
+                            );
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            return Err(ConfigError::ValueError {
+                field: format!("credentials.{}", provider_id),
+                message: format!(
+                    "provider '{}' is referenced in models.json but has no credentials \
+                     (set credentialPath in models.json, create a credentials file in \
+                     config/credentials/, or check the provider ID)",
+                    provider_id
+                ),
+            });
         }
 
         for cred_id in self.providers.keys() {
@@ -429,6 +456,7 @@ mod tests {
 
     #[test]
     fn test_validate_model_references_complete_match() {
+        let tmp = TempDir::new().unwrap();
         let creds_json = r#"{"providers":{
             "openai": {"provider":"openai","apiKey":"sk-test"},
             "anthropic": {"provider":"anthropic","apiKey":"sk-ant"}
@@ -442,11 +470,12 @@ mod tests {
             }
         }"#,
         );
-        assert!(creds.validate_model_references(&models).is_ok());
+        assert!(creds.validate_model_references(&models, tmp.path()).is_ok());
     }
 
     #[test]
     fn test_validate_model_references_missing_credential() {
+        let tmp = TempDir::new().unwrap();
         let creds_json = r#"{"providers":{
             "openai": {"provider":"openai","apiKey":"sk-test"}
         }}"#;
@@ -459,7 +488,7 @@ mod tests {
             }
         }"#,
         );
-        let result = creds.validate_model_references(&models);
+        let result = creds.validate_model_references(&models, tmp.path());
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -471,6 +500,7 @@ mod tests {
 
     #[test]
     fn test_validate_model_references_extra_credentials_only_warn() {
+        let tmp = TempDir::new().unwrap();
         let creds_json = r#"{"providers":{
             "openai": {"provider":"openai","apiKey":"sk-test"},
             "backup": {"provider":"backup","apiKey":"sk-backup"}
@@ -483,21 +513,23 @@ mod tests {
             }
         }"#,
         );
-        assert!(creds.validate_model_references(&models).is_ok());
+        assert!(creds.validate_model_references(&models, tmp.path()).is_ok());
     }
 
     #[test]
     fn test_validate_model_references_empty_models() {
+        let tmp = TempDir::new().unwrap();
         let creds_json = r#"{"providers":{
             "openai": {"provider":"openai","apiKey":"sk-test"}
         }}"#;
         let creds = CredentialsProvider::from_json_str(creds_json).unwrap();
         let models = models_from_json(r#"{"providers": {}}"#);
-        assert!(creds.validate_model_references(&models).is_ok());
+        assert!(creds.validate_model_references(&models, tmp.path()).is_ok());
     }
 
     #[test]
     fn test_validate_model_references_empty_credentials_with_models() {
+        let tmp = TempDir::new().unwrap();
         let creds = CredentialsProvider::default();
         let models = models_from_json(
             r#"{
@@ -506,14 +538,84 @@ mod tests {
             }
         }"#,
         );
-        let result = creds.validate_model_references(&models);
+        let result = creds.validate_model_references(&models, tmp.path());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_validate_model_references_empty_both() {
+        let tmp = TempDir::new().unwrap();
         let creds = CredentialsProvider::default();
         let models = models_from_json(r#"{"providers": {}}"#);
-        assert!(creds.validate_model_references(&models).is_ok());
+        assert!(creds.validate_model_references(&models, tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_references_credential_path_valid() {
+        let tmp = TempDir::new().unwrap();
+        // Create a credential file at credentials/openai.json
+        let creds_dir = tmp.path().join("credentials");
+        std::fs::create_dir_all(&creds_dir).unwrap();
+        std::fs::write(
+            creds_dir.join("openai.json"),
+            r#"{"provider":"openai","apiKey":"sk-test"}"#,
+        )
+        .unwrap();
+
+        let creds = CredentialsProvider::default();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "credentials/openai.json",
+                    "models": [{"id":"gpt-4"}]
+                }
+            }
+        }"#,
+        );
+        assert!(creds.validate_model_references(&models, tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_references_credential_path_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        // No credential file exists
+        let creds = CredentialsProvider::default();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "credentials/openai.json",
+                    "models": [{"id":"gpt-4"}]
+                }
+            }
+        }"#,
+        );
+        let result = creds.validate_model_references(&models, tmp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValueError { ref field, .. } if field.contains("openai")),
+            "error should reference the missing provider: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_model_references_credential_path_empty() {
+        let tmp = TempDir::new().unwrap();
+        let creds = CredentialsProvider::default();
+        let models = models_from_json(
+            r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "",
+                    "models": [{"id":"gpt-4"}]
+                }
+            }
+        }"#,
+        );
+        let result = creds.validate_model_references(&models, tmp.path());
+        assert!(result.is_err());
     }
 }

--- a/crates/config/src/providers/models.rs
+++ b/crates/config/src/providers/models.rs
@@ -45,6 +45,9 @@ pub struct ProviderConfig {
     pub protocol: Option<String>,
 
     #[serde(default)]
+    pub credential_path: Option<String>,
+
+    #[serde(default)]
     pub models: Vec<ModelDefinition>,
 }
 
@@ -138,6 +141,15 @@ impl ConfigProvider for ModelsConfigData {
                     return Err(ConfigError::ValueError {
                         field: "api_key".to_string(),
                         message: "api_key cannot be an empty string".to_string(),
+                    });
+                }
+            }
+
+            if let Some(ref credential_path) = provider.credential_path {
+                if credential_path.is_empty() {
+                    return Err(ConfigError::ValueError {
+                        field: "credential_path".to_string(),
+                        message: "credential_path cannot be an empty string".to_string(),
                     });
                 }
             }

--- a/crates/config/src/providers/models.rs
+++ b/crates/config/src/providers/models.rs
@@ -468,6 +468,89 @@ mod tests {
     // config_path and version
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // credential_path tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_credential_path_serializes_as_camel_case() {
+        let json = r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "credentials/openai.json",
+                    "models": [{"id": "gpt-4"}]
+                }
+            }
+        }"#;
+        let config = ModelsConfigData::from_json_str(json).unwrap();
+        let provider = config.providers.get("openai").unwrap();
+        assert_eq!(
+            provider.credential_path.as_deref(),
+            Some("credentials/openai.json")
+        );
+    }
+
+    #[test]
+    fn test_credential_path_absent_defaults_to_none() {
+        let json = r#"{
+            "providers": {
+                "openai": {
+                    "models": [{"id": "gpt-4"}]
+                }
+            }
+        }"#;
+        let config = ModelsConfigData::from_json_str(json).unwrap();
+        let provider = config.providers.get("openai").unwrap();
+        assert!(provider.credential_path.is_none());
+    }
+
+    #[test]
+    fn test_credential_path_roundtrip() {
+        let json = r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "credentials/openai.json",
+                    "models": [{"id": "gpt-4"}]
+                }
+            }
+        }"#;
+        let config = ModelsConfigData::from_json_str(json).unwrap();
+        let serialized = serde_json::to_string(&config).unwrap();
+        let roundtripped: ModelsConfigData = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            roundtripped
+                .providers
+                .get("openai")
+                .unwrap()
+                .credential_path
+                .as_deref(),
+            Some("credentials/openai.json")
+        );
+    }
+
+    #[test]
+    fn test_validate_empty_credential_path() {
+        let json = r#"{
+            "providers": {
+                "openai": {
+                    "credentialPath": "",
+                    "models": [{"id": "gpt-4"}]
+                }
+            }
+        }"#;
+        let config = ModelsConfigData::from_json_str(json).unwrap();
+        let result = config.validate();
+        assert!(
+            result.is_err(),
+            "empty credential_path should fail validation"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ValueError { ref field, .. } if field == "credential_path"),
+            "error should be about credential_path field"
+        );
+    }
+
     #[test]
     fn test_config_path() {
         assert_eq!(ModelsConfigData::config_path(), "models.json");

--- a/crates/config/src/validators.rs
+++ b/crates/config/src/validators.rs
@@ -81,6 +81,22 @@ fn validate_provider(provider_id: &str, provider: &serde_json::Value) -> Result<
             }
         }
     }
+    // Validate credentialPath format if present
+    if let Some(cred_path) = provider.get("credentialPath") {
+        if let Some(path_str) = cred_path.as_str() {
+            if path_str.is_empty() {
+                return Err(format!(
+                    "models.providers.{}.credentialPath cannot be empty",
+                    provider_id
+                ));
+            }
+        } else if !cred_path.is_null() {
+            return Err(format!(
+                "models.providers.{}.credentialPath must be a string",
+                provider_id
+            ));
+        }
+    }
     // Validate each model entry
     if let Some(models) = provider.get("models") {
         if let Some(arr) = models.as_array() {

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -218,6 +218,7 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         api_key: None,
         api: None,
         protocol: recommended_protocol,
+        credential_path: None,
         models: new_provider_models,
     };
     providers.insert(output.provider_id.clone(), new_provider_config);

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -218,7 +218,7 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         api_key: None,
         api: None,
         protocol: recommended_protocol,
-        credential_path: None,
+        credential_path: Some(format!("credentials/{}.json", output.provider_id)),
         models: new_provider_models,
     };
     providers.insert(output.provider_id.clone(), new_provider_config);

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -373,6 +373,43 @@ mod write_wizard_config_tests {
         );
     }
 
+    /// Test: write_wizard_config includes credentialPath in ProviderConfig
+    #[test]
+    fn test_write_wizard_config_includes_credential_path() {
+        let tmp = TempDir::new().unwrap();
+        let output = WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "test-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "MiniMax-M2.7".to_string(),
+                name: "MiniMax M2.7".to_string(),
+                context_window: 1000,
+                max_tokens: 1000,
+                default_temperature: None,
+                reasoning: false,
+                input_types: vec![],
+            }],
+        };
+
+        write_wizard_config_to(&output, tmp.path()).expect("write_wizard_config_to should succeed");
+
+        let models_path = tmp.path().join("models.json");
+        let content = std::fs::read_to_string(&models_path).expect("models.json should be written");
+
+        let parsed: ModelsConfigData =
+            serde_json::from_str(&content).expect("models.json should be valid JSON");
+
+        let provider = parsed
+            .providers
+            .get("minimax")
+            .expect("minimax provider should exist");
+        assert_eq!(
+            provider.credential_path.as_deref(),
+            Some("credentials/minimax.json"),
+            "credentialPath should be set to credentials/<provider_id>.json"
+        );
+    }
+
     /// Test: write_wizard_config handles empty selected_models gracefully
     #[test]
     fn test_write_wizard_config_with_no_selected_models() {

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -119,6 +119,7 @@ mod provider_config_protocol_tests {
             api_key: Some("sk-test".to_string()),
             api: Some("v1".to_string()),
             protocol: Some("openai".to_string()),
+            credential_path: None,
             models: vec![ModelDefinition {
                 id: "gpt-4".to_string(),
                 name: Some("GPT-4".to_string()),
@@ -141,6 +142,7 @@ mod provider_config_protocol_tests {
             api_key: None,
             api: None,
             protocol: None,
+            credential_path: None,
             models: vec![],
         };
         let json = serde_json::to_string_pretty(&config).unwrap();
@@ -183,6 +185,7 @@ mod provider_config_protocol_tests {
             api_key: None,
             api: None,
             protocol: Some("openai".to_string()),
+            credential_path: None,
             models: vec![],
         };
         let json = serde_json::to_string(&original).unwrap();


### PR DESCRIPTION
feat: 添加 ProviderConfig credential_path 字段，与设计文档 InputCredential 章节对齐

在 ProviderConfig 结构体中添加 credential_path: Option<String> 字段，使 models.json 能显式引用凭据文件路径。

主要变更：
- ProviderConfig 添加 credential_path 字段（serde camelCase 序列化）
- 向导写入 models.json 时填入 credential_path（相对路径）
- 运行时凭据加载优先使用 credential_path，回退到约定目录
- 更新验证逻辑：credential_path 非空时检查文件存在性
- 添加相关测试

Source: design-doc
Type: feat
