### PR TITLE
fix: add missing tool_call_id default in InternalMessage initialization

### DIFF
--- a/src/session/llm_caller.rs
+++ b/src/session/llm_caller.rs
@@ -161,6 +161,7 @@ pub async fn build_request(
             .map(|m| closeclaw_llm::types::InternalMessage {
                 role: m.role.clone(),
                 content: m.content.clone(),
+                ..Default::default()
             })
             .collect(),
         temperature: 0.7,


### PR DESCRIPTION
fix: add missing tool_call_id default in InternalMessage initialization

`InternalMessage` struct gained a `tool_call_id: Option<String>` field, but the initialization in `src/session/llm_caller.rs` was not updated. This caused a compile error (E0063) in CI. Fixed by adding `..Default::default()`, consistent with all other `InternalMessage` initializations in the codebase.

Source: CI
Type: fix
