### PR TITLE
fix: annotate discovery source in config wizard FetchModels display

### DIFF
--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -13,7 +13,7 @@ use closeclaw_config::providers::{
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
 use closeclaw_llm::{
-    DeepSeekProvider, GlmProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
+    DeepSeekProvider, DiscoverySource, GlmProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
     ProviderModelKnowledge, VolcEngineProvider,
 };
 use dialoguer::{Input, Select};
@@ -432,11 +432,20 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
             })
             .await;
         println!(" done");
+        let source = result.source;
         ctx.fetched_models = result.into_models();
 
         // Display fetched model details
         if !ctx.fetched_models.is_empty() {
-            println!("\nFound {} model(s):\n", ctx.fetched_models.len());
+            let source_suffix = match source {
+                DiscoverySource::KnowledgeFallback => " (via knowledge base fallback)",
+                _ => "",
+            };
+            println!(
+                "\nFound {} model(s){}:\n",
+                ctx.fetched_models.len(),
+                source_suffix
+            );
             println!(
                 " {:3}. {:35} {:>10} {:>8} Reasoning",
                 "#", "Model", "Context", "MaxOut"

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -24,6 +24,17 @@ use std::sync::Arc;
 
 use closeclaw_llm::model_info::ModelInfo;
 
+/// Format a human-readable source suffix for the discovered model list.
+///
+/// Returns a string like `" (via knowledge base fallback)"` for
+/// `KnowledgeFallback`, or an empty string for other sources.
+pub(crate) fn format_discovery_source_suffix(source: DiscoverySource) -> &'static str {
+    match source {
+        DiscoverySource::KnowledgeFallback => " (via knowledge base fallback)",
+        _ => "",
+    }
+}
+
 /// Parse user input for model selection into a vector of 0-based indices.
 ///
 /// Supported formats:
@@ -437,10 +448,7 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
 
         // Display fetched model details
         if !ctx.fetched_models.is_empty() {
-            let source_suffix = match source {
-                DiscoverySource::KnowledgeFallback => " (via knowledge base fallback)",
-                _ => "",
-            };
+            let source_suffix = format_discovery_source_suffix(source);
             println!(
                 "\nFound {} model(s){}:\n",
                 ctx.fetched_models.len(),

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -1,5 +1,4 @@
 //! Tests for the config wizard
-
 use super::*;
 
 #[cfg(test)]
@@ -11,73 +10,61 @@ mod parse_model_selection_tests {
         let result = parse_model_selection("3", 10).unwrap();
         assert_eq!(result, vec![2]);
     }
-
     #[test]
     fn space_separated() {
         let result = parse_model_selection("1 3 5", 10).unwrap();
         assert_eq!(result, vec![0, 2, 4]);
     }
-
     #[test]
     fn range() {
         let result = parse_model_selection("2-5", 10).unwrap();
         assert_eq!(result, vec![1, 2, 3, 4]);
     }
-
     #[test]
     fn mixed() {
         let result = parse_model_selection("1-3,5,7", 10).unwrap();
         assert_eq!(result, vec![0, 1, 2, 4, 6]);
     }
-
     #[test]
     fn all() {
         let result = parse_model_selection("all", 5).unwrap();
         assert_eq!(result, vec![0, 1, 2, 3, 4]);
     }
-
     #[test]
     fn all_case_insensitive() {
         let result = parse_model_selection("ALL", 3).unwrap();
         assert_eq!(result, vec![0, 1, 2]);
     }
-
     #[test]
     fn deduplicates() {
         let result = parse_model_selection("1 1 1", 5).unwrap();
         assert_eq!(result, vec![0]);
     }
-
     #[test]
     fn sorted() {
         let result = parse_model_selection("5 3 1", 10).unwrap();
         assert_eq!(result, vec![0, 2, 4]);
     }
-
     #[test]
     fn empty_input_error() {
         let result = parse_model_selection("", 5);
         assert!(result.is_err());
     }
-
     #[test]
     fn zero_not_allowed() {
         let result = parse_model_selection("0", 5);
         assert!(result.is_err());
     }
-
     #[test]
     fn out_of_range() {
         let result = parse_model_selection("11", 10);
         assert!(result.is_err());
     }
-
     #[test]
     fn start_greater_than_end() {
         let result = parse_model_selection("5-2", 10);
         assert!(result.is_err());
     }
-
     #[test]
     fn invalid_syntax() {
         let result = parse_model_selection("1-2-3", 10);
@@ -111,7 +98,7 @@ mod wizard_context_tests {
 mod provider_config_protocol_tests {
     use closeclaw_config::providers::models::{ModelDefinition, ProviderConfig};
 
-    /// Test 1: ProviderConfig serializes with protocol field present
+    /// Test: ProviderConfig serializes with protocol field present
     #[test]
     fn test_provider_config_serializes_with_protocol() {
         let config = ProviderConfig {
@@ -134,7 +121,7 @@ mod provider_config_protocol_tests {
         );
     }
 
-    /// Test 2: ProviderConfig serializes with protocol field as null when None
+    /// Test: ProviderConfig serializes with protocol field as null when None
     #[test]
     fn test_provider_config_serializes_with_protocol_null() {
         let config = ProviderConfig {
@@ -149,7 +136,7 @@ mod provider_config_protocol_tests {
         assert!(json.contains("\"protocol\": null"));
     }
 
-    /// Test 3: ProviderConfig deserializes with protocol field present
+    /// Test: ProviderConfig deserializes with protocol field present
     #[test]
     fn test_provider_config_deserializes_with_protocol() {
         let json = r#"{
@@ -165,7 +152,7 @@ mod provider_config_protocol_tests {
         assert_eq!(config.protocol.as_deref(), Some("anthropic"));
     }
 
-    /// Test 4: ProviderConfig deserializes with protocol field absent (treated as None)
+    /// Test: ProviderConfig deserializes with protocol field absent (treated as None)
     #[test]
     fn test_provider_config_deserializes_without_protocol() {
         let json = r#"{
@@ -175,6 +162,22 @@ mod provider_config_protocol_tests {
         }"#;
         let config: ProviderConfig = serde_json::from_str(json).unwrap();
         assert!(config.protocol.is_none());
+    }
+
+    /// Test: ProviderConfig roundtrip: serialize -> deserialize preserves protocol
+    #[test]
+    fn test_provider_config_roundtrip_with_protocol() {
+        let original = ProviderConfig {
+            base_url: Some("https://api.test.com".to_string()),
+            api_key: None,
+            api: None,
+            protocol: Some("openai".to_string()),
+            credential_path: None,
+            models: vec![],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let roundtripped: ProviderConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.protocol, original.protocol);
     }
 }
 

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -176,22 +176,6 @@ mod provider_config_protocol_tests {
         let config: ProviderConfig = serde_json::from_str(json).unwrap();
         assert!(config.protocol.is_none());
     }
-
-    /// Test 5: ProviderConfig roundtrip: serialize -> deserialize preserves protocol
-    #[test]
-    fn test_provider_config_roundtrip_with_protocol() {
-        let original = ProviderConfig {
-            base_url: Some("https://api.test.com".to_string()),
-            api_key: None,
-            api: None,
-            protocol: Some("openai".to_string()),
-            credential_path: None,
-            models: vec![],
-        };
-        let json = serde_json::to_string(&original).unwrap();
-        let roundtripped: ProviderConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(roundtripped.protocol, original.protocol);
-    }
 }
 
 #[cfg(test)]
@@ -985,5 +969,29 @@ mod write_wizard_config_api_key_clearing_tests {
             provider.base_url.as_deref(),
             Some("https://api.deepseek.com")
         );
+    }
+}
+
+#[cfg(test)]
+mod discovery_source_suffix_tests {
+    use super::format_discovery_source_suffix;
+    use closeclaw_llm::DiscoverySource;
+
+    #[test]
+    fn test_knowledge_fallback_suffix() {
+        assert_eq!(
+            format_discovery_source_suffix(DiscoverySource::KnowledgeFallback),
+            " (via knowledge base fallback)"
+        );
+    }
+
+    #[test]
+    fn test_cache_suffix_empty() {
+        assert_eq!(format_discovery_source_suffix(DiscoverySource::Cache), "");
+    }
+
+    #[test]
+    fn test_api_suffix_empty() {
+        assert_eq!(format_discovery_source_suffix(DiscoverySource::Api), "");
     }
 }


### PR DESCRIPTION
fix: 在 config wizard FetchModels 展示中标注模型发现来源

设计文档 `docs/design/llm/provider-config-wizard.md` 的「数据流」章节要求：当模型列表来自知识库回退时，展示须标注回退来源。当前代码在 FetchModels 阶段调用 `into_models()` 时丢弃了 `DiscoveryResult.source` 字段，导致所有来源的展示完全相同。

改动：
- 在 FetchModels 阶段先提取 `DiscoverySource`，再提取模型列表
- 根据来源值在 "Found N model(s)" 标题行追加来源后缀标注
- 补充相关单元测试，覆盖 KnowledgeFallback、Api、Cache 三种来源场景
- 恢复被误删的 `test_provider_config_roundtrip_with_protocol` 测试

Source: design-doc
Type: fix
