### PR TITLE
fix: correct reasoning_content mapping in OpenAI non-streaming response

### DIFF
--- a/crates/llm/src/protocol/openai.rs
+++ b/crates/llm/src/protocol/openai.rs
@@ -105,18 +105,27 @@ impl ChatProtocol for OpenAiProtocol {
 
         let usage = parse_usage(&body);
 
-        let content_blocks = if let Some(ref text) = content {
-            // content 非空 → 仅产出 Text（文档规则：content 非空优先取 content）
-            vec![RawContentBlock::Text(text.clone())]
+        // 按文档规则构建 content_blocks：
+        // content 非空 + reasoning_content 非空 → Thinking + Text
+        // content 非空 + reasoning_content 空 → Text
+        // content 空 + reasoning_content 非空 → Text（reasoning_content 作为 Text 内容）
+        // 两者都空 → 空 Text
+        let mut content_blocks = Vec::new();
+        if let Some(ref text) = content {
+            // content 非空：两者独立产出各自块（Thinking 在前）
+            if let Some(thinking) = reasoning_content {
+                content_blocks.push(RawContentBlock::Thinking {
+                    thinking,
+                    signature: None,
+                });
+            }
+            content_blocks.push(RawContentBlock::Text(text.clone()));
         } else if let Some(thinking) = reasoning_content {
-            // content 为空/仅空白且 reasoning_content 非空 → 仅产出 Thinking
-            vec![RawContentBlock::Thinking {
-                thinking,
-                signature: None,
-            }]
+            // content 空 + reasoning_content 非空 → reasoning_content 作为 Text 块
+            content_blocks.push(RawContentBlock::Text(thinking));
         } else {
-            // 两者都为空 → 产出空 Text
-            vec![RawContentBlock::Text(String::new())]
+            // 两者都空 → 空 Text 块
+            content_blocks.push(RawContentBlock::Text(String::new()));
         };
 
         Ok(InternalResponse {

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -240,9 +240,10 @@ fn test_parse_response_with_reasoning_content() {
     let resp = proto.parse_response(body).unwrap();
     // Empty content + reasoning_content → single Text block (reasoning_content as Text)
     assert_eq!(resp.content_blocks.len(), 1);
-    assert!(
-        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Let me think about this...")
-    );
+    let RawContentBlock::Text(text) = &resp.content_blocks[0] else {
+        panic!("expected Text block");
+    };
+    assert_eq!(text, "Let me think about this...");
 }
 
 #[test]
@@ -266,9 +267,10 @@ fn test_parse_response_with_both_content_and_reasoning() {
     let resp = proto.parse_response(body).unwrap();
     // Both content and reasoning → Thinking + Text (thinking first)
     assert_eq!(resp.content_blocks.len(), 2);
-    assert!(
-        matches!(&resp.content_blocks[0], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
-    );
+    let RawContentBlock::Thinking { thinking, .. } = &resp.content_blocks[0] else {
+        panic!("expected Thinking block");
+    };
+    assert_eq!(thinking, "Let me think about this...");
     assert!(
         matches!(&resp.content_blocks[1], RawContentBlock::Text(s) if s == "The answer is 42.")
     );

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -238,10 +238,10 @@ fn test_parse_response_with_reasoning_content() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Empty content → only Thinking block (no empty Text)
+    // Empty content + reasoning_content → single Text block (reasoning_content as Text)
     assert_eq!(resp.content_blocks.len(), 1);
     assert!(
-        matches!(&resp.content_blocks[0], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
+        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Let me think about this...")
     );
 }
 
@@ -264,10 +264,13 @@ fn test_parse_response_with_both_content_and_reasoning() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Both content and reasoning → only Text (content non-empty takes priority)
-    assert_eq!(resp.content_blocks.len(), 1);
+    // Both content and reasoning → Thinking + Text (thinking first)
+    assert_eq!(resp.content_blocks.len(), 2);
     assert!(
-        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "The answer is 42.")
+        matches!(&resp.content_blocks[0], RawContentBlock::Thinking { thinking: s, .. } if s == "Let me think about this...")
+    );
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::Text(s) if s == "The answer is 42.")
     );
 }
 
@@ -316,6 +319,72 @@ fn test_parse_response_no_reasoning_content() {
     // No reasoning_content → only Text block
     assert_eq!(resp.content_blocks.len(), 1);
     assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Hello!"));
+}
+
+#[test]
+fn test_parse_response_reasoning_as_text_when_content_empty() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "reasoning_content": "Deep reasoning here."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // content=null + reasoning_content non-empty → single Text block with reasoning content
+    assert_eq!(resp.content_blocks.len(), 1);
+    assert!(
+        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Deep reasoning here.")
+    );
+}
+
+#[test]
+fn test_parse_response_thinking_then_text_order() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_content": "Let me think about this..."
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    assert_eq!(resp.content_blocks.len(), 2);
+    // Thinking block first
+    match &resp.content_blocks[0] {
+        RawContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "Let me think about this...");
+            assert!(signature.is_none());
+        }
+        _ => panic!("Expected Thinking block first"),
+    }
+    // Text block second
+    match &resp.content_blocks[1] {
+        RawContentBlock::Text(text) => {
+            assert_eq!(text, "The answer is 42.");
+        }
+        _ => panic!("Expected Text block second"),
+    }
 }
 
 // ── reasoning_effort is NOT injected by protocol layer ───────────────────────


### PR DESCRIPTION
Fix OpenAI non-streaming response to correctly map `reasoning_content` to unified content blocks per `docs/design/llm/protocol-mapping.md`.

Previously, `parse_response` had two issues:
1. When both `content` and `reasoning_content` were non-empty, only a Text block was produced, discarding `reasoning_content`.
2. When `content` was empty and `reasoning_content` was non-empty, a Thinking block was produced instead of a Text block.

The fix implements the four combinations defined in the design doc:
- content + reasoning_content → Thinking + Text (thinking first)
- content only → Text
- reasoning_content only → Text (reasoning as text)
- neither → empty Text

Tests updated and expanded to cover all four cases.

Source: design-doc
Type: fix
