### PR TITLE
fix: replace manual Default impl with derive on InternalMessage

### DIFF
--- a/crates/llm/src/types.rs
+++ b/crates/llm/src/types.rs
@@ -202,7 +202,7 @@ pub struct SystemBlock {
 ///
 /// Contains the role and content of a chat message used internally
 /// by Protocol implementations when building provider requests.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InternalMessage {
     /// The role of the message sender (e.g., "user", "assistant").
     pub role: String,
@@ -214,16 +214,6 @@ pub struct InternalMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub tool_call_id: Option<String>,
-}
-
-impl Default for InternalMessage {
-    fn default() -> Self {
-        Self {
-            role: String::new(),
-            content: String::new(),
-            tool_call_id: None,
-        }
-    }
 }
 
 /// A tool definition passed via the API `tools` parameter.

--- a/crates/llm/src/types_tests.rs
+++ b/crates/llm/src/types_tests.rs
@@ -1,9 +1,20 @@
 //! Tests for LLM types (serde, roundtrip, etc.).
 
 use crate::types::{
-    ContentBlock, ContentBlockType, ContentDelta, InternalResponse, RawContentBlock, RawUsage,
-    SseStateMachine, StreamEvent, SystemBlock, UnifiedResponse, UnifiedUsage,
+    ContentBlock, ContentBlockType, ContentDelta, InternalMessage, InternalResponse,
+    RawContentBlock, RawUsage, SseStateMachine, StreamEvent, SystemBlock, UnifiedResponse,
+    UnifiedUsage,
 };
+
+// ── InternalMessage default test ─────────────────────────────────────────
+
+#[test]
+fn test_internal_message_default() {
+    let msg = InternalMessage::default();
+    assert_eq!(msg.role, "");
+    assert_eq!(msg.content, "");
+    assert!(msg.tool_call_id.is_none());
+}
 
 // ── ContentBlock serde symmetry tests ──────────────────────────────────────
 


### PR DESCRIPTION
fix: replace manual Default impl with derive on InternalMessage

Replace the hand-written `Default` implementation for `InternalMessage` with
`#[derive(Default)]` since all field defaults match the derived version. Add a
unit test to verify the default values.

Source: CI
Type: fix
