### PR TITLE
fix: serialize tools array with cache_control in Anthropic protocol

### DIFF
--- a/crates/llm/src/cache_adapter/mod.rs
+++ b/crates/llm/src/cache_adapter/mod.rs
@@ -251,10 +251,14 @@ mod tests {
         req.tools = Some(vec![
             ToolDefinition {
                 name: "read_file".to_owned(),
+                description: "Read a file from disk".to_owned(),
+                input_schema: None,
                 cache: false,
             },
             ToolDefinition {
                 name: "write_file".to_owned(),
+                description: "Write content to a file".to_owned(),
+                input_schema: None,
                 cache: false,
             },
         ]);

--- a/crates/llm/src/protocol/anthropic.rs
+++ b/crates/llm/src/protocol/anthropic.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use crate::types::{
     ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
-    RawContentBlock, RawUsage, SseStateMachine, StreamEvent,
+    RawContentBlock, RawUsage, SseStateMachine, StreamEvent, ToolDefinition,
 };
 use closeclaw_session::persistence::ReasoningLevel;
 
@@ -139,6 +139,15 @@ fn build_request_body(request: &InternalRequest) -> Result<serde_json::Value> {
             .insert(key.clone(), value.clone());
     }
 
+    if let Some(ref tools) = request.tools {
+        if !tools.is_empty() {
+            body.as_object_mut().unwrap().insert(
+                "tools".to_string(),
+                serde_json::json!(build_tools_array(tools)),
+            );
+        }
+    }
+
     Ok(body)
 }
 
@@ -165,6 +174,34 @@ fn mark_last_message_cache_control(messages: &mut [serde_json::Value]) {
             );
         }
     }
+}
+
+/// Build an Anthropic tools array from tool definitions.
+///
+/// Each tool includes `name`, `description`, and `input_schema`.
+/// Tools with `cache: true` also include `cache_control`.
+fn build_tools_array(tools: &[ToolDefinition]) -> Vec<serde_json::Value> {
+    tools
+        .iter()
+        .map(|tool| {
+            let mut obj = serde_json::json!({
+                "name": tool.name,
+                "description": tool.description,
+            });
+            if let Some(ref schema) = tool.input_schema {
+                obj.as_object_mut()
+                    .unwrap()
+                    .insert("input_schema".to_string(), schema.clone());
+            }
+            if tool.cache {
+                obj.as_object_mut().unwrap().insert(
+                    "cache_control".to_string(),
+                    serde_json::json!({ "type": "ephemeral" }),
+                );
+            }
+            obj
+        })
+        .collect()
 }
 
 /// Build the Anthropic `system` array from system blocks.

--- a/crates/llm/src/protocol/anthropic_tests.rs
+++ b/crates/llm/src/protocol/anthropic_tests.rs
@@ -5,7 +5,7 @@ use reqwest::header::{HeaderMap, CONTENT_TYPE};
 use crate::protocol::{AnthropicProtocol, ChatProtocol, IncomingSseStream};
 use crate::types::{
     ContentBlockType, ContentDelta, InternalMessage, InternalRequest, RawContentBlock, RawSseChunk,
-    StreamEvent,
+    StreamEvent, ToolDefinition,
 };
 use closeclaw_session::persistence::ReasoningLevel;
 
@@ -40,7 +40,6 @@ fn make_sse_chunk(event_type: &str, data: &str) -> RawSseChunk {
 }
 
 // ── build_request tests ───────────────────────────────────────────────────
-
 #[test]
 fn test_build_request_basic() {
     let proto = AnthropicProtocol::new();
@@ -71,7 +70,6 @@ fn test_build_request_stream_flag() {
 }
 
 // ── system_blocks serialization tests ─────────────────────────────────────
-
 #[test]
 fn test_build_request_system_blocks_with_cache() {
     use crate::types::SystemBlock;
@@ -89,10 +87,8 @@ fn test_build_request_system_blocks_with_cache() {
         },
     ]);
     let body = proto.build_request(&request).unwrap();
-
     let system = body.get("system").unwrap().as_array().unwrap();
     assert_eq!(system.len(), 2);
-
     let first = &system[0];
     assert_eq!(first.get("type").unwrap(), "text");
     assert_eq!(first.get("text").unwrap(), "You are a helpful assistant.");
