### PR TITLE
refactor: fix config wizard double write

### DIFF
--- a/src/cli/admin/config.rs
+++ b/src/cli/admin/config.rs
@@ -164,5 +164,14 @@ pub async fn handle_config_setup(skip: bool) -> Result<()> {
     }
 
     config_wizard::write_wizard_config(&output)?;
+
+    // Ensure the master agent exists after writing config.
+    let config_path = std::env::var("HOME")
+        .map(|h| std::path::PathBuf::from(h).join(".closeclaw"))
+        .map_err(|e| anyhow::anyhow!("HOME not set: {}", e))?;
+    let agents_dir = config_path.join("agents");
+    let config_dir = config_path.join("config");
+    config_wizard::ensure_master_agent(&config_dir, &agents_dir)?;
+
     Ok(())
 }

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -112,7 +112,6 @@ fn config_dir() -> PathBuf {
     PathBuf::from(home).join(".closeclaw").join("config")
 }
 
-#[allow(dead_code)]
 /// Create the initial `master` agent if it does not already exist.
 ///
 /// Writes:
@@ -120,7 +119,7 @@ fn config_dir() -> PathBuf {
 /// - `~/.closeclaw/config/agents.json` (appends "master" if missing)
 ///
 /// Idempotent: skips files that already exist.
-fn ensure_master_agent(config_dir: &Path, agents_dir: &Path) -> anyhow::Result<()> {
+pub(crate) fn ensure_master_agent(config_dir: &Path, agents_dir: &Path) -> anyhow::Result<()> {
     // ── Write master agent config.json if missing ──────────────────────────────
     let master_config_path = agents_dir.join("master").join("config.json");
     if !master_config_path.exists() {

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -615,23 +615,9 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
     let out_credential = ctx.credential.clone().unwrap();
     let out_selected_models = ctx.selected_models.clone();
 
-    // Write output to config files
-    if let Err(e) = write_wizard_config(&WizardOutput {
-        provider_id: out_provider_id.clone(),
-        credential: out_credential.clone(),
-        selected_models: out_selected_models.clone(),
-    }) {
-        eprintln!("[ERROR] Failed to write config: {}", e);
-        anyhow::bail!("write_wizard_config failed: {}", e);
-    }
-
-    // Create initial master agent if it does not exist yet.
-    // Failure here is non-fatal: the wizard config (models + credentials) is
-    // already written and should not be rolled back.
-    let agents_dir = config_dir().parent().unwrap().join("agents");
-    if let Err(e) = ensure_master_agent(&config_dir(), &agents_dir) {
-        eprintln!("[WARNING] Failed to create master agent: {}", e);
-    }
+    // NOTE: write_wizard_config() and ensure_master_agent() are called by
+    // handle_config_setup() after Confirm — run_wizard() only builds and
+    // returns the WizardOutput.
 
     Ok(Some(WizardOutput {
         provider_id: out_provider_id,


### PR DESCRIPTION
Fix config wizard double write

The config wizard was executing `write_wizard_config()` twice: once inside `run_wizard()` and again in `handle_config_setup()`. This caused duplicate file writes that didn't match the design doc's intended single-write behavior.

Changes:
- Remove `write_wizard_config()` and `ensure_master_agent()` calls from `run_wizard()`, making it purely interactive (builds and returns `WizardOutput` only)
- Move `ensure_master_agent()` to `handle_config_setup()` after `write_wizard_config()`, consolidating all write operations in one place
- Make `ensure_master_agent()` `pub(crate)` for cross-module access

Source: user
Type: refactor
