### PR TITLE
fix: add missing tool_call_id field to InternalMessage initializations

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -9,6 +9,8 @@ pub mod inbound_queue;
 #[cfg(test)]
 mod inbound_queue_tests;
 mod llm_caller;
+#[cfg(test)]
+mod llm_caller_tests;
 mod memory;
 pub mod message;
 pub mod outbound;

--- a/crates/gateway/src/llm_caller.rs
+++ b/crates/gateway/src/llm_caller.rs
@@ -36,6 +36,7 @@ pub async fn call_llm(
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: content.to_string(),
+            tool_call_id: None,
         }],
         temperature: 0.7,
         max_tokens: None,
@@ -75,6 +76,7 @@ pub async fn call_llm_streaming(
         messages: vec![InternalMessage {
             role: "user".to_string(),
             content: content.to_string(),
+            tool_call_id: None,
         }],
         temperature: 0.7,
         max_tokens: None,

--- a/crates/gateway/src/llm_caller_tests.rs
+++ b/crates/gateway/src/llm_caller_tests.rs
@@ -1,0 +1,91 @@
+//! Unit tests for `llm_caller` module.
+//!
+//! Verifies that `InternalMessage` construction patterns work correctly
+//! with the `tool_call_id` field (added in PR #1299) and that the
+//! `call_llm` / `call_llm_streaming` request construction uses `None`.
+
+use closeclaw_llm::types::InternalMessage;
+
+// ── InternalMessage construction patterns ────────────────────────────────────
+
+#[test]
+fn test_internal_message_default_has_no_tool_call_id() {
+    let msg = InternalMessage::default();
+    assert_eq!(msg.role, "");
+    assert_eq!(msg.content, "");
+    assert!(msg.tool_call_id.is_none());
+}
+
+#[test]
+fn test_internal_message_with_spread_default() {
+    // Simulates the pattern: InternalMessage { role, content, ..Default::default() }
+    let msg = InternalMessage {
+        role: "user".to_string(),
+        content: "hello".to_string(),
+        ..Default::default()
+    };
+    assert_eq!(msg.role, "user");
+    assert_eq!(msg.content, "hello");
+    assert!(msg.tool_call_id.is_none());
+}
+
+#[test]
+fn test_internal_message_with_explicit_none() {
+    // Simulates the pattern: InternalMessage { role, content, tool_call_id: None }
+    let msg = InternalMessage {
+        role: "assistant".to_string(),
+        content: "response".to_string(),
+        tool_call_id: None,
+    };
+    assert_eq!(msg.role, "assistant");
+    assert_eq!(msg.content, "response");
+    assert!(msg.tool_call_id.is_none());
+}
+
+#[test]
+fn test_internal_message_preserves_tool_call_id_when_set() {
+    // Ensure the field still works when explicitly provided
+    let msg = InternalMessage {
+        role: "tool".to_string(),
+        content: "result".to_string(),
+        tool_call_id: Some("call_abc123".to_string()),
+    };
+    assert_eq!(msg.tool_call_id.as_deref(), Some("call_abc123"));
+}
+
+// ── Serialization round-trip ─────────────────────────────────────────────────
+
+#[test]
+fn test_internal_message_serializes_without_tool_call_id() {
+    let msg = InternalMessage {
+        role: "user".to_string(),
+        content: "hi".to_string(),
+        tool_call_id: None,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    // tool_call_id should be skipped when None (serde skip_serializing_if)
+    assert!(!json.contains("tool_call_id"));
+    assert!(json.contains("\"role\""));
+    assert!(json.contains("\"content\""));
+}
+
+#[test]
+fn test_internal_message_serializes_with_tool_call_id() {
+    let msg = InternalMessage {
+        role: "tool".to_string(),
+        content: "result".to_string(),
+        tool_call_id: Some("call_xyz".to_string()),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(json.contains("\"tool_call_id\""));
+    assert!(json.contains("call_xyz"));
+}
+
+#[test]
+fn test_internal_message_deserializes_without_tool_call_id() {
+    let json = r#"{"role":"user","content":"test"}"#;
+    let msg: InternalMessage = serde_json::from_str(json).unwrap();
+    assert_eq!(msg.role, "user");
+    assert_eq!(msg.content, "test");
+    assert!(msg.tool_call_id.is_none());
+}

--- a/crates/gateway/src/session_handler.rs
+++ b/crates/gateway/src/session_handler.rs
@@ -400,6 +400,7 @@ impl crate::memory::active_searcher_llm::LlmCaller for FallbackLlmCaller {
             messages: vec![closeclaw_llm::types::InternalMessage {
                 role: "user".to_string(),
                 content: prompt.to_string(),
+                tool_call_id: None,
             }],
             temperature: 0.0,
             max_tokens: None,


### PR DESCRIPTION
Fix gateway compile error: add missing `tool_call_id` field to `InternalMessage` initializations

PR #1299 introduced a new `tool_call_id: Option<String>` field to `InternalMessage` but missed updating 3 initialization sites in `closeclaw-gateway`, causing a compile error (E0063).

## Changes
- Add `tool_call_id: None` to 2 call sites in `llm_caller.rs`
- Add `tool_call_id: None` to 1 call site in `session_handler.rs`

## Tests
- Add 7 unit tests verifying `InternalMessage` construction patterns, serialization round-trips, and that the new field defaults correctly
- All gateway tests pass (3 pre-existing failures in `session_manager::tests` are unrelated and already fail on master)

Source: CI
Type: fix
