### PR TITLE
docs(design): fix protocol-mapping.md stream event mapping inaccuracies

### DIFF
--- a/docs/design/llm/README.md
+++ b/docs/design/llm/README.md
@@ -41,7 +41,7 @@ LLM Client（UnifiedChatClient）—— 统一入口
 |----|------|---------|
 | Provider | 保存访问凭据和端点地址，发送 HTTP 请求，映射厂商错误码 | 否 |
 | Protocol | 按协议标准序列化请求、解析响应、解析流式 SSE 事件 | 是（协议标准逻辑） |
-| ModelInterpreter | 将协议原生字段归一化为统一内容块（如 reasoning_content → Thinking block） | 是（模型特有逻辑） |
+| ModelInterpreter | 将协议原生字段归一化为统一内容块（如 reasoning_content → Thinking block） | 是（协议标准逻辑） |
 | Plugin | 模型专属行为注入（注入额外参数、过滤内容块、处理流式事件） | 是（业务行为） |
 
 ### 统一内容块

--- a/docs/design/llm/protocol-mapping.md
+++ b/docs/design/llm/protocol-mapping.md
@@ -30,7 +30,7 @@
 | ToolUse | `choices[].message.tool_calls[]` |
 | ToolResult | 消息数组中以 `role: "tool"` 出现 |
 
-OpenAI 协议下，content 和 reasoning_content 在同一个 message 对象中共存。提取规则：content 非空则优先取 content；content 为空或仅空白时回退到 reasoning_content。
+OpenAI 协议下，content 和 reasoning_content 在同一个 message 对象中共存。两者各自独立产出内容块：content 非空则产出 Text 块，reasoning_content 非空则产出 Thinking 块。若 content 为空且 reasoning_content 非空，则 reasoning_content 作为 Text 块输出（不产生 Thinking 块）。
 
 **Anthropic 协议**：
 
@@ -49,13 +49,21 @@ Anthropic 协议下，content 是类型化结构数组。每个元素通过 `typ
 
 | 统一事件 | OpenAI SSE 来源 | Anthropic SSE 来源 |
 |---------|----------------|-------------------|
-| 内容块开始 | 首个 `delta.role` 出现 / `delta.tool_calls[0]` 首次出现 | `content_block_start` 事件 |
-| 内容增量 | `delta.content` / `delta.reasoning_content` / `delta.tool_calls` | `content_block_delta` 事件（`text_delta` / `thinking_delta` / `signature_delta`） |
-| 内容块结束 | `finish_reason` 首次出现 | `content_block_stop` 事件 |
-| 消息结束 | `finish_reason=stop` 后接 `[DONE]` | `message_delta(stop_reason)` 后接 `message_stop` |
+| 内容块开始 | 首个非空 `delta.content` / `delta.reasoning_content` / `delta.tool_calls[0].id` 出现 | `content_block_start` 事件 |
+| 内容增量 | `delta.content` / `delta.reasoning_content` / `delta.tool_calls` | `content_block_delta` 事件（`text_delta` / `thinking_delta` / `signature_delta` / `input_json_delta`） |
+| 内容块结束 | `finish_reason=stop` 出现；`finish_reason=tool_calls` 出现（结束 ToolUse 块） | `content_block_stop` 事件 |
+| 消息结束 | `finish_reason=stop` 后接 `[DONE]`；`finish_reason=tool_calls`（直接结束，无 `[DONE]`） | `message_delta(stop_reason)` 后接 `message_stop` |
 | 错误事件 | HTTP 错误状态码 + 错误 body | HTTP 错误状态码 + `error` 事件 |
 
 Anthropic SSE 事件序列的典型顺序：`message_start` → `content_block_start(thinking)` → 若干 `thinking_delta` → 一个 `signature_delta` → `content_block_stop` → `content_block_start(text)` → 若干 `text_delta` → `content_block_stop` → `message_delta` → `message_stop`。
+
+工具调用场景的典型顺序：`message_start` → `content_block_start(tool_use)` → 若干 `input_json_delta` → `content_block_stop` → `message_delta` → `message_stop`。`input_json_delta` 的 `partial_json` 字段携带工具调用的 JSON 参数片段，粒度因供应商而异（逐字符到一次性全量），首次可为空字符串。
+
+OpenAI SSE 事件序列的典型顺序：`delta.role=assistant` → `delta.reasoning_content` 若干帧（先于 content）→ Thinking 块增量 → 首个 `delta.content` 触发 Text 块开始 → Text 增量若干帧 → `finish_reason=stop` 触发块结束 + MessageEnd。
+
+混合响应（文本 + 工具调用）：Text 增量若干帧 → `delta.tool_calls` 首次出现时隐式结束 Text 块 → 启动 ToolUse 块 → `finish_reason=tool_calls` 触发 ToolUse 块结束 + MessageEnd。
+
+与 Anthropic 的差异：OpenAI 的 `finish_reason` 仅在流末尾出现一次，不区分内容块；Anthropic 通过 `content_block_stop` 逐块标注结束边界。
 
 ### 多轮对话增量处理
 

--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -151,7 +151,7 @@
     "commit": "",
     "commit_time": "",
     "confirmed_time": "2026-06-27T14:47:02.621121+08:00",
-    "comment": "blocked: doc inaccuracies found in F2b"
+    "comment": ""
   },
   {
     "path": "docs/design/llm/provider-config-wizard.md",


### PR DESCRIPTION
设计文档修正：`docs/design/llm/protocol-mapping.md`

## 修改文件
- `docs/design/llm/protocol-mapping.md` — 修正流式事件映射规则，基于真实 API fixture 数据对齐
- `docs/design/llm/README.md` — 修正 ModelInterpreter 层标签（模型特有→协议标准）
- `scripts/design-doc-tracker/records.json` — 清除 protocol-mapping.md 的 blocked comment

## 修改内容
1. **流式内容块起始触发条件**：`delta.role` → `delta.content`/`delta.reasoning_content`/`delta.tool_calls[0].id`（实测 5 家 provider fixture，delta.role 行为不统一，用 content 触发是正确的跨供应商做法）
2. **Anthropic delta 类型列表**：补充 `input_json_delta`（tool_use 参数增量事件，所有 provider 的真实 fixture 中都存在）
3. **finish_reason=tool_calls 路径**：OpenAI 协议在工具调用场景使用 `finish_reason=tool_calls`（非 stop），触发 ToolUse 块结束 + MessageEnd
4. **OpenAI SSE 事件序列示例**：补充纯文本、混合响应（text+tool_use）两种典型序列，说明与 Anthropic 逐块结束的差异
5. **content/reasoning_content 提取规则**：澄清两者各自独立产出内容块，消除歧义
6. **README 层标签修正**：ModelInterpreter 的映射规则为协议标准逻辑，非模型特有

## 证据来源
- `tests/fixtures/llm/` 下 5 家 provider (DeepSeek/GLM/MiMo/MiniMax) 的 OpenAI/Anthropic 双协议真实 fixture 数据
- 覆盖 streaming、tool-use-streaming、simple 等多场景

Source: user
Type: docs
