### PR TITLE
feat: implement IM adapter media_refs download for image/file/audio messages

### DIFF
--- a/crates/im_adapter/src/error.rs
+++ b/crates/im_adapter/src/error.rs
@@ -17,6 +17,9 @@ pub enum AdapterError {
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 
+    #[error("Media download failed: {0}")]
+    MediaDownloadFailed(String),
+
     #[error("Unsupported operation")]
     UnsupportedOperation,
 }

--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -78,6 +78,7 @@ fn make_message_event(message_type: &str, content_json: &str) -> FeishuEvent {
             app_id: "test_app_id".to_string(),
         },
         event: FeishuMessageEvent {
+            message_id: None,
             sender: FeishuSender {
                 sender_id: FeishuSenderId {
                     open_id: "ou_sender".to_string(),

--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -1,6 +1,6 @@
-//! Unit tests for Feishu adapter: expand_post_content, parse_message_event,
-//! parse_inbound (message_type propagation), and send_message/send_card_json
-//! receive_id_type verification.
+//! Unit tests for Feishu adapter: expand_post_content, parse_message_event
+//! (text/post/image/file/audio with graceful degradation), parse_inbound,
+//! and send_message/send_card_json receive_id_type verification.
 
 use super::*;
 use crate::platforms::feishu::FeishuPlugin;
@@ -68,6 +68,15 @@ async fn start_mock_server(received_id_type: Arc<tokio::sync::Mutex<Option<Strin
 
 /// Build a minimal FeishuEvent for a message event.
 fn make_message_event(message_type: &str, content_json: &str) -> FeishuEvent {
+    make_message_event_with_id(message_type, content_json, None)
+}
+
+/// Build a FeishuEvent with an explicit message_id.
+fn make_message_event_with_id(
+    message_type: &str,
+    content_json: &str,
+    message_id: Option<&str>,
+) -> FeishuEvent {
     FeishuEvent {
         schema: "2.0".to_string(),
         header: FeishuHeader {
@@ -78,7 +87,7 @@ fn make_message_event(message_type: &str, content_json: &str) -> FeishuEvent {
             app_id: "test_app_id".to_string(),
         },
         event: FeishuMessageEvent {
-            message_id: None,
+            message_id: message_id.map(String::from),
             sender: FeishuSender {
                 sender_id: FeishuSenderId {
                     open_id: "ou_sender".to_string(),
@@ -98,6 +107,18 @@ fn make_message_event(message_type: &str, content_json: &str) -> FeishuEvent {
 /// Build a webhook payload JSON from a message event.
 fn make_webhook_payload(message_type: &str, content_json: &str) -> Vec<u8> {
     let event = make_message_event(message_type, content_json);
+    let mut event_json = serde_json::json!({
+        "sender": {
+            "sender_id": { "open_id": event.event.sender.sender_id.open_id },
+            "sender_type": event.event.sender.sender_type,
+        },
+        "content": event.event.content,
+        "chat_id": event.event.chat_id,
+        "message_type": event.event.message_type,
+    });
+    if let Some(ref mid) = event.event.message_id {
+        event_json["message_id"] = serde_json::json!(mid);
+    }
     let payload = serde_json::json!({
         "schema": event.schema,
         "header": {
@@ -107,15 +128,7 @@ fn make_webhook_payload(message_type: &str, content_json: &str) -> Vec<u8> {
             "token": event.header.token,
             "app_id": event.header.app_id,
         },
-        "event": {
-            "sender": {
-                "sender_id": { "open_id": event.event.sender.sender_id.open_id },
-                "sender_type": event.event.sender.sender_type,
-            },
-            "content": event.event.content,
-            "chat_id": event.event.chat_id,
-            "message_type": event.event.message_type,
-        },
+        "event": event_json,
     });
     serde_json::to_vec(&payload).unwrap()
 }
@@ -273,75 +286,86 @@ fn test_expand_post_title_with_mixed_elements() {
 // parse_message_event tests
 // ===========================================================================
 
-#[test]
-fn test_parse_message_event_text_type() {
+#[tokio::test]
+async fn test_parse_message_event_text_type() {
     let adapter = make_test_adapter();
     let event = make_message_event("text", &serde_json::json!({"text": "hello"}).to_string());
-    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
     assert_eq!(msg.content, "hello");
     assert_eq!(msg.message_type, "text");
+    assert!(msg.media_refs.is_empty());
 }
 
-#[test]
-fn test_parse_message_event_post_type() {
+#[tokio::test]
+async fn test_parse_message_event_post_type() {
     let adapter = make_test_adapter();
     let content = serde_json::json!({
         "title": "T",
         "content": [[{"tag": "text", "text": "body"}]]
     });
     let event = make_message_event("post", &content.to_string());
-    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
     assert_eq!(msg.content, "T\nbody");
     assert_eq!(msg.message_type, "post");
+    assert!(msg.media_refs.is_empty());
 }
 
-#[test]
-fn test_parse_message_event_image_returns_none() {
+#[tokio::test]
+async fn test_parse_message_event_image_graceful_degradation() {
     let adapter = make_test_adapter();
-    let event = make_message_event(
+    let event = make_message_event_with_id(
         "image",
         &serde_json::json!({"image_key": "img_xxx"}).to_string(),
+        Some("om_msg_001"),
     );
-    let result = adapter.parse_message_event(event).unwrap();
-    assert!(result.is_none());
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "image");
+    assert!(msg.media_refs.is_empty(), "download should fail gracefully");
+    assert!(msg.content.is_empty());
 }
 
-#[test]
-fn test_parse_message_event_file_returns_none() {
+#[tokio::test]
+async fn test_parse_message_event_file_graceful_degradation() {
     let adapter = make_test_adapter();
-    let event = make_message_event(
+    let event = make_message_event_with_id(
         "file",
-        &serde_json::json!({"file_key": "file_xxx"}).to_string(),
+        &serde_json::json!({"file_key": "file_xxx", "file_name": "report.pdf"}).to_string(),
+        Some("om_msg_002"),
     );
-    let result = adapter.parse_message_event(event).unwrap();
-    assert!(result.is_none());
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "file");
+    assert!(msg.media_refs.is_empty(), "download should fail gracefully");
+    assert_eq!(msg.content, "report.pdf");
 }
 
-#[test]
-fn test_parse_message_event_audio_returns_none() {
+#[tokio::test]
+async fn test_parse_message_event_audio_graceful_degradation() {
     let adapter = make_test_adapter();
-    let event = make_message_event(
+    let event = make_message_event_with_id(
         "audio",
         &serde_json::json!({"file_key": "audio_xxx"}).to_string(),
+        Some("om_msg_003"),
     );
-    let result = adapter.parse_message_event(event).unwrap();
-    assert!(result.is_none());
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "audio");
+    assert!(msg.media_refs.is_empty(), "download should fail gracefully");
+    assert!(msg.content.is_empty());
 }
 
-#[test]
-fn test_parse_message_event_metadata_account_id() {
+#[tokio::test]
+async fn test_parse_message_event_metadata_account_id() {
     let adapter = make_test_adapter();
     let event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
-    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
     assert_eq!(msg.account_id.as_deref(), Some("ou_sender"));
 }
 
-#[test]
-fn test_parse_message_event_thread_id_from_root_id() {
+#[tokio::test]
+async fn test_parse_message_event_thread_id_from_root_id() {
     let adapter = make_test_adapter();
     let mut event = make_message_event("text", &serde_json::json!({"text": "hi"}).to_string());
     event.event.root_id = Some("om_root123".to_string());
-    let msg = adapter.parse_message_event(event).unwrap().unwrap();
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
     assert_eq!(msg.thread_id.as_deref(), Some("om_root123"));
 }
 
@@ -543,13 +567,14 @@ async fn test_parse_inbound_post_type() {
 }
 
 #[tokio::test]
-async fn test_parse_inbound_image_returns_none() {
+async fn test_parse_inbound_image_graceful_degradation() {
     let adapter = Arc::new(make_test_adapter());
     let plugin = FeishuPlugin::new(adapter);
     let payload = make_webhook_payload(
         "image",
         &serde_json::json!({"image_key": "img_xxx"}).to_string(),
     );
-    let result = plugin.parse_inbound(&payload).await.unwrap();
-    assert!(result.is_none());
+    let msg = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "image");
+    assert!(msg.media_refs.is_empty(), "download should fail gracefully");
 }

--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -7,6 +7,7 @@ use crate::platforms::feishu::FeishuPlugin;
 use crate::plugin::IMPlugin;
 use axum::{extract::Query, routing::post, Json, Router};
 use std::collections::HashMap as StdHashMap;
+use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
 
 /// Create a test FeishuAdapter (no real HTTP — only sync methods are exercised).
@@ -64,6 +65,72 @@ async fn start_mock_server(received_id_type: Arc<tokio::sync::Mutex<Option<Strin
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     format!("http://{}", addr)
+}
+
+/// Start a mock Feishu server that handles token + media download.
+/// Returns the base URL.
+async fn start_media_mock_server() -> String {
+    use axum::extract::{Path, RawQuery};
+    use axum::http::StatusCode;
+
+    let app = Router::new()
+        .route(
+            "/auth/v3/tenant_access_token/internal",
+            post(|Json(_body): Json<serde_json::Value>| async {
+                Json(serde_json::json!({
+                    "code": 0,
+                    "msg": "ok",
+                    "tenant_access_token": "mock_token"
+                }))
+            }),
+        )
+        .route(
+            "/im/v1/messages/:message_id/resources/:file_key",
+            axum::routing::get(
+                move |Path((_message_id, file_key)): Path<(String, String)>,
+                      RawQuery(query): RawQuery| async move {
+                    let media_type = query
+                        .and_then(|q| {
+                            q.split('&')
+                                .find(|p| p.starts_with("type="))
+                                .map(|p| p[5..].to_string())
+                        })
+                        .unwrap_or_default();
+                    (
+                        StatusCode::OK,
+                        [(
+                            "content-type",
+                            match media_type.as_str() {
+                                "image" => "image/png",
+                                _ => "application/octet-stream",
+                            },
+                        )],
+                        format!("MOCK_FILE_CONTENT_{}", file_key),
+                    )
+                },
+            ),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    format!("http://{}", addr)
+}
+
+/// Create a FeishuAdapter with a pre-populated valid cached token,
+/// pointing at the given base URL.
+fn make_adapter_with_cached_token(base_url: &str) -> FeishuAdapter {
+    let http_client = reqwest::Client::new();
+    FeishuAdapter {
+        app_id: "test_app_id".to_string(),
+        app_secret: "test_secret".to_string(),
+        verification_token: "test_token".to_string(),
+        http_client,
+        cached_token: Arc::new(tokio::sync::Mutex::new(Some(CachedToken {
+            token: "pre_cached_token".to_string(),
+            expires_at: Instant::now() + Duration::from_secs(3600),
+        }))),
+        base_url: base_url.to_string(),
+    }
 }
 
 /// Build a minimal FeishuEvent for a message event.
@@ -577,4 +644,84 @@ async fn test_parse_inbound_image_graceful_degradation() {
     let msg = plugin.parse_inbound(&payload).await.unwrap().unwrap();
     assert_eq!(msg.message_type, "image");
     assert!(msg.media_refs.is_empty(), "download should fail gracefully");
+}
+
+// ===========================================================================
+// Positive download tests (download succeeds → media_refs populated)
+// ===========================================================================
+
+#[tokio::test]
+async fn test_parse_image_message_success() {
+    let base_url = start_media_mock_server().await;
+    let adapter = make_adapter_with_cached_token(&base_url);
+    let event = make_message_event_with_id(
+        "image",
+        &serde_json::json!({"image_key": "img_test_123"}).to_string(),
+        Some("om_img_001"),
+    );
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "image");
+    assert_eq!(msg.content, "");
+    assert_eq!(msg.media_refs.len(), 1);
+    assert_eq!(msg.media_refs[0].key, "img_test_123");
+    assert!(msg.media_refs[0].url.contains("img_test_123"));
+    // Clean up temp file
+    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+}
+
+#[tokio::test]
+async fn test_parse_file_message_success() {
+    let base_url = start_media_mock_server().await;
+    let adapter = make_adapter_with_cached_token(&base_url);
+    let event = make_message_event_with_id(
+        "file",
+        &serde_json::json!({"file_key": "file_xyz_789", "file_name": "report.pdf"}).to_string(),
+        Some("om_file_002"),
+    );
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "file");
+    assert_eq!(msg.content, "report.pdf");
+    assert_eq!(msg.media_refs.len(), 1);
+    assert_eq!(msg.media_refs[0].key, "file_xyz_789");
+    assert!(msg.media_refs[0].url.contains("file_xyz_789"));
+    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+}
+
+#[tokio::test]
+async fn test_parse_audio_message_success() {
+    let base_url = start_media_mock_server().await;
+    let adapter = make_adapter_with_cached_token(&base_url);
+    let event = make_message_event_with_id(
+        "audio",
+        &serde_json::json!({"file_key": "audio_abc_456"}).to_string(),
+        Some("om_audio_003"),
+    );
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "audio");
+    assert!(msg.content.is_empty());
+    assert_eq!(msg.media_refs.len(), 1);
+    assert_eq!(msg.media_refs[0].key, "audio_abc_456");
+    assert!(msg.media_refs[0].url.contains("audio_abc_456"));
+    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+}
+
+#[tokio::test]
+async fn test_download_media_failure_graceful_degradation() {
+    let adapter = make_test_adapter();
+    let event = make_message_event_with_id(
+        "image",
+        &serde_json::json!({"image_key": "img_fail"}).to_string(),
+        Some("om_fail_001"),
+    );
+    let msg = adapter.parse_message_event(event).await.unwrap().unwrap();
+    assert_eq!(msg.message_type, "image");
+    assert!(
+        msg.media_refs.is_empty(),
+        "media_refs should be empty on download failure"
+    );
+    assert!(msg.content.is_empty());
+    // Message is still produced (not discarded)
+    assert_eq!(msg.platform, "feishu");
+    assert_eq!(msg.sender_id, "ou_sender");
+    assert_eq!(msg.peer_id, "oc_chat");
 }

--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -7,7 +7,8 @@ use crate::platforms::feishu::FeishuPlugin;
 use crate::plugin::IMPlugin;
 use axum::{extract::Query, routing::post, Json, Router};
 use std::collections::HashMap as StdHashMap;
-use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
 use tokio::net::TcpListener;
 
 /// Create a test FeishuAdapter (no real HTTP — only sync methods are exercised).
@@ -20,6 +21,7 @@ fn make_test_adapter() -> FeishuAdapter {
         http_client,
         cached_token: Arc::new(tokio::sync::Mutex::new(None)),
         base_url: FEISHU_API_BASE.to_string(),
+        temp_dir: std::env::temp_dir().join("closeclaw").join("media"),
     }
 }
 
@@ -33,6 +35,7 @@ fn make_adapter_with_base(base_url: &str) -> FeishuAdapter {
         http_client,
         cached_token: Arc::new(tokio::sync::Mutex::new(None)),
         base_url: base_url.to_string(),
+        temp_dir: std::env::temp_dir().join("closeclaw").join("media"),
     }
 }
 
@@ -116,20 +119,17 @@ async fn start_media_mock_server() -> String {
     format!("http://{}", addr)
 }
 
-/// Create a FeishuAdapter with a pre-populated valid cached token,
-/// pointing at the given base URL.
-fn make_adapter_with_cached_token(base_url: &str) -> FeishuAdapter {
+/// Create a FeishuAdapter pointing at a mock server with a custom temp_dir.
+fn make_adapter_with_temp_dir(base_url: &str, temp_dir: PathBuf) -> FeishuAdapter {
     let http_client = reqwest::Client::new();
     FeishuAdapter {
         app_id: "test_app_id".to_string(),
         app_secret: "test_secret".to_string(),
         verification_token: "test_token".to_string(),
         http_client,
-        cached_token: Arc::new(tokio::sync::Mutex::new(Some(CachedToken {
-            token: "pre_cached_token".to_string(),
-            expires_at: Instant::now() + Duration::from_secs(3600),
-        }))),
+        cached_token: Arc::new(tokio::sync::Mutex::new(None)),
         base_url: base_url.to_string(),
+        temp_dir,
     }
 }
 
@@ -652,8 +652,9 @@ async fn test_parse_inbound_image_graceful_degradation() {
 
 #[tokio::test]
 async fn test_parse_image_message_success() {
+    let tmp = TempDir::new().unwrap();
     let base_url = start_media_mock_server().await;
-    let adapter = make_adapter_with_cached_token(&base_url);
+    let adapter = make_adapter_with_temp_dir(&base_url, tmp.path().to_path_buf());
     let event = make_message_event_with_id(
         "image",
         &serde_json::json!({"image_key": "img_test_123"}).to_string(),
@@ -665,14 +666,14 @@ async fn test_parse_image_message_success() {
     assert_eq!(msg.media_refs.len(), 1);
     assert_eq!(msg.media_refs[0].key, "img_test_123");
     assert!(msg.media_refs[0].url.contains("img_test_123"));
-    // Clean up temp file
-    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+    // TempDir dropped → files cleaned up automatically
 }
 
 #[tokio::test]
 async fn test_parse_file_message_success() {
+    let tmp = TempDir::new().unwrap();
     let base_url = start_media_mock_server().await;
-    let adapter = make_adapter_with_cached_token(&base_url);
+    let adapter = make_adapter_with_temp_dir(&base_url, tmp.path().to_path_buf());
     let event = make_message_event_with_id(
         "file",
         &serde_json::json!({"file_key": "file_xyz_789", "file_name": "report.pdf"}).to_string(),
@@ -684,13 +685,14 @@ async fn test_parse_file_message_success() {
     assert_eq!(msg.media_refs.len(), 1);
     assert_eq!(msg.media_refs[0].key, "file_xyz_789");
     assert!(msg.media_refs[0].url.contains("file_xyz_789"));
-    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+    // TempDir dropped → files cleaned up automatically
 }
 
 #[tokio::test]
 async fn test_parse_audio_message_success() {
+    let tmp = TempDir::new().unwrap();
     let base_url = start_media_mock_server().await;
-    let adapter = make_adapter_with_cached_token(&base_url);
+    let adapter = make_adapter_with_temp_dir(&base_url, tmp.path().to_path_buf());
     let event = make_message_event_with_id(
         "audio",
         &serde_json::json!({"file_key": "audio_abc_456"}).to_string(),
@@ -702,7 +704,7 @@ async fn test_parse_audio_message_success() {
     assert_eq!(msg.media_refs.len(), 1);
     assert_eq!(msg.media_refs[0].key, "audio_abc_456");
     assert!(msg.media_refs[0].url.contains("audio_abc_456"));
-    let _ = tokio::fs::remove_file(&msg.media_refs[0].url).await;
+    // TempDir dropped → files cleaned up automatically
 }
 
 #[tokio::test]

--- a/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
@@ -258,7 +258,7 @@ impl FeishuAdapter {
     ///
     /// Calls `GET /im/v1/messages/{message_id}/resources/{file_key}?type={media_type}`
     /// with Bearer token authentication. Saves the file to
-    /// `{temp_dir}/closeclaw/media/{file_key}` and returns the local path.
+    /// `{temp_dir}/{file_key}` and returns the local path.
     #[allow(dead_code)]
     async fn download_media(
         &self,
@@ -461,6 +461,51 @@ impl FeishuAdapter {
         }
     }
 
+    /// Process an image, file, or audio message: download the media and
+    /// build the content text and `media_refs` list.
+    ///
+    /// Returns `(content_text, media_refs)`. On download failure the media
+    /// ref is omitted but the message is still produced (graceful degradation).
+    async fn process_media_message(
+        &self,
+        content: &serde_json::Value,
+        message_id: &str,
+        message_type: &str,
+    ) -> (String, Vec<MediaRef>) {
+        let media_type = if message_type == "image" {
+            "image"
+        } else {
+            "file"
+        };
+        let media_ref = if let Some(key) = Self::extract_media_key(content, message_type) {
+            match self.download_media(message_id, &key, media_type).await {
+                Ok(local_path) => Some(MediaRef {
+                    key,
+                    url: local_path,
+                }),
+                Err(e) => {
+                    tracing::warn!(
+                        message_type = %message_type,
+                        error = %e,
+                        "Failed to download media, continuing with empty media_refs"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let content_text = match message_type {
+            "file" => content
+                .get("file_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            _ => String::new(),
+        };
+        (content_text, media_ref.into_iter().collect())
+    }
+
     /// Parse a regular message event into a NormalizedMessage.
     ///
     /// For `image`, `file`, and `audio` message types, downloads the media
@@ -473,7 +518,6 @@ impl FeishuAdapter {
         let content: serde_json::Value = serde_json::from_str(&event.event.content)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 
-        let message_type = event.event.message_type.clone();
         let message_id = event.event.message_id.as_deref().unwrap_or("");
         let thread_id = event
             .event
@@ -482,7 +526,7 @@ impl FeishuAdapter {
             .or(event.event.parent_id);
         let sender_open_id = event.event.sender.sender_id.open_id.clone();
 
-        let (text, media_refs) = match message_type.as_str() {
+        let (text, media_refs) = match event.event.message_type.as_str() {
             "text" => (
                 content
                     .get("text")
@@ -493,39 +537,8 @@ impl FeishuAdapter {
             ),
             "post" => (expand_post_content(&content), vec![]),
             "image" | "file" | "audio" => {
-                let media_type = if message_type == "image" {
-                    "image"
-                } else {
-                    "file"
-                };
-                let media_ref = if let Some(key) = Self::extract_media_key(&content, &message_type)
-                {
-                    match self.download_media(message_id, &key, media_type).await {
-                        Ok(local_path) => Some(MediaRef {
-                            key,
-                            url: local_path,
-                        }),
-                        Err(e) => {
-                            tracing::warn!(
-                                message_type = %message_type,
-                                error = %e,
-                                "Failed to download media, continuing with empty media_refs"
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-                let content_text = match message_type.as_str() {
-                    "file" => content
-                        .get("file_name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                    _ => String::new(),
-                };
-                (content_text, media_ref.into_iter().collect())
+                self.process_media_message(&content, message_id, &event.event.message_type)
+                    .await
             }
             other => {
                 tracing::debug!(message_type = other, "Discarding unsupported message type");
@@ -539,7 +552,7 @@ impl FeishuAdapter {
             peer_id: event.event.chat_id,
             content: text,
             timestamp: chrono::Utc::now().timestamp_millis(),
-            message_type,
+            message_type: event.event.message_type,
             media_refs,
             quoted_message: None,
             thread_id,

--- a/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
@@ -1,7 +1,7 @@
 //! Feishu adapter — HTTP I/O, token management, and webhook parsing.
 
 use crate::error::AdapterError;
-use crate::normalized::NormalizedMessage;
+use crate::normalized::{MediaRef, NormalizedMessage};
 use crate::IMAdapter;
 use async_trait::async_trait;
 use closeclaw_gateway::Message;
@@ -456,39 +456,77 @@ impl FeishuAdapter {
         }
     }
 
-    /// Parse a regular message event into a Message.
+    /// Parse a regular message event into a NormalizedMessage.
     ///
-    /// Returns `Ok(None)` for non-text message types (image, file, audio, etc.).
-    fn parse_message_event(
+    /// For `image`, `file`, and `audio` message types, downloads the media
+    /// resource and populates `media_refs`. On download failure the message
+    /// is still produced with an empty `media_refs` (graceful degradation).
+    async fn parse_message_event(
         &self,
         event: FeishuEvent,
     ) -> Result<Option<NormalizedMessage>, AdapterError> {
         let content: serde_json::Value = serde_json::from_str(&event.event.content)
             .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
 
-        let (text, message_type) = match event.event.message_type.as_str() {
+        let message_type = event.event.message_type.clone();
+        let message_id = event.event.message_id.as_deref().unwrap_or("");
+        let thread_id = event
+            .event
+            .thread_id
+            .or(event.event.root_id)
+            .or(event.event.parent_id);
+        let sender_open_id = event.event.sender.sender_id.open_id.clone();
+
+        let (text, media_refs) = match message_type.as_str() {
             "text" => (
                 content
                     .get("text")
                     .and_then(|t| t.as_str())
                     .unwrap_or("")
                     .to_string(),
-                "text".to_string(),
+                vec![],
             ),
-            "post" => (expand_post_content(&content), "post".to_string()),
-            _other => {
-                tracing::debug!(message_type = _other, "Discarding unsupported message type");
+            "post" => (expand_post_content(&content), vec![]),
+            "image" | "file" | "audio" => {
+                let media_type = if message_type == "image" {
+                    "image"
+                } else {
+                    "file"
+                };
+                let media_ref = if let Some(key) = Self::extract_media_key(&content, &message_type)
+                {
+                    match self.download_media(message_id, &key, media_type).await {
+                        Ok(local_path) => Some(MediaRef {
+                            key,
+                            url: local_path,
+                        }),
+                        Err(e) => {
+                            tracing::warn!(
+                                message_type = %message_type,
+                                error = %e,
+                                "Failed to download media, continuing with empty media_refs"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                let content_text = match message_type.as_str() {
+                    "file" => content
+                        .get("file_name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    _ => String::new(),
+                };
+                (content_text, media_ref.into_iter().collect())
+            }
+            other => {
+                tracing::debug!(message_type = other, "Discarding unsupported message type");
                 return Ok(None);
             }
         };
-
-        let thread_id = event
-            .event
-            .thread_id
-            .or(event.event.root_id)
-            .or(event.event.parent_id);
-
-        let sender_open_id = event.event.sender.sender_id.open_id;
 
         Ok(Some(NormalizedMessage {
             platform: "feishu".to_string(),
@@ -497,7 +535,7 @@ impl FeishuAdapter {
             content: text,
             timestamp: chrono::Utc::now().timestamp_millis(),
             message_type,
-            media_refs: vec![],
+            media_refs,
             quoted_message: None,
             thread_id,
             account_id: Some(sender_open_id),
@@ -548,7 +586,7 @@ impl IMAdapter for FeishuAdapter {
             _ => {
                 let event: FeishuEvent = serde_json::from_value(raw)
                     .map_err(|e| AdapterError::InvalidPayload(e.to_string()))?;
-                self.parse_message_event(event)
+                self.parse_message_event(event).await
             }
         }
     }

--- a/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
@@ -38,6 +38,8 @@ pub(super) struct FeishuHeader {
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub(super) struct FeishuMessageEvent {
+    #[serde(default)]
+    pub(super) message_id: Option<String>,
     pub(super) sender: FeishuSender,
     pub(super) content: String,
     pub(super) chat_id: String,
@@ -245,6 +247,76 @@ impl FeishuAdapter {
         });
 
         Ok(new_token)
+    }
+
+    /// Download a media resource from Feishu API to a local temp file.
+    ///
+    /// Calls `GET /im/v1/messages/{message_id}/resources/{file_key}?type={media_type}`
+    /// with Bearer token authentication. Saves the file to
+    /// `{temp_dir}/closeclaw/media/{file_key}` and returns the local path.
+    #[allow(dead_code)]
+    async fn download_media(
+        &self,
+        message_id: &str,
+        file_key: &str,
+        media_type: &str,
+    ) -> Result<String, AdapterError> {
+        let token = self.get_tenant_token().await?;
+        let url = format!(
+            "{}/im/v1/messages/{}/resources/{}?type={}",
+            self.base_url, message_id, file_key, media_type
+        );
+
+        let resp = self
+            .http_client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await
+            .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            return Err(AdapterError::MediaDownloadFailed(format!(
+                "Feishu media download failed with status {}",
+                resp.status()
+            )));
+        }
+
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;
+
+        let dir = std::env::temp_dir().join("closeclaw").join("media");
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;
+
+        let path = dir.join(file_key);
+        tokio::fs::write(&path, &bytes)
+            .await
+            .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;
+
+        Ok(path.to_string_lossy().to_string())
+    }
+
+    /// Extract the media key from a Feishu message content JSON value.
+    ///
+    /// For `image` messages the key field is `image_key`.
+    /// For `file` and `audio` messages the key field is `file_key`.
+    #[allow(dead_code)]
+    fn extract_media_key(content: &serde_json::Value, media_type: &str) -> Option<String> {
+        match media_type {
+            "image" => content
+                .get("image_key")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            "file" | "audio" => content
+                .get("file_key")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            _ => None,
+        }
     }
 
     /// Fetch a fresh tenant access token from Feishu API (no caching).

--- a/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/mod.rs
@@ -9,6 +9,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -210,6 +211,9 @@ pub struct FeishuAdapter {
     http_client: Client,
     pub(super) cached_token: Arc<Mutex<Option<CachedToken>>>,
     base_url: String,
+    /// Base directory for downloaded media files.
+    /// Production uses `$TMPDIR/closeclaw/media`; tests inject [`tempfile::TempDir`] paths.
+    pub(super) temp_dir: PathBuf,
 }
 
 impl FeishuAdapter {
@@ -225,6 +229,7 @@ impl FeishuAdapter {
             http_client,
             cached_token: Arc::new(Mutex::new(None)),
             base_url: FEISHU_API_BASE.to_string(),
+            temp_dir: std::env::temp_dir().join("closeclaw").join("media"),
         }
     }
 
@@ -287,7 +292,7 @@ impl FeishuAdapter {
             .await
             .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;
 
-        let dir = std::env::temp_dir().join("closeclaw").join("media");
+        let dir = &self.temp_dir;
         tokio::fs::create_dir_all(&dir)
             .await
             .map_err(|e| AdapterError::MediaDownloadFailed(e.to_string()))?;

--- a/crates/im_adapter/src/platforms/feishu/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/mod.rs
@@ -176,6 +176,9 @@ fn convert_to_common_error(e: AdapterError) -> closeclaw_common::im_plugin::Adap
         AdapterError::UnsupportedOperation => {
             closeclaw_common::im_plugin::AdapterError::UnsupportedOperation
         }
+        AdapterError::MediaDownloadFailed(s) => {
+            closeclaw_common::im_plugin::AdapterError::SendFailed(s)
+        }
     }
 }
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -334,6 +334,9 @@ fn convert_common_adapter_error(
         closeclaw_im_adapter::error::AdapterError::IoError(e) => {
             closeclaw_common::im_plugin::AdapterError::IoError(e)
         }
+        closeclaw_im_adapter::error::AdapterError::MediaDownloadFailed(s) => {
+            closeclaw_common::im_plugin::AdapterError::SendFailed(s)
+        }
         closeclaw_im_adapter::error::AdapterError::UnsupportedOperation => {
             closeclaw_common::im_plugin::AdapterError::UnsupportedOperation
         }


### PR DESCRIPTION
feat: implement IM adapter media_refs download for image/file/audio messages

飞书 adapter 对 image/file/audio 消息类型之前静默丢弃（返回 Ok(None)），media_refs 始终为空。
本次实现飞书资源下载 API 调用，使非文本消息能通过 NormalizedMessage 传递给下游处理链路。

主要变更：
- 新增 download_media 方法，通过飞书 /im/v1/messages/{id}/resources/{key} API 下载资源
- 扩展 parse_message_event 支持 image/file/audio 三种消息类型，产出带 media_refs 的 NormalizedMessage
- 下载失败时记录 warning 但不阻断消息处理（降级处理）
- 提取 process_media_message 辅助方法控制函数体长度
- 使用 tempfile::TempDir 管理测试临时文件
- bridge.rs 补充 MediaDownloadFailed match arm

Source: CI
Type: feat
