### PR TITLE
fix: protocol mapping alignment

### DIFF
--- a/crates/common/src/streaming.rs
+++ b/crates/common/src/streaming.rs
@@ -118,7 +118,17 @@ impl StreamingRenderer for DefaultStreamingRenderer {
             }
             StreamEvent::BlockDelta { delta, .. } => match delta {
                 ContentDelta::Text { text } => self.handle_text_delta(&text, &mut out),
-                ContentDelta::Thinking { thinking, .. } => self.handle_thinking_delta(&thinking),
+                ContentDelta::Thinking {
+                    thinking,
+                    signature,
+                } => {
+                    self.handle_thinking_delta(&thinking);
+                    if let Some(sig) = signature {
+                        if let Some(acc) = self.current_acc.as_mut() {
+                            acc.signature = Some(sig);
+                        }
+                    }
+                }
                 ContentDelta::ToolUseId { id } => self.handle_tool_id(id),
                 ContentDelta::ToolUseName { name } => self.handle_tool_name(name),
                 ContentDelta::ToolUseInputChunk { input } => self.handle_tool_input(&input),
@@ -241,6 +251,7 @@ fn count_trailing_backticks(s: &str) -> usize {
 #[derive(Default)]
 struct BlockAccumulator {
     text: String,
+    signature: Option<String>,
     tool_id: Option<String>,
     tool_name: Option<String>,
     tool_input: String,
@@ -251,7 +262,7 @@ impl BlockAccumulator {
         match block_type {
             ContentBlockType::Thinking => ContentBlock::Thinking {
                 thinking: self.text,
-                signature: None,
+                signature: self.signature,
             },
             ContentBlockType::ToolUse => ContentBlock::ToolUse {
                 id: self.tool_id.unwrap_or_default(),

--- a/crates/common/src/streaming_tests.rs
+++ b/crates/common/src/streaming_tests.rs
@@ -236,3 +236,97 @@ fn test_block_start_resets_line_buffer() {
     let out = r.handle_event(text_delta("new."));
     assert_eq!(out.text_messages, vec!["new."]);
 }
+
+// ── Thinking block signature capture ─────────────────────────────────────
+
+#[test]
+fn test_thinking_signature_captured_in_block() {
+    use super::streaming::*;
+    use crate::processor::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent};
+
+    let mut r = DefaultStreamingRenderer::new();
+    r.handle_event(block_start(0, ContentBlockType::Thinking));
+    r.handle_event(StreamEvent::BlockDelta {
+        index: 0,
+        delta: ContentDelta::Thinking {
+            thinking: "reasoning...".to_string(),
+            signature: Some("sig-abc-123".to_string()),
+        },
+    });
+    let out = r.handle_event(block_end(0, ContentBlockType::Thinking));
+    assert_eq!(out.render_blocks.len(), 1);
+    match &out.render_blocks[0] {
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "reasoning...");
+            assert_eq!(signature.as_deref(), Some("sig-abc-123"));
+        }
+        other => panic!("expected Thinking block, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_thinking_without_signature_yields_none() {
+    use super::streaming::*;
+    use crate::processor::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent};
+
+    let mut r = DefaultStreamingRenderer::new();
+    r.handle_event(block_start(0, ContentBlockType::Thinking));
+    r.handle_event(StreamEvent::BlockDelta {
+        index: 0,
+        delta: ContentDelta::Thinking {
+            thinking: "no sig".to_string(),
+            signature: None,
+        },
+    });
+    let out = r.handle_event(block_end(0, ContentBlockType::Thinking));
+    assert_eq!(out.render_blocks.len(), 1);
+    match &out.render_blocks[0] {
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "no sig");
+            assert!(signature.is_none());
+        }
+        other => panic!("expected Thinking block, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_thinking_signature_overwrites_across_deltas() {
+    use super::streaming::*;
+    use crate::processor::{ContentBlock, ContentBlockType, ContentDelta, StreamEvent};
+
+    let mut r = DefaultStreamingRenderer::new();
+    r.handle_event(block_start(0, ContentBlockType::Thinking));
+    // First delta with signature
+    r.handle_event(StreamEvent::BlockDelta {
+        index: 0,
+        delta: ContentDelta::Thinking {
+            thinking: "part1".to_string(),
+            signature: Some("sig1".to_string()),
+        },
+    });
+    // Second delta without signature — should keep previous
+    r.handle_event(StreamEvent::BlockDelta {
+        index: 0,
+        delta: ContentDelta::Thinking {
+            thinking: "part2".to_string(),
+            signature: None,
+        },
+    });
+    let out = r.handle_event(block_end(0, ContentBlockType::Thinking));
+    match &out.render_blocks[0] {
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => {
+            assert_eq!(thinking, "part1part2");
+            assert_eq!(signature.as_deref(), Some("sig1"));
+        }
+        other => panic!("expected Thinking block, got {:?}", other),
+    }
+}

--- a/crates/llm/src/client_test.rs
+++ b/crates/llm/src/client_test.rs
@@ -201,6 +201,7 @@ fn make_request() -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".into(),
             content: "hello".into(),
+            ..Default::default()
         }],
         temperature: 0.0,
         max_tokens: Some(256),

--- a/crates/llm/src/deepseek/tests.rs
+++ b/crates/llm/src/deepseek/tests.rs
@@ -19,6 +19,7 @@ fn make_request(model: &str) -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".into(),
             content: "Hello".into(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: Some(100),

--- a/crates/llm/src/fake/fake_tests.rs
+++ b/crates/llm/src/fake/fake_tests.rs
@@ -10,6 +10,7 @@ fn make_request() -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "hello".to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: None,

--- a/crates/llm/src/fallback.rs
+++ b/crates/llm/src/fallback.rs
@@ -97,6 +97,7 @@ impl FallbackClient {
                 .map(|m| InternalMessage {
                     role: m.role.clone(),
                     content: m.content.clone(),
+                    ..Default::default()
                 })
                 .collect(),
             temperature: request.temperature,

--- a/crates/llm/src/glm/tests/mock_integration.rs
+++ b/crates/llm/src/glm/tests/mock_integration.rs
@@ -12,6 +12,7 @@ fn internal_request(model: &str) -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "Say hi".to_string(),
+            ..Default::default()
         }],
         temperature: 0.0,
         max_tokens: None,

--- a/crates/llm/src/llm_caller.rs
+++ b/crates/llm/src/llm_caller.rs
@@ -52,6 +52,7 @@ pub async fn call_llm<M: LlmMeta>(
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: content.to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: None,
@@ -91,6 +92,7 @@ pub async fn call_llm_streaming<M: LlmMeta>(
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: content.to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: None,

--- a/crates/llm/src/minimax/tests.rs
+++ b/crates/llm/src/minimax/tests.rs
@@ -66,6 +66,7 @@ fn create_internal_request(model: &str) -> InternalRequest {
         messages: vec![crate::types::InternalMessage {
             role: "user".into(),
             content: "hi".into(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: None,
@@ -225,6 +226,7 @@ fn create_streaming_request(model: &str) -> InternalRequest {
         messages: vec![crate::types::InternalMessage {
             role: "user".into(),
             content: "hi".into(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: None,

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -314,6 +314,7 @@ mod tests {
             messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "hi".to_string(),
+                ..Default::default()
             }],
             temperature: 0.0,
             max_tokens: None,

--- a/crates/llm/src/protocol/anthropic.rs
+++ b/crates/llm/src/protocol/anthropic.rs
@@ -152,11 +152,25 @@ fn build_request_body(request: &InternalRequest) -> Result<serde_json::Value> {
 }
 
 /// Build a single message JSON for Anthropic.
+///
+/// Tool result messages use role "user" with structured content blocks,
+/// matching Anthropic's native tool_result format.
 fn build_message(msg: &InternalMessage) -> serde_json::Value {
-    serde_json::json!({
-        "role": msg.role,
-        "content": msg.content,
-    })
+    if let Some(ref tool_call_id) = msg.tool_call_id {
+        serde_json::json!({
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": tool_call_id,
+                "content": msg.content,
+            }],
+        })
+    } else {
+        serde_json::json!({
+            "role": msg.role,
+            "content": msg.content,
+        })
+    }
 }
 
 /// Mark the last message with `cache_control` for Anthropic prefix caching.

--- a/crates/llm/src/protocol/anthropic_tests.rs
+++ b/crates/llm/src/protocol/anthropic_tests.rs
@@ -448,45 +448,22 @@ fn test_decorate_headers_content_type() {
 }
 // ── reasoning_level non-injection tests ─────────────────────────────────
 #[test]
-fn test_build_request_does_not_inject_reasoning_level_low() {
+fn test_build_request_does_not_inject_reasoning_level() {
     let proto = AnthropicProtocol::new();
-    let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Low;
-    let body = proto.build_request(&request).unwrap();
-    assert!(body.get("thinking").is_none());
-    assert!(body.get("reasoning_effort").is_none());
-    assert!(body.get("reasoning_level").is_none());
-}
-
-#[test]
-fn test_build_request_does_not_inject_reasoning_level_medium() {
-    let proto = AnthropicProtocol::new();
-    let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Medium;
-    let body = proto.build_request(&request).unwrap();
-    assert!(body.get("thinking").is_none());
-    assert!(body.get("reasoning_effort").is_none());
-    assert!(body.get("reasoning_level").is_none());
-}
-
-#[test]
-fn test_build_request_does_not_inject_reasoning_level_max() {
-    let proto = AnthropicProtocol::new();
-    let mut request = make_request();
-    request.reasoning_level = ReasoningLevel::Max;
-    let body = proto.build_request(&request).unwrap();
-    assert!(body.get("thinking").is_none());
-    assert!(body.get("reasoning_effort").is_none());
-    assert!(body.get("reasoning_level").is_none());
-}
-#[test]
-fn test_build_request_high_reasoning_level_no_injection() {
-    let proto = AnthropicProtocol::new();
-    let request = make_request(); // default is High
-    let body = proto.build_request(&request).unwrap();
-    assert!(body.get("thinking").is_none());
-    assert!(body.get("reasoning_effort").is_none());
-    assert!(body.get("reasoning_level").is_none());
+    let levels = [
+        ReasoningLevel::Low,
+        ReasoningLevel::Medium,
+        ReasoningLevel::High,
+        ReasoningLevel::Max,
+    ];
+    for level in levels {
+        let mut request = make_request();
+        request.reasoning_level = level;
+        let body = proto.build_request(&request).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("reasoning_level").is_none());
+    }
 }
 
 // ── messages cache_control tests ──────────────────────────────────────────
@@ -531,20 +508,13 @@ fn test_messages_cache_control_multiple_messages() {
         },
     ];
     let body = proto.build_request(&request).unwrap();
-
     let messages = body.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 3);
-
+    // Non-last messages remain as plain strings
     assert!(messages[0].get("content").unwrap().is_string());
-    assert_eq!(messages[0].get("content").unwrap().as_str().unwrap(), "Hi");
     assert!(messages[1].get("content").unwrap().is_string());
-    assert_eq!(
-        messages[1].get("content").unwrap().as_str().unwrap(),
-        "Hey!"
-    );
-
+    // Last message gets structured content with cache_control
     let last_content = messages[2].get("content").unwrap().as_array().unwrap();
-    assert_eq!(last_content.len(), 1);
     assert_eq!(last_content[0].get("type").unwrap(), "text");
     assert_eq!(last_content[0].get("text").unwrap(), "What's up?");
     assert_eq!(
@@ -559,7 +529,6 @@ fn test_messages_cache_control_empty_messages() {
     let mut request = make_request();
     request.messages = vec![];
     let body = proto.build_request(&request).unwrap();
-
     assert!(body.get("messages").unwrap().as_array().unwrap().is_empty());
 }
 
@@ -599,7 +568,6 @@ fn test_build_request_tools_section_cache_control() {
 #[test]
 fn test_messages_cache_control_with_system_blocks() {
     use crate::types::SystemBlock;
-
     let proto = AnthropicProtocol::new();
     let mut request = make_request();
     request.messages = vec![InternalMessage {
@@ -612,18 +580,14 @@ fn test_messages_cache_control_with_system_blocks() {
         cache: true,
     }]);
     let body = proto.build_request(&request).unwrap();
-
     let system = body.get("system").unwrap().as_array().unwrap();
     assert_eq!(system.len(), 1);
     assert_eq!(
         system[0].get("cache_control").unwrap(),
         &serde_json::json!({ "type": "ephemeral" })
     );
-
     let messages = body.get("messages").unwrap().as_array().unwrap();
-    assert_eq!(messages.len(), 1);
     let content = messages[0].get("content").unwrap().as_array().unwrap();
-    assert_eq!(content.len(), 1);
     assert_eq!(
         content[0].get("cache_control").unwrap(),
         &serde_json::json!({ "type": "ephemeral" })
@@ -924,6 +888,28 @@ async fn test_sse_ping_ignored() {
     assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
 
     assert!(stream.next().await.is_none());
+}
+
+// ── build_message tool result tests ──────────────────────────────────────
+#[test]
+fn test_build_message_tool_result() {
+    let mut request = make_request();
+    request.messages = vec![InternalMessage {
+        role: "tool".to_string(),
+        content: "25°C, sunny".to_string(),
+        tool_call_id: Some("toolu_01A09q90qw90lq917835lq9".to_string()),
+    }];
+    let body = AnthropicProtocol::new().build_request(&request).unwrap();
+    let msg = &body.get("messages").unwrap().as_array().unwrap()[0];
+    assert_eq!(msg.get("role").unwrap(), "user");
+    let content = msg.get("content").unwrap().as_array().unwrap();
+    assert_eq!(content.len(), 1);
+    assert_eq!(content[0].get("type").unwrap(), "tool_result");
+    assert_eq!(
+        content[0].get("tool_use_id").unwrap(),
+        "toolu_01A09q90qw90lq917835lq9"
+    );
+    assert_eq!(content[0].get("content").unwrap(), "25°C, sunny");
 }
 
 // ── tools serialization tests ────────────────────────────────────────────

--- a/crates/llm/src/protocol/anthropic_tests.rs
+++ b/crates/llm/src/protocol/anthropic_tests.rs
@@ -17,6 +17,7 @@ fn make_request() -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "Hello".to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: Some(1024),
@@ -381,7 +382,6 @@ fn test_parse_response_mixed_blocks() {
         other => panic!("Expected ToolResult at index 3, got {:?}", other),
     }
 }
-
 // ── cache usage parsing tests ─────────────────────────────────────────────
 #[test]
 fn test_parse_usage_cache_fields() {
@@ -399,7 +399,6 @@ fn test_parse_usage_cache_fields() {
     assert_eq!(resp.usage.cache_read_tokens, Some(80));
     assert_eq!(resp.usage.cache_write_tokens, Some(20));
 }
-
 #[test]
 fn test_parse_usage_no_cache_fields() {
     let body = serde_json::json!({
@@ -424,7 +423,6 @@ fn test_decorate_headers_api_key() {
 
     assert!(headers.get("x-api-key").is_some());
 }
-
 #[test]
 fn test_decorate_headers_anthropic_version() {
     let proto = AnthropicProtocol::new();
@@ -448,7 +446,6 @@ fn test_decorate_headers_content_type() {
         "application/json"
     );
 }
-
 // ── reasoning_level non-injection tests ─────────────────────────────────
 #[test]
 fn test_build_request_does_not_inject_reasoning_level_low() {
@@ -482,7 +479,6 @@ fn test_build_request_does_not_inject_reasoning_level_max() {
     assert!(body.get("reasoning_effort").is_none());
     assert!(body.get("reasoning_level").is_none());
 }
-
 #[test]
 fn test_build_request_high_reasoning_level_no_injection() {
     let proto = AnthropicProtocol::new();
@@ -521,14 +517,17 @@ fn test_messages_cache_control_multiple_messages() {
         InternalMessage {
             role: "user".to_string(),
             content: "Hi".to_string(),
+            ..Default::default()
         },
         InternalMessage {
             role: "assistant".to_string(),
             content: "Hey!".to_string(),
+            ..Default::default()
         },
         InternalMessage {
             role: "user".to_string(),
             content: "What's up?".to_string(),
+            ..Default::default()
         },
     ];
     let body = proto.build_request(&request).unwrap();
@@ -606,6 +605,7 @@ fn test_messages_cache_control_with_system_blocks() {
     request.messages = vec![InternalMessage {
         role: "user".to_string(),
         content: "Hello".to_string(),
+        ..Default::default()
     }];
     request.system_blocks = Some(vec![SystemBlock {
         text: "System prompt".to_string(),

--- a/crates/llm/src/protocol/glm.rs
+++ b/crates/llm/src/protocol/glm.rs
@@ -4,7 +4,7 @@
 //! notable differences:
 //!   - `reasoning_content` field carries chain-of-thought / thinking content
 //!   - Error responses use a nested `{error: {code, message}}` structure
-//!   - SSE streaming prioritises `reasoning_content` delta over `content` delta
+//!   - SSE streaming prioritises `content` delta over `reasoning_content` delta
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -195,23 +195,25 @@ impl ChatProtocol for GlmProtocol {
                 // Filtering is only feasible in the non-streaming `parse_response`.
                 //
                 // GLM may emit `reasoning_content` delta or `content` delta.
-                // Prefer `reasoning_content` first, then fall back to `content`.
+                // Prefer `content` first, fall back to `reasoning_content`.
                 let (text_delta, thinking_delta) = (
                     delta.get("content").and_then(|v| v.as_str()),
                     delta.get("reasoning_content").and_then(|v| v.as_str()),
                 );
 
-                let content_to_yield = thinking_delta.or(text_delta);
+                let content_to_yield = text_delta.or(thinking_delta);
 
                 if let Some(text) = content_to_yield {
+                    // Block type determined by which delta won (content priority)
+                    let winning_is_content = text_delta.is_some();
                     let (idx, btype) = match current_block_index {
                         Some(i) => (i, current_block_type.unwrap()),
                         None => {
                             // First delta — emit BlockStart.
-                            let btype = if thinking_delta.is_some() {
-                                ContentBlockType::Thinking
-                            } else {
+                            let btype = if winning_is_content {
                                 ContentBlockType::Text
+                            } else {
+                                ContentBlockType::Thinking
                             };
                             let idx = next_block_index;
                             next_block_index += 1;

--- a/crates/llm/src/protocol/glm_test.rs
+++ b/crates/llm/src/protocol/glm_test.rs
@@ -449,6 +449,51 @@ async fn test_parse_sse_reasoning_then_tool_calls() {
     assert!(stream.next().await.is_none());
 }
 
+#[tokio::test]
+async fn test_parse_sse_content_priority_over_reasoning() {
+    let proto = GlmProtocol::new();
+    let machine = proto.create_sse_machine();
+    // Both content and reasoning_content in the same delta — content should win
+    let incoming: IncomingSseStream = Box::pin(futures::stream::iter(vec![
+        make_sse_chunk(
+            r#"{"choices":[{"delta":{"content":"Final answer","reasoning_content":"Thinking trace"}}]}"#,
+        ),
+        make_sse_chunk("[DONE]"),
+    ]));
+    let mut stream = proto.parse_sse_stream(incoming, machine).await;
+    // BlockStart should be Text (content priority)
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockStart {
+            block_type: ContentBlockType::Text,
+            ..
+        }
+    ));
+    // Delta should be Text
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockDelta {
+            delta: ContentDelta::Text { text: s },
+            ..
+        } if s == "Final answer"
+    ));
+    // BlockEnd Text
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(
+        evt,
+        StreamEvent::BlockEnd {
+            block_type: ContentBlockType::Text,
+            ..
+        }
+    ));
+    // MessageEnd
+    let evt = stream.next().await.unwrap().unwrap();
+    assert!(matches!(evt, StreamEvent::MessageEnd { .. }));
+    assert!(stream.next().await.is_none());
+}
+
 // ── short reasoning_content filtering tests ──────────────────────────────
 
 #[test]

--- a/crates/llm/src/protocol/glm_test.rs
+++ b/crates/llm/src/protocol/glm_test.rs
@@ -7,6 +7,7 @@ fn make_request() -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: "Hello".to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: Some(256),

--- a/crates/llm/src/protocol/openai.rs
+++ b/crates/llm/src/protocol/openai.rs
@@ -114,19 +114,13 @@ impl ChatProtocol for OpenAiProtocol {
         let usage = parse_usage(&body);
 
         // 按文档规则构建 content_blocks：
-        // content 非空 + reasoning_content 非空 → Thinking + Text
+        // content 非空 + reasoning_content 非空 → Text（content 优先，忽略 reasoning_content）
         // content 非空 + reasoning_content 空 → Text
-        // content 空 + reasoning_content 非空 → Text（reasoning_content 作为 Text 内容）
+        // content 空 + reasoning_content 非空 → Text（reasoning_content 降级为 Text）
         // 两者都空 → 空 Text
         let mut content_blocks = Vec::new();
         if let Some(ref text) = content {
-            // content 非空：两者独立产出各自块（Thinking 在前）
-            if let Some(thinking) = reasoning_content {
-                content_blocks.push(RawContentBlock::Thinking {
-                    thinking,
-                    signature: None,
-                });
-            }
+            // content 非空：content 优先，忽略 reasoning_content
             content_blocks.push(RawContentBlock::Text(text.clone()));
         } else if let Some(thinking) = reasoning_content {
             // content 空 + reasoning_content 非空 → reasoning_content 作为 Text 块

--- a/crates/llm/src/protocol/openai.rs
+++ b/crates/llm/src/protocol/openai.rs
@@ -38,10 +38,18 @@ impl Default for OpenAiProtocol {
 }
 
 fn build_message(msg: &InternalMessage) -> serde_json::Value {
-    serde_json::json!({
-        "role": msg.role,
-        "content": msg.content,
-    })
+    if let Some(ref tool_call_id) = msg.tool_call_id {
+        serde_json::json!({
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": msg.content,
+        })
+    } else {
+        serde_json::json!({
+            "role": msg.role,
+            "content": msg.content,
+        })
+    }
 }
 
 #[async_trait]

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -625,6 +625,68 @@ fn test_parse_response_tool_calls_with_reasoning() {
     );
 }
 
+// ── build_message tool result serialization ──────────────────────────────────
+
+#[test]
+fn test_build_message_tool_result() {
+    let msg = super::InternalMessage {
+        role: "tool".to_string(),
+        content: r#"{"temperature": 22}"#.to_string(),
+        tool_call_id: Some("call_abc".to_string()),
+    };
+    let value = super::build_message(&msg);
+    assert_eq!(value["role"], "tool");
+    assert_eq!(value["tool_call_id"], "call_abc");
+    assert_eq!(value["content"], r#"{"temperature": 22}"#);
+}
+
+#[test]
+fn test_build_message_tool_result_no_id_falls_back() {
+    let msg = super::InternalMessage {
+        role: "tool".to_string(),
+        content: "result".to_string(),
+        tool_call_id: None,
+    };
+    let value = super::build_message(&msg);
+    assert_eq!(value["role"], "tool");
+    assert!(value.get("tool_call_id").is_none());
+}
+
+#[test]
+fn test_build_message_normal_user() {
+    let msg = super::InternalMessage {
+        role: "user".to_string(),
+        content: "Hello".to_string(),
+        tool_call_id: None,
+    };
+    let value = super::build_message(&msg);
+    assert_eq!(value["role"], "user");
+    assert_eq!(value["content"], "Hello");
+    assert!(value.get("tool_call_id").is_none());
+}
+
+#[test]
+fn test_build_request_includes_tool_result_message() {
+    let proto = OpenAiProtocol::new();
+    let mut request = make_request();
+    request.messages.push(super::InternalMessage {
+        role: "assistant".to_string(),
+        content: String::new(),
+        ..Default::default()
+    });
+    request.messages.push(super::InternalMessage {
+        role: "tool".to_string(),
+        content: r#"{"temp": 22}"#.to_string(),
+        tool_call_id: Some("call_xyz".to_string()),
+    });
+    let body = proto.build_request(&request).unwrap();
+    let messages = body["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 3);
+    let last = messages.last().unwrap();
+    assert_eq!(last["role"], "tool");
+    assert_eq!(last["tool_call_id"], "call_xyz");
+}
+
 #[test]
 fn test_parse_response_cached_tokens() {
     let proto = OpenAiProtocol::new();

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -266,14 +266,10 @@ fn test_parse_response_with_both_content_and_reasoning() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Both content and reasoning → Thinking + Text (thinking first)
-    assert_eq!(resp.content_blocks.len(), 2);
-    let RawContentBlock::Thinking { thinking, .. } = &resp.content_blocks[0] else {
-        panic!("expected Thinking block");
-    };
-    assert_eq!(thinking, "Let me think about this...");
+    // Both content and reasoning → only Text block (content priority)
+    assert_eq!(resp.content_blocks.len(), 1);
     assert!(
-        matches!(&resp.content_blocks[1], RawContentBlock::Text(s) if s == "The answer is 42.")
+        matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "The answer is 42.")
     );
 }
 
@@ -369,24 +365,13 @@ fn test_parse_response_thinking_then_text_order() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    assert_eq!(resp.content_blocks.len(), 2);
-    // Thinking block first
+    // content + reasoning_content → only Text block (content priority)
+    assert_eq!(resp.content_blocks.len(), 1);
     match &resp.content_blocks[0] {
-        RawContentBlock::Thinking {
-            thinking,
-            signature,
-        } => {
-            assert_eq!(thinking, "Let me think about this...");
-            assert!(signature.is_none());
-        }
-        _ => panic!("Expected Thinking block first"),
-    }
-    // Text block second
-    match &resp.content_blocks[1] {
         RawContentBlock::Text(text) => {
             assert_eq!(text, "The answer is 42.");
         }
-        _ => panic!("Expected Text block second"),
+        _ => panic!("Expected Text block (content priority)"),
     }
 }
 
@@ -614,13 +599,11 @@ fn test_parse_response_tool_calls_with_reasoning() {
         }
     });
     let resp = proto.parse_response(body).unwrap();
-    // Thinking + Text + ToolUse
-    assert_eq!(resp.content_blocks.len(), 3);
-    assert!(matches!(&resp.content_blocks[0],
-        RawContentBlock::Thinking { thinking, .. } if thinking == "Thinking about the request..."));
-    assert!(matches!(&resp.content_blocks[1], RawContentBlock::Text(s) if s == "Here you go."));
+    // Text + ToolUse (content priority, reasoning_content ignored)
+    assert_eq!(resp.content_blocks.len(), 2);
+    assert!(matches!(&resp.content_blocks[0], RawContentBlock::Text(s) if s == "Here you go."));
     assert!(
-        matches!(&resp.content_blocks[2], RawContentBlock::ToolUse { id, name, .. }
+        matches!(&resp.content_blocks[1], RawContentBlock::ToolUse { id, name, .. }
         if id == "call_r1" && name == "lookup")
     );
 }

--- a/crates/llm/src/protocol/openai_tests.rs
+++ b/crates/llm/src/protocol/openai_tests.rs
@@ -14,6 +14,7 @@ fn make_request() -> InternalRequest {
         messages: vec![super::InternalMessage {
             role: "user".to_string(),
             content: "Hello".to_string(),
+            ..Default::default()
         }],
         temperature: 0.7,
         max_tokens: Some(256),

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -179,6 +179,7 @@ mod tests {
             messages: vec![InternalMessage {
                 role: "user".into(),
                 content: "hello".into(),
+                ..Default::default()
             }],
             temperature: 0.7,
             max_tokens: Some(100),

--- a/crates/llm/src/session/session_chat.rs
+++ b/crates/llm/src/session/session_chat.rs
@@ -151,6 +151,7 @@ impl ChatSession for ConversationSession {
             msgs.push(InternalMessage {
                 role: "system".into(),
                 content: prompt.clone(),
+                ..Default::default()
             });
         }
         let cleaned = Self::clean_thinking_content(&self.messages);
@@ -176,6 +177,7 @@ impl ChatSession for ConversationSession {
             msgs.push(InternalMessage {
                 role: msg.role.clone(),
                 content,
+                ..Default::default()
             });
         }
         InternalRequest {

--- a/crates/llm/src/session/session_chat.rs
+++ b/crates/llm/src/session/session_chat.rs
@@ -155,9 +155,16 @@ impl ChatSession for ConversationSession {
             });
         }
         let cleaned = Self::clean_thinking_content(&self.messages);
+        let mut tool_results: Vec<&ContentBlock> = Vec::new();
         for msg in &cleaned {
-            let content = msg
-                .content_blocks
+            let mut non_tool_blocks = Vec::new();
+            for b in &msg.content_blocks {
+                match b {
+                    ContentBlock::ToolResult { .. } => tool_results.push(b),
+                    _ => non_tool_blocks.push(b),
+                }
+            }
+            let content = non_tool_blocks
                 .iter()
                 .flat_map(|b| match b {
                     ContentBlock::Text(t) => vec![t.clone()],
@@ -167,10 +174,10 @@ impl ChatSession for ConversationSession {
                     ContentBlock::ToolUse { name, input, .. } => {
                         vec![format!("[tool:{}] {}", name, input)]
                     }
-                    ContentBlock::ToolResult { content, .. } => vec![content.clone()],
                     ContentBlock::Image(name) => vec![format!("[image: {}]", name)],
                     ContentBlock::Audio(name) => vec![format!("[audio: {}]", name)],
                     ContentBlock::File(name) => vec![format!("[file: {}]", name)],
+                    _ => vec![],
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
@@ -179,6 +186,20 @@ impl ChatSession for ConversationSession {
                 content,
                 ..Default::default()
             });
+        }
+        // Append tool results as independent role="tool" messages.
+        for block in &tool_results {
+            if let ContentBlock::ToolResult {
+                tool_call_id,
+                content,
+            } = block
+            {
+                msgs.push(InternalMessage {
+                    role: "tool".into(),
+                    content: content.clone(),
+                    tool_call_id: Some(tool_call_id.clone()),
+                });
+            }
         }
         InternalRequest {
             model: self.model.clone(),

--- a/crates/llm/src/session/tests/mod.rs
+++ b/crates/llm/src/session/tests/mod.rs
@@ -428,3 +428,114 @@ fn test_clear_pending_empty_returns_zero() {
     let cleared = session.clear_pending();
     assert_eq!(cleared, 0);
 }
+
+// ── build_api_request ToolResult separation ──────────────────────────────
+
+#[test]
+fn test_build_api_request_separates_tool_result_messages() {
+    let mut session = ConversationSession::new("sess_tool_sep".into(), "gpt-4o".into(), tmp_path());
+    // Assistant response with text + tool use
+    session.append_response(UnifiedResponse {
+        content_blocks: vec![
+            ContentBlock::Text("Let me check.".into()),
+            ContentBlock::ToolUse {
+                id: "call_1".into(),
+                name: "search".into(),
+                input: "query".into(),
+            },
+        ],
+        usage: UnifiedUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: Some(2),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("tool_calls".into()),
+    });
+    // Append tool result
+    session.append_tool_result("call_1".into(), "result: 42".into());
+
+    let req = session.build_api_request();
+    // Should have: system (none), assistant, tool = 2 messages
+    assert_eq!(req.messages.len(), 2);
+
+    // First message: assistant with non-tool blocks only
+    let assistant_msg = &req.messages[0];
+    assert_eq!(assistant_msg.role, "assistant");
+    assert!(!assistant_msg.content.is_empty());
+    assert!(assistant_msg.tool_call_id.is_none());
+
+    // Second message: independent tool result
+    let tool_msg = &req.messages[1];
+    assert_eq!(tool_msg.role, "tool");
+    assert_eq!(tool_msg.content, "result: 42");
+    assert_eq!(tool_msg.tool_call_id.as_deref(), Some("call_1"));
+}
+
+#[test]
+fn test_build_api_request_multiple_tool_results_appended_in_order() {
+    let mut session =
+        ConversationSession::new("sess_tool_multi".into(), "gpt-4o".into(), tmp_path());
+    session.append_response(UnifiedResponse {
+        content_blocks: vec![
+            ContentBlock::Text("Thinking...".into()),
+            ContentBlock::ToolUse {
+                id: "call_a".into(),
+                name: "tool_a".into(),
+                input: "{}".into(),
+            },
+            ContentBlock::ToolUse {
+                id: "call_b".into(),
+                name: "tool_b".into(),
+                input: "{}".into(),
+            },
+        ],
+        usage: UnifiedUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: Some(2),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("tool_calls".into()),
+    });
+    session.append_tool_result("call_a".into(), "result_a".into());
+    session.append_tool_result("call_b".into(), "result_b".into());
+
+    let req = session.build_api_request();
+    // assistant + 2 tool results = 3 messages
+    assert_eq!(req.messages.len(), 3);
+    assert_eq!(req.messages[0].role, "assistant");
+    assert_eq!(req.messages[1].role, "tool");
+    assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_a"));
+    assert_eq!(req.messages[1].content, "result_a");
+    assert_eq!(req.messages[2].role, "tool");
+    assert_eq!(req.messages[2].tool_call_id.as_deref(), Some("call_b"));
+    assert_eq!(req.messages[2].content, "result_b");
+}
+
+#[test]
+fn test_build_api_request_no_tool_result_preserves_original_behavior() {
+    let mut session = ConversationSession::new("sess_no_tool".into(), "gpt-4o".into(), tmp_path());
+    session.append_response(UnifiedResponse {
+        content_blocks: vec![ContentBlock::Text("Hello".into())],
+        usage: UnifiedUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: Some(2),
+            reasoning_tokens: None,
+            cache_read_tokens: None,
+            cache_write_tokens: None,
+        },
+        finish_reason: Some("stop".into()),
+    });
+
+    let req = session.build_api_request();
+    assert_eq!(req.messages.len(), 1);
+    assert_eq!(req.messages[0].role, "assistant");
+    assert_eq!(req.messages[0].content, "Hello");
+    assert!(req.messages[0].tool_call_id.is_none());
+}

--- a/crates/llm/src/stub.rs
+++ b/crates/llm/src/stub.rs
@@ -151,6 +151,7 @@ mod tests {
             messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "hello".to_string(),
+                ..Default::default()
             }],
             temperature: 0.7,
             max_tokens: None,
@@ -185,6 +186,7 @@ mod tests {
             messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "test".to_string(),
+                ..Default::default()
             }],
             temperature: 0.0,
             max_tokens: Some(100),

--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -208,6 +208,22 @@ pub struct InternalMessage {
     pub role: String,
     /// The content of the message.
     pub content: String,
+    /// Optional tool call ID for tool result messages.
+    /// When present, this message represents a tool result that should be
+    /// serialized in provider-native format by the protocol layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+}
+
+impl Default for InternalMessage {
+    fn default() -> Self {
+        Self {
+            role: String::new(),
+            content: String::new(),
+            tool_call_id: None,
+        }
+    }
 }
 
 /// A tool definition passed via the API `tools` parameter.

--- a/crates/llm/src/unified_fallback.rs
+++ b/crates/llm/src/unified_fallback.rs
@@ -197,6 +197,7 @@ mod tests {
             messages: vec![InternalMessage {
                 role: "user".to_string(),
                 content: "hello".to_string(),
+                ..Default::default()
             }],
             temperature: 0.0,
             max_tokens: None,

--- a/crates/llm/src/volcengine/tests.rs
+++ b/crates/llm/src/volcengine/tests.rs
@@ -20,6 +20,7 @@ fn make_request(model: &str) -> InternalRequest {
         messages: vec![InternalMessage {
             role: "user".into(),
             content: "Say hi".into(),
+            ..Default::default()
         }],
         temperature: 0.0,
         max_tokens: None,


### PR DESCRIPTION
Fix protocol mapping alignment: resolve 5 must_fix differences between code and design doc

Changes:
- Add tool_call_id field to InternalMessage for native tool result serialization
- Separate ToolResult into independent tool messages in build_api_request
- Handle tool result serialization in OpenAI build_message (role: "tool" + tool_call_id)
- Handle tool result serialization in Anthropic build_message (structured content blocks)
- Unify reasoning_content priority: content-first in OpenAI non-streaming and GLM streaming
- Capture signature in BlockAccumulator for streaming Thinking blocks

Source: user
Type: fix
