### PR TITLE
fix: add debug logging for unsupported Feishu message types

### DIFF
--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -317,6 +317,17 @@ fn test_parse_message_event_file_returns_none() {
 }
 
 #[test]
+fn test_parse_message_event_audio_returns_none() {
+    let adapter = make_test_adapter();
+    let event = make_message_event(
+        "audio",
+        &serde_json::json!({"file_key": "audio_xxx"}).to_string(),
+    );
+    let result = adapter.parse_message_event(event).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
 fn test_parse_message_event_metadata_account_id() {
     let adapter = make_test_adapter();
     let event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());

--- a/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
@@ -404,7 +404,10 @@ impl FeishuAdapter {
                 "text".to_string(),
             ),
             "post" => (expand_post_content(&content), "post".to_string()),
-            _other => return Ok(None),
+            _other => {
+                tracing::debug!(message_type = _other, "Discarding unsupported message type");
+                return Ok(None);
+            }
         };
 
         let thread_id = event


### PR DESCRIPTION
补齐 `parse_message_event` 中非文本消息的 debug 日志，使代码行为与 design doc (`docs/design/im_adapter/platforms/feishu.md`) 一致。

非文本消息（image/file/audio 等）被丢弃时记录 `debug!` 级别日志，包含 message_type 信息，便于排查。同时补充 UT 覆盖。

Source: user
Type: fix
