### PR TITLE
docs(design): fix cache-adapter responsibility attribution

### DIFF
--- a/docs/design/llm/cache-adapter.md
+++ b/docs/design/llm/cache-adapter.md
@@ -10,13 +10,14 @@
 
 ```
 System Prompt 构建
-  → 加载静态区内容
-  → 组装动态区内容
-  → 缓存适配器（请求前置处理，在 Plugin Pipeline 之前）
+  ↓ 加载静态区内容
+  ↓ 组装动态区内容
+  ↓ system_prompt 模块切分静态区与动态区（通过 __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__ 边界标记）
+  ↓ 缓存适配器（请求前置处理，在 Plugin Pipeline 之前）
     ├─ Anthropic：静态区标记 cache_control（显式前缀缓存）
     └─ DeepSeek / OpenAI / 其他：无显式缓存参数（依赖前缀稳定性触发服务端自动前缀缓存）
-  → Plugin Pipeline（before_request → 后续 LLM Client 标准链路）
-  → 发送到 LLM API
+  ↓ Plugin Pipeline（before_request → 后续 LLM Client 标准链路）
+  ↓ 发送到 LLM API
 ```
 
 ### Anthropic 适配
@@ -31,17 +32,17 @@ DeepSeek 和 OpenAI 使用服务端自动前缀缓存，无需客户端显式标
 
 ### 边界标记
 
-缓存适配器依赖 system prompt 模块的 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 边界标记来切分可缓存前缀和不可缓存后缀。标记是缓存适配器的程序输入，而非仅供人类阅读的装饰文本。标记之前的内容作为静态区，标记之后的内容作为动态区；缓存适配器只对静态区标记缓存控制参数（Anthropic），对 DeepSeek / OpenAI 不做额外处理（service 端自动前缀缓存不依赖客户端标记），动态区内容统一透传不做修改。
+system prompt 模块通过 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 边界标记将 system prompt 切分为静态区和动态区，切分结果以预置字段传递给缓存适配器。缓存适配器不直接解析边界标记——它只消费上游已切分好的静态区和动态区内容，对静态区标记缓存控制参数（Anthropic），对动态区统一透传不做修改。DeepSeek / OpenAI 等服务端自动前缀缓存的供应商，静态区和动态区均透传不标记，命中率由 system prompt 模块保证的前缀稳定性覆盖。
+
+边界标记的定义、插入位置和切分规则详见 [system_prompt/kv-cache](../system_prompt/kv-cache.md)。
 
 ### 消息历史缓存
 
-缓存适配器仅处理静态区内容（system blocks）的缓存标记。messages 数组的 cache_control 标记由 Protocol 层在请求序列化时完成——Anthropic 协议在 messages 数组尾部标记 cache_control，使下一轮请求的完整前缀（上轮的 system prompt + 全部 messages）命中缓存。每轮请求只在消息序列的最尾部打一个 cache_control，指向前缀匹配点。
-
-DeepSeek 和 OpenAI 对消息历史部分按前缀匹配生效——消息数组只追加、前缀不变，历史消息的前缀部分与 system prompt 共同被服务端自动前缀缓存覆盖。每轮请求只需计费新增的消息尾部。
+消息历史的缓存标记（messages 数组尾部的 cache_control）由 Protocol 层在请求序列化时完成，不属于缓存适配器的职责。详见 [protocol-mapping](protocol-mapping.md) 的消息历史缓存策略。
 
 ### 工具 Schema 缓存
 
-当工具定义通过 API 的 `tools` 参数传递时，所有工具 Schema 统一标记 cache_control，使工具定义在整个 session 内被前缀缓存覆盖。额外加载的工具定义追加在 base Schema 之后，切换时仅损失追加部分的缓存，不影响 base Schema 的命中。
+当工具定义通过 API 的 `tools` 参数传递时（Anthropic），所有工具 Schema 统一标记 cache_control，使工具定义在整个 session 内被前缀缓存覆盖。额外加载的工具定义追加在 base Schema 之后，切换时仅损失追加部分的缓存，不影响 base Schema 的命中。
 
 当工具定义以文本形式嵌入 system prompt 时，它作为静态层的一部分自然被前缀缓存覆盖，无需在 tools 参数上单独标记。
 
