### PR TITLE
docs: update CONTRIBUTING.md project structure for Cargo workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,27 +81,40 @@ cargo build && cargo test
 
 ## 项目结构
 
+CloseClaw 采用 Cargo workspace，各模块为独立 crate：
+
 ```
-src/
-├── main.rs              # 入口点
-├── lib.rs               # pub mod 导出
-├── common/              # 跨模块共享的类型、工具
-│   ├── mod.rs
-│   ├── types.rs
-│   └── utils.rs
-├── <module>/
-│   ├── mod.rs           # pub use + pub mod
-│   ├── <module>.rs      # 核心逻辑
-│   └── <module>_tests.rs # 单元测试
+Cargo.toml               # workspace 根（members 声明）
+crates/
+├── common/              # closeclaw-common（共享类型、trait、常量）
+├── config/              # closeclaw-config
+├── session/             # closeclaw-session
+├── llm/                 # closeclaw-llm
+├── permission/          # closeclaw-permission
+├── gateway/             # closeclaw-gateway
+├── tools/               # closeclaw-tools
+├── skills/              # closeclaw-skills
+└── im_adapter/          # closeclaw-im-adapter
+src/                     # 主 crate（closeclaw，bin 入口 + 胶水代码）
+├── main.rs
+├── lib.rs
+├── ...
 tests/
 ├── integration/         # 集成测试
 ├── e2e/                 # E2E 测试
 └── fixtures/            # 共享测试数据
 ```
 
+**依赖规则**（分层，禁止逆向依赖）：
+- Layer 0（叶子）：`closeclaw-common`
+- Layer 1：`closeclaw-config`, `closeclaw-session`
+- Layer 2：`closeclaw-llm`, `closeclaw-permission`
+- Layer 3：`closeclaw-gateway`, `closeclaw-tools`, `closeclaw-skills`, `closeclaw-im-adapter`
+- Layer 4：主 crate（依赖所有层）
+
 **规则**：
-- 跨模块共享的类型和工具放 `src/common/`
-- 模块嵌套不超过 4 级目录
+- 跨模块共享的类型和 trait 放 `closeclaw-common`
+- 各 crate 内部模块嵌套不超过 4 级目录
 - 每个文件独立可读
 
 ---
@@ -143,7 +156,7 @@ tests/
 
 | 类型 | 位置 |
 |------|------|
-| 单元测试 | `src/<module>/<module>_tests.rs` |
+| 单元测试 | `crates/<crate>/src/<module>_tests.rs` |
 | 集成测试 | `tests/integration/` |
 | E2E | `tests/e2e/` |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,19 +85,24 @@ CloseClaw 采用 Cargo workspace，各模块为独立 crate：
 
 ```
 Cargo.toml               # workspace 根（members 声明）
-crates/
+crates/                  # 功能库 — 可独立编译、按依赖分层
 ├── common/              # closeclaw-common（共享类型、trait、常量）
 ├── config/              # closeclaw-config
-├── session/             # closeclaw-session
+├── session/             # closeclaw-session（持久化、bootstrap、recovery）
 ├── llm/                 # closeclaw-llm
 ├── permission/          # closeclaw-permission
 ├── gateway/             # closeclaw-gateway
 ├── tools/               # closeclaw-tools
 ├── skills/              # closeclaw-skills
 └── im_adapter/          # closeclaw-im-adapter
-src/                     # 主 crate（closeclaw，bin 入口 + 胶水代码）
-├── main.rs
-├── lib.rs
+src/                     # 主 crate（closeclaw）— 组合根
+│                         # 将各功能库组装为守护进程，包含应用级编排：
+├── main.rs              #   bin 入口、daemon 生命周期、CLI 交互、
+├── daemon/              #   斜杠命令、processor chain、记忆系统、
+├── cli/                 #   系统提示词、管理 API、后台任务等
+├── slash/               #
+├── processor_chain/     # 设计理念：功能逻辑下沉到 crates/，
+├── memory/              # 主 crate 只做组装和编排（composition root）
 ├── ...
 tests/
 ├── integration/         # 集成测试
@@ -110,7 +115,7 @@ tests/
 - Layer 1：`closeclaw-config`, `closeclaw-session`
 - Layer 2：`closeclaw-llm`, `closeclaw-permission`
 - Layer 3：`closeclaw-gateway`, `closeclaw-tools`, `closeclaw-skills`, `closeclaw-im-adapter`
-- Layer 4：主 crate（依赖所有层）
+- Layer 4：主 crate（依赖所有层，做组装和编排）
 
 **规则**：
 - 跨模块共享的类型和 trait 放 `closeclaw-common`


### PR DESCRIPTION
#1252 完成 workspace 拆分后，CONTRIBUTING.md 的项目结构一节已过时（仍描述拆分前的 flat src/ 结构）。本次更新：

- **项目结构**：从旧扁平 `src/` 更新为 Cargo workspace（`crates/` 9 个子 crate + `src/` 主 crate），补充分层依赖规则（Layer 0-4）
- **测试布局**：单元测试路径从 `src/<module>/` 更新为 `crates/<crate>/src/`
- **共享代码规则**：从"放 `src/common/`"更新为"放 `closeclaw-common`"

Source: issue #1252
Type: docs
