### PR TITLE
fix: preserve existing provider config and unselected models in write_wizard_config_to

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -22,8 +22,7 @@ use std::panic;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-#[cfg(test)]
-use crate::llm::ModelInfo;
+use crate::llm::model_info::ModelInfo;
 
 /// Parse user input for model selection into a vector of 0-based indices.
 ///
@@ -164,6 +163,75 @@ fn ensure_master_agent(config_dir: &Path, agents_dir: &Path) -> anyhow::Result<(
     Ok(())
 }
 
+/// Merge selected models with existing models for a provider.
+///
+/// Strategy:
+/// - Existing models not in `selected_models` are preserved (not deleted)
+/// - Existing models matching by id are replaced entirely (name/enabled updated)
+/// - New models from `selected_models` are appended
+fn merge_models(
+    existing_models: Vec<ModelDefinition>,
+    selected_models: &[ModelInfo],
+) -> Vec<ModelDefinition> {
+    let mut merged: Vec<ModelDefinition> = existing_models;
+    for selected in selected_models {
+        if let Some(existing) = merged.iter_mut().find(|m| m.id == selected.id) {
+            *existing = ModelDefinition {
+                id: selected.id.clone(),
+                name: Some(selected.name.clone()),
+                enabled: Some(true),
+            };
+        } else {
+            merged.push(ModelDefinition {
+                id: selected.id.clone(),
+                name: Some(selected.name.clone()),
+                enabled: Some(true),
+            });
+        }
+    }
+    merged
+}
+
+/// Inherit base_url, api_key, api from an existing provider config if present.
+fn inherit_provider_fields(
+    existing_provider: &Option<ProviderConfig>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    existing_provider
+        .as_ref()
+        .map(|ep| (ep.base_url.clone(), ep.api_key.clone(), ep.api.clone()))
+        .unwrap_or((None, None, None))
+}
+
+/// Load existing models config or return a default.
+fn load_or_create_models_config(models_path: &Path) -> anyhow::Result<ModelsConfigData> {
+    if models_path.exists() {
+        let content = std::fs::read_to_string(models_path)?;
+        Ok(ModelsConfigData::from_json_str(&content)
+            .unwrap_or_else(|_| ModelsConfigData::default()))
+    } else {
+        Ok(ModelsConfigData::default())
+    }
+}
+
+/// Write provider credentials to `credentials/<provider_id>.json`.
+fn write_provider_credentials(
+    config_path: &Path,
+    provider_id: &str,
+    credential: &str,
+) -> anyhow::Result<PathBuf> {
+    let creds_dir = config_path.join("credentials");
+    std::fs::create_dir_all(&creds_dir)?;
+    let cred_file = creds_dir.join(format!("{}.json", provider_id));
+    let creds = AnyProviderCredentials::ApiKey(ApiKeyCredentials {
+        provider: provider_id.to_string(),
+        api_key: credential.to_string(),
+    });
+    let creds_json = serde_json::to_string_pretty(&creds)?;
+    std::fs::write(&cred_file, creds_json)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", cred_file.display(), e))?;
+    Ok(cred_file)
+}
+
 /// Write wizard output to config files.
 ///
 /// Merging strategy:
