### PR TITLE
chore: update design-doc-tracker records

### DIFF
--- a/scripts/design-doc-tracker/records.json
+++ b/scripts/design-doc-tracker/records.json
@@ -127,9 +127,9 @@
   },
   {
     "path": "docs/design/im_adapter/streaming-render.md",
-    "commit": "64c74f4f368ef292d11b143a218603ac913402fc",
-    "commit_time": "2026-06-27T14:32:35+08:00",
-    "confirmed_time": "2026-06-27T14:39:39.852794+08:00",
+    "commit": "c523d70523dd409c80d16374843f1c000add5a6f",
+    "commit_time": "2026-06-28T09:10:53+08:00",
+    "confirmed_time": "2026-06-28T09:18:07.042310+08:00",
     "comment": ""
   },
   {
@@ -144,7 +144,7 @@
     "commit": "136edef20d57977748391e78287803c88180fc28",
     "commit_time": "2026-06-26T17:48:33+08:00",
     "confirmed_time": "2026-06-26T17:55:59.491929+08:00",
-    "comment": ""
+    "comment": "blocked: F2b found doc issues: (1) default_temperature field optionality not documented; (2) retry count mismatch (code=4, doc=3); (3) backoff ceiling mismatch (code=8s, doc=4s); (4) knowledge fill-vs-override semantic ambiguity."
   },
   {
     "path": "docs/design/llm/protocol-mapping.md",


### PR DESCRIPTION
## 操作记录

- **文档路径**: docs/design/llm/model-discovery.md
- **操作类型**: blocked
- **原因简述**: 该文档存在多处代码与文档不一致的 must_fix 差异：
  - default_temperature 字段可选性未在文档中说明
  - 重试次数参数（代码 vs 文档）
  - 退避参数（代码 vs 文档）
  - 知识库填充语义（代码 vs 文档）