### PR TITLE
fix: align provider config wizard with design doc

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -474,11 +474,13 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
                 let proto = kb.recommended_protocol(provider_id, &m.id);
                 let proto_str = proto.as_str();
                 format!(
-                    "{:3}. {} {}{}  protocol: {} (recommended)",
+                    "{:3}. {} {}{}  ctx: {}K  max: {}K  protocol: {}",
                     i + 1,
                     mark,
                     m.name,
                     reasoning_flag,
+                    m.context_window / 1000,
+                    m.max_tokens / 1000,
                     proto_str
                 )
             })

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -263,12 +263,15 @@ pub fn write_wizard_config_to(output: &WizardOutput, config_path: &Path) -> anyh
         kb.recommended_protocol(&output.provider_id, &m.id)
             .to_string()
     });
-    let (base_url, api_key, api) = inherit_provider_fields(&existing_provider);
+    let (base_url, _api_key, api) = inherit_provider_fields(&existing_provider);
+    // api_key is never stored in models.json — credentials live in a separate
+    // file referenced by credential_path. Setting it to None prevents leaking
+    // secrets into the config file.
     providers.insert(
         output.provider_id.clone(),
         ProviderConfig {
             base_url,
-            api_key,
+            api_key: None,
             api,
             protocol: recommended_protocol,
             credential_path: Some(format!("credentials/{}.json", output.provider_id)),

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -412,6 +412,31 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
             .await;
         println!(" done");
         ctx.fetched_models = result.into_models();
+
+        // Display fetched model details
+        if !ctx.fetched_models.is_empty() {
+            println!("\nFound {} model(s):\n", ctx.fetched_models.len());
+            println!(
+                " {:3}. {:35} {:>10} {:>8} Reasoning",
+                "#", "Model", "Context", "MaxOut"
+            );
+            println!(
+                "{:->4}- {:->35}- {:->10}- {:->8}- {:->9}",
+                "", "", "", "", ""
+            );
+            for (i, m) in ctx.fetched_models.iter().enumerate() {
+                let reasoning = if m.reasoning { "✅" } else { "❌" };
+                println!(
+                    " {:3}. {:35} {:>10} {:>8} {}",
+                    i + 1,
+                    m.name,
+                    m.context_window,
+                    m.max_tokens,
+                    reasoning
+                );
+            }
+            println!();
+        }
     }
 
     ctx.current_state = WizardState::SelectModels;

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -302,6 +302,25 @@ pub fn write_wizard_config(output: &WizardOutput) -> anyhow::Result<()> {
     write_wizard_config_to(output, &config_dir())
 }
 
+/// Compute a default selection string for already-configured models.
+///
+/// Given a list of fetched models and a set of already-configured model IDs,
+/// returns a comma-separated string of 1-based indices (e.g. "1,3,5")
+/// for models that exist in `configured_ids`. Returns an empty string if no
+/// models are already configured.
+pub fn compute_default_selection(
+    models: &[ModelInfo],
+    configured_ids: &std::collections::HashSet<String>,
+) -> String {
+    let indices: Vec<String> = models
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| configured_ids.contains(&m.id))
+        .map(|(i, _)| (i + 1).to_string())
+        .collect();
+    indices.join(",")
+}
+
 /// Locate the models.json config file, if it exists.
 fn find_models_config() -> Option<std::path::PathBuf> {
     let possible = ["config/models.json", "configs/models.json"];
@@ -498,13 +517,12 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         println!();
 
         // Compute default selection for already-configured models
-        let configured_indices: Vec<String> = models
+        let configured_ids: std::collections::HashSet<String> = models
             .iter()
-            .enumerate()
-            .filter(|(_, m)| ctx.existing_config.contains_key(&m.id))
-            .map(|(i, _)| (i + 1).to_string())
+            .filter(|m| ctx.existing_config.contains_key(&m.id))
+            .map(|m| m.id.clone())
             .collect();
-        let default_selection = configured_indices.join(",");
+        let default_selection = compute_default_selection(models, &configured_ids);
 
         let input: String = tokio::task::spawn_blocking(move || {
             let mut prompt = Input::new().with_prompt("Your selection");

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -494,10 +494,24 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
         }
         println!();
 
-        let input: String =
-            tokio::task::spawn_blocking(|| Input::new().with_prompt("Your selection").interact())
-                .await
-                .map_err(|e| anyhow::anyhow!("dialoguer interrupted: {}", e))??;
+        // Compute default selection for already-configured models
+        let configured_indices: Vec<String> = models
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| ctx.existing_config.contains_key(&m.id))
+            .map(|(i, _)| (i + 1).to_string())
+            .collect();
+        let default_selection = configured_indices.join(",");
+
+        let input: String = tokio::task::spawn_blocking(move || {
+            let mut prompt = Input::new().with_prompt("Your selection");
+            if !default_selection.is_empty() {
+                prompt = prompt.with_initial_text(default_selection);
+            }
+            prompt.interact()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("dialoguer interrupted: {}", e))??;
 
         match parse_model_selection(&input, models.len()) {
             Ok(indices) => {

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -308,7 +308,7 @@ pub fn write_wizard_config(output: &WizardOutput) -> anyhow::Result<()> {
 /// returns a comma-separated string of 1-based indices (e.g. "1,3,5")
 /// for models that exist in `configured_ids`. Returns an empty string if no
 /// models are already configured.
-pub fn compute_default_selection(
+pub(crate) fn compute_default_selection(
     models: &[ModelInfo],
     configured_ids: &std::collections::HashSet<String>,
 ) -> String {

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -339,10 +339,26 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
     let mut ctx = WizardContext::default();
 
     // ── SelectProvider ──────────────────────────────────────────────────
-    let selection = tokio::task::spawn_blocking(|| {
+    let kb = ProviderModelKnowledge::new();
+    let provider_display: Vec<String> = PROVIDERS
+        .iter()
+        .map(|p| {
+            let proto = kb.recommended_protocol(p.id, "");
+            let proto_str = if proto.as_str().is_empty() {
+                "N/A"
+            } else {
+                proto.as_str()
+            };
+            format!(
+                "{} — {} (推荐协议: {})",
+                p.display_name, p.description, proto_str
+            )
+        })
+        .collect();
+    let selection = tokio::task::spawn_blocking(move || {
         Select::new()
             .with_prompt("Select a provider")
-            .items(&PROVIDERS.iter().map(|p| p.display_name).collect::<Vec<_>>())
+            .items(&provider_display)
             .default(0)
             .interact()
     })

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -793,7 +793,8 @@ mod provider_info_tests {
     #[test]
     fn test_provider_info_roundtrip_with_description() {
         // &'static str fields require static source for deserialization
-        let json = r#"{"id":"test","display_name":"Test","provider_type":"Deepseek","description":"test description"}"#;
+        let json = "{\"id\":\"test\",\"display_name\":\"Test\",
+             \"provider_type\":\"Deepseek\",\"description\":\"test description\"}";
         let roundtripped: ProviderInfo = serde_json::from_str(json).unwrap();
         assert_eq!(roundtripped.id, "test");
         assert_eq!(roundtripped.display_name, "Test");

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -753,3 +753,236 @@ mod ensure_master_agent_tests {
         assert_agents_json(&agents_json_path, &["helper", "master"]);
     }
 }
+
+#[cfg(test)]
+mod provider_info_tests {
+    use super::types::{ProviderInfo, ProviderType};
+    use super::PROVIDERS;
+
+    #[test]
+    fn test_provider_info_serialize_with_description() {
+        let info = ProviderInfo {
+            id: "test",
+            display_name: "Test Provider",
+            provider_type: ProviderType::Minimax,
+            description: "A test provider",
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(
+            json.contains("description"),
+            "JSON should contain description: {}",
+            json
+        );
+        assert!(json.contains("A test provider"));
+    }
+
+    #[test]
+    fn test_provider_info_deserialize_with_description() {
+        let json = r#"{
+            "id": "test",
+            "display_name": "Test Provider",
+            "provider_type": "Minimax",
+            "description": "A test provider"
+        }"#;
+        let info: ProviderInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.id, "test");
+        assert_eq!(info.display_name, "Test Provider");
+        assert_eq!(info.description, "A test provider");
+    }
+
+    #[test]
+    fn test_provider_info_roundtrip_with_description() {
+        // &'static str fields require static source for deserialization
+        let json = r#"{"id":"test","display_name":"Test","provider_type":"Deepseek","description":"test description"}"#;
+        let roundtripped: ProviderInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(roundtripped.id, "test");
+        assert_eq!(roundtripped.display_name, "Test");
+        assert_eq!(roundtripped.description, "test description");
+        assert_eq!(roundtripped.provider_type, ProviderType::Deepseek);
+    }
+
+    #[test]
+    fn test_all_providers_have_description() {
+        for provider in PROVIDERS {
+            assert!(
+                !provider.description.is_empty(),
+                "Provider '{}' should have a non-empty description",
+                provider.id
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod compute_default_selection_tests {
+    use super::compute_default_selection;
+    use crate::llm::model_info::ModelInfo;
+    use std::collections::HashSet;
+
+    fn make_model(id: &str) -> ModelInfo {
+        ModelInfo {
+            id: id.to_string(),
+            name: id.to_string(),
+            context_window: 1000,
+            max_tokens: 1000,
+            default_temperature: None,
+            reasoning: false,
+            input_types: vec![],
+        }
+    }
+
+    #[test]
+    fn test_no_configured_models_returns_empty() {
+        let models = vec![make_model("a"), make_model("b"), make_model("c")];
+        let configured = HashSet::new();
+        assert_eq!(compute_default_selection(&models, &configured), "");
+    }
+
+    #[test]
+    fn test_single_configured_model() {
+        let models = vec![make_model("a"), make_model("b"), make_model("c")];
+        let mut configured = HashSet::new();
+        configured.insert("b".to_string());
+        assert_eq!(compute_default_selection(&models, &configured), "2");
+    }
+
+    #[test]
+    fn test_multiple_configured_models_sorted() {
+        let models = vec![
+            make_model("a"),
+            make_model("b"),
+            make_model("c"),
+            make_model("d"),
+        ];
+        let mut configured = HashSet::new();
+        configured.insert("d".to_string());
+        configured.insert("a".to_string());
+        assert_eq!(compute_default_selection(&models, &configured), "1,4");
+    }
+
+    #[test]
+    fn test_all_models_configured() {
+        let models = vec![make_model("a"), make_model("b"), make_model("c")];
+        let configured: HashSet<String> = models.iter().map(|m| m.id.clone()).collect();
+        assert_eq!(compute_default_selection(&models, &configured), "1,2,3");
+    }
+
+    #[test]
+    fn test_empty_model_list() {
+        let models = vec![];
+        let mut configured = HashSet::new();
+        configured.insert("a".to_string());
+        assert_eq!(compute_default_selection(&models, &configured), "");
+    }
+
+    #[test]
+    fn test_configured_ids_not_in_models_ignored() {
+        let models = vec![make_model("a"), make_model("b")];
+        let mut configured = HashSet::new();
+        configured.insert("x".to_string());
+        configured.insert("y".to_string());
+        assert_eq!(compute_default_selection(&models, &configured), "");
+    }
+}
+
+#[cfg(test)]
+mod write_wizard_config_api_key_clearing_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Test: write_wizard_config always sets api_key to None in models.json
+    #[test]
+    fn test_write_wizard_config_clears_api_key() {
+        let tmp = TempDir::new().unwrap();
+        let output = WizardOutput {
+            provider_id: "glm".to_string(),
+            credential: "my-secret-api-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "glm-4".to_string(),
+                name: "GLM 4".to_string(),
+                context_window: 128_000,
+                max_tokens: 4_096,
+                default_temperature: Some(0.7),
+                reasoning: false,
+                input_types: vec![],
+            }],
+        };
+
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        let models_path = tmp.path().join("models.json");
+        let content = std::fs::read_to_string(&models_path).unwrap();
+        let parsed: ModelsConfigData = serde_json::from_str(&content).unwrap();
+        let provider = parsed.providers.get("glm").unwrap();
+
+        assert!(
+            provider.api_key.is_none(),
+            "api_key should be None (cleared), got: {:?}",
+            provider.api_key
+        );
+        assert_eq!(
+            provider.credential_path.as_deref(),
+            Some("credentials/glm.json"),
+            "credential_path should reference the credentials file"
+        );
+    }
+
+    /// Test: api_key is None even when existing config had api_key set
+    #[test]
+    fn test_write_wizard_config_clears_existing_api_key() {
+        let tmp = TempDir::new().unwrap();
+        let mut providers = std::collections::HashMap::new();
+        providers.insert(
+            "deepseek".to_string(),
+            ProviderConfig {
+                base_url: Some("https://api.deepseek.com".to_string()),
+                api_key: Some("old-secret-key".to_string()),
+                api: None,
+                protocol: None,
+                credential_path: Some("credentials/deepseek.json".to_string()),
+                models: vec![],
+            },
+        );
+        let initial = ModelsConfigData {
+            mode: "merge".to_string(),
+            providers,
+        };
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        std::fs::write(
+            tmp.path().join("models.json"),
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        let output = WizardOutput {
+            provider_id: "deepseek".to_string(),
+            credential: "new-key".to_string(),
+            selected_models: vec![ModelInfo {
+                id: "deepseek-v3".to_string(),
+                name: "DeepSeek V3".to_string(),
+                context_window: 64_000,
+                max_tokens: 8_192,
+                default_temperature: None,
+                reasoning: true,
+                input_types: vec![],
+            }],
+        };
+
+        write_wizard_config_to(&output, tmp.path()).unwrap();
+
+        let parsed: ModelsConfigData =
+            serde_json::from_str(&std::fs::read_to_string(tmp.path().join("models.json")).unwrap())
+                .unwrap();
+        let provider = parsed.providers.get("deepseek").unwrap();
+
+        assert!(
+            provider.api_key.is_none(),
+            "api_key should be None after wizard rewrite, got: {:?}",
+            provider.api_key
+        );
+        assert_eq!(
+            provider.base_url.as_deref(),
+            Some("https://api.deepseek.com")
+        );
+    }
+}

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -492,7 +492,7 @@ mod write_wizard_config_tests {
             provider.base_url.as_deref(),
             Some("https://custom.api.com/v1")
         );
-        assert_eq!(provider.api_key.as_deref(), Some("sk-existing-key"));
+        assert_eq!(provider.api_key, None);
         assert_eq!(provider.api.as_deref(), Some("v2"));
     }
 

--- a/src/cli/config_wizard/types.rs
+++ b/src/cli/config_wizard/types.rs
@@ -23,6 +23,7 @@ pub struct ProviderInfo {
     pub id: &'static str,
     pub display_name: &'static str,
     pub provider_type: ProviderType,
+    pub description: &'static str,
 }
 
 /// Provider type enumeration
@@ -40,21 +41,25 @@ pub const PROVIDERS: &[ProviderInfo] = &[
         id: "minimax",
         display_name: "MiniMax",
         provider_type: ProviderType::Minimax,
+        description: "多模态大模型，推荐 Anthropic 协议",
     },
     ProviderInfo {
         id: "glm",
         display_name: "GLM",
         provider_type: ProviderType::Glm,
+        description: "智谱 AI 大模型，推荐 OpenAI 协议",
     },
     ProviderInfo {
         id: "volcengine",
         display_name: "Volcengine",
         provider_type: ProviderType::Volcengine,
+        description: "火山引擎大模型",
     },
     ProviderInfo {
         id: "deepseek",
         display_name: "DeepSeek",
         provider_type: ProviderType::Deepseek,
+        description: "深度求索推理模型，推荐 Anthropic 协议",
     },
 ];
 


### PR DESCRIPTION
对齐 provider-config-wizard 的 design doc，修复 5 处代码与文档的差异：

1. SelectProvider 展示推荐协议和简要说明（而非仅 display_name）
2. FetchModels 完成后展示模型详情（推理标志、上下文窗口、最大输出 token）
3. SelectModels 增加 context_window 和 max_tokens 列
4. SelectModels 预选已配置模型（输入框预填编号）
5. WriteConfig 清除明文 api_key（凭据仅通过 credential_path 引用）

Source: design doc
Type: fix