@@ -49,13 +50,14 @@ DeepSeek 和 OpenAI 对消息历史部分按前缀匹配生效——消息数组
 
 ```
 system_prompt 模块构建 system prompt
-  → 拆分静态区（bootstrap 文件 + ToolsSection + SkillListingSection + MemorySection）与动态区（ChannelContext + WorkingDirectory + GitStatus）
-  → 缓存适配器接收（供应商 ID、静态区内容、动态区内容、会话 ID）
-    → Anthropic：静态区标记缓存控制 → 标准协议请求
-    → DeepSeek / OpenAI：无额外处理（前缀稳定性由 system prompt 模块保证）→ 标准协议请求
-  → 进入 LLM Client 标准调用链路
-  → 发送请求
-  → 从用量字段监控缓存命中（cached_tokens 计数）
+  ↓ 拆分静态区（bootstrap 文件 + ToolsSection + SkillListingSection + MemorySection）与动态区（ChannelContext + WorkingDirectory + GitStatus + 追加区）
+  ↓ 缓存适配器接收（供应商 ID、静态区内容、动态区内容、会话 ID）
+    ├─ Anthropic：静态区标记缓存控制 → 标准协议请求
+    └─ DeepSeek / OpenAI：无额外处理（前缀稳定性由 system prompt 模块保证）→ 标准协议请求
+  ↓ Plugin Pipeline（before_request）
+  ↓ LLM Client 标准调用链路
+  ↓ 发送请求
+  ↓ 从用量字段监控缓存命中（cached_tokens 计数）
 ```
 
 ## 模块关系

--- a/docs/design/llm/protocol-mapping.md
+++ b/docs/design/llm/protocol-mapping.md
@@ -63,6 +63,16 @@ Anthropic SSE 事件序列的典型顺序：`message_start` → `content_block_s
 
 多轮场景的 fixture 使用 `turns` 结构记录每轮的完整 messages 数组和对应响应，展示消息列表在各轮之间的增量变化。
 
+### 消息历史缓存
+
+各协议在请求 messages 数组上的缓存标记策略不同。消息历史的缓存标记使下一轮请求的完整前缀（上轮的 system prompt + 全部 messages）命中 cache，仅新增的消息尾部按全价计费。
+
+**Anthropic 协议**：支持显式缓存标记。在 messages 数组的尾部消息上打 `cache_control: {"type": "ephemeral"}`，指向前缀匹配点。每轮请求只在尾部打一个标记——消息数组只追加不修改，前缀稳定使缓存持续命中。
+
+**OpenAI / DeepSeek 协议**：使用服务端自动前缀缓存，无需客户端在 messages 上显式标记。消息数组只追加、前缀不变，历史消息的前缀部分自动被服务端缓存覆盖。
+
+> 消息历史缓存标记属于 Protocol 层的序列化行为，与缓存适配器（处理 system prompt 静态区缓存）职责分离。缓存适配器详见 [cache-adapter](cache-adapter.md)。
+
 ## 数据流
 
 ```

--- a/docs/design/system_prompt/README.md
+++ b/docs/design/system_prompt/README.md
@@ -22,7 +22,7 @@ Session 创建 / 恢复 / Compaction
   ╔════════════════════════╗
   ║  静态层（session 持久）  ║  ← 走 Section 级缓存
   ╠════════════════════════╣
-  ║  __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__      ║  ← cache adapter 的切分点
+  ║  __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__      ║  ← 切分点（system_prompt 模块切分）
   ╠════════════════════════╣
   ║  动态层（每请求即时构建）  ║  ← 默认内容不变，不参与显式前缀缓存标记
   ╠════════════════════════╣
@@ -39,7 +39,7 @@ Session 创建 / 恢复 / Compaction
 |------|------|
 | [static-layer.md](static-layer.md) | 静态层：bootstrap 文件、系统生成的 Section、Section 级缓存与失效规则 |
 | [dynamic-layer.md](dynamic-layer.md) | 动态层：每请求即时注入的 ChannelContext / WorkingDirectory / GitStatus（可配置关闭） |
-| [kv-cache.md](kv-cache.md) | 边界标记 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 的位置和语义，作为 cache adapter 的切分合约 |
+| [kv-cache.md](kv-cache.md) | 边界标记 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 的位置和语义，作为静态/动态区切分的接口合约 |
 | [appends.md](appends.md) | 追加区：`/system` 指令管理的独立分区，持久化不受压缩影响 |
 
 ## 数据流
@@ -59,7 +59,9 @@ API 请求到达
   →
   拼接：静态层 + __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__ + 动态层 + 追加区
   →