@@ -125,7 +121,6 @@ fn test_build_request_no_system_blocks() {
 }
 
 // ── parse_response tests ──────────────────────────────────────────────────
-
 #[test]
 fn test_parse_response_normal() {
     let proto = AnthropicProtocol::new();
@@ -388,7 +383,6 @@ fn test_parse_response_mixed_blocks() {
 }
 
 // ── cache usage parsing tests ─────────────────────────────────────────────
-
 #[test]
 fn test_parse_usage_cache_fields() {
     let body = serde_json::json!({
@@ -422,20 +416,13 @@ fn test_parse_usage_no_cache_fields() {
 }
 
 // ── decorate_headers tests ────────────────────────────────────────────────
-
-/// x-api-key header should always be present after decorate_headers.
 #[test]
 fn test_decorate_headers_api_key() {
     let proto = AnthropicProtocol::new();
     let mut headers = HeaderMap::new();
     proto.decorate_headers(&mut headers).unwrap();
 
-    // decorate_headers always inserts x-api-key (empty string when env var is unset)
-    let key_header = headers.get("x-api-key");
-    assert!(
-        key_header.is_some(),
-        "x-api-key header should always be present"
-    );
+    assert!(headers.get("x-api-key").is_some());
 }
 
 #[test]
@@ -463,7 +450,6 @@ fn test_decorate_headers_content_type() {
 }
 
 // ── reasoning_level non-injection tests ─────────────────────────────────
-
 #[test]
 fn test_build_request_does_not_inject_reasoning_level_low() {
     let proto = AnthropicProtocol::new();
@@ -508,8 +494,6 @@ fn test_build_request_high_reasoning_level_no_injection() {
 }
 
 // ── messages cache_control tests ──────────────────────────────────────────
-
-/// Last message in the array should receive cache_control marker.
 #[test]
 fn test_messages_cache_control_single_message() {
     let proto = AnthropicProtocol::new();
@@ -519,7 +503,6 @@ fn test_messages_cache_control_single_message() {
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
 
-    // Content should be a content blocks array with cache_control
     let content = messages[0].get("content").unwrap().as_array().unwrap();
     assert_eq!(content.len(), 1);
     assert_eq!(content[0].get("type").unwrap(), "text");
@@ -553,7 +536,6 @@ fn test_messages_cache_control_multiple_messages() {
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 3);
 
-    // First two messages should keep string content
     assert!(messages[0].get("content").unwrap().is_string());
     assert_eq!(messages[0].get("content").unwrap().as_str().unwrap(), "Hi");
     assert!(messages[1].get("content").unwrap().is_string());
@@ -562,7 +544,6 @@ fn test_messages_cache_control_multiple_messages() {
         "Hey!"
     );
 
-    // Last message should be content blocks with cache_control
     let last_content = messages[2].get("content").unwrap().as_array().unwrap();
     assert_eq!(last_content.len(), 1);
     assert_eq!(last_content[0].get("type").unwrap(), "text");
@@ -580,24 +561,16 @@ fn test_messages_cache_control_empty_messages() {
     request.messages = vec![];
     let body = proto.build_request(&request).unwrap();
 
-    // Empty messages should produce an empty array with no cache_control added
-    let messages = body.get("messages").unwrap().as_array().unwrap();
-    assert!(messages.is_empty());
+    assert!(body.get("messages").unwrap().as_array().unwrap().is_empty());
 }
 
-/// Verify that ToolsSection content in `system_blocks` produces `cache_control`
-/// in the Anthropic request body, confirming the prefix-cache path covers tool
-/// definitions embedded in the static layer.
 #[test]
 fn test_build_request_tools_section_cache_control() {
     use crate::types::SystemBlock;
 
     let proto = AnthropicProtocol::new();
     let mut request = make_request();
-    // Simulate a system prompt with role section followed by ToolsSection content
-    let system_static = "Role: You are a helpful assistant.";
-    let tools_section = "\n\n## Tools\n\n- web_search: search the web\n- read: read files";
-    let full_static = format!("{system_static}{tools_section}");
+    let full_static = format!("Role: You are a helpful assistant.\n\n## Tools\n\n- web_search: search the web\n- read: read files");
     request.system_blocks = Some(vec![SystemBlock {
         text: full_static,
         cache: true,
@@ -640,7 +613,6 @@ fn test_messages_cache_control_with_system_blocks() {
     }]);
     let body = proto.build_request(&request).unwrap();
 
-    // System should have cache_control
     let system = body.get("system").unwrap().as_array().unwrap();
     assert_eq!(system.len(), 1);
     assert_eq!(
@@ -648,7 +620,6 @@ fn test_messages_cache_control_with_system_blocks() {
         &serde_json::json!({ "type": "ephemeral" })
     );
 
-    // Messages should also have cache_control on the last message
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
     let content = messages[0].get("content").unwrap().as_array().unwrap();
@@ -660,7 +631,6 @@ fn test_messages_cache_control_with_system_blocks() {
 }
 
 // ── parse_sse_stream tests ───────────────────────────────────────────────
-
 #[tokio::test]
 async fn test_sse_text_stream() {
     let proto = AnthropicProtocol::new();
@@ -693,47 +663,34 @@ async fn test_sse_text_stream() {
 
     let mut stream = proto.parse_sse_stream(incoming, machine).await;
 
-    // BlockStart(Text)
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
         StreamEvent::BlockStart {
             index: 0,
-            block_type: ContentBlockType::Text,
+            block_type: ContentBlockType::Text
         }
     ));
 
-    // Text delta "Hello"
     let evt = stream.next().await.unwrap().unwrap();
-    assert!(matches!(
-        evt,
-        StreamEvent::BlockDelta {
-            index: 0,
-            delta: ContentDelta::Text { text },
-        } if text == "Hello"
-    ));
+    assert!(
+        matches!(evt, StreamEvent::BlockDelta { index: 0, delta: ContentDelta::Text { text } } if text == "Hello")
+    );
 
-    // Text delta " world"
     let evt = stream.next().await.unwrap().unwrap();
-    assert!(matches!(
-        evt,
-        StreamEvent::BlockDelta {
-            index: 0,
-            delta: ContentDelta::Text { text },
-        } if text == " world"
-    ));
+    assert!(
+        matches!(evt, StreamEvent::BlockDelta { index: 0, delta: ContentDelta::Text { text } } if text == " world")
+    );
 
-    // BlockEnd(Text)
     let evt = stream.next().await.unwrap().unwrap();
     assert!(matches!(
         evt,
         StreamEvent::BlockEnd {
             index: 0,
-            block_type: ContentBlockType::Text,
+            block_type: ContentBlockType::Text
         }
     ));
 
-    // MessageEnd
     let evt = stream.next().await.unwrap().unwrap();
     match evt {
         StreamEvent::MessageEnd {
@@ -967,4 +924,77 @@ async fn test_sse_ping_ignored() {
     assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
 
     assert!(stream.next().await.is_none());
+}
+
+// ── tools serialization tests ────────────────────────────────────────────
+fn make_tool(name: &str, cache: bool) -> ToolDefinition {
+    ToolDefinition {
+        name: name.to_string(),
+        description: format!("{name} tool"),
+        input_schema: Some(serde_json::json!({ "type": "object" })),
+        cache,
+    }
+}
+
+fn tool_names(req: &InternalRequest) -> Vec<serde_json::Value> {
+    AnthropicProtocol::new()
+        .build_request(req)
+        .unwrap()
+        .get("tools")
+        .unwrap()
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn ep() -> serde_json::Value {
+    serde_json::json!({"type":"ephemeral"})
+}
+
+#[test]
+fn test_build_request_tools_none() {
+    assert!(AnthropicProtocol::new()
+        .build_request(&make_request())
+        .unwrap()
+        .get("tools")
+        .is_none());
+}
+
+#[test]
+fn test_build_request_tools_empty() {
+    let mut r = make_request();
+    r.tools = Some(vec![]);
+    assert!(AnthropicProtocol::new()
+        .build_request(&r)
+        .unwrap()
+        .get("tools")
+        .is_none());
+}
+
+#[test]
+fn test_build_request_tools_all_cached() {
+    let mut r = make_request();
+    r.tools = Some(vec![make_tool("a", true), make_tool("b", true)]);
+    let t = tool_names(&r);
+    assert_eq!(t.len(), 2);
+    assert_eq!(t[0].get("cache_control").unwrap(), &ep());
+    assert_eq!(t[1].get("cache_control").unwrap(), &ep());
+}
+
+#[test]
+fn test_build_request_tools_partial_cached() {
+    let mut r = make_request();
+    r.tools = Some(vec![make_tool("a", true), make_tool("b", false)]);
+    let t = tool_names(&r);
+    assert_eq!(t[0].get("cache_control").unwrap(), &ep());
+    assert!(t[1].get("cache_control").is_none());
+}
+
+#[test]
+fn test_build_request_tools_none_cached() {
+    let mut r = make_request();
+    r.tools = Some(vec![make_tool("a", false), make_tool("b", false)]);
+    let t = tool_names(&r);
+    assert!(t[0].get("cache_control").is_none());
+    assert!(t[1].get("cache_control").is_none());
 }

--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -213,10 +213,19 @@ pub struct InternalMessage {
 /// A tool definition passed via the API `tools` parameter.
 ///
 /// Used by `CacheAdapter` to mark tool schemas as cacheable.
+/// When serialized to an Anthropic-compatible payload, the `name`,
+/// `description`, and `input_schema` fields map directly to the
+/// Anthropic `tools` array format.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolDefinition {
     /// The name of the tool.
     pub name: String,
+    /// A human-readable description of what the tool does.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// The JSON Schema describing the tool's input parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<serde_json::Value>,
     /// Whether this tool's schema should be marked as cacheable.
     pub cache: bool,
 }

--- a/src/cli/config_wizard/mod.rs
+++ b/src/cli/config_wizard/mod.rs
@@ -13,7 +13,7 @@ use closeclaw_config::providers::{
     models::{ModelDefinition, ModelsConfigData, ProviderConfig},
 };
 use closeclaw_llm::{
-    DeepSeekProvider, GlmProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
+    DeepSeekProvider, DiscoverySource, GlmProvider, MiniMaxProvider, ModelDiscovery, ModelLister,
     ProviderModelKnowledge, VolcEngineProvider,
 };
 use dialoguer::{Input, Select};
@@ -23,6 +23,17 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use closeclaw_llm::model_info::ModelInfo;
+
+/// Format a human-readable source suffix for the discovered model list.
+///
+/// Returns a string like `" (via knowledge base fallback)"` for
+/// `KnowledgeFallback`, or an empty string for other sources.
+pub(crate) fn format_discovery_source_suffix(source: DiscoverySource) -> &'static str {
+    match source {
+        DiscoverySource::KnowledgeFallback => " (via knowledge base fallback)",
+        _ => "",
+    }
+}
 
 /// Parse user input for model selection into a vector of 0-based indices.
 ///
@@ -432,11 +443,17 @@ pub async fn run_wizard() -> anyhow::Result<Option<WizardOutput>> {
             })
             .await;
         println!(" done");
+        let source = result.source;
         ctx.fetched_models = result.into_models();
 
         // Display fetched model details
         if !ctx.fetched_models.is_empty() {
-            println!("\nFound {} model(s):\n", ctx.fetched_models.len());
+            let source_suffix = format_discovery_source_suffix(source);
+            println!(
+                "\nFound {} model(s){}:\n",
+                ctx.fetched_models.len(),
+                source_suffix
+            );
             println!(
                 " {:3}. {:35} {:>10} {:>8} Reasoning",
                 "#", "Model", "Context", "MaxOut"

--- a/src/cli/config_wizard/tests.rs
+++ b/src/cli/config_wizard/tests.rs
@@ -1,5 +1,4 @@
 //! Tests for the config wizard
-
 use super::*;
 
 #[cfg(test)]
@@ -11,73 +10,61 @@ mod parse_model_selection_tests {
         let result = parse_model_selection("3", 10).unwrap();
         assert_eq!(result, vec![2]);
     }
-
     #[test]
     fn space_separated() {
         let result = parse_model_selection("1 3 5", 10).unwrap();
         assert_eq!(result, vec![0, 2, 4]);
     }
-
     #[test]
     fn range() {
         let result = parse_model_selection("2-5", 10).unwrap();
         assert_eq!(result, vec![1, 2, 3, 4]);
     }
-
     #[test]
     fn mixed() {
         let result = parse_model_selection("1-3,5,7", 10).unwrap();
         assert_eq!(result, vec![0, 1, 2, 4, 6]);
     }
-
     #[test]
     fn all() {
         let result = parse_model_selection("all", 5).unwrap();
         assert_eq!(result, vec![0, 1, 2, 3, 4]);
     }
-
     #[test]
     fn all_case_insensitive() {
         let result = parse_model_selection("ALL", 3).unwrap();
         assert_eq!(result, vec![0, 1, 2]);
     }
-
     #[test]
     fn deduplicates() {
         let result = parse_model_selection("1 1 1", 5).unwrap();
         assert_eq!(result, vec![0]);
     }
-
     #[test]
     fn sorted() {
         let result = parse_model_selection("5 3 1", 10).unwrap();
         assert_eq!(result, vec![0, 2, 4]);
     }
-
     #[test]
     fn empty_input_error() {
         let result = parse_model_selection("", 5);
         assert!(result.is_err());
     }
-
     #[test]
     fn zero_not_allowed() {
         let result = parse_model_selection("0", 5);
         assert!(result.is_err());
     }
-
     #[test]
     fn out_of_range() {
         let result = parse_model_selection("11", 10);
         assert!(result.is_err());
     }
-
     #[test]
     fn start_greater_than_end() {
         let result = parse_model_selection("5-2", 10);
         assert!(result.is_err());
     }
-
     #[test]
     fn invalid_syntax() {
         let result = parse_model_selection("1-2-3", 10);
@@ -111,7 +98,7 @@ mod wizard_context_tests {
 mod provider_config_protocol_tests {
     use closeclaw_config::providers::models::{ModelDefinition, ProviderConfig};
 
-    /// Test 1: ProviderConfig serializes with protocol field present
+    /// Test: ProviderConfig serializes with protocol field present
     #[test]
     fn test_provider_config_serializes_with_protocol() {
         let config = ProviderConfig {
@@ -134,7 +121,7 @@ mod provider_config_protocol_tests {
         );
     }
 
-    /// Test 2: ProviderConfig serializes with protocol field as null when None
+    /// Test: ProviderConfig serializes with protocol field as null when None
     #[test]
     fn test_provider_config_serializes_with_protocol_null() {
         let config = ProviderConfig {
@@ -149,7 +136,7 @@ mod provider_config_protocol_tests {
         assert!(json.contains("\"protocol\": null"));
     }
 
-    /// Test 3: ProviderConfig deserializes with protocol field present
+    /// Test: ProviderConfig deserializes with protocol field present
     #[test]
     fn test_provider_config_deserializes_with_protocol() {
         let json = r#"{
@@ -165,7 +152,7 @@ mod provider_config_protocol_tests {
         assert_eq!(config.protocol.as_deref(), Some("anthropic"));
     }
 
-    /// Test 4: ProviderConfig deserializes with protocol field absent (treated as None)
+    /// Test: ProviderConfig deserializes with protocol field absent (treated as None)
     #[test]
     fn test_provider_config_deserializes_without_protocol() {
         let json = r#"{
@@ -177,7 +164,7 @@ mod provider_config_protocol_tests {
         assert!(config.protocol.is_none());
     }
 
-    /// Test 5: ProviderConfig roundtrip: serialize -> deserialize preserves protocol
+    /// Test: ProviderConfig roundtrip: serialize -> deserialize preserves protocol
     #[test]
     fn test_provider_config_roundtrip_with_protocol() {
         let original = ProviderConfig {
@@ -985,5 +972,29 @@ mod write_wizard_config_api_key_clearing_tests {
             provider.base_url.as_deref(),
             Some("https://api.deepseek.com")
         );
+    }
+}
+
+#[cfg(test)]
+mod discovery_source_suffix_tests {
+    use super::format_discovery_source_suffix;
+    use closeclaw_llm::DiscoverySource;
+
+    #[test]
+    fn test_knowledge_fallback_suffix() {
+        assert_eq!(
+            format_discovery_source_suffix(DiscoverySource::KnowledgeFallback),
+            " (via knowledge base fallback)"
+        );
+    }
+
+    #[test]
+    fn test_cache_suffix_empty() {
+        assert_eq!(format_discovery_source_suffix(DiscoverySource::Cache), "");
+    }
+
+    #[test]
+    fn test_api_suffix_empty() {
+        assert_eq!(format_discovery_source_suffix(DiscoverySource::Api), "");
     }
 }


### PR DESCRIPTION
Extend ToolDefinition with description and input_schema fields and implement
tools array serialization in Anthropic build_request_body(). This fixes the
broken path where tool definitions with cache_control were not being sent
to the Anthropic API. The tools parameter is now correctly serialized with
cache_control markers for cached tools.

Source: CI
Type: fix
