### PR TITLE
fix: parse OpenAI non-streaming tool_calls and preserve signature in DefaultInterpreter

### DIFF
--- a/crates/llm/src/interpreter.rs
+++ b/crates/llm/src/interpreter.rs
@@ -69,7 +69,7 @@ impl ModelInterpreter for DefaultInterpreter {
         let content_blocks: Vec<ContentBlock> = response
             .content_blocks
             .into_iter()
-            .map(raw_content_block_to_content_block)
+            .map(Into::into)
             .collect();
         let usage = UnifiedUsage {
             prompt_tokens: response.usage.prompt_tokens,
@@ -162,24 +162,6 @@ impl InterpreterRegistry {
 impl Default for InterpreterRegistry {
     fn default() -> Self {
         Self::new(vec![])
-    }
-}
-
-fn raw_content_block_to_content_block(raw: RawContentBlock) -> ContentBlock {
-    match raw {
-        RawContentBlock::Text(s) => ContentBlock::Text(s),
-        RawContentBlock::Thinking { thinking: s, .. } => ContentBlock::Thinking {
-            thinking: s,
-            signature: None,
-        },
-        RawContentBlock::ToolUse { id, name, input } => ContentBlock::ToolUse { id, name, input },
-        RawContentBlock::ToolResult {
-            tool_call_id,
-            content,
-        } => ContentBlock::ToolResult {
-            tool_call_id,
-            content,
-        },
     }
 }
 

--- a/crates/llm/src/interpreter_test.rs
+++ b/crates/llm/src/interpreter_test.rs
@@ -407,3 +407,36 @@ fn test_deepseek_interpreter_stream_event_passthrough() {
         Some(event)
     );
 }
+
+// ── Gap 2: DefaultInterpreter preserves signature ─────────────────────────────
+
+#[test]
+fn test_default_interpreter_preserves_signature() {
+    let sig = Some("test-signature-abc123".to_string());
+    let response = InternalResponse {
+        content_blocks: vec![RawContentBlock::Thinking {
+            thinking: "thinking with sig".into(),
+            signature: sig.clone(),
+        }],
+        usage: RawUsage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: Some(15),
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    };
+    let unified = DefaultInterpreter.interpret_response(response);
+    assert_eq!(unified.content_blocks.len(), 1);
+    match &unified.content_blocks[0] {
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "thinking with sig");
+            assert_eq!(signature, &sig);
+        }
+        other => panic!("expected Thinking block, got {:?}", other),
+    }
+}

--- a/crates/llm/src/protocol/openai.rs
+++ b/crates/llm/src/protocol/openai.rs
@@ -128,6 +128,33 @@ impl ChatProtocol for OpenAiProtocol {
             content_blocks.push(RawContentBlock::Text(String::new()));
         };
 
+        // Parse tool_calls from message (doc: choices[].message.tool_calls[] → ToolUse)
+        if let Some(tool_calls) = message
+            .and_then(|msg| msg.get("tool_calls"))
+            .and_then(|v| v.as_array())
+        {
+            for tc in tool_calls {
+                let id = tc
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let name = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let input = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                content_blocks.push(RawContentBlock::ToolUse { id, name, input });
+            }
+        }
+
         Ok(InternalResponse {
             content_blocks,
             usage,

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -452,6 +452,178 @@ fn test_build_request_default_does_not_inject_reasoning_effort() {
     );
 }
 
+// ── Gap 1: non-streaming tool_calls parsing ─────────────────────────────────
+
+#[test]
+fn test_parse_response_with_tool_calls() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Let me check that.",
+                "tool_calls": [{
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"location\": \"Beijing\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // Text block first, then ToolUse
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(
+        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Let me check that.")
+    );
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::ToolUse { id, name, input }
+            if id == "call_001" && name == "get_weather" && input == "{\"location\": \"Beijing\"}")
+    );
+}
+
+#[test]
+fn test_parse_response_with_tool_calls_only() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_002",
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "arguments": "{}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // content=null + no reasoning → empty Text + ToolUse
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::ToolUse { id, .. } if id == "call_002")
+    );
+}
+
+#[test]
+fn test_parse_response_with_multiple_tool_calls() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\": \"Shanghai\"}"
+                        }
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {
+                            "name": "get_time",
+                            "arguments": "{\"timezone\": \"CST\"}"
+                        }
+                    },
+                    {
+                        "id": "call_c",
+                        "type": "function",
+                        "function": {
+                            "name": "notify",
+                            "arguments": "{}"
+                        }
+                    }
+                ]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // empty Text + 3 ToolUse blocks
+    assert_eq!(resp.content_blocks.len(), 4);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s.is_empty()));
+    assert!(
+        matches!(&resp.content_blocks[1], RawContentBlock::ToolUse { id, name, .. }
+        if id == "call_a" && name == "get_weather")
+    );
+    assert!(
+        matches!(&resp.content_blocks[2], RawContentBlock::ToolUse { id, name, .. }
+        if id == "call_b" && name == "get_time")
+    );
+    assert!(
+        matches!(&resp.content_blocks[3], RawContentBlock::ToolUse { id, name, .. }
+        if id == "call_c" && name == "notify")
+    );
+}
+
+#[test]
+fn test_parse_response_tool_calls_with_reasoning() {
+    let proto = OpenAiProtocol::new();
+    let body = serde_json::json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "Here you go.",
+                "reasoning_content": "Thinking about the request...",
+                "tool_calls": [{
+                    "id": "call_r1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": "{\"q\": \"rust\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150
+        }
+    });
+    let resp = proto.parse_response(body).unwrap();
+    // Thinking + Text + ToolUse
+    assert_eq!(resp.content_blocks.len(), 3);
+    assert!(matches!(&resp.content_blocks[0],
+        RawContentBlock::Thinking { thinking, .. } if thinking == "Thinking about the request..."));
+    assert!(matches!(&resp.content_blocks[1], RawContentBlock::Text(s) if s == "Here you go."));
+    assert!(
+        matches!(&resp.content_blocks[2], RawContentBlock::ToolUse { id, name, .. }
+        if id == "call_r1" && name == "lookup")
+    );
+}
+
 #[test]
 fn test_parse_response_cached_tokens() {
     let proto = OpenAiProtocol::new();


### PR DESCRIPTION
- Parse OpenAI non-streaming `tool_calls` from `choices[].message.tool_calls[]` into `RawContentBlock::ToolUse` blocks
- Remove redundant `raw_content_block_to_content_block()` in DefaultInterpreter, use `Into::into` to preserve `signature` field in Thinking blocks
- Add 5 unit tests covering all logic branches

Source: user
Type: fix