-  cache adapter 以边界标记为切分点注入缓存控制参数
+  以边界标记为切分点，分离静态区和动态区为独立字段，传入 InternalRequest
+  →
+  cache adapter 接收已分离的字段，注入缓存控制参数
   →
   发送 LLM 请求
 ```
@@ -89,7 +91,7 @@ Archived session 被访问
 - **Bootstrap Loader**：提供 bootstrap 文件内容，按 Minimal/Full 模式加载。
 - **ToolRegistry**：提供 ToolsSection 的分组索引。
 - **DiskSkillRegistry**：按 agent 过滤并提供 skill 列表数据。
-- **Cache Adapter**：以边界标记为切分点，对静态层注入缓存控制参数。详见 [llm/cache-adapter](docs/design/llm/cache-adapter.md)。
+- **Cache Adapter**：接收已切分的静态区和动态区字段，对静态层注入缓存控制参数。详见 [llm/cache-adapter](docs/design/llm/cache-adapter.md)。
 
 ### 无关
 

--- a/docs/design/system_prompt/kv-cache.md
+++ b/docs/design/system_prompt/kv-cache.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-边界标记是 System Prompt 静态层和动态层之间的分隔锚点，同时作为 cache adapter 的程序输入——cache adapter 以其为切分点，对静态前缀注入缓存控制参数，为动态后缀和消息历史透传不做标记。
+边界标记是 System Prompt 静态层和动态层之间的分隔锚点。system prompt 模块在组装完成后以边界标记为切分点将全文拆分为静态区和动态区，切分结果作为独立字段传入 cache adapter。cache adapter 不直接读取边界标记——它只消费上游已切分好的静态区和动态区，对静态区注入缓存控制参数，动态区透传不做标记。
 
 ## 架构
 
@@ -10,7 +10,9 @@
 
 静态层和动态层之间通过 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 标记分隔。标记的位置在 System Prompt 组装完成后的最终文本中，静态层之后、动态层之前。
 
-标记是 cache adapter 的程序输入，而非仅供人类阅读的装饰文本——cache adapter 以标记为切分点，标记之前的内容作为可缓存前缀（cache adapter 对其标记显式缓存控制参数），标记之后的内容每次请求重新计算，不参与显式前缀缓存（但服务端自动前缀缓存的 provider 仍可因稳定前缀获益）。追加区位于动态层之后、对话历史之前。
+标记的位置在静态层之后、动态层之前，追加区位于动态层之后、对话历史之前。system prompt 模块以标记为切分点将静态区与动态区分离，分离后的静态区和动态区作为独立字段传递给 cache adapter。静态区被标记缓存控制参数（Anthropic 显式缓存），动态区每次请求重新计算、不参与显式前缀缓存（但服务端自动前缀缓存的 provider 仍可因稳定前缀获益）。
+
+标记是 system prompt 模块与 cache adapter 之间的接口合约——system prompt 模块负责切分并传递分离后的字段，cache adapter 负责按供应商策略处理各字段。接口细节详见 [llm/cache-adapter](../llm/cache-adapter.md)。
 
 ### 前缀缓存
 
@@ -21,9 +23,11 @@ API 侧 KV Cache 通过 cache adapter 层实现。静态层和动态层通过边
 ```
 System Prompt 组装完成（静态层 + 边界标记 + 动态层 + 追加区）
   →
-  cache adapter 读取边界标记位置
-    → 标记之前：静态前缀（Anthropic 注入 cache_control 参数，其他供应商透传）
-    → 标记之后：动态后缀 + 追加区（透传）
+  system_prompt 模块以边界标记为切分点，分离为静态区字段和动态区字段
+  →
+  cache adapter 接收已分离的字段
+    → 静态区：Anthropic 注入 cache_control 参数，其他供应商透传
+    → 动态区 + 追加区：透传
   →
   发送 LLM 请求
 ```
@@ -36,7 +40,7 @@ System Prompt 组装完成（静态层 + 边界标记 + 动态层 + 追加区）
 
 ### 下游
 
-- **Cache Adapter**：以边界标记为切分点，对静态层按供应商策略处理（Anthropic 注入 cache_control，DeepSeek/OpenAI 透传）。详见 [llm/cache-adapter](docs/design/llm/cache-adapter.md)。
+- **Cache Adapter**：接收 system prompt 模块切分好的静态区和动态区字段，按供应商策略处理（Anthropic 注入 cache_control，DeepSeek/OpenAI 透传）。详见 [llm/cache-adapter](../llm/cache-adapter.md)。
 
 ### 无关
 

--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -137,7 +137,7 @@
     "commit": "",
     "commit_time": "",
     "confirmed_time": "2026-06-26T13:19:05.908214+08:00",
-    "comment": "blocked: doc has responsibility attribution issues"
+    "comment": ""
   },
   {
     "path": "docs/design/llm/model-discovery.md",


### PR DESCRIPTION
设计文档：cache-adapter + protocol-mapping + system_prompt（职责归属修正）

## 修改文件
- `docs/design/llm/cache-adapter.md` — 修正边界标记职责描述（上游切分→预置字段传入，不直接解析标记）、补充数据流缺失的 Plugin Pipeline 步骤、流程图格式优化
- `docs/design/llm/protocol-mapping.md` — 新增消息历史缓存策略节（从 cache-adapter 迁移到 Protocol 层归属）
- `docs/design/system_prompt/kv-cache.md` — 对齐接口描述：system_prompt 模块负责切分，cache adapter 消费已切分字段
- `docs/design/system_prompt/README.md` — 同步修正架构图标注、数据流、模块关系描述

## 附带修改
- `scripts/design-doc-tracker/records.json` — 清除 cache-adapter.md 的 blocked 标记

## 代码对照发现
- 边界标记切分由 `system_prompt/inject.rs` → `split_static_dynamic()` 完成，结果以 `system_static`/`system_dynamic` 字段传入 InternalRequest，cache adapter 只读字段——文档与代码逻辑一致
- `mark_last_message_cache_control` 在 `protocol/anthropic.rs`（Protocol 层），与文档迁移方向一致

Source: user
Type: docs
