### PR TITLE
fix: align GLM provider implementation with design doc

### DIFF
--- a/crates/llm/src/glm/mod.rs
+++ b/crates/llm/src/glm/mod.rs
@@ -11,9 +11,11 @@ use crate::provider::{Provider, ProviderError, Result, SseStream};
 use crate::types::{InternalRequest, InternalResponse, ProtocolId};
 
 mod models;
+pub mod plugin;
 mod quota;
 mod streaming;
 mod types;
+pub use plugin::GlmPlugin;
 
 #[allow(unused_imports)]
 pub(crate) use crate::types::{RawContentBlock, RawSseChunk, RawUsage};

--- a/crates/llm/src/glm/plugin.rs
+++ b/crates/llm/src/glm/plugin.rs
@@ -1,0 +1,105 @@
+//! GLM-specific request plugin.
+//!
+//! Injects `thinking.type` into [`InternalRequest::extra_body`] based on the
+//! configured [`ReasoningLevel`], allowing the protocol layer to forward
+//! it to the GLM API.
+
+use crate::plugin::ModelPlugin;
+use crate::types::InternalRequest;
+use closeclaw_session::persistence::ReasoningLevel;
+use serde_json::json;
+
+/// Plugin that enriches GLM requests with provider-specific parameters.
+///
+/// Currently handles `thinking.type` injection based on the configured
+/// [`ReasoningLevel`].
+pub struct GlmPlugin;
+
+impl ModelPlugin for GlmPlugin {
+    fn name(&self) -> &str {
+        "glm"
+    }
+
+    fn before_request(&self, request: &mut InternalRequest) {
+        let thinking_type = match request.reasoning_level {
+            ReasoningLevel::Low => "disabled",
+            ReasoningLevel::Medium => "enabled",
+            ReasoningLevel::High => "enabled",
+            ReasoningLevel::Max => "enabled",
+        };
+
+        request
+            .extra_body
+            .insert("thinking".to_string(), json!({"type": thinking_type}));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::InternalRequest;
+
+    fn make_request(level: ReasoningLevel) -> InternalRequest {
+        InternalRequest {
+            model: "glm-model".to_string(),
+            messages: vec![],
+            temperature: 0.0,
+            max_tokens: Some(256),
+            stream: false,
+            extra_body: Default::default(),
+            system_static: None,
+            system_dynamic: None,
+            system_blocks: None,
+            tools: None,
+            session_id: None,
+            reasoning_level: level,
+            turn_count: None,
+        }
+    }
+
+    #[test]
+    fn test_name() {
+        let plugin = GlmPlugin;
+        assert_eq!(plugin.name(), "glm");
+    }
+
+    #[test]
+    fn test_before_request_low_disabled() {
+        let plugin = GlmPlugin;
+        let mut req = make_request(ReasoningLevel::Low);
+        plugin.before_request(&mut req);
+
+        let thinking = req.extra_body.get("thinking").unwrap();
+        assert_eq!(thinking, &json!({"type": "disabled"}));
+    }
+
+    #[test]
+    fn test_before_request_medium_enabled() {
+        let plugin = GlmPlugin;
+        let mut req = make_request(ReasoningLevel::Medium);
+        plugin.before_request(&mut req);
+
+        let thinking = req.extra_body.get("thinking").unwrap();
+        assert_eq!(thinking, &json!({"type": "enabled"}));
+    }
+
+    #[test]
+    fn test_before_request_high_enabled() {
+        let plugin = GlmPlugin;
+        let mut req = make_request(ReasoningLevel::High);
+        plugin.before_request(&mut req);
+
+        let thinking = req.extra_body.get("thinking").unwrap();
+        assert_eq!(thinking, &json!({"type": "enabled"}));
+    }
+
+    #[test]
+    fn test_before_request_max_enabled() {
+        let plugin = GlmPlugin;
+        let mut req = make_request(ReasoningLevel::Max);
+        plugin.before_request(&mut req);
+
+        let thinking = req.extra_body.get("thinking").unwrap();
+        assert_eq!(thinking, &json!({"type": "enabled"}));
+    }
+}

--- a/crates/llm/src/glm/quota.rs
+++ b/crates/llm/src/glm/quota.rs
@@ -11,12 +11,15 @@ impl GlmProvider {
     ///
     /// The `base_url` should be the GLM API base
     /// (e.g. `https://open.bigmodel.cn/api`);
-    /// this method appends `/paas/quota` internally.
+    /// this method appends `/api/monitor/usage/quota/limit` internally.
     pub async fn fetch_usage(
         &self,
         base_url: &str,
     ) -> std::result::Result<GlmQuotaResponse, ProviderError> {
-        let url = format!("{}/paas/quota", base_url.trim_end_matches('/'));
+        let url = format!(
+            "{}/api/monitor/usage/quota/limit",
+            base_url.trim_end_matches('/')
+        );
 
         let response = self
             .client

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -52,6 +52,7 @@ pub use fake::FakeProvider;
 
 pub use anthropic::AnthropicProvider;
 pub use deepseek::DeepSeekProvider;
+pub use glm::GlmPlugin;
 pub use glm::GlmProvider;
 pub use http_client::{HttpClient, ReqwestHttpClient};
 pub use knowledge::{ModelRecommendParams, ProviderModelKnowledge, ReasoningLevels};

--- a/crates/llm/src/protocol/glm.rs
+++ b/crates/llm/src/protocol/glm.rs
@@ -21,6 +21,10 @@ use crate::protocol::{
 
 const PATH: &str = "/api/paas/v4/chat/completions";
 
+/// Minimum trimmed length for `reasoning_content` to be treated as a
+/// reasoning block. Shorter values are demoted to plain text.
+const MIN_REASONING_LENGTH: usize = 2;
+
 /// GLM protocol implementation.
 #[derive(Debug, Clone)]
 pub struct GlmProtocol {
@@ -113,10 +117,16 @@ impl ChatProtocol for GlmProtocol {
 
         let content_blocks = match (text, reasoning) {
             (Some(t), _) => vec![RawContentBlock::Text(t)],
-            (_, Some(r)) => vec![RawContentBlock::Thinking {
-                thinking: r,
-                signature: None,
-            }],
+            // Non-empty content takes precedence over reasoning (unchanged).
+            // Short reasoning (e.g. whitespace-only or scattered chars) is
+            // demoted to plain text per design doc requirements.
+            (None, Some(r)) if r.trim().len() > MIN_REASONING_LENGTH => {
+                vec![RawContentBlock::Thinking {
+                    thinking: r,
+                    signature: None,
+                }]
+            }
+            (None, Some(r)) => vec![RawContentBlock::Text(r)],
             (None, None) => vec![],
         };
 
@@ -179,6 +189,11 @@ impl ChatProtocol for GlmProtocol {
                     None => continue,
                 };
 
+                // NOTE: Short-reasoning filtering is intentionally NOT applied
+                // here. In streaming mode, reasoning_content arrives incrementally
+                // per delta — we cannot know the total length at emit time.
+                // Filtering is only feasible in the non-streaming `parse_response`.
+                //
                 // GLM may emit `reasoning_content` delta or `content` delta.
                 // Prefer `reasoning_content` first, then fall back to `content`.
                 let (text_delta, thinking_delta) = (

--- a/crates/llm/src/protocol/glm.rs
+++ b/crates/llm/src/protocol/glm.rs
@@ -14,7 +14,6 @@ use crate::types::{
     ContentBlockType, ContentDelta, InternalMessage, InternalRequest, InternalResponse, ProtocolId,
     RawContentBlock, RawUsage, SseStateMachine, StreamEvent,
 };
-use closeclaw_session::persistence::ReasoningLevel;
 
 use crate::protocol::{
     ChatProtocol, IncomingSseStream, OutgoingEventStream, ProtocolError, Result,
@@ -72,16 +71,6 @@ impl ChatProtocol for GlmProtocol {
                 .unwrap()
                 .insert("max_tokens".to_string(), serde_json::json!(max_tokens));
         }
-
-        // Map ReasoningLevel → thinking parameter for GLM.
-        let thinking_type = match request.reasoning_level {
-            ReasoningLevel::Low => "disabled",
-            _ => "enabled",
-        };
-        body.as_object_mut().unwrap().insert(
-            "thinking".to_string(),
-            serde_json::json!({ "type": thinking_type }),
-        );
 
         for (key, value) in &request.extra_body {
             body.as_object_mut()

--- a/crates/llm/src/protocol/glm_test.rs
+++ b/crates/llm/src/protocol/glm_test.rs
@@ -448,6 +448,82 @@ async fn test_parse_sse_reasoning_then_tool_calls() {
     assert!(stream.next().await.is_none());
 }
 
+// ── short reasoning_content filtering tests ──────────────────────────────
+
+#[test]
+fn test_parse_response_short_reasoning_empty_content() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": " "
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    // Short reasoning with empty content → demoted to Text block
+    assert!(matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == " "));
+}
+
+#[test]
+fn test_parse_response_short_reasoning_with_content() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "Final answer",
+                "reasoning_content": "ok"
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    // Non-empty content takes precedence; short reasoning is ignored
+    assert!(matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == "Final answer"));
+}
+
+#[test]
+fn test_parse_response_normal_reasoning_unchanged() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": "Let me think step by step..."
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    // Normal-length reasoning → Thinking block (unchanged)
+    assert!(
+        matches!(resp.content_blocks[0], RawContentBlock::Thinking { thinking: ref s, .. } if s == "Let me think step by step...")
+    );
+}
+
+#[test]
+fn test_parse_response_two_char_reasoning_empty_content() {
+    let proto = GlmProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": "ab"
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 1);
+    // Exactly MIN_REASONING_LENGTH (2) trimmed → demoted to Text
+    assert!(matches!(resp.content_blocks[0], RawContentBlock::Text(ref s) if s == "ab"));
+}
+
 // ── extra_body passthrough tests ───────────────────────────────────────────
 
 #[test]

--- a/crates/llm/src/protocol/glm_test.rs
+++ b/crates/llm/src/protocol/glm_test.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::types::{InternalMessage, RawSseChunk};
-use closeclaw_session::persistence::ReasoningLevel;
 
 fn make_request() -> InternalRequest {
     InternalRequest {
@@ -18,7 +17,7 @@ fn make_request() -> InternalRequest {
         system_blocks: None,
         tools: None,
         session_id: None,
-        reasoning_level: ReasoningLevel::default(),
+        reasoning_level: Default::default(),
         turn_count: None,
     }
 }
@@ -449,53 +448,54 @@ async fn test_parse_sse_reasoning_then_tool_calls() {
     assert!(stream.next().await.is_none());
 }
 
-// ── ReasoningLevel → thinking parameter mapping tests ──────────────────────
+// ── extra_body passthrough tests ───────────────────────────────────────────
 
 #[test]
-fn test_build_request_reasoning_level_low_disables_thinking() {
+fn test_build_request_no_thinking_when_extra_body_empty() {
+    let proto = GlmProtocol::new();
+    let request = make_request();
+    let body = proto.build_request(&request).unwrap();
+    assert!(body.get("thinking").is_none());
+}
+
+#[test]
+fn test_build_request_thinking_passthrough_via_extra_body() {
     let proto = GlmProtocol::new();
     let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Low;
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "thinking".to_string(),
+        serde_json::json!({ "type": "enabled" }),
+    );
+    request.extra_body = extra;
+    let body = proto.build_request(&request).unwrap();
+    let thinking = body.get("thinking").unwrap();
+    assert_eq!(thinking.get("type").unwrap(), "enabled");
+}
+
+#[test]
+fn test_build_request_extra_body_overrides_default_thinking() {
+    let proto = GlmProtocol::new();
+    let mut request = make_request();
+    let mut extra = serde_json::Map::new();
+    extra.insert(
+        "thinking".to_string(),
+        serde_json::json!({ "type": "disabled" }),
+    );
+    request.extra_body = extra;
     let body = proto.build_request(&request).unwrap();
     let thinking = body.get("thinking").unwrap();
     assert_eq!(thinking.get("type").unwrap(), "disabled");
 }
 
 #[test]
-fn test_build_request_reasoning_level_medium_enables_thinking() {
+fn test_build_request_extra_body_passthrough_non_thinking() {
     let proto = GlmProtocol::new();
     let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Medium;
+    let mut extra = serde_json::Map::new();
+    extra.insert("custom_key".to_string(), serde_json::json!(42));
+    request.extra_body = extra;
     let body = proto.build_request(&request).unwrap();
-    let thinking = body.get("thinking").unwrap();
-    assert_eq!(thinking.get("type").unwrap(), "enabled");
-}
-
-#[test]
-fn test_build_request_reasoning_level_high_enables_thinking() {
-    let proto = GlmProtocol::new();
-    let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::High;
-    let body = proto.build_request(&request).unwrap();
-    let thinking = body.get("thinking").unwrap();
-    assert_eq!(thinking.get("type").unwrap(), "enabled");
-}
-
-#[test]
-fn test_build_request_reasoning_level_max_enables_thinking() {
-    let proto = GlmProtocol::new();
-    let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Max;
-    let body = proto.build_request(&request).unwrap();
-    let thinking = body.get("thinking").unwrap();
-    assert_eq!(thinking.get("type").unwrap(), "enabled");
-}
-
-#[test]
-fn test_build_request_default_reasoning_level_enables_thinking() {
-    let proto = GlmProtocol::new();
-    let request = make_request(); // default is High
-    let body = proto.build_request(&request).unwrap();
-    let thinking = body.get("thinking").unwrap();
-    assert_eq!(thinking.get("type").unwrap(), "enabled");
+    assert_eq!(body.get("custom_key").unwrap(), &serde_json::json!(42));
+    assert!(body.get("thinking").is_none());
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -257,6 +257,9 @@ async fn build_unified_chain(
             let plugin_pipeline = if entry.provider == "deepseek" {
                 closeclaw_llm::plugin::PluginPipeline::new()
                     .add(Box::new(closeclaw_llm::deepseek::DeepSeekPlugin))
+            } else if entry.provider == "glm" {
+                closeclaw_llm::plugin::PluginPipeline::new()
+                    .add(Box::new(closeclaw_llm::glm::GlmPlugin))
             } else {
                 closeclaw_llm::plugin::PluginPipeline::new()
             };


### PR DESCRIPTION
align GLM provider implementation with design doc

This PR aligns the GLM LLM provider code with the design document
`docs/design/llm/providers/glm.md`, fixing 3 inconsistencies:

1. **GlmPlugin for thinking injection**：创建 `GlmPlugin` 实现 `ModelPlugin`
   trait，通过 `before_request` 向 `extra_body` 注入 `thinking.type` 参数，
   替代 `GlmProtocol::build_request` 中的硬编码逻辑。注册到 GLM provider
   的 plugin pipeline。

2. **Quota API path**：将 `fetch_usage` 的 URL 从 `/paas/quota` 改为文档
   规定的 `/api/monitor/usage/quota/limit`。

3. **极短 reasoning_content 过滤**：非流式响应中，`reasoning_content`
   trim 后长度 ≤ 2 时不视为推理块，降级为普通文本处理。
   流式场景因增量到达无法预知总长度，保持现有行为。

Source: design-doc
Type: fix