@@ -180,98 +248,44 @@ fn ensure_master_agent(config_dir: &Path, agents_dir: &Path) -> anyhow::Result<(
 //- against `tests/cli_config_wizard_test.py` (python3 E2E test using pexpect).
 pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(config_path)?;
-
-    // ── Load or create models.json ─────────────────────────────────────────────
     let models_path = config_path.join("models.json");
-    let existing: ModelsConfigData = if models_path.exists() {
-        let content = std::fs::read_to_string(&models_path)?;
-        ModelsConfigData::from_json_str(&content).unwrap_or_else(|_| ModelsConfigData::default())
-    } else {
-        ModelsConfigData::default()
-    };
-
-    // ── Merge: preserve all existing providers, replace selected provider ───────
+    let existing = load_or_create_models_config(&models_path)?;
     let mut providers = existing.providers;
-    // Save existing config before removal so we can inherit fields
     let existing_provider = providers.get(&output.provider_id).cloned();
-    // Remove entries for the selected provider so we can replace them
     providers.remove(&output.provider_id);
-
-    // ── Build the new provider config from WizardOutput.selected_models ────────
-    // Merge strategy: preserve existing models, update/append selected models.
-    // - Existing models not in selected_models are preserved (not deleted)
-    // - Existing models matching by id are replaced entirely (name/enabled updated)
-    // - New models from selected_models are appended
     let existing_models = existing_provider
         .as_ref()
         .map(|ep| ep.models.clone())
         .unwrap_or_default();
-
-    let mut merged_models: Vec<ModelDefinition> = existing_models;
-    for selected in &output.selected_models {
-        if let Some(existing) = merged_models.iter_mut().find(|m| m.id == selected.id) {
-            // Same id → replace entirely
-            *existing = ModelDefinition {
-                id: selected.id.clone(),
-                name: Some(selected.name.clone()),
-                enabled: Some(true),
-            };
-        } else {
-            // New id → append
-            merged_models.push(ModelDefinition {
-                id: selected.id.clone(),
-                name: Some(selected.name.clone()),
-                enabled: Some(true),
-            });
-        }
-    }
-
-    // ── Query recommended_protocol from knowledge base ────────────────────────
+    let merged_models = merge_models(existing_models, &output.selected_models);
     let recommended_protocol = output.selected_models.first().map(|m| {
         let kb = ProviderModelKnowledge::new();
         kb.recommended_protocol(&output.provider_id, &m.id)
             .to_string()
     });
-
-    // Inherit base_url, api_key, api from existing config if present
-    let (base_url, api_key, api) = existing_provider
-        .map(|ep| (ep.base_url, ep.api_key, ep.api))
-        .unwrap_or((None, None, None));
-
-    let new_provider_config = ProviderConfig {
-        base_url,
-        api_key,
-        api,
-        protocol: recommended_protocol,
-        credential_path: Some(format!("credentials/{}.json", output.provider_id)),
-        models: merged_models,
-    };
-    providers.insert(output.provider_id.clone(), new_provider_config);
-
+    let (base_url, api_key, api) = inherit_provider_fields(&existing_provider);
+    providers.insert(
+        output.provider_id.clone(),
+        ProviderConfig {
+            base_url,
+            api_key,
+            api,
+            protocol: recommended_protocol,
+            credential_path: Some(format!("credentials/{}.json", output.provider_id)),
+            models: merged_models,
+        },
+    );
     let merged = ModelsConfigData {
         mode: "merge".to_string(),
         providers,
     };
     <ModelsConfigData as crate::config::providers::ConfigProvider>::validate(&merged)
         .map_err(|e| anyhow::anyhow!("merged config validation failed: {}", e))?;
-
-    // ── Write models.json ─────────────────────────────────────────────────────
     let json = serde_json::to_string_pretty(&merged)?;
     std::fs::write(&models_path, json)
         .map_err(|e| anyhow::anyhow!("failed to write {}: {}", models_path.display(), e))?;
-
-    // ── Write credentials ────────────────────────────────────────────────────
-    let creds_dir = config_path.join("credentials");
-    std::fs::create_dir_all(&creds_dir)?;
-    let cred_file = creds_dir.join(format!("{}.json", output.provider_id));
-    let creds = AnyProviderCredentials::ApiKey(ApiKeyCredentials {
-        provider: output.provider_id.clone(),
-        api_key: output.credential.clone(),
-    });
-    let creds_json = serde_json::to_string_pretty(&creds)?;
-    std::fs::write(&cred_file, creds_json)
-        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", cred_file.display(), e))?;
-
+    let cred_file =
+        write_provider_credentials(config_path, &output.provider_id, &output.credential)?;
     println!(
         "✅ Configuration written:\n   models: {}\n   credentials: {}",
         models_path.display(),

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -210,13 +210,20 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
 
     // ── Merge: preserve all existing providers, replace selected provider ───────
     let mut providers = existing.providers;
+    // Save existing config before removal so we can inherit fields
+    let existing_provider = providers.get(&output.provider_id).cloned();
     // Remove entries for the selected provider so we can replace them
     providers.remove(&output.provider_id);
 
+    // Inherit base_url, api_key, api from existing config if present
+    let (base_url, api_key, api) = existing_provider
+        .map(|ep| (ep.base_url, ep.api_key, ep.api))
+        .unwrap_or((None, None, None));
+
     let new_provider_config = ProviderConfig {
-        base_url: None,
-        api_key: None,
-        api: None,
+        base_url,
+        api_key,
+        api,
         protocol: recommended_protocol,
         credential_path: Some(format!("credentials/{}.json", output.provider_id)),
         models: new_provider_models,

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -190,16 +190,41 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         ModelsConfigData::default()
     };
 
+    // ── Merge: preserve all existing providers, replace selected provider ───────
+    let mut providers = existing.providers;
+    // Save existing config before removal so we can inherit fields
+    let existing_provider = providers.get(&output.provider_id).cloned();
+    // Remove entries for the selected provider so we can replace them
+    providers.remove(&output.provider_id);
+
     // ── Build the new provider config from WizardOutput.selected_models ────────
-    let new_provider_models: Vec<ModelDefinition> = output
-        .selected_models
-        .iter()
-        .map(|m| ModelDefinition {
-            id: m.id.clone(),
-            name: Some(m.name.clone()),
-            enabled: Some(true),
-        })
-        .collect();
+    // Merge strategy: preserve existing models, update/append selected models.
+    // - Existing models not in selected_models are preserved (not deleted)
+    // - Existing models matching by id are replaced entirely (name/enabled updated)
+    // - New models from selected_models are appended
+    let existing_models = existing_provider
+        .as_ref()
+        .map(|ep| ep.models.clone())
+        .unwrap_or_default();
+
+    let mut merged_models: Vec<ModelDefinition> = existing_models;
+    for selected in &output.selected_models {
+        if let Some(existing) = merged_models.iter_mut().find(|m| m.id == selected.id) {
+            // Same id → replace entirely
+            *existing = ModelDefinition {
+                id: selected.id.clone(),
+                name: Some(selected.name.clone()),
+                enabled: Some(true),
+            };
+        } else {
+            // New id → append
+            merged_models.push(ModelDefinition {
+                id: selected.id.clone(),
+                name: Some(selected.name.clone()),
+                enabled: Some(true),
+            });
+        }
+    }
 
     // ── Query recommended_protocol from knowledge base ────────────────────────
     let recommended_protocol = output.selected_models.first().map(|m| {
@@ -207,13 +232,6 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         kb.recommended_protocol(&output.provider_id, &m.id)
             .to_string()
     });
-
-    // ── Merge: preserve all existing providers, replace selected provider ───────
-    let mut providers = existing.providers;
-    // Save existing config before removal so we can inherit fields
-    let existing_provider = providers.get(&output.provider_id).cloned();
-    // Remove entries for the selected provider so we can replace them
-    providers.remove(&output.provider_id);
 
     // Inherit base_url, api_key, api from existing config if present
     let (base_url, api_key, api) = existing_provider
@@ -226,7 +244,7 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         api,
         protocol: recommended_protocol,
         credential_path: Some(format!("credentials/{}.json", output.provider_id)),
-        models: new_provider_models,
+        models: merged_models,
     };
     providers.insert(output.provider_id.clone(), new_provider_config);
 

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -312,9 +312,9 @@ mod write_wizard_config_tests {
         );
     }
 
