### PR TITLE
feat: account_id 身份映射实现

### DIFF
--- a/crates/common/src/identity.rs
+++ b/crates/common/src/identity.rs
@@ -1,0 +1,198 @@
+//! Identity mapping and resolution for cross-platform user identity.
+//!
+//! Provides [`IdentityMapping`] for configuration-driven platform→account_id
+//! mapping, [`IdentityResolver`] trait for uniform resolution, and
+//! [`ConfigIdentityResolver`] as the default config-backed implementation.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// IdentityMapping
+// ---------------------------------------------------------------------------
+
+/// A single identity mapping entry loaded from configuration.
+///
+/// Maps a `(platform, sender_id)` pair to a local `account_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityMapping {
+    /// Platform identifier, e.g. `"feishu"`, `"discord"`.
+    pub platform: String,
+
+    /// Sender's platform-specific user ID.
+    pub sender_id: String,
+
+    /// Local account identifier that the sender maps to.
+    pub account_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// IdentityResolver trait
+// ---------------------------------------------------------------------------
+
+/// Resolves a `(platform, sender_id)` pair to a local `account_id`.
+///
+/// Implementations are expected to be constructed at startup with
+/// configuration data and remain read-only at runtime.
+pub trait IdentityResolver: Send + Sync {
+    /// Look up the local `account_id` for the given platform and sender.
+    ///
+    /// Returns `None` when no mapping exists for the pair.
+    fn resolve(&self, platform: &str, sender_id: &str) -> Option<String>;
+}
+
+// ---------------------------------------------------------------------------
+// ConfigIdentityResolver
+// ---------------------------------------------------------------------------
+
+/// An [`IdentityResolver`] backed by a set of [`IdentityMapping`] entries
+/// loaded from a JSON configuration file.
+///
+/// Internally stores a `HashMap` keyed by `(platform, sender_id)` for
+/// O(1) lookups.
+#[derive(Debug, Clone)]
+pub struct ConfigIdentityResolver {
+    mappings: HashMap<(String, String), String>,
+}
+
+impl ConfigIdentityResolver {
+    /// Build a resolver from a list of mapping entries.
+    pub fn new(mappings: Vec<IdentityMapping>) -> Self {
+        let map: HashMap<(String, String), String> = mappings
+            .into_iter()
+            .map(|m| ((m.platform, m.sender_id), m.account_id))
+            .collect();
+        Self { mappings: map }
+    }
+
+    /// Parse a JSON array of mapping entries and build the resolver.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        let entries: Vec<IdentityMapping> = serde_json::from_str(json)?;
+        Ok(Self::new(entries))
+    }
+
+    /// Return the number of configured mappings.
+    pub fn len(&self) -> usize {
+        self.mappings.len()
+    }
+
+    /// Return `true` when no mappings are configured.
+    pub fn is_empty(&self) -> bool {
+        self.mappings.is_empty()
+    }
+}
+
+impl IdentityResolver for ConfigIdentityResolver {
+    fn resolve(&self, platform: &str, sender_id: &str) -> Option<String> {
+        self.mappings
+            .get(&(platform.to_string(), sender_id.to_string()))
+            .cloned()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_mappings() -> Vec<IdentityMapping> {
+        vec![
+            IdentityMapping {
+                platform: "feishu".to_string(),
+                sender_id: "ou_aaa".to_string(),
+                account_id: "local_user_1".to_string(),
+            },
+            IdentityMapping {
+                platform: "feishu".to_string(),
+                sender_id: "ou_bbb".to_string(),
+                account_id: "local_user_2".to_string(),
+            },
+            IdentityMapping {
+                platform: "discord".to_string(),
+                sender_id: "12345".to_string(),
+                account_id: "local_user_1".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn test_resolve_match() {
+        let resolver = ConfigIdentityResolver::new(sample_mappings());
+        assert_eq!(
+            resolver.resolve("feishu", "ou_aaa"),
+            Some("local_user_1".to_string())
+        );
+        assert_eq!(
+            resolver.resolve("discord", "12345"),
+            Some("local_user_1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_no_match() {
+        let resolver = ConfigIdentityResolver::new(sample_mappings());
+        assert_eq!(resolver.resolve("feishu", "ou_unknown"), None);
+        assert_eq!(resolver.resolve("slack", "ou_aaa"), None);
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let resolver = ConfigIdentityResolver::new(vec![]);
+        assert!(resolver.is_empty());
+        assert_eq!(resolver.len(), 0);
+        assert_eq!(resolver.resolve("feishu", "ou_aaa"), None);
+    }
+
+    #[test]
+    fn test_many_to_one() {
+        let mappings = vec![
+            IdentityMapping {
+                platform: "feishu".to_string(),
+                sender_id: "ou_aaa".to_string(),
+                account_id: "alice".to_string(),
+            },
+            IdentityMapping {
+                platform: "discord".to_string(),
+                sender_id: "12345".to_string(),
+                account_id: "alice".to_string(),
+            },
+        ];
+        let resolver = ConfigIdentityResolver::new(mappings);
+        assert_eq!(
+            resolver.resolve("feishu", "ou_aaa"),
+            Some("alice".to_string())
+        );
+        assert_eq!(
+            resolver.resolve("discord", "12345"),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_json() {
+        let json = r#"[
+            {"platform":"feishu","sender_id":"ou_xxx","account_id":"local_user_1"},
+            {"platform":"discord","sender_id":"42","account_id":"local_user_2"}
+        ]"#;
+        let resolver = ConfigIdentityResolver::from_json(json).unwrap();
+        assert_eq!(resolver.len(), 2);
+        assert_eq!(
+            resolver.resolve("feishu", "ou_xxx"),
+            Some("local_user_1".to_string())
+        );
+        assert_eq!(
+            resolver.resolve("discord", "42"),
+            Some("local_user_2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_from_json_invalid() {
+        let json = r#"not valid json"#;
+        assert!(ConfigIdentityResolver::from_json(json).is_err());
+    }
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod compaction;
 pub mod gateway_spawn;
 pub mod gateway_stop;
 pub mod gateway_types;
+pub mod identity;
 pub mod im_plugin;
 pub mod processor;
 pub mod session_lookup;
@@ -43,6 +44,7 @@ pub use gateway_types::{
     DmScope, GatewayConfig, GatewayError, HandleResult, InboundChainInput, InboundRequest, Message,
     Session,
 };
+pub use identity::{ConfigIdentityResolver, IdentityMapping, IdentityResolver};
 pub use im_plugin::{
     AdapterError, IMAdapter, IMPlugin, MediaRef, NormalizedMessage, QuotedMessage, RenderedOutput,
     StreamingOutput,

--- a/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
+++ b/crates/im_adapter/src/platforms/feishu/adapter/adapter_tests.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::platforms::feishu::FeishuPlugin;
 use crate::plugin::IMPlugin;
 use axum::{extract::Query, routing::post, Json, Router};
+use closeclaw_common::identity::{ConfigIdentityResolver, IdentityMapping};
 use std::collections::HashMap as StdHashMap;
 
 use tempfile::TempDir;
@@ -726,4 +727,49 @@ async fn test_download_media_failure_graceful_degradation() {
     assert_eq!(msg.platform, "feishu");
     assert_eq!(msg.sender_id, "ou_sender");
     assert_eq!(msg.peer_id, "oc_chat");
+}
+
+// ===========================================================================
+// Identity mapping tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_parse_inbound_with_identity_mapping() {
+    let adapter = Arc::new(make_test_adapter());
+    let resolver = ConfigIdentityResolver::new(vec![IdentityMapping {
+        platform: "feishu".to_string(),
+        sender_id: "ou_sender".to_string(),
+        account_id: "mapped_user".to_string(),
+    }]);
+    let plugin = FeishuPlugin::with_identity_resolver(adapter, Some(Arc::new(resolver)));
+    let payload = make_webhook_payload("text", &serde_json::json!({"text": "hi"}).to_string());
+    let msg = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    assert_eq!(msg.account_id.as_deref(), Some("mapped_user"));
+    assert_eq!(msg.sender_id, "ou_sender");
+}
+
+#[tokio::test]
+async fn test_parse_inbound_without_mapping_fallback() {
+    let adapter = Arc::new(make_test_adapter());
+    // Resolver has a mapping for a different sender, not ou_sender.
+    let resolver = ConfigIdentityResolver::new(vec![IdentityMapping {
+        platform: "feishu".to_string(),
+        sender_id: "ou_other".to_string(),
+        account_id: "other_user".to_string(),
+    }]);
+    let plugin = FeishuPlugin::with_identity_resolver(adapter, Some(Arc::new(resolver)));
+    let payload = make_webhook_payload("text", &serde_json::json!({"text": "hi"}).to_string());
+    let msg = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    // No matching mapping → fallback to sender_open_id
+    assert_eq!(msg.account_id.as_deref(), Some("ou_sender"));
+}
+
+#[tokio::test]
+async fn test_parse_inbound_no_resolver_fallback() {
+    let adapter = Arc::new(make_test_adapter());
+    let plugin = FeishuPlugin::new(adapter);
+    let payload = make_webhook_payload("text", &serde_json::json!({"text": "hi"}).to_string());
+    let msg = plugin.parse_inbound(&payload).await.unwrap().unwrap();
+    // No resolver at all → fallback to sender_open_id
+    assert_eq!(msg.account_id.as_deref(), Some("ou_sender"));
 }

--- a/crates/im_adapter/src/platforms/feishu/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/mod.rs
@@ -16,6 +16,7 @@ use crate::plugin::{IMPlugin, RenderedOutput};
 use crate::streaming::DefaultStreamingRenderer;
 use crate::IMAdapter;
 use async_trait::async_trait;
+use closeclaw_common::identity::IdentityResolver;
 use closeclaw_common::processor::ContentBlock;
 use closeclaw_common::processor::DslParseResult;
 use closeclaw_gateway::Message;
@@ -216,6 +217,7 @@ fn convert_to_common_normalized(
 pub struct FeishuPlugin {
     adapter: Arc<FeishuAdapter>,
     renderer: std::sync::Mutex<DefaultStreamingRenderer>,
+    identity_resolver: Option<Arc<dyn IdentityResolver>>,
 }
 
 impl FeishuPlugin {
@@ -223,6 +225,20 @@ impl FeishuPlugin {
         Self {
             adapter,
             renderer: std::sync::Mutex::new(DefaultStreamingRenderer::new()),
+            identity_resolver: None,
+        }
+    }
+
+    /// Create a Feishu plugin with an optional identity resolver.
+    #[allow(dead_code)]
+    pub(crate) fn with_identity_resolver(
+        adapter: Arc<FeishuAdapter>,
+        identity_resolver: Option<Arc<dyn IdentityResolver>>,
+    ) -> Self {
+        Self {
+            adapter,
+            renderer: std::sync::Mutex::new(DefaultStreamingRenderer::new()),
+            identity_resolver,
         }
     }
 }
@@ -233,6 +249,10 @@ impl IMPlugin for FeishuPlugin {
         "feishu"
     }
 
+    fn identity_resolver(&self) -> Option<&dyn IdentityResolver> {
+        self.identity_resolver.as_deref()
+    }
+
     async fn parse_inbound(
         &self,
         payload: &[u8],
@@ -241,6 +261,12 @@ impl IMPlugin for FeishuPlugin {
         if let Some(ref mut m) = msg {
             m.content = normalize_urls(&m.content);
             m.content = add_code_block_language_hint(&m.content);
+            // Apply identity mapping: map (platform, sender_id) → account_id
+            if let Some(resolver) = self.identity_resolver() {
+                m.account_id = resolver
+                    .resolve(&m.platform, &m.sender_id)
+                    .or_else(|| m.account_id.take());
+            }
         }
         Ok(msg)
     }

--- a/crates/im_adapter/src/platforms/feishu/mod.rs
+++ b/crates/im_adapter/src/platforms/feishu/mod.rs
@@ -16,7 +16,7 @@ use crate::plugin::{IMPlugin, RenderedOutput};
 use crate::streaming::DefaultStreamingRenderer;
 use crate::IMAdapter;
 use async_trait::async_trait;
-use closeclaw_common::identity::IdentityResolver;
+use closeclaw_common::identity::{ConfigIdentityResolver, IdentityResolver};
 use closeclaw_common::processor::ContentBlock;
 use closeclaw_common::processor::DslParseResult;
 use closeclaw_gateway::Message;
@@ -45,7 +45,11 @@ inventory::submit!(PlatformEntry {
 ///
 /// Reads credentials from environment variables.  If any required
 /// variable is missing the plugin is silently not registered.
-pub async fn register(gateway: &Arc<closeclaw_gateway::Gateway>, _config_dir: &str) {
+///
+/// Identity mapping is loaded from `{config_dir}/config/identity.json`
+/// (if the file exists).  A missing or empty file results in no
+/// mapping — the fallback uses `sender_id` as `account_id`.
+pub async fn register(gateway: &Arc<closeclaw_gateway::Gateway>, config_dir: &str) {
     let app_id = std::env::var("FEISHU_APP_ID").ok();
     let app_secret = std::env::var("FEISHU_APP_SECRET").ok();
     let verification_token = std::env::var("FEISHU_VERIFICATION_TOKEN").ok();
@@ -53,15 +57,66 @@ pub async fn register(gateway: &Arc<closeclaw_gateway::Gateway>, _config_dir: &s
         (app_id, app_secret, verification_token)
     {
         let adapter = Arc::new(FeishuAdapter::new(app_id, app_secret, verification_token));
-        // Wrap our IMPlugin for the gateway's trait (closeclaw_common::IMPlugin).
-        // The bridge module in the main crate provides IMPluginAdapter for this.
-        // Here we use a simple wrapper that delegates directly.
-        let plugin: Arc<dyn crate::plugin::IMPlugin> = Arc::new(FeishuPlugin::new(adapter));
+
+        // Load identity mapping from config file (best-effort).
+        let identity_resolver: Option<Arc<dyn IdentityResolver>> =
+            load_identity_resolver(config_dir);
+
+        let plugin: Arc<dyn crate::plugin::IMPlugin> = Arc::new(
+            FeishuPlugin::with_identity_resolver(adapter, identity_resolver),
+        );
         let wrapped = wrap_plugin_for_gateway(plugin);
         gateway.register_plugin(wrapped).await;
         info!("Feishu plugin registered");
     } else {
         info!("Feishu credentials not found in env — Feishu plugin not registered");
+    }
+}
+
+/// Try to load identity mappings from `{config_dir}/config/identity.json`.
+///
+/// Returns `Some(Arc<ConfigIdentityResolver>)` when the file exists and
+/// contains a valid JSON array, or `None` on any error / missing file.
+fn load_identity_resolver(config_dir: &str) -> Option<Arc<dyn IdentityResolver>> {
+    let path = std::path::Path::new(config_dir)
+        .join("config")
+        .join("identity.json");
+    match std::fs::read_to_string(&path) {
+        Ok(json) => match ConfigIdentityResolver::from_json(&json) {
+            Ok(resolver) => {
+                if resolver.is_empty() {
+                    info!("identity.json loaded but empty — no mappings configured");
+                    None
+                } else {
+                    info!(
+                        count = resolver.len(),
+                        "identity mapping loaded from {}",
+                        path.display()
+                    );
+                    Some(Arc::new(resolver))
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "failed to parse identity.json — skipping identity mapping"
+                );
+                None
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            info!("identity.json not found — identity mapping disabled");
+            None
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "failed to read identity.json — skipping identity mapping"
+            );
+            None
+        }
     }
 }
 
@@ -221,6 +276,7 @@ pub struct FeishuPlugin {
 }
 
 impl FeishuPlugin {
+    #[allow(dead_code)]
     pub(crate) fn new(adapter: Arc<FeishuAdapter>) -> Self {
         Self {
             adapter,

--- a/crates/im_adapter/src/plugin.rs
+++ b/crates/im_adapter/src/plugin.rs
@@ -14,6 +14,7 @@ use crate::error::AdapterError;
 use crate::normalized::NormalizedMessage;
 use crate::streaming::{DefaultStreamingRenderer, StreamingOutput, StreamingRenderer};
 use async_trait::async_trait;
+use closeclaw_common::identity::IdentityResolver;
 use closeclaw_common::processor::{ContentBlock, DslParseResult, StreamEvent};
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
@@ -65,6 +66,16 @@ pub struct RenderedOutput {
 pub trait IMPlugin: Send + Sync {
     /// Returns the platform identifier, e.g. `"feishu"` or `"discord"`.
     fn platform(&self) -> &str;
+
+    /// Returns the identity resolver for cross-platform account mapping.
+    ///
+    /// The default implementation returns `None`, meaning no identity
+    /// mapping is applied and `account_id` falls back to `sender_id`.
+    /// Platforms that support identity mapping override this to return
+    /// a resolver instance.
+    fn identity_resolver(&self) -> Option<&dyn IdentityResolver> {
+        None
+    }
 
     /// Parse an inbound webhook payload into a [`NormalizedMessage`].
     ///


### PR DESCRIPTION
实现 account_id 身份映射机制，使 CloseClaw 能够将不同平台的 sender_id 统一映射到本地账号标识。

变更内容：
- 在 common crate 新增 IdentityResolver trait 和 ConfigIdentityResolver，支持配置驱动的 (platform, sender_id) → account_id 多对一映射
- 扩展 IMPlugin trait，添加 identity_resolver 方法
- 飞书插件集成 identity resolver，在 parse_inbound 阶段完成身份映射
- 无映射配置时 fallback 到 sender_id，保持向后兼容
- 新增单元测试覆盖映射匹配、无匹配、空配置、多对一等场景

Source: user
Type: feat
