### PR TITLE
feat: register DeepSeekPlugin and remove redundant openai protocol injection

### DIFF
--- a/crates/llm/src/protocol/openai.rs
+++ b/crates/llm/src/protocol/openai.rs
@@ -7,14 +7,12 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 
+use crate::protocol::{
+    ChatProtocol, IncomingSseStream, OutgoingEventStream, ProtocolError, Result,
+};
 use crate::types::{
     ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
     RawContentBlock, RawUsage, SseStateMachine, StreamEvent,
-};
-use closeclaw_session::persistence::ReasoningLevel;
-
-use crate::protocol::{
-    ChatProtocol, IncomingSseStream, OutgoingEventStream, ProtocolError, Result,
 };
 
 const PATH: &str = "/v1/chat/completions";
@@ -67,31 +65,6 @@ impl ChatProtocol for OpenAiProtocol {
             body.as_object_mut()
                 .unwrap()
                 .insert("max_tokens".to_string(), serde_json::json!(max_tokens));
-        }
-
-        // Map ReasoningLevel → reasoning_effort for DeepSeek and OpenAI-compatible providers.
-        match request.reasoning_level {
-            ReasoningLevel::Low => {
-                body.as_object_mut()
-                    .unwrap()
-                    .insert("reasoning_effort".to_string(), serde_json::json!("off"));
-            }
-            ReasoningLevel::Medium => {
-                body.as_object_mut()
-                    .unwrap()
-                    .insert("reasoning_effort".to_string(), serde_json::json!("base"));
-            }
-            ReasoningLevel::High => {
-                body.as_object_mut()
-                    .unwrap()
-                    .insert("reasoning_effort".to_string(), serde_json::json!("high"));
-            }
-            ReasoningLevel::Max => {
-                body.as_object_mut().unwrap().insert(
-                    "reasoning_effort".to_string(),
-                    serde_json::json!("reasoner"),
-                );
-            }
         }
 
         for (key, value) in &request.extra_body {

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -318,50 +318,67 @@ fn test_parse_response_no_reasoning_content() {
     assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Hello!"));
 }
 
-// ── reasoning_level → reasoning_effort mapping tests ───────────────────────
+// ── reasoning_effort is NOT injected by protocol layer ───────────────────────
+// reasoning_effort is injected by DeepSeekPlugin via extra_body, not by the protocol.
+// These tests verify the protocol layer does not inject reasoning_effort directly.
 
 #[test]
-fn test_build_request_reasoning_level_low() {
+fn test_build_request_does_not_inject_reasoning_effort_low() {
     let proto = OpenAiProtocol::new();
     let mut request = make_request();
     request.reasoning_level = ReasoningLevel::Low;
     let body = proto.build_request(&request).unwrap();
-    assert_eq!(body.get("reasoning_effort").unwrap(), "off");
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "protocol layer should not inject reasoning_effort"
+    );
 }
 
 #[test]
-fn test_build_request_reasoning_level_medium() {
+fn test_build_request_does_not_inject_reasoning_effort_medium() {
     let proto = OpenAiProtocol::new();
     let mut request = make_request();
     request.reasoning_level = ReasoningLevel::Medium;
     let body = proto.build_request(&request).unwrap();
-    assert_eq!(body.get("reasoning_effort").unwrap(), "base");
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "protocol layer should not inject reasoning_effort"
+    );
 }
 
 #[test]
-fn test_build_request_reasoning_level_high() {
+fn test_build_request_does_not_inject_reasoning_effort_high() {
     let proto = OpenAiProtocol::new();
     let mut request = make_request();
     request.reasoning_level = ReasoningLevel::High;
     let body = proto.build_request(&request).unwrap();
-    assert_eq!(body.get("reasoning_effort").unwrap(), "high");
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "protocol layer should not inject reasoning_effort"
+    );
 }
 
 #[test]
-fn test_build_request_reasoning_level_max() {
+fn test_build_request_does_not_inject_reasoning_effort_max() {
     let proto = OpenAiProtocol::new();
     let mut request = make_request();
     request.reasoning_level = ReasoningLevel::Max;
     let body = proto.build_request(&request).unwrap();
-    assert_eq!(body.get("reasoning_effort").unwrap(), "reasoner");
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "protocol layer should not inject reasoning_effort"
+    );
 }
 
 #[test]
-fn test_build_request_default_reasoning_level_is_high() {
+fn test_build_request_default_does_not_inject_reasoning_effort() {
     let proto = OpenAiProtocol::new();
     let request = make_request();
     let body = proto.build_request(&request).unwrap();
-    assert_eq!(body.get("reasoning_effort").unwrap(), "high");
+    assert!(
+        body.get("reasoning_effort").is_none(),
+        "protocol layer should not inject reasoning_effort by default"
+    );
 }
 
 #[test]

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -254,7 +254,12 @@ async fn build_unified_chain(
         .map(|(entry, provider)| {
             let protocol = Arc::new(closeclaw_llm::protocol::OpenAiProtocol::default());
             let interpreter_registry = closeclaw_llm::interpreter::InterpreterRegistry::new(vec![]);
-            let plugin_pipeline = closeclaw_llm::plugin::PluginPipeline::new();
+            let plugin_pipeline = if entry.provider == "deepseek" {
+                closeclaw_llm::plugin::PluginPipeline::new()
+                    .add(Box::new(closeclaw_llm::deepseek::DeepSeekPlugin))
+            } else {
+                closeclaw_llm::plugin::PluginPipeline::new()
+            };
             let client = Arc::new(closeclaw_llm::client::UnifiedChatClient::new(
                 provider,
                 protocol,


### PR DESCRIPTION
Register DeepSeekPlugin in `build_unified_chain` for deepseek provider, and remove redundant `reasoning_effort` injection from `openai.rs` protocol layer. Aligns code behavior with design doc data flow.

Source: design-doc
Type: feat