-    /// Test: write_wizard_config_to overwrites existing config (not appends)
+    /// Test: re-running wizard preserves existing models not in selected_models
     #[test]
-    fn test_write_wizard_config_to_overwrites_existing() {
+    fn test_write_wizard_config_to_preserves_existing_models() {
         let tmp = TempDir::new().unwrap();
 
         // First write: 1 model
@@ -333,7 +333,7 @@ mod write_wizard_config_tests {
         };
         write_wizard_config_to(&output1, tmp.path()).unwrap();
 
-        // Second write: 2 different models
+        // Second write: 2 different models (MiniMax-M2.7 NOT selected)
         let output2 = WizardOutput {
             provider_id: "minimax".to_string(),
             credential: "test-api-key-2".to_string(),
@@ -360,17 +360,237 @@ mod write_wizard_config_tests {
         };
         write_wizard_config_to(&output2, tmp.path()).unwrap();
 
-        // Verify: minimax provider should have exactly 2 models (overwrite, not append)
+        // Verify: first model preserved alongside 2 new ones = 3 total
         let models_path = tmp.path().join("models.json");
         let content = std::fs::read_to_string(&models_path).unwrap();
         let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
         let provider = parsed.providers.get("minimax").unwrap();
         assert_eq!(
             provider.models.len(),
-            2,
-            "should have exactly 2 models after overwrite, got: {}",
+            3,
+            "should have 3 models (1 existing + 2 new), got: {}",
             provider.models.len()
         );
+        let ids: Vec<&str> = provider.models.iter().map(|m| m.id.as_str()).collect();
+        assert!(
+            ids.contains(&"MiniMax-M2.7"),
+            "first write's model MiniMax-M2.7 should be preserved, got: {:?}",
+            ids
+        );
+    }
+
+    /// Test: re-running wizard with same model replaces it entirely
+    #[test]
+    fn test_write_wizard_config_to_replaces_existing_model_by_id() {
+        let tmp = TempDir::new().unwrap();
+
+        // First write: MiniMax-M2.7 with old name
+        let output1 = WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "test-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "MiniMax-M2.7".to_string(),
+                name: "Old Name".to_string(),
+                context_window: 1000,
+                max_tokens: 1000,
+                default_temperature: None,
+                reasoning: false,
+                input_types: vec![],
+            }],
+        };
+        write_wizard_config_to(&output1, tmp.path()).unwrap();
+
+        // Second write: same id, new name
+        let output2 = WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "test-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "MiniMax-M2.7".to_string(),
+                name: "New Name".to_string(),
+                context_window: 2000,
+                max_tokens: 2000,
+                default_temperature: None,
+                reasoning: false,
+                input_types: vec![],
+            }],
+        };
+        write_wizard_config_to(&output2, tmp.path()).unwrap();
+
+        // Verify: still 1 model, name updated to New Name
+        let models_path = tmp.path().join("models.json");
+        let content = std::fs::read_to_string(&models_path).unwrap();
+        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let provider = parsed.providers.get("minimax").unwrap();
+        assert_eq!(provider.models.len(), 1);
+        assert_eq!(provider.models[0].name.as_deref(), Some("New Name"));
+        assert_eq!(provider.models[0].enabled, Some(true));
+    }
+
+    /// Test: existing provider's base_url/api_key/api are preserved after rewrite
+    #[test]
+    fn test_write_wizard_config_to_preserves_provider_base_fields() {
+        let tmp = TempDir::new().unwrap();
+
+        // Manually write initial config with custom base_url, api_key, api
+        let initial = ModelsConfigData {
+            mode: "merge".to_string(),
+            providers: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "minimax".to_string(),
+                    ProviderConfig {
+                        base_url: Some("https://custom.api.com/v1".to_string()),
+                        api_key: Some("sk-existing-key".to_string()),
+                        api: Some("v2".to_string()),
+                        protocol: Some("openai".to_string()),
+                        credential_path: Some("credentials/minimax.json".to_string()),
+                        models: vec![ModelDefinition {
+                            id: "MiniMax-M2.7".to_string(),
+                            name: Some("MiniMax M2.7".to_string()),
+                            enabled: Some(true),
+                        }],
+                    },
+                );
+                map
+            },
+        };
+        let models_path = tmp.path().join("models.json");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        std::fs::write(
+            &models_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Re-run wizard for minimax
+        let output = WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "new-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "abab6.5-chat".to_string(),
+                name: "ABAB6.5 Chat".to_string(),
+                context_window: 2000,
+                max_tokens: 2000,
+                default_temperature: None,
+                reasoning: false,
+                input_types: vec![],
+            }],
+        };
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        // Verify base_url, api_key, api are preserved
+        let content = std::fs::read_to_string(&models_path).unwrap();
+        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let provider = parsed.providers.get("minimax").unwrap();
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://custom.api.com/v1"),
+            "base_url should be preserved"
+        );
+        assert_eq!(
+            provider.api_key.as_deref(),
+            Some("sk-existing-key"),
+            "api_key should be preserved"
+        );
+        assert_eq!(
+            provider.api.as_deref(),
+            Some("v2"),
+            "api should be preserved"
+        );
+    }
+
+    /// Test: existing unselected models are preserved after rewrite
+    #[test]
+    fn test_write_wizard_config_to_preserves_unselected_models() {
+        let tmp = TempDir::new().unwrap();
+
+        // Manually write initial config with 3 models
+        let initial = ModelsConfigData {
+            mode: "merge".to_string(),
+            providers: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "minimax".to_string(),
+                    ProviderConfig {
+                        base_url: None,
+                        api_key: None,
+                        api: None,
+                        protocol: None,
+                        credential_path: Some("credentials/minimax.json".to_string()),
+                        models: vec![
+                            ModelDefinition {
+                                id: "model-a".to_string(),
+                                name: Some("Model A".to_string()),
+                                enabled: Some(true),
+                            },
+                            ModelDefinition {
+                                id: "model-b".to_string(),
+                                name: Some("Model B".to_string()),
+                                enabled: Some(true),
+                            },
+                            ModelDefinition {
+                                id: "model-c".to_string(),
+                                name: Some("Model C".to_string()),
+                                enabled: Some(false),
+                            },
+                        ],
+                    },
+                );
+                map
+            },
+        };
+        let models_path = tmp.path().join("models.json");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        std::fs::write(
+            &models_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        // Re-run wizard selecting only model-a and a new model-d
+        let output = WizardOutput {
+            provider_id: "minimax".to_string(),
+            credential: "test-key".to_string(),
+            selected_models: vec![
+                ModelInfo {
+                    id: "model-a".to_string(),
+                    name: "Model A Updated".to_string(),
+                    context_window: 1000,
+                    max_tokens: 1000,
+                    default_temperature: None,
+                    reasoning: false,
+                    input_types: vec![],
+                },
+                ModelInfo {
+                    id: "model-d".to_string(),
+                    name: "Model D".to_string(),
+                    context_window: 3000,
+                    max_tokens: 3000,
+                    default_temperature: None,
+                    reasoning: false,
+                    input_types: vec![],
+                },
+            ],
+        };
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        // Verify: model-b and model-c preserved, model-a updated, model-d added
+        let content = std::fs::read_to_string(&models_path).unwrap();
+        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let provider = parsed.providers.get("minimax").unwrap();
+        assert_eq!(
+            provider.models.len(),
+            4,
+            "should have 4 models (model-a updated + model-b, model-c preserved + model-d new)"
+        );
+        let ids: Vec<&str> = provider.models.iter().map(|m| m.id.as_str()).collect();
+        assert!(ids.contains(&"model-b"), "model-b should be preserved");
+        assert!(ids.contains(&"model-c"), "model-c should be preserved");
+        assert!(ids.contains(&"model-d"), "model-d should be added");
+        // model-a should be updated
+        let model_a = provider.models.iter().find(|m| m.id == "model-a").unwrap();
+        assert_eq!(model_a.name.as_deref(), Some("Model A Updated"));
+        assert_eq!(model_a.enabled, Some(true));
     }
 
     /// Test: write_wizard_config includes credentialPath in ProviderConfig

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -199,6 +199,57 @@ mod write_wizard_config_tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Helper: write initial ModelsConfigData to models.json
+    fn write_initial_config(
+        tmp: &TempDir,
+        providers: std::collections::HashMap<String, ProviderConfig>,
+    ) {
+        let models_path = tmp.path().join("models.json");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        let initial = ModelsConfigData {
+            mode: "merge".to_string(),
+            providers,
+        };
+        std::fs::write(
+            &models_path,
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Helper: create a WizardOutput
+    fn make_wizard_output(
+        provider_id: &str,
+        credential: &str,
+        models: Vec<ModelInfo>,
+    ) -> WizardOutput {
+        WizardOutput {
+            provider_id: provider_id.to_string(),
+            credential: credential.to_string(),
+            selected_models: models,
+        }
+    }
+
+    /// Helper: create a simple ModelInfo
+    fn make_model(id: &str, name: &str, context_window: u32, max_tokens: u32) -> ModelInfo {
+        ModelInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            context_window,
+            max_tokens,
+            default_temperature: None,
+            reasoning: false,
+            input_types: vec![],
+        }
+    }
+
+    /// Helper: read and parse models.json
+    fn read_parsed_config(tmp: &TempDir) -> ModelsConfigData {
+        let models_path = tmp.path().join("models.json");
+        let content = std::fs::read_to_string(&models_path).unwrap();
+        serde_json::from_str(&content).unwrap()
+    }
+
     /// Test: write_wizard_config outputs protocol field in ProviderConfig
     #[test]
     fn test_write_wizard_config_includes_protocol() {
@@ -430,164 +481,92 @@ mod write_wizard_config_tests {
     #[test]
     fn test_write_wizard_config_to_preserves_provider_base_fields() {
         let tmp = TempDir::new().unwrap();
-
-        // Manually write initial config with custom base_url, api_key, api
-        let initial = ModelsConfigData {
-            mode: "merge".to_string(),
-            providers: {
-                let mut map = std::collections::HashMap::new();
-                map.insert(
-                    "minimax".to_string(),
-                    ProviderConfig {
-                        base_url: Some("https://custom.api.com/v1".to_string()),
-                        api_key: Some("sk-existing-key".to_string()),
-                        api: Some("v2".to_string()),
-                        protocol: Some("openai".to_string()),
-                        credential_path: Some("credentials/minimax.json".to_string()),
-                        models: vec![ModelDefinition {
-                            id: "MiniMax-M2.7".to_string(),
-                            name: Some("MiniMax M2.7".to_string()),
-                            enabled: Some(true),
-                        }],
-                    },
-                );
-                map
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "minimax".to_string(),
+            ProviderConfig {
+                base_url: Some("https://custom.api.com/v1".to_string()),
+                api_key: Some("sk-existing-key".to_string()),
+                api: Some("v2".to_string()),
+                protocol: Some("openai".to_string()),
+                credential_path: Some("credentials/minimax.json".to_string()),
+                models: vec![ModelDefinition {
+                    id: "MiniMax-M2.7".to_string(),
+                    name: Some("MiniMax M2.7".to_string()),
+                    enabled: Some(true),
+                }],
             },
-        };
-        let models_path = tmp.path().join("models.json");
-        std::fs::create_dir_all(tmp.path()).unwrap();
-        std::fs::write(
-            &models_path,
-            serde_json::to_string_pretty(&initial).unwrap(),
-        )
-        .unwrap();
+        );
+        write_initial_config(&tmp, providers);
 
-        // Re-run wizard for minimax
-        let output = WizardOutput {
-            provider_id: "minimax".to_string(),
-            credential: "new-api-key".to_string(),
-            selected_models: vec![ModelInfo {
-                id: "abab6.5-chat".to_string(),
-                name: "ABAB6.5 Chat".to_string(),
-                context_window: 2000,
-                max_tokens: 2000,
-                default_temperature: None,
-                reasoning: false,
-                input_types: vec![],
-            }],
-        };
+        let output = make_wizard_output(
+            "minimax",
+            "new-api-key",
+            vec![make_model("abab6.5-chat", "ABAB6.5 Chat", 2000, 2000)],
+        );
         write_wizard_config_to(&output, tmp.path()).unwrap();
 
-        // Verify base_url, api_key, api are preserved
-        let content = std::fs::read_to_string(&models_path).unwrap();
-        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let parsed = read_parsed_config(&tmp);
         let provider = parsed.providers.get("minimax").unwrap();
         assert_eq!(
             provider.base_url.as_deref(),
-            Some("https://custom.api.com/v1"),
-            "base_url should be preserved"
+            Some("https://custom.api.com/v1")
         );
-        assert_eq!(
-            provider.api_key.as_deref(),
-            Some("sk-existing-key"),
-            "api_key should be preserved"
-        );
-        assert_eq!(
-            provider.api.as_deref(),
-            Some("v2"),
-            "api should be preserved"
-        );
+        assert_eq!(provider.api_key.as_deref(), Some("sk-existing-key"));
+        assert_eq!(provider.api.as_deref(), Some("v2"));
     }
 
     /// Test: existing unselected models are preserved after rewrite
     #[test]
     fn test_write_wizard_config_to_preserves_unselected_models() {
         let tmp = TempDir::new().unwrap();
-
-        // Manually write initial config with 3 models
-        let initial = ModelsConfigData {
-            mode: "merge".to_string(),
-            providers: {
-                let mut map = std::collections::HashMap::new();
-                map.insert(
-                    "minimax".to_string(),
-                    ProviderConfig {
-                        base_url: None,
-                        api_key: None,
-                        api: None,
-                        protocol: None,
-                        credential_path: Some("credentials/minimax.json".to_string()),
-                        models: vec![
-                            ModelDefinition {
-                                id: "model-a".to_string(),
-                                name: Some("Model A".to_string()),
-                                enabled: Some(true),
-                            },
-                            ModelDefinition {
-                                id: "model-b".to_string(),
-                                name: Some("Model B".to_string()),
-                                enabled: Some(true),
-                            },
-                            ModelDefinition {
-                                id: "model-c".to_string(),
-                                name: Some("Model C".to_string()),
-                                enabled: Some(false),
-                            },
-                        ],
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "minimax".to_string(),
+            ProviderConfig {
+                base_url: None,
+                api_key: None,
+                api: None,
+                protocol: None,
+                credential_path: Some("credentials/minimax.json".to_string()),
+                models: vec![
+                    ModelDefinition {
+                        id: "model-a".to_string(),
+                        name: Some("Model A".to_string()),
+                        enabled: Some(true),
                     },
-                );
-                map
+                    ModelDefinition {
+                        id: "model-b".to_string(),
+                        name: Some("Model B".to_string()),
+                        enabled: Some(true),
+                    },
+                    ModelDefinition {
+                        id: "model-c".to_string(),
+                        name: Some("Model C".to_string()),
+                        enabled: Some(false),
+                    },
+                ],
             },
-        };
-        let models_path = tmp.path().join("models.json");
-        std::fs::create_dir_all(tmp.path()).unwrap();
-        std::fs::write(
-            &models_path,
-            serde_json::to_string_pretty(&initial).unwrap(),
-        )
-        .unwrap();
+        );
+        write_initial_config(&tmp, providers);
 
-        // Re-run wizard selecting only model-a and a new model-d
-        let output = WizardOutput {
-            provider_id: "minimax".to_string(),
-            credential: "test-key".to_string(),
-            selected_models: vec![
-                ModelInfo {
-                    id: "model-a".to_string(),
-                    name: "Model A Updated".to_string(),
-                    context_window: 1000,
-                    max_tokens: 1000,
-                    default_temperature: None,
-                    reasoning: false,
-                    input_types: vec![],
-                },
-                ModelInfo {
-                    id: "model-d".to_string(),
-                    name: "Model D".to_string(),
-                    context_window: 3000,
-                    max_tokens: 3000,
-                    default_temperature: None,
-                    reasoning: false,
-                    input_types: vec![],
-                },
+        let output = make_wizard_output(
+            "minimax",
+            "test-key",
+            vec![
+                make_model("model-a", "Model A Updated", 1000, 1000),
+                make_model("model-d", "Model D", 3000, 3000),
             ],
-        };
+        );
         write_wizard_config_to(&output, tmp.path()).unwrap();
 
-        // Verify: model-b and model-c preserved, model-a updated, model-d added
-        let content = std::fs::read_to_string(&models_path).unwrap();
-        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let parsed = read_parsed_config(&tmp);
         let provider = parsed.providers.get("minimax").unwrap();
-        assert_eq!(
-            provider.models.len(),
-            4,
-            "should have 4 models (model-a updated + model-b, model-c preserved + model-d new)"
-        );
+        assert_eq!(provider.models.len(), 4);
         let ids: Vec<&str> = provider.models.iter().map(|m| m.id.as_str()).collect();
-        assert!(ids.contains(&"model-b"), "model-b should be preserved");
-        assert!(ids.contains(&"model-c"), "model-c should be preserved");
-        assert!(ids.contains(&"model-d"), "model-d should be added");
-        // model-a should be updated
+        assert!(ids.contains(&"model-b"));
+        assert!(ids.contains(&"model-c"));
+        assert!(ids.contains(&"model-d"));
         let model_a = provider.models.iter().find(|m| m.id == "model-a").unwrap();
         assert_eq!(model_a.name.as_deref(), Some("Model A Updated"));
         assert_eq!(model_a.enabled, Some(true));

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -243,6 +243,15 @@ mod write_wizard_config_tests {
         }
     }
 
+    /// Helper: create a simple ModelDefinition
+    fn make_model_def(id: &str, name: &str, enabled: bool) -> ModelDefinition {
+        ModelDefinition {
+            id: id.to_string(),
+            name: Some(name.to_string()),
+            enabled: Some(enabled),
+        }
+    }
+
     /// Helper: read and parse models.json
     fn read_parsed_config(tmp: &TempDir) -> ModelsConfigData {
         let models_path = tmp.path().join("models.json");
@@ -367,54 +376,25 @@ mod write_wizard_config_tests {
     #[test]
     fn test_write_wizard_config_to_preserves_existing_models() {
         let tmp = TempDir::new().unwrap();
-
         // First write: 1 model
-        let output1 = WizardOutput {
-            provider_id: "minimax".to_string(),
-            credential: "test-api-key".to_string(),
-            selected_models: vec![ModelInfo {
-                id: "MiniMax-M2.7".to_string(),
-                name: "MiniMax M2.7".to_string(),
-                context_window: 1000,
-                max_tokens: 1000,
-                default_temperature: None,
-                reasoning: false,
-                input_types: vec![],
-            }],
-        };
+        let output1 = make_wizard_output(
+            "minimax",
+            "test-api-key",
+            vec![make_model("MiniMax-M2.7", "MiniMax M2.7", 1000, 1000)],
+        );
         write_wizard_config_to(&output1, tmp.path()).unwrap();
-
         // Second write: 2 different models (MiniMax-M2.7 NOT selected)
-        let output2 = WizardOutput {
-            provider_id: "minimax".to_string(),
-            credential: "test-api-key-2".to_string(),
-            selected_models: vec![
-                ModelInfo {
-                    id: "abab6.5-chat".to_string(),
-                    name: "ABAB6.5 Chat".to_string(),
-                    context_window: 2000,
-                    max_tokens: 2000,
-                    default_temperature: None,
-                    reasoning: false,
-                    input_types: vec![],
-                },
-                ModelInfo {
-                    id: "abab6.5-chat-pro".to_string(),
-                    name: "ABAB6.5 Chat Pro".to_string(),
-                    context_window: 4000,
-                    max_tokens: 4000,
-                    default_temperature: None,
-                    reasoning: false,
-                    input_types: vec![],
-                },
+        let output2 = make_wizard_output(
+            "minimax",
+            "test-api-key-2",
+            vec![
+                make_model("abab6.5-chat", "ABAB6.5 Chat", 2000, 2000),
+                make_model("abab6.5-chat-pro", "ABAB6.5 Chat Pro", 4000, 4000),
             ],
-        };
+        );
         write_wizard_config_to(&output2, tmp.path()).unwrap();
-
         // Verify: first model preserved alongside 2 new ones = 3 total
-        let models_path = tmp.path().join("models.json");
-        let content = std::fs::read_to_string(&models_path).unwrap();
-        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let parsed = read_parsed_config(&tmp);
         let provider = parsed.providers.get("minimax").unwrap();
         assert_eq!(
             provider.models.len(),
@@ -530,21 +510,9 @@ mod write_wizard_config_tests {
                 protocol: None,
                 credential_path: Some("credentials/minimax.json".to_string()),
                 models: vec![
-                    ModelDefinition {
-                        id: "model-a".to_string(),
-                        name: Some("Model A".to_string()),
-                        enabled: Some(true),
-                    },
-                    ModelDefinition {
-                        id: "model-b".to_string(),
-                        name: Some("Model B".to_string()),
-                        enabled: Some(true),
-                    },
-                    ModelDefinition {
-                        id: "model-c".to_string(),
-                        name: Some("Model C".to_string()),
-                        enabled: Some(false),
-                    },
+                    make_model_def("model-a", "Model A", true),
+                    make_model_def("model-b", "Model B", true),
+                    make_model_def("model-c", "Model C", false),
                 ],
             },
         );


### PR DESCRIPTION
fix: preserve existing provider config and unselected models in write_wizard_config_to

修复 `write_wizard_config_to` 的合并策略与 design doc 不一致的问题：

1. 移除 provider 前先保存其现有配置，重建时继承 base_url/api_key/api 字段，避免丢失自定义配置
2. 构建模型列表时，先保留现有模型，再用 selected_models 更新/追加，不删除未重选的已有模型
3. 拆分超限函数体（>50行）为辅助函数以符合 CONTRIBUTING.md 硬性限制

Source: design doc docs/design/llm/provider-config-wizard.md
Type: fix
